### PR TITLE
GOL-220 Shard manager improvements part 1

### DIFF
--- a/api-gateway-examples/README.md
+++ b/api-gateway-examples/README.md
@@ -12,7 +12,7 @@ The API definition essentially comprises a set of endpoints, each associated wit
 
 The registration process for this endpoint definition is straightforward. Further configuration details can be discussed later as needed.
 
-## An example, including integration with an externa API Gateway
+## An example, including integration with an external API Gateway
 
 After deploying our Golem service, integration with external API Gateways, like Tyk, becomes straightforward. 
 This setup enables us to utilize the robust infrastructure and security features provided by the API Gateway while leveraging Golem for request processing.

--- a/golem-api-grpc/proto/golem/shardmanager/shard_manager_service.proto
+++ b/golem-api-grpc/proto/golem/shardmanager/shard_manager_service.proto
@@ -35,5 +35,4 @@ message RegisterResponse {
 
 message RegisterSuccess {
   uint32 number_of_shards = 1;
-  repeated golem.shardmanager.ShardId shard_ids = 2;
 }

--- a/golem-shard-manager/config/shard-manager.toml
+++ b/golem-shard-manager/config/shard-manager.toml
@@ -3,6 +3,8 @@ enable_json_log = false
 number_of_shards = 1024
 http_port = 8080
 
+rebalance_threshold = 0.1
+
 [redis]
 # host
 # port
@@ -17,12 +19,12 @@ min_delay = "100ms"
 max_delay = "2s"
 multiplier = 2
 
-[instance_server_service]
+[worker_executors]
 assign_shards_timeout = "5s"
 health_check_timeout = "2s"
 revoke_shards_timeout = "5s"
 
-[instance_server_service.retries]
+[worker_executors.retries]
 max_attempts = 5
 min_delay = "100ms"
 max_delay = "2s"

--- a/golem-shard-manager/src/model.rs
+++ b/golem-shard-manager/src/model.rs
@@ -156,6 +156,10 @@ impl RoutingTable {
     pub fn remove_pod(&mut self, pod: &Pod) {
         self.shard_assignments.remove(pod);
     }
+
+    pub fn has_pod(&self, pod: &Pod) -> bool {
+        self.shard_assignments.contains_key(pod)
+    }
 }
 
 impl From<RoutingTable> for golem::shardmanager::RoutingTable {

--- a/golem-shard-manager/src/model.rs
+++ b/golem-shard-manager/src/model.rs
@@ -13,17 +13,19 @@
 // limitations under the License.
 
 use core::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
 use bincode::{Decode, Encode};
-use golem_api_grpc::proto::golem;
-use golem_common::model::ShardId;
 use serde::{Deserialize, Serialize};
 
+use golem_api_grpc::proto::golem;
+use golem_common::model::ShardId;
+
 use crate::error::ShardManagerError;
+use crate::rebalancing::Rebalance;
 
 #[derive(
     Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Encode, Decode,
@@ -83,14 +85,14 @@ impl Display for Pod {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RoutingTable {
     pub number_of_shards: usize,
-    pub shard_assignments: HashMap<Pod, HashSet<ShardId>>,
+    pub shard_assignments: BTreeMap<Pod, BTreeSet<ShardId>>,
 }
 
 impl RoutingTable {
     pub fn new(number_of_shards: usize) -> Self {
         Self {
             number_of_shards,
-            shard_assignments: HashMap::new(),
+            shard_assignments: BTreeMap::new(),
         }
     }
 
@@ -102,39 +104,44 @@ impl RoutingTable {
             .collect()
     }
 
+    pub fn get_entries_vec(&self) -> Vec<RoutingTableEntry> {
+        self.shard_assignments
+            .clone()
+            .into_iter()
+            .map(|(pod, shard_ids)| RoutingTableEntry::new(pod, shard_ids))
+            .collect()
+    }
+
     pub fn get_pods(&self) -> HashSet<Pod> {
         self.shard_assignments.clone().into_keys().collect()
     }
 
-    pub fn rebalance(&mut self, rebalance: &Rebalance) {
-        for (pod, shard_ids) in rebalance.assignments.assignments.clone() {
+    pub fn rebalance(&mut self, rebalance: Rebalance) {
+        for (pod, shard_ids) in &rebalance.get_assignments().assignments {
             self.shard_assignments
-                .get_mut(&pod)
-                .unwrap()
+                .entry(pod.clone())
+                .or_default()
                 .extend(shard_ids);
         }
-        for (pod, shard_ids) in rebalance.unassignments.unassignments.clone() {
+        for (pod, shard_ids) in &rebalance.get_unassignments().unassignments {
             self.shard_assignments
-                .get_mut(&pod)
-                .unwrap()
+                .entry(pod.clone())
+                .or_default()
                 .retain(|shard_id| !shard_ids.contains(shard_id));
         }
     }
 
-    pub fn get_unassigned_shards(&self) -> HashSet<ShardId> {
-        let mut unassigned_shards: HashSet<ShardId> = (0..self.number_of_shards)
+    pub fn get_unassigned_shards(&self) -> BTreeSet<ShardId> {
+        let mut unassigned_shards: BTreeSet<ShardId> = (0..self.number_of_shards)
             .map(|shard_id| ShardId::new(shard_id as i64))
             .collect();
         for assigned_shards in self.shard_assignments.values() {
-            unassigned_shards = unassigned_shards
-                .difference(assigned_shards)
-                .cloned()
-                .collect();
+            unassigned_shards.retain(|shard_id| !assigned_shards.contains(shard_id));
         }
         unassigned_shards
     }
 
-    pub fn get_shards(&self, pod: &Pod) -> Option<HashSet<ShardId>> {
+    pub fn get_shards(&self, pod: &Pod) -> Option<BTreeSet<ShardId>> {
         self.shard_assignments.get(pod).cloned()
     }
 
@@ -143,7 +150,7 @@ impl RoutingTable {
     }
 
     pub fn add_pod(&mut self, pod: &Pod) {
-        self.shard_assignments.insert(pod.clone(), HashSet::new());
+        self.shard_assignments.insert(pod.clone(), BTreeSet::new());
     }
 
     pub fn remove_pod(&mut self, pod: &Pod) {
@@ -174,7 +181,7 @@ impl From<RoutingTable> for golem::shardmanager::RoutingTable {
 
 impl From<golem::shardmanager::RoutingTable> for RoutingTable {
     fn from(routing_table: golem::shardmanager::RoutingTable) -> Self {
-        let mut shard_assignments: HashMap<Pod, HashSet<ShardId>> = HashMap::new();
+        let mut shard_assignments: BTreeMap<Pod, BTreeSet<ShardId>> = BTreeMap::new();
         for entry in routing_table.shard_assignments {
             let pod = entry.pod.unwrap().into();
             let shard_id = entry.shard_id.unwrap().into();
@@ -200,11 +207,11 @@ impl Display for RoutingTable {
 
 pub struct RoutingTableEntry {
     pub pod: Pod,
-    pub shard_ids: HashSet<ShardId>,
+    pub shard_ids: BTreeSet<ShardId>,
 }
 
 impl RoutingTableEntry {
-    pub fn new(pod: Pod, shard_ids: HashSet<ShardId>) -> Self {
+    pub fn new(pod: Pod, shard_ids: BTreeSet<ShardId>) -> Self {
         Self { pod, shard_ids }
     }
     pub fn get_shard_count(&self) -> usize {
@@ -249,7 +256,7 @@ impl Display for RoutingTableEntry {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Assignments {
-    pub assignments: HashMap<Pod, HashSet<ShardId>>,
+    pub assignments: BTreeMap<Pod, BTreeSet<ShardId>>,
 }
 
 impl Assignments {
@@ -259,8 +266,12 @@ impl Assignments {
 
     pub fn new() -> Self {
         Self {
-            assignments: HashMap::new(),
+            assignments: BTreeMap::new(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.assignments.is_empty()
     }
 }
 
@@ -282,7 +293,7 @@ impl Display for Assignments {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Unassignments {
-    pub unassignments: HashMap<Pod, HashSet<ShardId>>,
+    pub unassignments: BTreeMap<Pod, BTreeSet<ShardId>>,
 }
 
 impl Unassignments {
@@ -292,8 +303,12 @@ impl Unassignments {
 
     pub fn new() -> Self {
         Self {
-            unassignments: HashMap::new(),
+            unassignments: BTreeMap::new(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.unassignments.is_empty()
     }
 }
 
@@ -309,108 +324,6 @@ impl Display for Unassignments {
             f,
             "[{}]",
             shard_assignments_map_to_string(&self.unassignments)
-        )
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Rebalance {
-    pub assignments: Assignments,
-    pub unassignments: Unassignments,
-}
-
-impl Rebalance {
-    pub fn from_routing_table(routing_table: &RoutingTable) -> Self {
-        let mut assignments = Assignments::new();
-        let mut unassignments = Unassignments::new();
-        let pod_count = routing_table.get_pod_count();
-        if pod_count == 0 {
-            return Rebalance {
-                assignments,
-                unassignments,
-            };
-        }
-        let mut routing_table_entries = routing_table.get_entries();
-        let unassigned_shards = routing_table.get_unassigned_shards();
-        for unassigned_shard in unassigned_shards {
-            let mut routing_table_entry = routing_table_entries.pop_first().unwrap();
-            assignments.assign(routing_table_entry.pod.clone(), unassigned_shard);
-            routing_table_entry.shard_ids.insert(unassigned_shard);
-            routing_table_entries.insert(routing_table_entry);
-        }
-        if pod_count == 1 {
-            return Rebalance {
-                assignments,
-                unassignments,
-            };
-        };
-        loop {
-            let mut first = routing_table_entries.pop_first().unwrap();
-            let mut last = routing_table_entries.pop_last().unwrap();
-            if first.pod == last.pod || last.get_shard_count() - first.get_shard_count() <= 1 {
-                break;
-            }
-            let shard_id = *last.shard_ids.iter().next().unwrap();
-            first.shard_ids.insert(shard_id);
-            last.shard_ids.remove(&shard_id);
-            assignments.assign(first.pod.clone(), shard_id);
-            unassignments.unassign(last.pod.clone(), shard_id);
-            routing_table_entries.insert(first);
-            routing_table_entries.insert(last);
-        }
-        Rebalance {
-            assignments,
-            unassignments,
-        }
-    }
-
-    pub fn get_pods(&self) -> HashSet<Pod> {
-        let mut pods = HashSet::new();
-        for pod in self.assignments.assignments.keys() {
-            pods.insert(pod.clone());
-        }
-        for pod in self.unassignments.unassignments.keys() {
-            pods.insert(pod.clone());
-        }
-        pods
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.assignments.assignments.is_empty() && self.unassignments.unassignments.is_empty()
-    }
-
-    pub fn new() -> Self {
-        Rebalance {
-            assignments: Assignments::new(),
-            unassignments: Unassignments::new(),
-        }
-    }
-
-    pub fn remove_pods(&mut self, pods: &HashSet<Pod>) {
-        self.assignments
-            .assignments
-            .retain(|pod, _| !pods.contains(pod));
-        self.unassignments
-            .unassignments
-            .retain(|pod, _| !pods.contains(pod));
-    }
-
-    pub fn remove_shards(&mut self, shard_ids: &HashSet<ShardId>) {
-        for assigned_shard_ids in &mut self.assignments.assignments.values_mut() {
-            assigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
-        }
-        for unassigned_shard_ids in &mut self.unassignments.unassignments.values_mut() {
-            unassigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
-        }
-    }
-}
-
-impl Display for Rebalance {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{{ assignments: {}, unassignments: {} }}",
-            self.assignments, self.unassignments
         )
     }
 }
@@ -433,11 +346,11 @@ impl ShardManagerState {
             ));
         }
         let mut assignments: Vec<(Pod, Vec<ShardId>)> = Vec::new();
-        for (pod, shard_ids) in &rebalance.assignments.assignments {
+        for (pod, shard_ids) in &rebalance.get_assignments().assignments {
             assignments.push((pod.clone(), shard_ids.iter().cloned().collect()));
         }
         let mut unassignments: Vec<(Pod, Vec<ShardId>)> = Vec::new();
-        for (pod, shard_ids) in &rebalance.unassignments.unassignments {
+        for (pod, shard_ids) in &rebalance.get_unassignments().unassignments {
             unassignments.push((pod.clone(), shard_ids.iter().cloned().collect()));
         }
         ShardManagerState {
@@ -449,7 +362,7 @@ impl ShardManagerState {
     }
 
     pub fn get_routing_table(&self) -> RoutingTable {
-        let mut shard_assignments: HashMap<Pod, HashSet<ShardId>> = HashMap::new();
+        let mut shard_assignments: BTreeMap<Pod, BTreeSet<ShardId>> = BTreeMap::new();
         for (pod, shard_ids) in &self.shard_assignments {
             shard_assignments.insert(pod.clone(), shard_ids.iter().cloned().collect());
         }
@@ -472,10 +385,7 @@ impl ShardManagerState {
                 unassignments.unassign(pod.clone(), *shard_id);
             }
         }
-        Rebalance {
-            assignments,
-            unassignments,
-        }
+        Rebalance::new(assignments, unassignments)
     }
 }
 
@@ -507,7 +417,7 @@ fn shard_assignments_to_string(shard_assignments: &[(Pod, Vec<ShardId>)]) -> Str
     elements.join(", ")
 }
 
-fn shard_assignments_map_to_string(shard_assignments: &HashMap<Pod, HashSet<ShardId>>) -> String {
+fn shard_assignments_map_to_string(shard_assignments: &BTreeMap<Pod, BTreeSet<ShardId>>) -> String {
     let elements: Vec<String> = shard_assignments
         .iter()
         .map(|(pod, shard_ids)| {

--- a/golem-shard-manager/src/persistence.rs
+++ b/golem-shard-manager/src/persistence.rs
@@ -17,7 +17,8 @@ use bytes::Bytes;
 use golem_common::redis::RedisPool;
 
 use crate::error::ShardManagerError;
-use crate::model::{Rebalance, RoutingTable, ShardManagerState};
+use crate::model::{RoutingTable, ShardManagerState};
+use crate::rebalancing::Rebalance;
 
 #[async_trait]
 pub trait PersistenceService {
@@ -76,7 +77,7 @@ impl PersistenceService for PersistenceServiceDefault {
                     shard_manager_state.get_rebalance(),
                 ))
             }
-            None => Ok((RoutingTable::new(self.number_of_shards), Rebalance::new())),
+            None => Ok((RoutingTable::new(self.number_of_shards), Rebalance::empty())),
         }
     }
 }

--- a/golem-shard-manager/src/rebalancing.rs
+++ b/golem-shard-manager/src/rebalancing.rs
@@ -1,0 +1,602 @@
+use crate::model::{Assignments, Pod, RoutingTable, Unassignments};
+use golem_common::model::ShardId;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Rebalance {
+    assignments: Assignments,
+    unassignments: Unassignments,
+}
+
+impl Rebalance {
+    pub fn new(assignments: Assignments, unassignments: Unassignments) -> Self {
+        Rebalance {
+            assignments,
+            unassignments,
+        }
+    }
+
+    /// Constructs a rebalance plan from the current state of the routing table.
+    ///
+    /// The `threshold` parameter is used to reduce the number of shard reassignments by
+    /// allowing a given number of shards to be over or under the optimal count per pod.
+    ///
+    /// The optimal count (balanced state) is number_of_shards/pod_count.
+    /// Threshold is a percentage of the optimal count, so for 10 pods with 1000 shards,
+    /// and a threshold of 10%, pods with shard count between 90 and 110 will be considered
+    /// balanced.
+    pub fn from_routing_table(routing_table: &RoutingTable, threshold: f64) -> Self {
+        let mut assignments = Assignments::new();
+        let mut unassignments = Unassignments::new();
+        let pod_count = routing_table.get_pod_count();
+        if pod_count == 0 {
+            return Rebalance {
+                assignments,
+                unassignments,
+            };
+        }
+
+        let mut routing_table_entries = routing_table.get_entries_vec();
+
+        let mut empty_pods = BTreeSet::new();
+        for (idx, entry) in routing_table_entries.iter().enumerate() {
+            if entry.shard_ids.is_empty() {
+                empty_pods.insert(idx);
+            }
+        }
+        let mut initial_target_pods = empty_pods.iter().copied().collect::<Vec<_>>(); // this will be updated during the unassignment step, while empty_pods is used later in the assignment step
+        let optimal_count = routing_table.number_of_shards / pod_count;
+        let upper_threshold = (optimal_count as f64 * (1.0 + threshold)).ceil() as usize;
+        let lower_threshold = (optimal_count as f64 * (1.0 - threshold)).floor() as usize;
+
+        // Distributing unassigned shards evenly first among the new pods, once they reached
+        // the optimal per-pod shard count, distribute the rest among all pods
+        let unassigned_shards = routing_table.get_unassigned_shards();
+        let mut idx = 0;
+        for unassigned_shard in unassigned_shards {
+            if initial_target_pods.is_empty() {
+                // No more initial empty pods, distribute shards among all pods
+                println!("Assigning shard: {} to {}", unassigned_shard, idx);
+                let routing_table_entry = &mut routing_table_entries[idx];
+                assignments.assign(routing_table_entry.pod.clone(), unassigned_shard);
+                routing_table_entry.shard_ids.insert(unassigned_shard);
+                idx = (idx + 1) % pod_count;
+            } else {
+                let target_idx = initial_target_pods[idx];
+                let routing_table_entry = &mut routing_table_entries[target_idx];
+
+                println!(
+                    "Assigning shard to originally empty pod: {} to {}",
+                    unassigned_shard, target_idx
+                );
+                assignments.assign(routing_table_entry.pod.clone(), unassigned_shard);
+                routing_table_entry.shard_ids.insert(unassigned_shard);
+                idx = (idx + 1) % initial_target_pods.len();
+
+                if routing_table_entry.shard_ids.len() == optimal_count {
+                    // This pod reached the optimal count, removing it from the list targets
+                    initial_target_pods.remove(idx);
+                    if initial_target_pods.is_empty() {
+                        idx = 0;
+                    } else {
+                        idx = (idx + 1) % initial_target_pods.len();
+                    }
+                }
+            }
+        }
+
+        if pod_count == 1 {
+            return Rebalance {
+                assignments,
+                unassignments,
+            };
+        };
+
+        // We redistribute shards from each entry having more than the optimal count
+        // to the last one until it becomes balanced, and repeat if we have more than one unbalanced entry.
+        // We also apply a threshold to the optimal count, to reduce the number of shard reassignments.
+        loop {
+            for (idx, entry) in routing_table_entries.iter().enumerate() {
+                println!("Pod {} has {} shards", idx, entry.shard_ids.len());
+            }
+            println!("===");
+
+            if let Some((target_idx, _)) = routing_table_entries
+                .iter()
+                .enumerate()
+                .find(|(_, entry)| entry.shard_ids.len() < lower_threshold)
+            {
+                println!("Found a pod with too few shards: {}", target_idx);
+                let mut source_idx = if target_idx == 0 { 1 } else { 0 };
+
+                loop {
+                    println!("Target count: {}..{}", lower_threshold, upper_threshold);
+                    let current_target_len = routing_table_entries[target_idx].shard_ids.len();
+                    if current_target_len < lower_threshold {
+                        let shard_id = routing_table_entries[source_idx]
+                            .shard_ids
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .clone();
+                        println!(
+                            "Moving first shard from {} to {}: {}",
+                            source_idx, target_idx, shard_id
+                        );
+                        routing_table_entries[source_idx]
+                            .shard_ids
+                            .remove(&shard_id);
+                        routing_table_entries[target_idx]
+                            .shard_ids
+                            .insert(shard_id.clone());
+                        assignments.assign(
+                            routing_table_entries[target_idx].pod.clone(),
+                            shard_id.clone(),
+                        );
+                        unassignments.unassign(
+                            routing_table_entries[source_idx].pod.clone(),
+                            shard_id.clone(),
+                        );
+
+                        source_idx = (source_idx + 1) % pod_count;
+                        while (source_idx == target_idx) || (empty_pods.contains(&source_idx)) {
+                            source_idx = (source_idx + 1) % pod_count;
+                        }
+                    } else {
+                        println!("Target reached a balanced state");
+                        // target reached a balanced state
+                        break;
+                    }
+                }
+            } else {
+                println!("All pods are balanced");
+                break;
+            }
+        }
+
+        Rebalance {
+            assignments,
+            unassignments,
+        }
+    }
+
+    pub fn get_assignments(&self) -> &Assignments {
+        &self.assignments
+    }
+
+    pub fn get_unassignments(&self) -> &Unassignments {
+        &self.unassignments
+    }
+
+    pub fn get_pods(&self) -> HashSet<Pod> {
+        let mut pods = HashSet::new();
+        for pod in self.assignments.assignments.keys() {
+            pods.insert(pod.clone());
+        }
+        for pod in self.unassignments.unassignments.keys() {
+            pods.insert(pod.clone());
+        }
+        pods
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.assignments.assignments.is_empty() && self.unassignments.unassignments.is_empty()
+    }
+
+    pub fn empty() -> Self {
+        Rebalance {
+            assignments: Assignments::new(),
+            unassignments: Unassignments::new(),
+        }
+    }
+
+    pub fn remove_pods(&mut self, pods: &HashSet<Pod>) {
+        self.assignments
+            .assignments
+            .retain(|pod, _| !pods.contains(pod));
+        self.unassignments
+            .unassignments
+            .retain(|pod, _| !pods.contains(pod));
+    }
+
+    pub fn remove_shards(&mut self, shard_ids: &HashSet<ShardId>) {
+        for assigned_shard_ids in &mut self.assignments.assignments.values_mut() {
+            assigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
+        }
+        for unassigned_shard_ids in &mut self.unassignments.unassignments.values_mut() {
+            unassigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
+        }
+    }
+}
+
+impl Display for Rebalance {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{{ assignments: {}, unassignments: {} }}",
+            self.assignments, self.unassignments
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::{Pod, RoutingTable};
+    use crate::rebalancing::Rebalance;
+    use golem_common::model::ShardId;
+
+    fn assign_shard(routing_table: &mut RoutingTable, pod: &Pod, shard_id: i64) {
+        routing_table
+            .shard_assignments
+            .entry(pod.clone())
+            .or_default()
+            .insert(ShardId::new(shard_id));
+    }
+
+    fn get_assigned_ids(rebalance: &Rebalance, pod: &Pod) -> Vec<ShardId> {
+        let mut assigned_ids = rebalance
+            .get_assignments()
+            .assignments
+            .get(pod)
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        assigned_ids.sort();
+        assigned_ids
+    }
+
+    fn get_unassigned_ids(rebalance: &Rebalance, pod: &Pod) -> Vec<ShardId> {
+        let mut assigned_ids = rebalance
+            .get_unassignments()
+            .unassignments
+            .get(pod)
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        assigned_ids.sort();
+        assigned_ids
+    }
+
+    #[test]
+    fn rebalance_empty_table() {
+        let routing_table = RoutingTable::new(1000);
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+        assert!(rebalance.is_empty());
+    }
+
+    #[test]
+    fn rebalance_single_pod_no_unassigned() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let mut routing_table = RoutingTable::new(4);
+        routing_table.add_pod(&pod1);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod1, 3);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+        assert!(rebalance.is_empty());
+    }
+
+    #[test]
+    fn rebalance_single_pod_unassigned() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let mut routing_table = RoutingTable::new(6);
+        routing_table.add_pod(&pod1);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 3);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+
+        assert!(rebalance.get_unassignments().is_empty());
+
+        let mut assigned_ids = get_assigned_ids(&rebalance, &pod1);
+        assigned_ids.sort();
+        assert_eq!(
+            assigned_ids,
+            vec![
+                ShardId::new(1),
+                ShardId::new(2),
+                ShardId::new(4),
+                ShardId::new(5),
+            ]
+        );
+    }
+
+    #[test]
+    fn rebalance_three_balanced_pods_no_unassigned() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(9);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod2, 3);
+        assign_shard(&mut routing_table, &pod2, 4);
+        assign_shard(&mut routing_table, &pod2, 5);
+        assign_shard(&mut routing_table, &pod3, 6);
+        assign_shard(&mut routing_table, &pod3, 7);
+        assign_shard(&mut routing_table, &pod3, 8);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+        assert!(rebalance.is_empty());
+    }
+
+    #[test]
+    fn rebalance_three_balanced_pods_unassigned() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(9);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod2, 4);
+        assign_shard(&mut routing_table, &pod2, 5);
+        assign_shard(&mut routing_table, &pod3, 6);
+        assign_shard(&mut routing_table, &pod3, 7);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+        assert!(rebalance.get_unassignments().is_empty());
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+        assert_eq!(assigned_ids_1, vec![ShardId::new(2)]);
+        assert_eq!(assigned_ids_2, vec![ShardId::new(3)]);
+        assert_eq!(assigned_ids_3, vec![ShardId::new(8)]);
+    }
+
+    #[test]
+    fn rebalance_one_new_pod() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(9);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod1, 3);
+        assign_shard(&mut routing_table, &pod2, 4);
+        assign_shard(&mut routing_table, &pod2, 5);
+        assign_shard(&mut routing_table, &pod2, 6);
+        assign_shard(&mut routing_table, &pod2, 7);
+        assign_shard(&mut routing_table, &pod2, 8);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+
+        let unassigned_ids_1 = get_unassigned_ids(&rebalance, &pod1);
+        let unassigned_ids_2 = get_unassigned_ids(&rebalance, &pod2);
+        let unassigned_ids_3 = get_unassigned_ids(&rebalance, &pod3);
+
+        assert_eq!(assigned_ids_1, vec![ShardId::new(5)]);
+        assert_eq!(assigned_ids_2, vec![]);
+        assert_eq!(
+            assigned_ids_3,
+            vec![ShardId::new(0), ShardId::new(1), ShardId::new(4)]
+        );
+
+        assert_eq!(unassigned_ids_1, vec![ShardId::new(0), ShardId::new(1)]);
+        assert_eq!(unassigned_ids_2, vec![ShardId::new(4), ShardId::new(5)]);
+        assert_eq!(unassigned_ids_3, vec![]);
+    }
+
+    #[test]
+    fn rebalance_one_new_pod_with_threshold() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(9);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod1, 3);
+        assign_shard(&mut routing_table, &pod2, 4);
+        assign_shard(&mut routing_table, &pod2, 5);
+        assign_shard(&mut routing_table, &pod2, 6);
+        assign_shard(&mut routing_table, &pod2, 7);
+        assign_shard(&mut routing_table, &pod2, 8);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.33);
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+
+        let unassigned_ids_1 = get_unassigned_ids(&rebalance, &pod1);
+        let unassigned_ids_2 = get_unassigned_ids(&rebalance, &pod2);
+        let unassigned_ids_3 = get_unassigned_ids(&rebalance, &pod3);
+
+        assert_eq!(assigned_ids_1, vec![]);
+        assert_eq!(assigned_ids_2, vec![]);
+        assert_eq!(assigned_ids_3, vec![ShardId::new(0), ShardId::new(4)]);
+
+        assert_eq!(unassigned_ids_1, vec![ShardId::new(0)]);
+        assert_eq!(unassigned_ids_2, vec![ShardId::new(4)]);
+        assert_eq!(unassigned_ids_3, vec![]);
+    }
+
+    #[test]
+    fn rebalance_one_new_pod_after_removing_two() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(12);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod2, 6);
+        assign_shard(&mut routing_table, &pod2, 7);
+        assign_shard(&mut routing_table, &pod2, 8);
+        // 3,4,5 and 9,10,11 are unassigned
+        // pod3 is empty
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+
+        let unassigned_ids_1 = get_unassigned_ids(&rebalance, &pod1);
+        let unassigned_ids_2 = get_unassigned_ids(&rebalance, &pod2);
+        let unassigned_ids_3 = get_unassigned_ids(&rebalance, &pod3);
+
+        assert_eq!(assigned_ids_1, vec![ShardId::new(10)]);
+        assert_eq!(assigned_ids_2, vec![ShardId::new(11)]);
+        assert_eq!(
+            assigned_ids_3,
+            vec![
+                ShardId::new(3),
+                ShardId::new(4),
+                ShardId::new(5),
+                ShardId::new(9)
+            ]
+        );
+
+        assert_eq!(unassigned_ids_1, vec![]);
+        assert_eq!(unassigned_ids_2, vec![]);
+        assert_eq!(unassigned_ids_3, vec![]);
+    }
+
+    #[test]
+    fn rebalance_two_new_pods() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+
+        let mut routing_table = RoutingTable::new(9);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod1, 3);
+        assign_shard(&mut routing_table, &pod1, 4);
+        assign_shard(&mut routing_table, &pod1, 5);
+        assign_shard(&mut routing_table, &pod1, 6);
+        assign_shard(&mut routing_table, &pod1, 7);
+        assign_shard(&mut routing_table, &pod1, 8);
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+
+        let unassigned_ids_1 = get_unassigned_ids(&rebalance, &pod1);
+        let unassigned_ids_2 = get_unassigned_ids(&rebalance, &pod2);
+        let unassigned_ids_3 = get_unassigned_ids(&rebalance, &pod3);
+
+        assert_eq!(assigned_ids_1, vec![]);
+        assert_eq!(
+            assigned_ids_2,
+            vec![ShardId::new(0), ShardId::new(1), ShardId::new(2)]
+        );
+        assert_eq!(
+            assigned_ids_3,
+            vec![ShardId::new(3), ShardId::new(4), ShardId::new(5)]
+        );
+
+        assert_eq!(
+            unassigned_ids_1,
+            vec![
+                ShardId::new(0),
+                ShardId::new(1),
+                ShardId::new(2),
+                ShardId::new(3),
+                ShardId::new(4),
+                ShardId::new(5)
+            ]
+        );
+        assert_eq!(unassigned_ids_2, vec![]);
+        assert_eq!(unassigned_ids_3, vec![]);
+    }
+
+    #[test]
+    fn rebalance_two_new_pods_after_removing_one() {
+        let pod1 = Pod::new("pod1".to_string(), 9000);
+        let pod2 = Pod::new("pod2".to_string(), 9001);
+        let pod3 = Pod::new("pod3".to_string(), 9002);
+        let pod4 = Pod::new("pod4".to_string(), 9003);
+
+        let mut routing_table = RoutingTable::new(12);
+        routing_table.add_pod(&pod1);
+        routing_table.add_pod(&pod2);
+        routing_table.add_pod(&pod3);
+        routing_table.add_pod(&pod4);
+
+        assign_shard(&mut routing_table, &pod1, 0);
+        assign_shard(&mut routing_table, &pod1, 1);
+        assign_shard(&mut routing_table, &pod1, 2);
+        assign_shard(&mut routing_table, &pod1, 3);
+        assign_shard(&mut routing_table, &pod2, 7);
+        assign_shard(&mut routing_table, &pod2, 8);
+        assign_shard(&mut routing_table, &pod2, 9);
+        assign_shard(&mut routing_table, &pod2, 10);
+        // pod1 and pod2 has 4-4 shards because previously we had 3 pods for 12 shards
+        // 4,5,6,11 are unassigned
+        // pod3 and pod4 are empty
+
+        let rebalance = Rebalance::from_routing_table(&routing_table, 0.0);
+
+        let assigned_ids_1 = get_assigned_ids(&rebalance, &pod1);
+        let assigned_ids_2 = get_assigned_ids(&rebalance, &pod2);
+        let assigned_ids_3 = get_assigned_ids(&rebalance, &pod3);
+        let assigned_ids_4 = get_assigned_ids(&rebalance, &pod4);
+
+        let unassigned_ids_1 = get_unassigned_ids(&rebalance, &pod1);
+        let unassigned_ids_2 = get_unassigned_ids(&rebalance, &pod2);
+        let unassigned_ids_3 = get_unassigned_ids(&rebalance, &pod3);
+        let unassigned_ids_4 = get_unassigned_ids(&rebalance, &pod4);
+
+        println!("Assigned ids 1: {:?}", assigned_ids_1);
+        println!("Assigned ids 2: {:?}", assigned_ids_2);
+        println!("Assigned ids 3: {:?}", assigned_ids_3);
+        println!("Assigned ids 4: {:?}", assigned_ids_4);
+
+        println!("Unassigned ids 1: {:?}", unassigned_ids_1);
+        println!("Unassigned ids 2: {:?}", unassigned_ids_2);
+        println!("Unassigned ids 3: {:?}", unassigned_ids_3);
+        println!("Unassigned ids 4: {:?}", unassigned_ids_4);
+    }
+}

--- a/golem-shard-manager/src/server.rs
+++ b/golem-shard-manager/src/server.rs
@@ -16,25 +16,27 @@ mod error;
 mod http_server;
 mod model;
 mod persistence;
+mod rebalancing;
+mod shard_management;
 mod shard_manager_config;
 mod worker_executor;
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::env;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
-use async_rwlock::RwLock;
 use error::ShardManagerError;
 use golem_api_grpc::proto;
 use golem_api_grpc::proto::golem;
 use golem_api_grpc::proto::golem::shardmanager::shard_manager_service_server::{
     ShardManagerService, ShardManagerServiceServer,
 };
-use golem_common::model::{ShardAssignment, ShardId};
+use golem_common::model::ShardId;
 use model::{Assignments, Pod, RoutingTable, Unassignments};
 use persistence::{PersistenceService, PersistenceServiceDefault};
 use prometheus::{default_registry, Registry};
+use shard_management::ShardManagement;
 use shard_manager_config::ShardManagerConfig;
 use tonic::transport::Server;
 use tonic::Response;
@@ -43,12 +45,12 @@ use tracing_subscriber::EnvFilter;
 use worker_executor::{WorkerExecutorService, WorkerExecutorServiceDefault};
 
 use crate::http_server::HttpServerImpl;
-use crate::model::Rebalance;
+use crate::rebalancing::Rebalance;
 
 pub struct ShardManagerServiceImpl {
-    routing_table: Arc<RwLock<RoutingTable>>,
+    shard_management: ShardManagement,
     persistence_service: Arc<dyn PersistenceService + Send + Sync>,
-    instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
+    worker_executor_service: Arc<dyn WorkerExecutorService + Send + Sync>,
     shard_manager_config: Arc<ShardManagerConfig>,
 }
 
@@ -59,7 +61,7 @@ impl ShardManagerServiceImpl {
         shard_manager_config: Arc<ShardManagerConfig>,
     ) -> Result<ShardManagerServiceImpl, ShardManagerError> {
         info!("Reading routing table from persistent storage");
-        let (mut routing_table, mut rebalance) = persistence_service.read().await.unwrap();
+        let (routing_table, rebalance) = persistence_service.read().await.unwrap();
         info!(
             "Routing table read from persistent storage: {}",
             routing_table
@@ -69,20 +71,22 @@ impl ShardManagerServiceImpl {
             info!("No rebalance was in progress.");
         } else {
             info!("A rebalance was in progress: {}", rebalance);
-            ShardManagerServiceImpl::rebalance(
-                &mut routing_table,
-                &mut rebalance,
-                instance_server_service.clone(),
-                persistence_service.clone(),
-            )
-            .await?;
-            info!("In progress rebalance completed: {}", routing_table);
+            // ShardManagerServiceImpl::rebalance(
+            //     &mut routing_table,
+            //     rebalance,
+            //     instance_server_service.clone(),
+            //     persistence_service.clone(),
+            // )
+            // .await?;
+            // info!("In progress rebalance completed: {}", routing_table);
         }
 
+        let shard_management = ShardManagement::new(routing_table, rebalance).await;
+
         let shard_manager_service = ShardManagerServiceImpl {
-            routing_table: Arc::new(RwLock::new(routing_table)),
+            shard_management,
             persistence_service,
-            instance_server_service,
+            worker_executor_service: instance_server_service,
             shard_manager_config,
         };
 
@@ -94,7 +98,7 @@ impl ShardManagerServiceImpl {
     }
 
     async fn get_routing_table_internal(&self) -> RoutingTable {
-        let routing_table = self.routing_table.read().await.clone();
+        let routing_table = self.shard_management.current_snapshot().await;
         info!("Shard Manager providing routing table: {}", routing_table);
         routing_table
     }
@@ -102,57 +106,52 @@ impl ShardManagerServiceImpl {
     async fn register_internal(
         &self,
         request: tonic::Request<golem::shardmanager::RegisterRequest>,
-    ) -> Result<ShardAssignment, ShardManagerError> {
+    ) -> Result<(), ShardManagerError> {
         let pod = Pod::from_register_request(request)?;
         info!("Shard Manager received request to register pod: {}", pod);
-        let mut routing_table = self.routing_table.write().await;
-        info!("Shard Manager registering pod: {}", pod);
-        match routing_table.get_shards(&pod) {
-            Some(shard_ids) => {
-                let number_of_shards = routing_table.number_of_shards;
-                let shard_assignment = ShardAssignment::new(number_of_shards, shard_ids);
-                info!("Pod already registered and assigned: {}", shard_assignment);
-                Ok(shard_assignment)
-            }
-            None => {
-                routing_table.add_pod(&pod);
-                let number_of_shards = routing_table.number_of_shards;
-                let shard_ids = routing_table.get_shards(&pod).unwrap();
-                let shard_assignment = ShardAssignment::new(number_of_shards, shard_ids);
-                info!("Pod registered and assigned: {}", shard_assignment);
-                Ok(shard_assignment)
-            }
-        }
+        self.shard_management.register_pod(pod).await;
+        Ok(())
+        // let mut routing_table = self.routing_table.write().await;
+        // info!("Shard Manager registering pod: {}", pod);
+        // match routing_table.get_shards(&pod) {
+        //     Some(shard_ids) => {
+        //         let number_of_shards = routing_table.number_of_shards;
+        //         let shard_assignment = ShardAssignment::new(number_of_shards, shard_ids);
+        //         info!("Pod already registered and assigned: {}", shard_assignment);
+        //         Ok(shard_assignment)
+        //     }
+        //     None => {
+        //         routing_table.add_pod(&pod);
+        //         let number_of_shards = routing_table.number_of_shards;
+        //         let shard_ids = routing_table.get_shards(&pod).unwrap();
+        //         let shard_assignment = ShardAssignment::new(number_of_shards, shard_ids);
+        //         info!("Pod registered and assigned: {}", shard_assignment);
+        //         Ok(shard_assignment)
+        //     }
+        // }
     }
 
     fn start_health_check(&self) {
         let delay = self.shard_manager_config.health_check.delay;
-        let routing_table = self.routing_table.clone();
-        let persistence_service = self.persistence_service.clone();
-        let instance_server_service = self.instance_server_service.clone();
+        let shard_management = self.shard_management.clone();
+        let worker_executor_service = self.worker_executor_service.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(delay).await;
-                Self::health_check(
-                    routing_table.clone(),
-                    persistence_service.clone(),
-                    instance_server_service.clone(),
-                )
-                .await
+                Self::health_check(shard_management.clone(), worker_executor_service.clone()).await
             }
         });
     }
 
     async fn health_check(
-        routing_table: Arc<RwLock<RoutingTable>>,
-        persistence_service: Arc<dyn PersistenceService + Send + Sync>,
-        instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
+        shard_management: ShardManagement,
+        worker_executor_service: Arc<dyn WorkerExecutorService + Send + Sync>,
     ) {
         debug!("Shard Manager scheduled to conduct health check");
-        let mut routing_table = routing_table.write().await;
+        let routing_table = shard_management.current_snapshot().await;
         debug!("Shard Manager checking health of registered pods...");
         let failed_pods =
-            Self::health_check_pods(&routing_table.get_pods(), instance_server_service.clone())
+            Self::health_check_pods(&routing_table.get_pods(), worker_executor_service.clone())
                 .await;
         if failed_pods.is_empty() {
             debug!("All registered pods are healthy")
@@ -162,33 +161,33 @@ impl ShardManagerServiceImpl {
                 failed_pods
             );
             for failed_pod in failed_pods {
-                routing_table.remove_pod(&failed_pod);
+                shard_management.unregister_pod(failed_pod).await;
             }
         }
-        let mut rebalance = Rebalance::from_routing_table(&routing_table);
-        if !rebalance.is_empty() {
-            Self::rebalance(
-                &mut routing_table,
-                &mut rebalance,
-                instance_server_service.clone(),
-                persistence_service.clone(),
-            )
-            .await
-            .ok();
-        }
+        // let rebalance = Rebalance::from_routing_table(&routing_table);
+        // if !rebalance.is_empty() {
+        //     Self::rebalance(
+        //         &mut routing_table,
+        //         rebalance,
+        //         worker_executor_service.clone(),
+        //         persistence_service.clone(),
+        //     )
+        //     .await
+        //     .ok();
+        // }
         debug!("Golem Shard Manager finished checking health of registered pods");
     }
 
     async fn health_check_pods(
         pods: &HashSet<Pod>,
-        instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
+        worker_executor: Arc<dyn WorkerExecutorService + Send + Sync>,
     ) -> HashSet<Pod> {
         let futures: Vec<_> = pods
             .iter()
             .map(|pod| {
-                let instance_server_service = instance_server_service.clone();
+                let worker_executor = worker_executor.clone();
                 Box::pin(async move {
-                    match instance_server_service.health_check(pod).await {
+                    match worker_executor.health_check(pod).await {
                         true => None,
                         false => Some(pod.clone()),
                     }
@@ -204,15 +203,15 @@ impl ShardManagerServiceImpl {
 
     async fn revoke_shards(
         unassignments: &Unassignments,
-        instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
-    ) -> Vec<(Pod, HashSet<ShardId>)> {
+        worker_executor: Arc<dyn WorkerExecutorService + Send + Sync>,
+    ) -> Vec<(Pod, BTreeSet<ShardId>)> {
         let futures: Vec<_> = unassignments
             .unassignments
             .iter()
             .map(|(pod, shard_ids)| {
-                let instance_server_service = instance_server_service.clone();
+                let worker_executor = worker_executor.clone();
                 Box::pin(async move {
-                    match instance_server_service.revoke_shards(pod, shard_ids).await {
+                    match worker_executor.revoke_shards(pod, shard_ids).await {
                         Ok(_) => None,
                         Err(_) => Some((pod.clone(), shard_ids.clone())),
                     }
@@ -229,7 +228,7 @@ impl ShardManagerServiceImpl {
     async fn assign_shards(
         assignments: &Assignments,
         instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
-    ) -> Vec<(Pod, HashSet<ShardId>)> {
+    ) -> Vec<(Pod, BTreeSet<ShardId>)> {
         let futures: Vec<_> = assignments
             .assignments
             .iter()
@@ -252,7 +251,7 @@ impl ShardManagerServiceImpl {
 
     async fn rebalance(
         routing_table: &mut RoutingTable,
-        rebalance: &mut Rebalance,
+        mut rebalance: Rebalance,
         instance_server_service: Arc<dyn WorkerExecutorService + Send + Sync>,
         persistence_service: Arc<dyn PersistenceService + Send + Sync>,
     ) -> Result<(), ShardManagerError> {
@@ -269,12 +268,18 @@ impl ShardManagerServiceImpl {
             "Writing planned rebalance: {} to persistent storage",
             rebalance
         );
-        persistence_service.write(routing_table, rebalance).await?;
+        persistence_service.write(routing_table, &rebalance).await?;
         info!("Planned rebalance written to persistent storage");
 
-        info!("Executing shard unassignments: {}", rebalance.unassignments);
-        let failed_unassignments =
-            Self::revoke_shards(&rebalance.unassignments, instance_server_service.clone()).await;
+        info!(
+            "Executing shard unassignments: {}",
+            rebalance.get_unassignments()
+        );
+        let failed_unassignments = Self::revoke_shards(
+            rebalance.get_unassignments(),
+            instance_server_service.clone(),
+        )
+        .await;
         let failed_shards = failed_unassignments
             .iter()
             .flat_map(|(_, shard_ids)| shard_ids.clone())
@@ -282,8 +287,11 @@ impl ShardManagerServiceImpl {
         rebalance.remove_shards(&failed_shards);
         info!("The following shards could not be unassigned and have been removed from rebalance: {:?}", failed_shards);
 
-        info!("Executing shard assignments: {}", rebalance.assignments);
-        Self::assign_shards(&rebalance.assignments, instance_server_service.clone()).await;
+        info!(
+            "Executing shard assignments: {}",
+            rebalance.get_assignments()
+        );
+        Self::assign_shards(rebalance.get_assignments(), instance_server_service.clone()).await;
         routing_table.rebalance(rebalance);
         info!("Executed shard assignments");
 
@@ -292,7 +300,7 @@ impl ShardManagerServiceImpl {
             routing_table
         );
         persistence_service
-            .write(routing_table, &Rebalance::new())
+            .write(routing_table, &Rebalance::empty())
             .await?;
         info!("Updated routing table written to persistent storage");
 
@@ -322,15 +330,10 @@ impl ShardManagerService for ShardManagerServiceImpl {
         request: tonic::Request<golem::shardmanager::RegisterRequest>,
     ) -> Result<tonic::Response<golem::shardmanager::RegisterResponse>, tonic::Status> {
         match self.register_internal(request).await {
-            Ok(shard_assignment) => Ok(Response::new(golem::shardmanager::RegisterResponse {
+            Ok(_) => Ok(Response::new(golem::shardmanager::RegisterResponse {
                 result: Some(golem::shardmanager::register_response::Result::Success(
                     golem::shardmanager::RegisterSuccess {
-                        number_of_shards: shard_assignment.number_of_shards as u32,
-                        shard_ids: shard_assignment
-                            .shard_ids
-                            .into_iter()
-                            .map(|s| s.into())
-                            .collect(),
+                        number_of_shards: self.shard_manager_config.number_of_shards as u32,
                     },
                 )),
             })),

--- a/golem-shard-manager/src/shard_management.rs
+++ b/golem-shard-manager/src/shard_management.rs
@@ -1,0 +1,137 @@
+use crate::model::{Pod, RoutingTable};
+use crate::rebalancing::Rebalance;
+use async_rwlock::RwLock;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
+
+#[derive(Clone)]
+pub struct ShardManagement {
+    routing_table: Arc<RwLock<RoutingTable>>,
+    change: Arc<Notify>,
+    #[allow(dead_code)]
+    worker_handle: Arc<WorkerHandle>, // Just kept here for abort on dropping
+    updates: Arc<Mutex<ShardManagementChanges>>,
+}
+
+impl ShardManagement {
+    /// Initializes the shard management with an initial routing table and optionally
+    /// a pending rebalance.
+    pub async fn new(routing_table: RoutingTable, pending_rebalance: Rebalance) -> Self {
+        let routing_table = Arc::new(RwLock::new(routing_table));
+
+        if !pending_rebalance.is_empty() {
+            // TODO: persist rebalance plan
+            // TODO: execute rebalance
+            routing_table.write().await.rebalance(pending_rebalance);
+            // TODO: persist new routing table
+        }
+
+        let change = Arc::new(Notify::new());
+        let updates = Arc::new(Mutex::new(ShardManagementChanges::new()));
+
+        let routing_table_clone = routing_table.clone();
+        let notify_clone = change.clone();
+        let updates_clone = updates.clone();
+
+        let worker_handle = Arc::new(WorkerHandle::new(tokio::spawn(async move {
+            Self::worker(routing_table_clone, notify_clone, updates_clone).await
+        })));
+
+        ShardManagement {
+            routing_table,
+            change,
+            worker_handle,
+            updates,
+        }
+    }
+
+    /// Registers a new pod to be added
+    pub async fn register_pod(&self, pod: Pod) {
+        self.updates.lock().await.add_new_pod(pod);
+    }
+
+    /// Marks a pod to be removed
+    pub async fn unregister_pod(&self, pod: Pod) {
+        self.updates.lock().await.remove_pod(pod);
+    }
+
+    /// Gets the current snapshot of the routing table
+    pub async fn current_snapshot(&self) -> RoutingTable {
+        self.routing_table.read().await.clone()
+    }
+
+    async fn worker(
+        routing_table: Arc<RwLock<RoutingTable>>,
+        change: Arc<Notify>,
+        updates: Arc<Mutex<ShardManagementChanges>>,
+    ) {
+        loop {
+            change.notified().await;
+            let (new_pods, removed_pods) = updates.lock().await.reset();
+            let mut current_routing_table = routing_table.read().await.clone();
+
+            for pod in removed_pods {
+                current_routing_table.remove_pod(&pod);
+            }
+
+            for pod in new_pods {
+                current_routing_table.add_pod(&pod);
+            }
+            let rebalance = Rebalance::from_routing_table(&current_routing_table, 0.0); // TODO: configurable threshold
+
+            // TODO: persist rebalance plan
+            // TODO: execute rebalance
+            routing_table.write().await.rebalance(rebalance);
+            // TODO: persist new routing table
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ShardManagementChanges {
+    new_pods: HashSet<Pod>,
+    removed_pods: HashSet<Pod>,
+}
+
+impl ShardManagementChanges {
+    pub fn new() -> Self {
+        ShardManagementChanges {
+            new_pods: HashSet::new(),
+            removed_pods: HashSet::new(),
+        }
+    }
+
+    pub fn add_new_pod(&mut self, pod: Pod) {
+        self.removed_pods.remove(&pod);
+        self.new_pods.insert(pod);
+    }
+
+    pub fn remove_pod(&mut self, pod: Pod) {
+        self.new_pods.remove(&pod);
+        self.removed_pods.insert(pod);
+    }
+
+    pub fn reset(&mut self) -> (HashSet<Pod>, HashSet<Pod>) {
+        let new = self.new_pods.clone();
+        let removed = self.removed_pods.clone();
+        self.new_pods.clear();
+        self.removed_pods.clear();
+        (new, removed)
+    }
+}
+
+struct WorkerHandle(JoinHandle<()>);
+
+impl WorkerHandle {
+    pub fn new(handle: JoinHandle<()>) -> Self {
+        WorkerHandle(handle)
+    }
+}
+
+impl Drop for WorkerHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}

--- a/golem-shard-manager/src/shard_manager_config.rs
+++ b/golem-shard-manager/src/shard_manager_config.rs
@@ -22,11 +22,12 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize)]
 pub struct ShardManagerConfig {
     pub redis: RedisConfig,
-    pub instance_server_service: WorkerExecutorServiceConfig,
+    pub worker_executors: WorkerExecutorServiceConfig,
     pub health_check: HealthCheckConfig,
     pub enable_json_log: bool,
     pub http_port: u16,
     pub number_of_shards: usize,
+    pub rebalance_threshold: f64,
 }
 
 impl ShardManagerConfig {

--- a/golem-shard-manager/src/worker_executor.rs
+++ b/golem-shard-manager/src/worker_executor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 use golem_api_grpc::proto::golem;
@@ -34,7 +34,7 @@ pub trait WorkerExecutorService {
     async fn assign_shards(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError>;
 
     async fn health_check(&self, pod: &Pod) -> bool;
@@ -42,7 +42,7 @@ pub trait WorkerExecutorService {
     async fn revoke_shards(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError>;
 }
 
@@ -55,7 +55,7 @@ impl WorkerExecutorService for WorkerExecutorServiceDefault {
     async fn assign_shards(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError> {
         info!("Assigning shards {:?} to pod {:?}", shard_ids, pod);
 
@@ -110,7 +110,7 @@ impl WorkerExecutorService for WorkerExecutorServiceDefault {
     async fn revoke_shards(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError> {
         info!("Revoking shards {:?} from pod {:?}", shard_ids, pod);
 
@@ -146,7 +146,7 @@ impl WorkerExecutorServiceDefault {
     async fn assign_shards_internal(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError> {
         let assign_shards_request = golem::workerexecutor::AssignShardsRequest {
             shard_ids: shard_ids
@@ -231,7 +231,7 @@ impl WorkerExecutorServiceDefault {
     async fn revoke_shards_internal(
         &self,
         pod: &Pod,
-        shard_ids: &HashSet<ShardId>,
+        shard_ids: &BTreeSet<ShardId>,
     ) -> Result<(), ShardManagerError> {
         let revoke_shards_request = golem::workerexecutor::RevokeShardsRequest {
             shard_ids: shard_ids

--- a/golem-worker-executor-base/src/services/shard_manager.rs
+++ b/golem-worker-executor-base/src/services/shard_manager.rs
@@ -56,7 +56,7 @@ impl ShardManagerServiceGrpc {
 impl ShardManagerService for ShardManagerServiceGrpc {
     async fn register(&self, host: String, port: u16) -> Result<ShardAssignment, GolemError> {
         let uri: hyper::Uri = self.config.url().to_string().parse().unwrap();
-        let desc = format!("Registering instance server with shard manager at {}", uri);
+        let desc = format!("Registering worker executor with shard manager at {}", uri);
         with_retries(
             &desc,
             "shard_manager",
@@ -94,16 +94,12 @@ impl ShardManagerService for ShardManagerServiceGrpc {
                             result:
                                 Some(shardmanager::register_response::Result::Success(
                                     shardmanager::RegisterSuccess {
-                                        number_of_shards,
-                                        shard_ids,
+                                        number_of_shards
                                     },
                                 )),
                         } => Ok(ShardAssignment {
                             number_of_shards: number_of_shards as usize,
-                            shard_ids: shard_ids
-                                .into_iter()
-                                .map(|shard_id| shard_id.into())
-                                .collect(),
+                            shard_ids: HashSet::new()
                         }),
                         shardmanager::RegisterResponse {
                             result: Some(shardmanager::register_response::Result::Failure(failure)),

--- a/golem-worker-executor-base/src/services/shard_manager.rs
+++ b/golem-worker-executor-base/src/services/shard_manager.rs
@@ -93,13 +93,11 @@ impl ShardManagerService for ShardManagerServiceGrpc {
                         shardmanager::RegisterResponse {
                             result:
                                 Some(shardmanager::register_response::Result::Success(
-                                    shardmanager::RegisterSuccess {
-                                        number_of_shards
-                                    },
+                                    shardmanager::RegisterSuccess { number_of_shards },
                                 )),
                         } => Ok(ShardAssignment {
                             number_of_shards: number_of_shards as usize,
-                            shard_ids: HashSet::new()
+                            shard_ids: HashSet::new(),
                         }),
                         shardmanager::RegisterResponse {
                             result: Some(shardmanager::register_response::Result::Failure(failure)),


### PR DESCRIPTION
- Rebalancing extracted to separate module
- Tests for rebalancing
- Improved rebalancing logic based on the tests, support up/downscaling and registering more than one pod at once
- Routing table is managed in an "actor like" way, with registering and healthcheck only indicating changes in the available pods in a non-blocking way. A single thread applies the changes to the routing table and sends out the updates to the workers and manages the persistency.
- The register gRPC call no longer returns immediately the associated shards, so it can use the above mentioned non-blocking registration. The registered workers gets assign messages the next time the routing table gets updated (which is immediate if there was no change in process already)
- Some small refactorings to reduce the number of clones
- Switched to `BTreeMap` for reproducible results

The new/improved rebalacing algorithm:

- First we take a note if there are any registered pods that are completely empty. 
- Then we go through each _unassigned shard_ and associate them with pods. First we fill up the originally empty (new) pods, up to the optimal shard count which is (shard_count/pod_count). Once we reached that the rest of the unassigned shards are distributed evenly among all pods.
- At this point it is not guaranteed that the shard assignment is balanced, especially if there was a change in the number of available pods.
- So we improve the balancing in iterations, each iteration we pick a target pod which has less shards than the optimal (with some threshold - the threshold reduces the number of revokes/assigns by allowing some level of unbalancedness). 
- We move shards from other pods - except the ones that were initially empty as they got filled up with the unassigned pods and we want to keep those together to reduce movements - to the picked target pod
- We repeat this until we no longer have any pods below the threshold
