### PR TITLE
Remove wasmtime as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "golem-wit"]
 	path = golem-wit
 	url = https://github.com/golemcloud/golem-wit
-[submodule "wasmtime"]
-	path = wasmtime
-	url = https://github.com/golemcloud/wasmtime
 [submodule "golem-openapi-client-generator"]
 	path = golem-openapi-client-generator
 	url = https://github.com/golemcloud/golem-openapi-client-generator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1117,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-entity",
 ]
@@ -1118,6 +1125,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1137,6 +1145,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -1144,10 +1153,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 
 [[package]]
 name = "cranelift-control"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "arbitrary",
 ]
@@ -1155,6 +1166,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1163,6 +1175,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1173,10 +1186,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 
 [[package]]
 name = "cranelift-native"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1186,6 +1201,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.104.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2171,6 +2187,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
+ "wasm-wave",
  "wasmtime",
  "wit-bindgen",
 ]
@@ -3116,6 +3133,38 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "logos"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "mach"
@@ -5884,6 +5933,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5905,6 +5955,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -6009,6 +6060,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-wave"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132211e87e40f5470a159f6f44aa87c37f0e24321c42cb1d957d18de1ff576cd"
+dependencies = [
+ "indexmap 2.2.2",
+ "logos",
+ "thiserror",
+ "wasmtime",
+ "wit-parser",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.118.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6042,6 +6106,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6079,6 +6144,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cfg-if",
 ]
@@ -6086,6 +6152,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "base64",
@@ -6104,6 +6171,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6117,10 +6185,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6144,6 +6214,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift-shared"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -6158,6 +6229,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -6179,6 +6251,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cc",
@@ -6192,6 +6265,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -6217,6 +6291,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "object",
  "once_cell",
@@ -6227,6 +6302,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6236,6 +6312,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cc",
@@ -6264,6 +6341,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -6275,6 +6353,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6284,6 +6363,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6317,6 +6397,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6338,6 +6419,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -6353,6 +6435,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "heck",
@@ -6363,6 +6446,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wmemcheck"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 
 [[package]]
 name = "wast"
@@ -6422,6 +6506,7 @@ checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 [[package]]
 name = "wiggle"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6435,6 +6520,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "heck",
@@ -6448,6 +6534,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "17.0.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6486,6 +6573,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.15.0"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -6752,6 +6840,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-17#df86b3ea017d87d38831e3315af96adb38569aa7"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = [
 exclude = [
     "test-templates/shopping-cart",
     "test-templates/write-stdout",
-    "wasmtime",
     "test-templates/blob-store-service",
     "test-templates/clock-service",
     "test-templates/clocks",
@@ -122,7 +121,7 @@ warp = "0.3.6"
 webpki-roots = { version = "0.26.0" }
 
 [patch.crates-io]
-wasmtime = { path = "wasmtime/crates/wasmtime" }
-wasmtime-runtime = { path = "wasmtime/crates/runtime" }
-wasmtime-wasi = { path = "wasmtime/crates/wasi" }
-wasmtime-wasi-http = { path = "wasmtime/crates/wasi-http" }
+wasmtime = { git = "https://github.com/golemcloud/wasmtime.git", branch = "golem-wasmtime-17" }
+wasmtime-runtime = { git = "https://github.com/golemcloud/wasmtime.git", branch = "golem-wasmtime-17" }
+wasmtime-wasi = { git = "https://github.com/golemcloud/wasmtime.git", branch = "golem-wasmtime-17" }
+wasmtime-wasi-http = { git = "https://github.com/golemcloud/wasmtime.git", branch = "golem-wasmtime-17" }


### PR DESCRIPTION
Resolves #228 (but unlike the original idea, not publishing the wasmtime fork just using Cargo's git dependency)