### PR TITLE
Clean up config default instances

### DIFF
--- a/golem-service-base/src/config.rs
+++ b/golem-service-base/src/config.rs
@@ -21,6 +21,15 @@ pub enum TemplateStoreConfig {
     Local(TemplateStoreLocalConfig),
 }
 
+impl Default for TemplateStoreConfig {
+    fn default() -> Self {
+        TemplateStoreConfig::Local(TemplateStoreLocalConfig {
+            root_path: "/tmp".to_string(),
+            object_prefix: "".to_string(),
+        })
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct TemplateStoreS3Config {
     pub bucket_name: String,

--- a/golem-service-base/src/routing_table.rs
+++ b/golem-service-base/src/routing_table.rs
@@ -38,6 +38,15 @@ impl RoutingTableConfig {
     }
 }
 
+impl Default for RoutingTableConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_string(),
+            port: 9001,
+        }
+    }
+}
+
 impl RoutingTableError {
     pub fn unexpected(details: impl Into<String>) -> Self {
         RoutingTableError::Unexpected(details.into())

--- a/golem-template-service/src/config.rs
+++ b/golem-template-service/src/config.rs
@@ -31,6 +31,15 @@ pub struct WorkerExecutorClientCacheConfig {
     pub time_to_idle: Duration,
 }
 
+impl Default for WorkerExecutorClientCacheConfig {
+    fn default() -> Self {
+        Self {
+            max_capacity: 1000,
+            time_to_idle: Duration::from_secs(60 * 60 * 4),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct TemplateServiceConfig {
     pub enable_tracing_console: bool,
@@ -50,6 +59,15 @@ pub enum DbConfig {
     Sqlite(DbSqliteConfig),
 }
 
+impl Default for DbConfig {
+    fn default() -> Self {
+        DbConfig::Sqlite(DbSqliteConfig {
+            database: "golem_template_service.db".to_string(),
+            max_connections: 10,
+        })
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct DbPostgresConfig {
     pub host: String,
@@ -63,8 +81,10 @@ pub struct DbPostgresConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "type", content = "config")]
+#[derive(Default)]
 pub enum TemplateCompilationConfig {
     Enabled(TemplateCompilationEnabledConfig),
+    #[default]
     Disabled,
 }
 
@@ -86,7 +106,16 @@ impl TemplateServiceConfig {
 
 impl Default for TemplateServiceConfig {
     fn default() -> Self {
-        Self::new()
+        Self {
+            enable_tracing_console: false,
+            enable_json_log: false,
+            http_port: 8081,
+            grpc_port: 9091,
+            db: DbConfig::default(),
+            template_store: TemplateStoreConfig::default(),
+            compilation: TemplateCompilationConfig::default(),
+            worker_executor_client_cache: WorkerExecutorClientCacheConfig::default(),
+        }
     }
 }
 

--- a/golem-worker-service-base/src/app_config.rs
+++ b/golem-worker-service-base/src/app_config.rs
@@ -32,19 +32,43 @@ pub struct WorkerExecutorClientCacheConfig {
     pub time_to_idle: Duration,
 }
 
+impl Default for WorkerExecutorClientCacheConfig {
+    fn default() -> Self {
+        Self {
+            max_capacity: 1000,
+            time_to_idle: Duration::from_secs(60 * 60 * 4),
+        }
+    }
+}
+
 impl WorkerServiceBaseConfig {
     pub fn is_local_env(&self) -> bool {
         self.environment.to_lowercase() == "local"
     }
-}
 
-impl Default for WorkerServiceBaseConfig {
-    fn default() -> Self {
+    pub fn new() -> Self {
         Figment::new()
             .merge(Toml::file("config/worker-service.toml"))
             .merge(Env::prefixed("GOLEM__").split("__"))
             .extract()
             .expect("Failed to parse config")
+    }
+}
+
+impl Default for WorkerServiceBaseConfig {
+    fn default() -> Self {
+        Self {
+            environment: "local".to_string(),
+            redis: RedisConfig::default(),
+            template_service: TemplateServiceConfig::default(),
+            enable_tracing_console: false,
+            enable_json_log: false,
+            port: 9000,
+            custom_request_port: 9001,
+            worker_grpc_port: 9092,
+            routing_table: RoutingTableConfig::default(),
+            worker_executor_client_cache: WorkerExecutorClientCacheConfig::default(),
+        }
     }
 }
 
@@ -69,5 +93,16 @@ impl TemplateServiceConfig {
             .path_and_query("/")
             .build()
             .expect("Failed to build ComponentService URI")
+    }
+}
+
+impl Default for TemplateServiceConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_string(),
+            port: 8080,
+            access_token: Uuid::new_v4(),
+            retries: RetryConfig::default(),
+        }
     }
 }

--- a/golem-worker-service/src/config.rs
+++ b/golem-worker-service/src/config.rs
@@ -1,7 +1,7 @@
 use golem_worker_service_base::app_config::WorkerServiceBaseConfig;
 
 pub fn get_config() -> WorkerServiceBaseConfig {
-    WorkerServiceBaseConfig::default()
+    WorkerServiceBaseConfig::new()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In some services for config types the `Default` instance was incorrectly used as the entry point for loading the external config (from toml files and environment variables).
This was very confusing and causes some surprises. 

The goal of the default instances is to provide a default value of the type which can be used as a baseline when programmatically creating a custom value of that type, so only the fields that differ from the default value need to be specified. It should not depend on any external resources like files and environment variables.

This PR cleans this up so now all services are implemented the same:
- `new()` constructor function on the top level config class to load it with the config library
- The `Default` instances are pure and just generate a reasonable default value. It can be used in tests for example, or to avoid the current hacky way of generation OpenAPI yamls.

(Note that worker-executor and shard-manager always followed this pattern)