### PR TITLE
Improved divergence detection

### DIFF
--- a/golem-worker-executor-base/src/durable_host/durability.rs
+++ b/golem-worker-executor-base/src/durable_host/durability.rs
@@ -24,7 +24,7 @@ pub trait Durability<Ctx: WorkerCtx, SerializedSuccess, SerializedErr> {
     ) -> Result<Success, Err>
     where
         Success: Send,
-        Err: Send,
+        Err: From<GolemError> + Send,
         AsyncFn: for<'b> FnOnce(
                 &'b mut DurableWorkerCtx<Ctx>,
             )
@@ -77,7 +77,7 @@ pub trait Durability<Ctx: WorkerCtx, SerializedSuccess, SerializedErr> {
     ) -> Result<Success, Err>
     where
         Success: Clone + Send,
-        Err: Send,
+        Err: From<GolemError> + Send,
         AsyncFn: for<'b> FnOnce(
                 &'b mut DurableWorkerCtx<Ctx>,
             )
@@ -108,7 +108,7 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
     ) -> Result<Success, Err>
     where
         Success: Send,
-        Err: Send,
+        Err: From<GolemError> + Send,
         AsyncFn: for<'b> FnOnce(
                 &'b mut DurableWorkerCtx<Ctx>,
             )
@@ -130,8 +130,7 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
         let begin_index = self
             .state
             .begin_function(&wrapped_function_type.clone())
-            .await
-            .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+            .await?;
         if self.state.is_live() || self.state.persistence_level == PersistenceLevel::PersistNothing
         {
             let result = function(self).await;
@@ -150,22 +149,18 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
             result
         } else {
             let oplog_entry =
-                crate::get_oplog_entry!(self.state, OplogEntry::ImportedFunctionInvoked)
-                    .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+                crate::get_oplog_entry!(self.state, OplogEntry::ImportedFunctionInvoked)?;
+            Self::validate_oplog_entry(&oplog_entry, function_name)?;
             let response = oplog_entry
                 .payload::<Result<SerializedSuccess, SerializedErr>>()
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "failed to deserialize function response: {:?}: {err}",
-                        oplog_entry
-                    )
-                })
+                .map_err(|err| {
+                    GolemError::unexpected_oplog_entry("ImportedFunctionInvoked payload", err)
+                })?
                 .unwrap();
 
             self.state
                 .end_function(&wrapped_function_type, begin_index)
-                .await
-                .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+                .await?;
 
             match response {
                 Ok(serialized_success) => {
@@ -185,7 +180,7 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
     ) -> Result<Success, Err>
     where
         Success: Clone + Send,
-        Err: Send,
+        Err: From<GolemError> + Send,
         AsyncFn: for<'b> FnOnce(
                 &'b mut DurableWorkerCtx<Ctx>,
             )
@@ -199,8 +194,7 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
         let begin_index = self
             .state
             .begin_function(&wrapped_function_type.clone())
-            .await
-            .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+            .await?;
         if self.state.is_live() || self.state.persistence_level == PersistenceLevel::PersistNothing
         {
             let result = function(self).await;
@@ -219,22 +213,18 @@ impl<Ctx: WorkerCtx, SerializedSuccess: Sync, SerializedErr: Sync>
             result
         } else {
             let oplog_entry =
-                crate::get_oplog_entry!(self.state, OplogEntry::ImportedFunctionInvoked)
-                    .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+                crate::get_oplog_entry!(self.state, OplogEntry::ImportedFunctionInvoked)?;
+            Self::validate_oplog_entry(&oplog_entry, function_name)?;
             let response = oplog_entry
                 .payload::<Result<SerializedSuccess, SerializedErr>>()
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "failed to deserialize function response: {:?}: {err}",
-                        oplog_entry
-                    )
-                })
+                .map_err(|err| {
+                    GolemError::unexpected_oplog_entry("ImportedFunctionInvoked payload", err)
+                })?
                 .unwrap();
 
             self.state
                 .end_function(&wrapped_function_type, begin_index)
-                .await
-                .map_err(|err| Into::<SerializedErr>::into(err).into())?;
+                .await?;
 
             response
                 .map(|serialized_success| serialized_success.into())
@@ -278,5 +268,23 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
             }
         }
         Ok(())
+    }
+
+    fn validate_oplog_entry(
+        oplog_entry: &OplogEntry,
+        expected_function_name: &str,
+    ) -> Result<(), GolemError> {
+        if let OplogEntry::ImportedFunctionInvoked { function_name, .. } = oplog_entry {
+            if function_name != expected_function_name {
+                Err(GolemError::unexpected_oplog_entry(
+                    expected_function_name,
+                    function_name,
+                ))
+            } else {
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
     }
 }

--- a/golem-worker-executor-base/src/durable_host/io/streams.rs
+++ b/golem-worker-executor-base/src/durable_host/io/streams.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 use wasmtime_wasi::preview2::{ResourceTable, StreamError};
@@ -19,6 +20,7 @@ use wasmtime_wasi::preview2::{ResourceTable, StreamError};
 use crate::durable_host::io::{ManagedStdErr, ManagedStdOut};
 use crate::durable_host::serialized::SerializableStreamError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
+use crate::error::GolemError;
 use crate::metrics::wasm::record_host_function_call;
 use crate::model::PersistenceLevel;
 use crate::workerctx::WorkerCtx;
@@ -284,5 +286,11 @@ fn is_incoming_http_body_stream(table: &ResourceTable, stream: &Resource<InputSt
                     .is_some()
         }
         InputStream::File(_) => false,
+    }
+}
+
+impl From<GolemError> for StreamError {
+    fn from(value: GolemError) -> Self {
+        StreamError::Trap(anyhow!(value))
     }
 }

--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -555,7 +555,10 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
             if let Some(function_output) = response {
                 let is_diverged = function_output != output;
                 if is_diverged {
-                    return Err(anyhow!("Function {:?} with inputs {:?} has diverged! Output was {:?} when function was replayed but was {:?} when function was originally invoked", full_function_name, function_input, output, function_output));
+                    return Err(anyhow!(GolemError::unexpected_oplog_entry(
+                        format!("{full_function_name}({function_input:?}) => {function_output:?}"),
+                        format!("{full_function_name}({function_input:?}) => {output:?}"),
+                    )));
                 }
             }
         }

--- a/golem-worker-executor-base/src/durable_host/sockets/ip_name_lookup.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/ip_name_lookup.rs
@@ -17,6 +17,7 @@ use wasmtime::component::Resource;
 
 use crate::durable_host::serialized::{SerializableError, SerializableIpAddresses};
 use crate::durable_host::{Durability, DurableWorkerCtx};
+use crate::error::GolemError;
 use crate::metrics::wasm::record_host_function_call;
 use crate::workerctx::WorkerCtx;
 use golem_common::model::oplog::WrappedFunctionType;
@@ -108,4 +109,10 @@ async fn drain_resolve_address_stream(
         }
     }
     Ok(addresses)
+}
+
+impl From<GolemError> for SocketError {
+    fn from(value: GolemError) -> Self {
+        Self::trap(value)
+    }
 }


### PR DESCRIPTION
Resolves #388 

- Checks the imported function's name during replay
- Payload deserialization errors are considered divergence
- Makes sure all divergence errors are reported as `GolemError::UnexpectedOplogEntry` so we can handle them during the update