### PR TITLE
Referencing golem-wit as a rust crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 .idea/
 ./golem-worker-executor/data/
 ./golem-worker-executor-base/data/
+./golem-worker-executor-base/golem-wit/
 zig-cache/
 dump.rdb
 ./test-templates/*.wat

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "golem-wit"]
-	path = golem-wit
-	url = https://github.com/golemcloud/golem-wit
 [submodule "golem-openapi-client-generator"]
 	path = golem-openapi-client-generator
 	url = https://github.com/golemcloud/golem-openapi-client-generator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "golem-wit"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce8a760c192419ae1e55fcef20470a248bbd2e19135ae13b6886ddb8619d142"
+
+[[package]]
 name = "golem-worker-executor"
 version = "0.0.0"
 dependencies = [
@@ -2276,6 +2282,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "cap-time-ext",
+ "cargo_metadata",
  "chrono",
  "console-subscriber",
  "ctor",
@@ -2291,6 +2298,7 @@ dependencies = [
  "golem-common",
  "golem-wasm-ast",
  "golem-wasm-rpc",
+ "golem-wit",
  "http 0.2.11",
  "http 1.0.0",
  "http-body 1.0.0",
@@ -2309,6 +2317,7 @@ dependencies = [
  "rustls 0.22.2",
  "serde",
  "serde_json",
+ "symlink",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5172,6 +5181,12 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"

--- a/golem-worker-executor-base/Cargo.toml
+++ b/golem-worker-executor-base/Cargo.toml
@@ -42,6 +42,7 @@ fs-set-times = "0.20.1"
 futures = { workspace = true }
 futures-util = { workspace = true }
 gethostname = "0.4.3"
+golem-wit = "0.1.0"
 http = { workspace = true }
 http_02 = { package = "http", version = "0.2.11" }
 http-body = "1.0.0" # keep in sync with wasmtime
@@ -87,6 +88,10 @@ redis = { version = "0.24.0", features = ["default"] }
 serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 warp = { workspace = true }
+
+[build-dependencies]
+cargo_metadata = "0.18.1"
+symlink = "0.1.0"
 
 [[test]]
 name = "integration"

--- a/golem-worker-executor-base/build.rs
+++ b/golem-worker-executor-base/build.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use cargo_metadata::MetadataCommand;
+use std::path::Path;
 use symlink::{remove_symlink_dir, symlink_dir};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,7 +8,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if target_root.exists() {
         let _ = remove_symlink_dir(target_root);
     }
-    println!("Creating symlink from {} to {}", golem_wit_root, target_root.display());
+    println!(
+        "Creating symlink from {} to {}",
+        golem_wit_root,
+        target_root.display()
+    );
     symlink_dir(golem_wit_root, target_root)?;
     Ok(())
 }

--- a/golem-worker-executor-base/build.rs
+++ b/golem-worker-executor-base/build.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+use cargo_metadata::MetadataCommand;
+use symlink::{remove_symlink_dir, symlink_dir};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let golem_wit_root = find_package_root("golem-wit");
+    let target_root = Path::new("./golem-wit");
+    if target_root.exists() {
+        let _ = remove_symlink_dir(target_root);
+    }
+    println!("Creating symlink from {} to {}", golem_wit_root, target_root.display());
+    symlink_dir(golem_wit_root, target_root)?;
+    Ok(())
+}
+
+fn find_package_root(name: &str) -> String {
+    let metadata = MetadataCommand::new()
+        .manifest_path("./Cargo.toml")
+        .exec()
+        .unwrap();
+    let package = metadata.packages.iter().find(|p| p.name == name).unwrap();
+    package.manifest_path.parent().unwrap().to_string()
+}

--- a/golem-worker-executor-base/src/preview2/mod.rs
+++ b/golem-worker-executor-base/src/preview2/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 wasmtime::component::bindgen!({
-    path: "../golem-wit/wit",
+    path: "golem-wit/wit",
     interfaces: "
       import golem:api/host;
 

--- a/test-templates/build-components.sh
+++ b/test-templates/build-components.sh
@@ -107,7 +107,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "zig" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new zig-out/bin/main.wasm -o "$target" --adapt ../../golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
+    wasm-tools component new zig-out/bin/main.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -131,7 +131,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "tinygo" ]; then
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
     wasm-tools component embed ./wit main.wasm --output main.embed.wasm
-    wasm-tools component new main.embed.wasm -o "$target" --adapt ../../golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
+    wasm-tools component new main.embed.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -152,7 +152,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "grain" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new main.gr.wasm -o "$target" --adapt ../../golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
+    wasm-tools component new main.gr.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -199,7 +199,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "java" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new target/generated/wasm/teavm-wasm/classes.wasm -o "$target" --adapt ../../golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
+    wasm-tools component new target/generated/wasm/teavm-wasm/classes.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -220,7 +220,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "dotnet" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new bin/Release/net7.0/$subdir.wasm -o "$target" --adapt ../../golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
+    wasm-tools component new bin/Release/net7.0/$subdir.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -242,7 +242,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "swift" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new main.opt.wasm -o "$target" --adapt ../../golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
+    wasm-tools component new main.opt.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier3/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit
@@ -264,7 +264,7 @@ if [ "$single_lang" = "false" ] || [ "$lang" = "c" ]; then
     echo "Turning the module into a WebAssembly Component..."
     target="../$subdir.wasm"
     target_wat="../$subdir.wat"
-    wasm-tools component new main.wasm -o "$target" --adapt ../../golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
+    wasm-tools component new main.wasm -o "$target" --adapt ../../golem-worker-executor-base/golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm
     wasm-tools print "$target" >"$target_wat"
 
     popd || exit

--- a/test-templates/js-1/componentize.js
+++ b/test-templates/js-1/componentize.js
@@ -7,7 +7,7 @@ const jsSource = await readFile('main.js', 'utf8');
 const { component } = await componentize(jsSource, {
   witPath: resolve('wit'),
   enableStdout: true,
-  preview2Adapter: '../../golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm'
+  preview2Adapter: '../../golem-worker-executor-base/golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm'
 });
 
 await writeFile('out/component.wasm', component);

--- a/test-templates/js-2/componentize.js
+++ b/test-templates/js-2/componentize.js
@@ -7,7 +7,7 @@ const jsSource = await readFile('main.js', 'utf8');
 const { component } = await componentize(jsSource, {
   witPath: resolve('wit'),
   enableStdout: true,
-  preview2Adapter: '../../golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm',
+  preview2Adapter: '../../golem-worker-executor-base/golem-wit/adapters/tier2/wasi_snapshot_preview1.wasm',
   debug: true
 });
 


### PR DESCRIPTION
Unfortunately `bindgen!` only accepts string literals so had to symlink the resolved crate to a fix relative path