### PR TITLE
Api Definition: Separate Create and Update

### DIFF
--- a/golem-api-grpc/proto/golem/apidefinition/api_definition_service.proto
+++ b/golem-api-grpc/proto/golem/apidefinition/api_definition_service.proto
@@ -7,7 +7,8 @@ import "golem/apidefinition/api_definition_error.proto";
 import "golem/apidefinition/api_definition.proto";
 
 service ApiDefinitionService {
-  rpc CreateOrUpdateApiDefinition (CreateOrUpdateApiDefinitionRequest) returns (CreateOrUpdateApiDefinitionResponse) {}
+  rpc CreateApiDefinition (CreateApiDefinitionRequest) returns (CreateApiDefinitionResponse) {}
+  rpc UpdateApiDefinition (UpdateApiDefinitionRequest) returns (UpdateApiDefinitionResponse) {}
   rpc GetApiDefinition (GetApiDefinitionRequest) returns (GetApiDefinitionResponse) {}
   rpc GetApiDefinitionVersions (GetApiDefinitionVersionsRequest) returns (GetApiDefinitionVersionsResponse) {}
   rpc GetAllApiDefinitions (GetAllApiDefinitionsRequest) returns (GetAllApiDefinitionsResponse) {}
@@ -15,15 +16,28 @@ service ApiDefinitionService {
 }
 
 
-message CreateOrUpdateApiDefinitionRequest {
+message CreateApiDefinitionRequest {
   oneof api_definition {
     ApiDefinition definition = 1;
     string openapi = 2;
   }
 }
 
+message CreateApiDefinitionResponse {
+  oneof result {
+    ApiDefinition success = 1;
+    ApiDefinitionError error = 2;
+  }
+}
 
-message CreateOrUpdateApiDefinitionResponse {
+message UpdateApiDefinitionRequest {
+  oneof api_definition {
+    ApiDefinition definition = 1;
+    string openapi = 2;
+  }
+}
+
+message UpdateApiDefinitionResponse {
   oneof result {
     ApiDefinition success = 1;
     ApiDefinitionError error = 2;

--- a/golem-cli/src/api_definition.rs
+++ b/golem-cli/src/api_definition.rs
@@ -153,6 +153,19 @@ mod tests {
             })
         }
 
+        async fn post(
+            &self,
+            value: &HttpApiDefinition,
+        ) -> Result<HttpApiDefinition, Error<ApiDefinitionError>> {
+            let mut calls = self.calls.lock().unwrap();
+            calls.push_str(format!("post: {:?}", value).as_str());
+            Ok(HttpApiDefinition {
+                id: "".to_string(),
+                version: "".to_string(),
+                routes: vec![],
+            })
+        }
+
         async fn delete(
             &self,
             api_definition_id: &str,

--- a/golem-cli/src/clients/errors.rs
+++ b/golem-cli/src/clients/errors.rs
@@ -66,7 +66,7 @@ impl ResponseContentErrorMapper for ApiDefinitionError {
             ApiDefinitionError::Error400(error) => display_worker_service_errors_body(error),
             ApiDefinitionError::Error401(error) => error.error,
             ApiDefinitionError::Error403(error) => error.error,
-            ApiDefinitionError::Error404(error) => error.message,
+            ApiDefinitionError::Error404(error) => error.error,
             ApiDefinitionError::Error409(error) => error.to_string(),
             ApiDefinitionError::Error500(error) => error.error,
         }
@@ -214,8 +214,8 @@ mod tests {
     use golem_client::{
         api::ApiDefinitionError,
         model::{
-            MessageBody, MessagesErrorsBody, MethodPattern, RouteValidationError,
-            ValidationErrorsBody, WorkerServiceErrorBody, WorkerServiceErrorsBody,
+            ErrorBody, MessagesErrorsBody, MethodPattern, RouteValidationError,
+            ValidationErrorsBody, WorkerServiceErrorsBody,
         },
     };
     use uuid::Uuid;
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn api_definition_error_401() {
-        let error = ApiDefinitionError::Error401(WorkerServiceErrorBody {
+        let error = ApiDefinitionError::Error401(ErrorBody {
             error: "401".to_string(),
         });
         assert_eq!(error.map(), "401".to_string())
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn api_definition_error_403() {
-        let error = ApiDefinitionError::Error403(WorkerServiceErrorBody {
+        let error = ApiDefinitionError::Error403(ErrorBody {
             error: "403".to_string(),
         });
         assert_eq!(error.map(), "403".to_string())
@@ -246,15 +246,15 @@ mod tests {
 
     #[test]
     fn api_definition_error_404() {
-        let error = ApiDefinitionError::Error404(MessageBody {
-            message: "404".to_string(),
+        let error = ApiDefinitionError::Error404(ErrorBody {
+            error: "404".to_string(),
         });
         assert_eq!(error.map(), "404".to_string())
     }
 
     #[test]
     fn api_definition_error_500() {
-        let error = ApiDefinitionError::Error500(WorkerServiceErrorBody {
+        let error = ApiDefinitionError::Error500(ErrorBody {
             error: "500".to_string(),
         });
         assert_eq!(error.map(), "500".to_string())

--- a/golem-common/src/redis.rs
+++ b/golem-common/src/redis.rs
@@ -378,22 +378,6 @@ impl<'a> RedisLabelledApi<'a> {
         )
     }
 
-    pub async fn sismember<K, V>(&self, key: K, member: V) -> RedisResult<bool>
-    where
-        K: AsRef<str>,
-        V: TryInto<RedisValue> + Send,
-        V::Error: Into<RedisError> + Send,
-    {
-        self.ensure_connected().await?;
-        let start = Instant::now();
-        let result: usize = self.record(
-            start,
-            "SISMEMBER",
-            self.pool.sismember(self.prefixed_key(key), member).await,
-        )?;
-        Ok(result == 1)
-    }
-
     pub async fn xadd<R, K, C, I, F>(
         &self,
         key: K,

--- a/golem-worker-service-base/src/api/common.rs
+++ b/golem-worker-service-base/src/api/common.rs
@@ -110,16 +110,12 @@ mod conversion {
                     ApiRegistrationRepoError::AlreadyExists(_) => {
                         ApiEndpointError::already_exists(error)
                     }
-                    ApiRegistrationRepoError::InternalError(_) => ApiEndpointError::internal(error),
+                    ApiRegistrationRepoError::NotFound(_) => ApiEndpointError::not_found(error),
+                    ApiRegistrationRepoError::Internal(_) => ApiEndpointError::internal(error),
                 },
                 ApiRegistrationError::ValidationError(e) => e.into(),
-                ApiRegistrationError::TemplateNotFoundError(template_id) => {
-                    let templates = template_id
-                        .iter()
-                        .map(|t| t.to_string())
-                        .collect::<Vec<String>>()
-                        .join(", ");
-                    ApiEndpointError::bad_request(format!("Templates not found, {}", templates))
+                e @ ApiRegistrationError::TemplateNotFoundError(_) => {
+                    ApiEndpointError::bad_request(e)
                 }
             }
         }
@@ -153,8 +149,13 @@ mod conversion {
                             error: error.to_string(),
                         })),
                     },
-                    ApiRegistrationRepoError::InternalError(_) => ApiDefinitionError {
+                    ApiRegistrationRepoError::Internal(_) => ApiDefinitionError {
                         error: Some(api_definition_error::Error::InternalError(ErrorBody {
+                            error: error.to_string(),
+                        })),
+                    },
+                    ApiRegistrationRepoError::NotFound(_) => ApiDefinitionError {
+                        error: Some(api_definition_error::Error::NotFound(ErrorBody {
                             error: error.to_string(),
                         })),
                     },

--- a/golem-worker-service-base/src/api/common.rs
+++ b/golem-worker-service-base/src/api/common.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use golem_service_base::model::ErrorBody;
 use poem_openapi::payload::Json;
 use poem_openapi::{ApiResponse, Object, Union};
 
@@ -24,47 +25,37 @@ pub struct ValidationErrorsBody {
     errors: Vec<RouteValidationError>,
 }
 
-#[derive(Object)]
-pub struct WorkerServiceErrorBody {
-    error: String,
-}
-
-#[derive(Object)]
-pub struct MessageBody {
-    message: String,
-}
-
 #[derive(ApiResponse)]
 pub enum ApiEndpointError {
     #[oai(status = 400)]
     BadRequest(Json<WorkerServiceErrorsBody>),
     #[oai(status = 401)]
-    Unauthorized(Json<WorkerServiceErrorBody>),
+    Unauthorized(Json<ErrorBody>),
     #[oai(status = 403)]
-    Forbidden(Json<WorkerServiceErrorBody>),
+    Forbidden(Json<ErrorBody>),
     #[oai(status = 404)]
-    NotFound(Json<MessageBody>),
+    NotFound(Json<ErrorBody>),
     #[oai(status = 409)]
     AlreadyExists(Json<String>),
     #[oai(status = 500)]
-    InternalError(Json<WorkerServiceErrorBody>),
+    InternalError(Json<ErrorBody>),
 }
 
 impl ApiEndpointError {
     pub fn unauthorized<T: Display>(error: T) -> Self {
-        Self::Unauthorized(Json(WorkerServiceErrorBody {
+        Self::Unauthorized(Json(ErrorBody {
             error: error.to_string(),
         }))
     }
 
     pub fn forbidden<T: Display>(error: T) -> Self {
-        Self::Forbidden(Json(WorkerServiceErrorBody {
+        Self::Forbidden(Json(ErrorBody {
             error: error.to_string(),
         }))
     }
 
     pub fn internal<T: Display>(error: T) -> Self {
-        Self::InternalError(Json(WorkerServiceErrorBody {
+        Self::InternalError(Json(ErrorBody {
             error: error.to_string(),
         }))
     }
@@ -78,8 +69,8 @@ impl ApiEndpointError {
     }
 
     pub fn not_found<T: Display>(error: T) -> Self {
-        Self::NotFound(Json(MessageBody {
-            message: error.to_string(),
+        Self::NotFound(Json(ErrorBody {
+            error: error.to_string(),
         }))
     }
 

--- a/golem-worker-service-base/src/service/api_definition.rs
+++ b/golem-worker-service-base/src/service/api_definition.rs
@@ -22,7 +22,7 @@ pub type ApiResult<T, E> = Result<T, ApiRegistrationError<E>>;
 // validations, authorisations etc is the right approach. However we are keeping it simple for now.
 #[async_trait]
 pub trait ApiDefinitionService<AuthCtx, Namespace, ApiDefinition, ValidationError> {
-    async fn register(
+    async fn create(
         &self,
         definition: &ApiDefinition,
         namespace: Namespace,
@@ -209,7 +209,7 @@ where
     Namespace: ApiNamespace + Send + Sync,
     ApiDefinition: GolemApiDefinition + Sync,
 {
-    async fn register(
+    async fn create(
         &self,
         definition: &ApiDefinition,
         namespace: Namespace,
@@ -226,7 +226,7 @@ where
             version: definition.get_version().clone(),
         };
 
-        self.register_repo.register(definition, &key).await?;
+        self.register_repo.create(definition, &key).await?;
 
         Ok(key.id)
     }
@@ -324,7 +324,7 @@ impl<AuthCtx, Namespace, ApiDefinition, ValidationError>
 where
     Namespace: Default + Send + Sync + 'static,
 {
-    async fn register(
+    async fn create(
         &self,
         _definition: &ApiDefinition,
         _namespace: Namespace,

--- a/golem-worker-service/src/api/mod.rs
+++ b/golem-worker-service/src/api/mod.rs
@@ -1,4 +1,4 @@
-pub mod register_api_definition_api;
+pub mod register_api_definition;
 pub mod worker;
 
 pub mod worker_connect;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 type ApiServices = (
     WorkerApi,
-    register_api_definition_api::RegisterApiDefinitionApi,
+    register_api_definition::RegisterApiDefinitionApi,
     HealthcheckApi,
 );
 
@@ -56,7 +56,7 @@ pub fn make_open_api_service(services: &Services) -> OpenApiService<ApiServices,
                 template_service: services.template_service.clone(),
                 worker_service: services.worker_service.clone(),
             },
-            register_api_definition_api::RegisterApiDefinitionApi::new(
+            register_api_definition::RegisterApiDefinitionApi::new(
                 services.definition_service.clone(),
             ),
             HealthcheckApi,

--- a/golem-worker-service/src/api/register_api_definition.rs
+++ b/golem-worker-service/src/api/register_api_definition.rs
@@ -47,7 +47,7 @@ impl RegisterApiDefinitionApi {
             ApiEndpointError::bad_request(e)
         })?;
 
-        self.register_api(&definition).await?;
+        self.create_api(&definition).await?;
 
         let definition: HttpApiDefinition =
             definition.try_into().map_err(ApiEndpointError::internal)?;
@@ -67,7 +67,7 @@ impl RegisterApiDefinitionApi {
             .try_into()
             .map_err(ApiEndpointError::bad_request)?;
 
-        self.register_api(&definition).await?;
+        self.create_api(&definition).await?;
 
         let definition: HttpApiDefinition =
             definition.try_into().map_err(ApiEndpointError::internal)?;
@@ -90,7 +90,7 @@ impl RegisterApiDefinitionApi {
             .update(&definition, CommonNamespace::default(), &EmptyAuthCtx {})
             .await
             .map_err(|e| {
-                error!("API Definition ID: {} - update error: {e:?}", definition.id,);
+                error!("API Definition ID: {} - update error: {e:?}", definition.id);
                 e
             })?;
 
@@ -183,12 +183,9 @@ impl RegisterApiDefinitionApi {
 }
 
 impl RegisterApiDefinitionApi {
-    async fn register_api(
-        &self,
-        definition: &CoreHttpApiDefinition,
-    ) -> Result<(), ApiEndpointError> {
+    async fn create_api(&self, definition: &CoreHttpApiDefinition) -> Result<(), ApiEndpointError> {
         self.definition_service
-            .register(definition, CommonNamespace::default(), &EmptyAuthCtx {})
+            .create(definition, CommonNamespace::default(), &EmptyAuthCtx {})
             .await
             .map_err(|e| {
                 error!(

--- a/golem-worker-service/src/api/register_api_definition.rs
+++ b/golem-worker-service/src/api/register_api_definition.rs
@@ -258,6 +258,26 @@ mod test {
     }
 
     #[tokio::test]
+    async fn update_non_existant() {
+        let api = make_route();
+        let client = TestClient::new(api);
+
+        let definition = golem_worker_service_base::api_definition::http::HttpApiDefinition {
+            id: ApiDefinitionId("test".to_string()),
+            version: ApiVersion("42.0".to_string()),
+            routes: vec![],
+        };
+
+        let response = client
+            .put("/v1/api/definitions")
+            .body_json(&definition)
+            .send()
+            .await;
+
+        response.assert_status(http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
     async fn get_all() {
         let api = make_route();
         let client = TestClient::new(api);

--- a/golem-worker-service/src/api/register_api_definition.rs
+++ b/golem-worker-service/src/api/register_api_definition.rs
@@ -74,7 +74,7 @@ impl RegisterApiDefinitionApi {
 
         Ok(Json(definition))
     }
-    #[oai(path = "/", method = "post")]
+    #[oai(path = "/", method = "put")]
     async fn update(
         &self,
         payload: Json<HttpApiDefinition>,
@@ -241,7 +241,7 @@ mod test {
         };
 
         let response = client
-            .put("/v1/api/definitions")
+            .post("/v1/api/definitions")
             .body_json(&definition)
             .send()
             .await;
@@ -249,7 +249,7 @@ mod test {
         response.assert_status_is_ok();
 
         let response = client
-            .put("/v1/api/definitions")
+            .post("/v1/api/definitions")
             .body_json(&definition)
             .send()
             .await;
@@ -268,7 +268,7 @@ mod test {
             routes: vec![],
         };
         let response = client
-            .put("/v1/api/definitions")
+            .post("/v1/api/definitions")
             .body_json(&definition)
             .send()
             .await;
@@ -280,7 +280,7 @@ mod test {
             routes: vec![],
         };
         let response = client
-            .put("/v1/api/definitions")
+            .post("/v1/api/definitions")
             .body_json(&definition)
             .send()
             .await;

--- a/golem-worker-service/src/grpcapi/register_api_definition.rs
+++ b/golem-worker-service/src/grpcapi/register_api_definition.rs
@@ -165,7 +165,7 @@ impl GrpcApiDefinitionService {
         };
 
         self.definition_service
-            .register(
+            .create(
                 &internal_definition,
                 CommonNamespace::default(),
                 &EmptyAuthCtx {},

--- a/golem-worker-service/src/grpcapi/register_api_definition.rs
+++ b/golem-worker-service/src/grpcapi/register_api_definition.rs
@@ -5,14 +5,15 @@ use async_trait::async_trait;
 use golem_api_grpc::proto::golem::{
     apidefinition::{
         api_definition_error, api_definition_service_server::ApiDefinitionService,
-        create_or_update_api_definition_request, create_or_update_api_definition_response,
+        create_api_definition_request, create_api_definition_response,
         delete_api_definition_response, get_all_api_definitions_response,
         get_api_definition_response, get_api_definition_versions_response,
+        update_api_definition_request, update_api_definition_response,
         ApiDefinition as GrpcApiDefinition, ApiDefinitionError, ApiDefinitionList,
-        CreateOrUpdateApiDefinitionRequest, CreateOrUpdateApiDefinitionResponse,
-        DeleteApiDefinitionRequest, DeleteApiDefinitionResponse, GetAllApiDefinitionsRequest,
-        GetAllApiDefinitionsResponse, GetApiDefinitionRequest, GetApiDefinitionResponse,
-        GetApiDefinitionVersionsRequest, GetApiDefinitionVersionsResponse,
+        CreateApiDefinitionRequest, CreateApiDefinitionResponse, DeleteApiDefinitionRequest,
+        DeleteApiDefinitionResponse, GetAllApiDefinitionsRequest, GetAllApiDefinitionsResponse,
+        GetApiDefinitionRequest, GetApiDefinitionResponse, GetApiDefinitionVersionsRequest,
+        GetApiDefinitionVersionsResponse, UpdateApiDefinitionRequest, UpdateApiDefinitionResponse,
     },
     common::{Empty, ErrorBody, ErrorsBody},
 };
@@ -48,19 +49,30 @@ impl GrpcApiDefinitionService {
 
 #[async_trait]
 impl ApiDefinitionService for GrpcApiDefinitionService {
-    async fn create_or_update_api_definition(
+    async fn create_api_definition(
         &self,
-        request: tonic::Request<CreateOrUpdateApiDefinitionRequest>,
-    ) -> Result<tonic::Response<CreateOrUpdateApiDefinitionResponse>, tonic::Status> {
-        let result = match self
-            .create_or_update_api_definition(request.into_inner())
-            .await
-        {
-            Ok(result) => create_or_update_api_definition_response::Result::Success(result),
-            Err(error) => create_or_update_api_definition_response::Result::Error(error),
+        request: tonic::Request<CreateApiDefinitionRequest>,
+    ) -> Result<tonic::Response<CreateApiDefinitionResponse>, tonic::Status> {
+        let result = match self.create_api_definition(request.into_inner()).await {
+            Ok(result) => create_api_definition_response::Result::Success(result),
+            Err(error) => create_api_definition_response::Result::Error(error),
         };
 
-        Ok(tonic::Response::new(CreateOrUpdateApiDefinitionResponse {
+        Ok(tonic::Response::new(CreateApiDefinitionResponse {
+            result: Some(result),
+        }))
+    }
+
+    async fn update_api_definition(
+        &self,
+        request: tonic::Request<UpdateApiDefinitionRequest>,
+    ) -> Result<tonic::Response<UpdateApiDefinitionResponse>, tonic::Status> {
+        let result = match self.update_api_definition(request.into_inner()).await {
+            Ok(result) => update_api_definition_response::Result::Success(result),
+            Err(error) => update_api_definition_response::Result::Error(error),
+        };
+
+        Ok(tonic::Response::new(UpdateApiDefinitionResponse {
             result: Some(result),
         }))
     }
@@ -132,19 +144,19 @@ impl ApiDefinitionService for GrpcApiDefinitionService {
 }
 
 impl GrpcApiDefinitionService {
-    async fn create_or_update_api_definition(
+    async fn create_api_definition(
         &self,
-        request: CreateOrUpdateApiDefinitionRequest,
+        request: CreateApiDefinitionRequest,
     ) -> Result<GrpcApiDefinition, ApiDefinitionError> {
         let definition = request
             .api_definition
             .ok_or(bad_request("Missing Api Definition"))?;
 
         let internal_definition = match definition {
-            create_or_update_api_definition_request::ApiDefinition::Definition(definition) => {
+            create_api_definition_request::ApiDefinition::Definition(definition) => {
                 definition.clone().try_into().map_err(bad_request)?
             }
-            create_or_update_api_definition_request::ApiDefinition::Openapi(definition) => {
+            create_api_definition_request::ApiDefinition::Openapi(definition) => {
                 let value =
                     serde_json::from_str(&definition).map_err(|_| bad_request("Invalid JSON"))?;
 
@@ -154,6 +166,39 @@ impl GrpcApiDefinitionService {
 
         self.definition_service
             .register(
+                &internal_definition,
+                CommonNamespace::default(),
+                &EmptyAuthCtx {},
+            )
+            .await?;
+
+        let definition = internal_definition.try_into().map_err(internal_error)?;
+
+        Ok(definition)
+    }
+
+    async fn update_api_definition(
+        &self,
+        request: UpdateApiDefinitionRequest,
+    ) -> Result<GrpcApiDefinition, ApiDefinitionError> {
+        let definition = request
+            .api_definition
+            .ok_or(bad_request("Missing Api Definition"))?;
+
+        let internal_definition = match definition {
+            update_api_definition_request::ApiDefinition::Definition(definition) => {
+                definition.clone().try_into().map_err(bad_request)?
+            }
+            update_api_definition_request::ApiDefinition::Openapi(definition) => {
+                let value =
+                    serde_json::from_str(&definition).map_err(|_| bad_request("Invalid JSON"))?;
+
+                get_api_definition(value).map_err(bad_request)?
+            }
+        };
+
+        self.definition_service
+            .update(
                 &internal_definition,
                 CommonNamespace::default(),
                 &EmptyAuthCtx {},

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -887,19 +887,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -911,7 +911,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
   /v1/api/definitions:
     get:
       tags:
@@ -953,19 +953,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -977,7 +977,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
     put:
       tags:
       - ApiDefinition
@@ -1005,19 +1005,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -1029,7 +1029,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
     post:
       tags:
       - ApiDefinition
@@ -1057,19 +1057,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -1081,7 +1081,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
     delete:
       tags:
       - ApiDefinition
@@ -1120,19 +1120,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -1144,7 +1144,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
   /v1/api/definitions/all:
     get:
       tags:
@@ -1169,19 +1169,19 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '403':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
         '404':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/MessageBody'
+                $ref: '#/components/schemas/ErrorBody'
         '409':
           description: ''
           content:
@@ -1193,7 +1193,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/WorkerServiceErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
   /healthcheck:
     get:
       tags:
@@ -2196,13 +2196,6 @@ components:
         result: {}
       required:
       - result
-    MessageBody:
-      type: object
-      properties:
-        message:
-          type: string
-      required:
-      - message
     MessagesErrorsBody:
       type: object
       properties:
@@ -2538,13 +2531,6 @@ components:
             $ref: '#/components/schemas/WorkerFilter'
       required:
       - filters
-    WorkerServiceErrorBody:
-      type: object
-      properties:
-        error:
-          type: string
-      required:
-      - error
     WorkerServiceErrorsBody:
       discriminator:
         propertyName: type

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -1030,6 +1030,58 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/WorkerServiceErrorBody'
+    post:
+      tags:
+      - ApiDefinition
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/HttpApiDefinition'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/HttpApiDefinition'
+        '400':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/WorkerServiceErrorsBody'
+        '401':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/WorkerServiceErrorBody'
+        '403':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/WorkerServiceErrorBody'
+        '404':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/MessageBody'
+        '409':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: string
+        '500':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/WorkerServiceErrorBody'
     delete:
       tags:
       - ApiDefinition


### PR DESCRIPTION
closes https://github.com/golemcloud/golem/issues/402

- Separate create/update methods for API Definitions
   - `register` methods are renamed to `create`
- New NotFound Registry Error

### Miscellaneous changes
- Made Internal errors `anyhow::Error` instead of `String`
- Export fred `RedisError` to implement `From<RedisError> for ApiRegistrationRepoError` instead of using `map_err` everywhere
- Remove `MessageBody` and `WorkerServiceErrorBody` in favor of `ErrorBody` which is used everywhere else in API