### PR TITLE
Worker Service Base: Redis Impl

### DIFF
--- a/golem-common/src/redis.rs
+++ b/golem-common/src/redis.rs
@@ -662,9 +662,11 @@ impl RedisTransaction {
         self.trx.sadd(self.prefixed_key(key), members).await
     }
 
-    pub async fn srem<K>(&self, key: K, members: Vec<String>) -> RedisResult<()>
+    pub async fn srem<K, V>(&self, key: K, members: V) -> RedisResult<()>
     where
         K: AsRef<str>,
+        V: TryInto<MultipleValues> + Send,
+        V::Error: Into<RedisError> + Send,
     {
         self.trx.srem(self.prefixed_key(key), members).await
     }

--- a/golem-worker-service-base/src/auth.rs
+++ b/golem-worker-service-base/src/auth.rs
@@ -28,7 +28,9 @@ pub struct AuthServiceNoop {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EmptyAuthCtx {}
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, bincode::Encode, bincode::Decode, serde::Deserialize,
+)]
 pub struct CommonNamespace(String);
 
 impl Default for CommonNamespace {

--- a/golem-worker-service-base/src/service/api_definition_service.rs
+++ b/golem-worker-service-base/src/service/api_definition_service.rs
@@ -162,10 +162,7 @@ impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx> {
     }
 }
 
-impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx>
-where
-    Namespace: ApiNamespace,
-{
+impl<Namespace: ApiNamespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx> {
     pub async fn is_authorized(
         &self,
         permission: Permission,
@@ -190,10 +187,8 @@ where
 }
 
 #[async_trait]
-impl<Namespace, AuthCtx: Send + Sync> ApiDefinitionService<Namespace, AuthCtx>
+impl<Namespace: ApiNamespace, AuthCtx: Send + Sync> ApiDefinitionService<Namespace, AuthCtx>
     for RegisterApiDefinitionDefault<Namespace, AuthCtx>
-where
-    Namespace: ApiNamespace,
 {
     async fn register(
         &self,

--- a/golem-worker-service-base/src/service/api_definition_service.rs
+++ b/golem-worker-service-base/src/service/api_definition_service.rs
@@ -41,32 +41,56 @@ pub trait ApiDefinitionService<Namespace, AuthCtx> {
     ) -> Result<Vec<ApiDefinition>, ApiRegistrationError>;
 }
 
+pub trait NamespaceT:
+    Eq
+    + Hash
+    + PartialEq
+    + Clone
+    + Debug
+    + Display
+    + Send
+    + Sync
+    + bincode::Encode
+    + bincode::Decode
+    + serde::de::DeserializeOwned
+{
+}
+impl<
+        T: Eq
+            + Hash
+            + PartialEq
+            + Clone
+            + Debug
+            + Display
+            + Send
+            + Sync
+            + bincode::Encode
+            + bincode::Decode
+            + serde::de::DeserializeOwned,
+    > NamespaceT for T
+{
+}
+
 // An ApiDefinitionKey is just the original ApiDefinitionId with additional information of version and a possibility of namespace.
 // A namespace here can be for example: account, project, production, dev or a composite value, or infact as simple
 // as a constant string or unit.
 // A namespace is not pre-tied to any other parts of original ApiDefinitionId to keep the ApiDefinition part simple, reusable.
-#[derive(Eq, Hash, PartialEq, Clone, Debug)]
-pub struct ApiDefinitionKey<Namespace: Eq + Hash + PartialEq + Clone + Debug> {
+#[derive(
+    Eq, Hash, PartialEq, Clone, Debug, serde::Deserialize, bincode::Encode, bincode::Decode,
+)]
+pub struct ApiDefinitionKey<Namespace> {
     pub namespace: Namespace,
     pub id: ApiDefinitionId,
     pub version: Version,
 }
 
-impl<Namespace: Eq + Hash + PartialEq + Clone + Debug + Display> ApiDefinitionKey<Namespace> {
+impl<Namespace: Display> ApiDefinitionKey<Namespace> {
     pub fn with_namespace_displayed(&self) -> ApiDefinitionKey<String> {
         ApiDefinitionKey {
             namespace: self.namespace.to_string(),
             id: self.id.clone(),
             version: self.version.clone(),
         }
-    }
-}
-
-impl<Namespace: Display + Eq + Hash + PartialEq + Clone + Debug> Display
-    for ApiDefinitionKey<Namespace>
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}:{}", self.namespace, self.id, self.version.0)
     }
 }
 
@@ -125,8 +149,9 @@ impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx> {
     }
 }
 
-impl<Namespace: Eq + Hash + PartialEq + Clone + Debug + Display, AuthCtx>
-    RegisterApiDefinitionDefault<Namespace, AuthCtx>
+impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx>
+where
+    Namespace: NamespaceT,
 {
     pub async fn is_authorized(
         &self,
@@ -152,11 +177,10 @@ impl<Namespace: Eq + Hash + PartialEq + Clone + Debug + Display, AuthCtx>
 }
 
 #[async_trait]
-impl<
-        Namespace: Eq + Hash + PartialEq + Clone + Debug + Display + Send + Sync,
-        AuthCtx: Send + Sync,
-    > ApiDefinitionService<Namespace, AuthCtx>
+impl<Namespace, AuthCtx: Send + Sync> ApiDefinitionService<Namespace, AuthCtx>
     for RegisterApiDefinitionDefault<Namespace, AuthCtx>
+where
+    Namespace: NamespaceT,
 {
     async fn register(
         &self,

--- a/golem-worker-service-base/src/service/api_definition_service.rs
+++ b/golem-worker-service-base/src/service/api_definition_service.rs
@@ -41,7 +41,7 @@ pub trait ApiDefinitionService<Namespace, AuthCtx> {
     ) -> Result<Vec<ApiDefinition>, ApiRegistrationError>;
 }
 
-pub trait NamespaceT:
+pub trait ApiNamespace:
     Eq
     + Hash
     + PartialEq
@@ -67,7 +67,7 @@ impl<
             + bincode::Encode
             + bincode::Decode
             + serde::de::DeserializeOwned,
-    > NamespaceT for T
+    > ApiNamespace for T
 {
 }
 
@@ -151,7 +151,7 @@ impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx> {
 
 impl<Namespace, AuthCtx> RegisterApiDefinitionDefault<Namespace, AuthCtx>
 where
-    Namespace: NamespaceT,
+    Namespace: ApiNamespace,
 {
     pub async fn is_authorized(
         &self,
@@ -180,7 +180,7 @@ where
 impl<Namespace, AuthCtx: Send + Sync> ApiDefinitionService<Namespace, AuthCtx>
     for RegisterApiDefinitionDefault<Namespace, AuthCtx>
 where
-    Namespace: NamespaceT,
+    Namespace: ApiNamespace,
 {
     async fn register(
         &self,


### PR DESCRIPTION
Closes https://github.com/golemcloud/golem/issues/253

- Introduce convenience trait `ApiNamespace`
- Add transaction API 
   - Each Namespace has it's own Redis Set containing all the `ApiDefinitionId`. This enables looking up all Api Definitions for a given namespace. Namespace now requires Encode/Decode trait bounds
   - Each API Definition is also inserted uniquely by key 
   - Add and Delete use Transaction api 
- Improve tests 
   - TODO: Currently test is marked as `#ignore`, but we should really convert this to an integration test.  See https://github.com/golemcloud/golem/issues/264