### PR TITLE
CLI - worker list, doc and count processing

### DIFF
--- a/golem-cli/src/worker.rs
+++ b/golem-cli/src/worker.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 use clap::builder::ValueParser;
 use clap::Subcommand;
-use golem_client::model::InvokeParameters;
+use golem_client::model::{InvokeParameters, WorkerMetadata, WorkersMetadataResponse};
 
 use crate::clients::worker::WorkerClient;
 use crate::model::{
@@ -175,19 +175,24 @@ pub enum WorkerSubcommand {
         #[command(flatten)]
         template_id_or_name: TemplateIdOrName,
 
-        // Filter
+        /// Filter for worker metadata in form of `property op value`.
+        ///
+        /// Filter examples: `name = worker-name`, `version >= 0`, `status = Running`, `env.var1 = value`.
+        /// Can be used multiple times (AND condition is applied between them)
         #[arg(short, long)]
         filter: Option<Vec<String>>,
 
-        // Cursor
+        /// Position where to start listing, if not provided, starts from the beginning
+        ///
+        /// It is used to get the next page of results. To get next page, use the cursor returned in the response
         #[arg(short, long)]
         cursor: Option<u64>,
 
-        // Count
-        #[arg(short = 's', long)]
+        /// Count of listed values, if count is not provided, returns all values
+        #[arg(short = 'n', long)]
         count: Option<u64>,
 
-        // Precise
+        /// Precision in relation to worker status, if true, calculate the most up-to-date status for each worker, default is false
         #[arg(short, long)]
         precise: Option<bool>,
     },
@@ -353,12 +358,43 @@ impl<'r, C: WorkerClient + Send + Sync, R: TemplateHandler + Send + Sync> Worker
             } => {
                 let template_id = self.templates.resolve_id(template_id_or_name).await?;
 
-                let response = self
-                    .client
-                    .list_metadata(template_id, filter, cursor, count, precise)
-                    .await?;
+                if count.is_some() {
+                    let response = self
+                        .client
+                        .list_metadata(template_id, filter, cursor, count, precise)
+                        .await?;
 
-                Ok(GolemResult::Ok(Box::new(response)))
+                    Ok(GolemResult::Ok(Box::new(response)))
+                } else {
+                    let mut workers: Vec<WorkerMetadata> = vec![];
+                    let mut new_cursor = cursor;
+
+                    loop {
+                        let response = self
+                            .client
+                            .list_metadata(
+                                template_id.clone(),
+                                filter.clone(),
+                                new_cursor,
+                                Some(50),
+                                precise,
+                            )
+                            .await?;
+
+                        workers.extend(response.workers);
+
+                        new_cursor = response.cursor;
+
+                        if new_cursor.is_none() {
+                            break;
+                        }
+                    }
+
+                    Ok(GolemResult::Ok(Box::new(WorkersMetadataResponse {
+                        workers,
+                        cursor: None,
+                    })))
+                }
             }
         }
     }

--- a/golem-cli/tests/worker.rs
+++ b/golem-cli/tests/worker.rs
@@ -505,7 +505,7 @@ fn worker_list(
         "version >= 0",
         &cfg.arg('f', "filter"),
         format!("name like {}_worker", name).as_str(),
-        &cfg.arg('s', "count"),
+        &cfg.arg('n', "count"),
         (workers_count / 2).to_string().as_str(),
     ])?;
 
@@ -521,7 +521,7 @@ fn worker_list(
         "version >= 0",
         &cfg.arg('f', "filter"),
         format!("name like {}_worker", name).as_str(),
-        &cfg.arg('s', "count"),
+        &cfg.arg('n', "count"),
         (workers_count - result.workers.len()).to_string().as_str(),
         &cfg.arg('c', "cursor"),
         result.cursor.unwrap().to_string().as_str(),
@@ -539,7 +539,7 @@ fn worker_list(
             "version >= 0",
             &cfg.arg('f', "filter"),
             format!("name like {}_worker", name).as_str(),
-            &cfg.arg('s', "count"),
+            &cfg.arg('n', "count"),
             workers_count.to_string().as_str(),
             &cfg.arg('c', "cursor"),
             cursor2.to_string().as_str(),


### PR DESCRIPTION
related to: #300 

```
golem-cli worker list -h
Retrieves metadata about an existing workers in a template

Usage: golem-cli worker list [OPTIONS] --template-id <TEMPLATE_ID> --template-name <TEMPLATE_NAME>

Options:
  -T, --template-id <TEMPLATE_ID>
  -v, --verbose...                     Increase logging verbosity
  -q, --quiet...                       Decrease logging verbosity
  -t, --template-name <TEMPLATE_NAME>
  -f, --filter <FILTER>                Filter for worker metadata in form of `property op value`
  -c, --cursor <CURSOR>                Position where to start listing, if not provided, starts from the beginning
  -n, --count <COUNT>                  Count of listed values, if count is not provided, returns all values
  -p, --precise <PRECISE>              Precision in relation to worker status, if true, calculate the most up-to-date status for each worker, default is false [possible values: true, false]
  -h, --help                           Print help (see more with '--help')

```

```
golem-cli worker list --help
Retrieves metadata about an existing workers in a template

Usage: golem-cli worker list [OPTIONS] --template-id <TEMPLATE_ID> --template-name <TEMPLATE_NAME>

Options:
  -T, --template-id <TEMPLATE_ID>


  -v, --verbose...
          Increase logging verbosity

  -q, --quiet...
          Decrease logging verbosity

  -t, --template-name <TEMPLATE_NAME>


  -f, --filter <FILTER>
          Filter for worker metadata in form of `property op value`.

          Filter examples: `name = worker-name`, `version >= 0`, `status = Running`, `env.var1 = value`. Can be used multiple times (AND condition is applied between them)

  -c, --cursor <CURSOR>
          Position where to start listing, if not provided, starts from the beginning

          It is used to get the next page of results. To get next page, use the cursor returned in the response

  -n, --count <COUNT>
          Count of listed values, if count is not provided, returns all values

  -p, --precise <PRECISE>
          Precision in relation to worker status, if true, calculate the most up-to-date status for each worker, default is false

          [possible values: true, false]

  -h, --help
          Print help (see a summary with '-h')
```