### PR TITLE
Cleanup and durability fixes for the promise API

### DIFF
--- a/golem-common/src/model/oplog.rs
+++ b/golem-common/src/model/oplog.rs
@@ -1,8 +1,6 @@
 use crate::config::RetryConfig;
 use crate::model::regions::OplogRegion;
-use crate::model::{
-    AccountId, CallingConvention, InvocationKey, PromiseId, Timestamp, VersionedWorkerId,
-};
+use crate::model::{AccountId, CallingConvention, InvocationKey, Timestamp, VersionedWorkerId};
 use crate::serialization::{
     deserialize_with_version, serialize, try_deserialize, SERIALIZATION_VERSION_V1,
 };
@@ -41,17 +39,6 @@ pub enum OplogEntry {
         timestamp: Timestamp,
         response: Vec<u8>,
         consumed_fuel: i64,
-    },
-    /// Promise created
-    CreatePromise {
-        timestamp: Timestamp,
-        promise_id: PromiseId,
-    },
-    /// Promise completed
-    CompletePromise {
-        timestamp: Timestamp,
-        promise_id: PromiseId,
-        data: Vec<u8>,
     },
     /// Worker suspended
     Suspend { timestamp: Timestamp },
@@ -196,21 +183,6 @@ impl OplogEntry {
     pub fn exited() -> OplogEntry {
         OplogEntry::Exited {
             timestamp: Timestamp::now_utc(),
-        }
-    }
-
-    pub fn create_promise(promise_id: PromiseId) -> OplogEntry {
-        OplogEntry::CreatePromise {
-            timestamp: Timestamp::now_utc(),
-            promise_id,
-        }
-    }
-
-    pub fn complete_promise(promise_id: PromiseId, data: Vec<u8>) -> OplogEntry {
-        OplogEntry::CompletePromise {
-            timestamp: Timestamp::now_utc(),
-            promise_id,
-            data,
         }
     }
 

--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -50,8 +50,8 @@ use golem_common::config::RetryConfig;
 use golem_common::model::oplog::{OplogEntry, WrappedFunctionType};
 use golem_common::model::regions::{DeletedRegions, OplogRegion};
 use golem_common::model::{
-    AccountId, CallingConvention, InvocationKey, PromiseId, VersionedWorkerId, WorkerId,
-    WorkerMetadata, WorkerStatus, WorkerStatusRecord,
+    AccountId, CallingConvention, InvocationKey, VersionedWorkerId, WorkerId, WorkerMetadata,
+    WorkerStatus, WorkerStatusRecord,
 };
 use golem_wasm_rpc::wasmtime::ResourceStore;
 use golem_wasm_rpc::{Uri, Value};
@@ -228,21 +228,6 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
 
     pub fn as_wasi_http_view(&mut self) -> DurableWorkerCtxWasiHttpView<Ctx> {
         DurableWorkerCtxWasiHttpView(self)
-    }
-
-    pub async fn create_promise(&self, oplog_idx: u64) -> PromiseId {
-        self.public_state
-            .promise_service
-            .create(&self.worker_id.worker_id, oplog_idx)
-            .await
-    }
-
-    pub async fn poll_promise(&self, id: PromiseId) -> Result<Option<Vec<u8>>, GolemError> {
-        self.public_state.promise_service.poll(id).await
-    }
-
-    pub async fn complete_promise(&self, id: PromiseId, data: Vec<u8>) -> Result<bool, GolemError> {
-        self.public_state.promise_service.complete(id, data).await
     }
 
     pub fn check_interrupt(&self) -> Option<InterruptKind> {

--- a/golem-worker-executor-base/src/grpc.rs
+++ b/golem-worker-executor-base/src/grpc.rs
@@ -305,8 +305,9 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
         };
 
         if should_activate {
-            // By making sure the worker is in memory, if it is waiting for the promise it is going to
-            // be notified when we complete it below.
+            // By making sure the worker is in memory. If it was suspended because of waiting
+            // for a promise, replaying that call will now not suspend as the promise has been
+            // completed, and the worker will continue running.
             Worker::activate(
                 &self.services,
                 &metadata.worker_id.worker_id,

--- a/golem-worker-executor-base/src/worker.rs
+++ b/golem-worker-executor-base/src/worker.rs
@@ -763,12 +763,6 @@ fn calculate_latest_worker_status(
             OplogEntry::ExportedFunctionCompleted { .. } => {
                 result = WorkerStatus::Idle;
             }
-            OplogEntry::CreatePromise { .. } => {
-                result = WorkerStatus::Running;
-            }
-            OplogEntry::CompletePromise { .. } => {
-                result = WorkerStatus::Running;
-            }
             OplogEntry::Suspend { .. } => {
                 result = WorkerStatus::Suspended;
             }


### PR DESCRIPTION
Resolves #283 
Related to #321 

Notes:
- `create` is safe to be reexecuted because the (redis) promise implementation uses the `NX` flag 
- `await` has to be reexecuted because the worker goes suspended when the promise is not yet set, and only gets recovered once it has been completed. we need to reevaluate the promise state during that recovery
- `complete` need to be durable because we don't want to overwrite the completed promise's state 
- `delete` need to be durable to not try to delete a promise more than once
