### PR TITLE
Increase client_max_body_size for golem-router

### DIFF
--- a/golem-router/golem-services.conf.template
+++ b/golem-router/golem-services.conf.template
@@ -3,6 +3,8 @@ events {
 }
 
 http {
+    client_max_body_size 4m; # Increase this especially if your template size is higher than this
+
     # For docker we need this for service discovery in docker network
     resolver 127.0.0.11;
 


### PR DESCRIPTION
To avoid errors during upload templates of larger size (debug mode especially).
A shopping-cart debug mode creates 2+ megabytes. To be safer side I increased to 4m