### PR TITLE
Suspend bench

### DIFF
--- a/golem-test-framework/src/components/mod.rs
+++ b/golem-test-framework/src/components/mod.rs
@@ -118,10 +118,10 @@ async fn wait_for_startup_grpc(host: &str, grpc_port: u16, name: &str) {
         if success {
             break;
         } else {
-            if start.elapsed().as_secs() > 30 {
+            if start.elapsed().as_secs() > 90 {
                 panic!("Failed to verify that {name} is running");
             }
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(2)).await;
         }
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -37,3 +37,7 @@ path = "tests/sharding.rs"
 [[bin]]
 name = "benchmark_simple_worker_echo"
 path = "src/benchmarks/simple_worker_echo.rs"
+
+[[bin]]
+name = "benchmark_suspend_worker"
+path = "src/benchmarks/suspend_worker.rs"

--- a/integration-tests/src/benchmarks/suspend_worker.rs
+++ b/integration-tests/src/benchmarks/suspend_worker.rs
@@ -1,0 +1,134 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use clap::Parser;
+use golem_wasm_rpc::Value;
+
+use golem_common::model::WorkerId;
+use golem_test_framework::config::{CliParams, CliTestDependencies, TestDependencies};
+use golem_test_framework::dsl::benchmark::{Benchmark, BenchmarkApi, BenchmarkRecorder};
+use golem_test_framework::dsl::TestDsl;
+
+#[derive(Clone)]
+struct Context {
+    deps: CliTestDependencies,
+    worker_ids: Vec<WorkerId>,
+}
+
+struct InvokeWorkerLatency {
+    config: CliParams,
+}
+
+#[async_trait]
+impl Benchmark for InvokeWorkerLatency {
+    type IterationContext = Context;
+
+    fn name() -> &'static str {
+        "suspend"
+    }
+
+    async fn create(config: CliParams) -> Self {
+        Self { config }
+    }
+
+    async fn setup_iteration(&self) -> Self::IterationContext {
+        // Initialize infrastructure
+        let deps = CliTestDependencies::new(self.config.clone()).await;
+
+        // Upload test template
+        let template_id = deps.store_template("clocks").await;
+        let mut worker_ids = Vec::new();
+
+        // Create 'size' workers
+        for i in 0..self.config.benchmark_config.size {
+            let worker_id = deps
+                .start_worker(&template_id, &format!("worker-{i}"))
+                .await;
+            worker_ids.push(worker_id);
+        }
+
+        Self::IterationContext { deps, worker_ids }
+    }
+
+    async fn warmup(&self, context: &Self::IterationContext) {
+        // Invoke each worker a few times in parallel
+        let mut fibers = Vec::new();
+        for worker_id in &context.worker_ids {
+            let context_clone = context.clone();
+            let worker_id_clone = worker_id.clone();
+            let fiber = tokio::task::spawn(async move {
+                context_clone
+                    .deps
+                    .invoke_and_await(
+                        &worker_id_clone,
+                        "sleep-for",
+                        vec![Value::F64(1.0)],
+                    )
+                    .await
+                    .expect("invoke_and_await failed");
+            });
+            fibers.push(fiber);
+        }
+
+        for fiber in fibers {
+            fiber.await.expect("fiber failed");
+        }
+    }
+
+    async fn run(&self, context: &Self::IterationContext, recorder: BenchmarkRecorder) {
+        // Invoke each worker a 'length' times in parallel and record the duration
+        let mut fibers = Vec::new();
+        for (n, worker_id) in context.worker_ids.iter().enumerate() {
+            let context_clone = context.clone();
+            let worker_id_clone = worker_id.clone();
+            let recorder_clone = recorder.clone();
+            // let length = self.config.benchmark_config.length;
+            let fiber = tokio::task::spawn(async move {
+                let start = SystemTime::now();
+                context_clone
+                    .deps
+                    .invoke_and_await(
+                        &worker_id_clone,
+                        "sleep-for",
+                        vec![Value::F64(10.0)],
+                    )
+                    .await
+                    .expect("invoke_and_await failed");
+                let elapsed = start.elapsed().expect("SystemTime elapsed failed");
+                recorder_clone.duration(&"invocation".to_string(), elapsed);
+                recorder_clone.duration(&format!("worker-{n}"), elapsed);
+            });
+            fibers.push(fiber);
+        }
+
+        for fiber in fibers {
+            fiber.await.expect("fiber failed");
+        }
+    }
+
+    async fn cleanup_iteration(&self, context: Self::IterationContext) {
+        context.deps.kill_all();
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let params = CliParams::parse();
+    CliTestDependencies::init_logging(&params);
+    let result = InvokeWorkerLatency::run_benchmark(params).await;
+    println!("{}", result);
+}


### PR DESCRIPTION
fixes: #384

```sh 
./target/debug/benchmark_suspend_worker --length 3 spawned
```

result
```
Results for 'worker-7':
Duration:
  Avg: 10.036015666s
  Min: 10.031044s
  Max: 10.03895s
Results for 'worker-3':
Duration:
  Avg: 10.035762222s
  Min: 10.032683s
  Max: 10.037873s
Results for 'worker-1':
Duration:
  Avg: 10.036104666s
  Min: 10.031829s
  Max: 10.039348s
Results for 'worker-5':
Duration:
  Avg: 10.035954666s
  Min: 10.029747s
  Max: 10.046311s
Results for 'worker-0':
Duration:
  Avg: 10.035976888s
  Min: 10.031721s
  Max: 10.03879s
Results for 'worker-8':
Duration:
  Avg: 10.035595222s
  Min: 10.030308s
  Max: 10.038076s
Results for 'worker-9':
Duration:
  Avg: 10.036201333s
  Min: 10.032083s
  Max: 10.039173s
Results for 'worker-4':
Duration:
  Avg: 10.035727666s
  Min: 10.03134s
  Max: 10.038s
Results for 'worker-2':
Duration:
  Avg: 10.035879555s
  Min: 10.032827s
  Max: 10.038473s
Results for 'invocation':
Duration:
  Avg: 10.035944966s
  Min: 10.029747s
  Max: 10.046311s
Results for 'worker-6':
Duration:
  Avg: 10.036231777s
  Min: 10.031208s
  Max: 10.039941s
```

```
./target/debug/benchmark_suspend_worker --length 3 minikube --namespace bench
```
result
```
Results for 'worker-3':
Duration:
  Avg: 10.048397555s
  Min: 10.022889s
  Max: 10.110327s
Results for 'worker-7':
Duration:
  Avg: 10.039464666s
  Min: 10.02599s
  Max: 10.075385s
Results for 'worker-4':
Duration:
  Avg: 10.048867555s
  Min: 10.024189s
  Max: 10.121513s
Results for 'worker-1':
Duration:
  Avg: 10.045283777s
  Min: 10.025162s
  Max: 10.080743s
Results for 'worker-5':
Duration:
  Avg: 10.066041333s
  Min: 10.026313s
  Max: 10.110272s
Results for 'invocation':
Duration:
  Avg: 10.0513808s
  Min: 10.021377s
  Max: 10.131838s
Results for 'worker-0':
Duration:
  Avg: 10.044772888s
  Min: 10.026916s
  Max: 10.078585s
Results for 'worker-9':
Duration:
  Avg: 10.045343s
  Min: 10.025903s
  Max: 10.078391s
Results for 'worker-2':
Duration:
  Avg: 10.066876333s
  Min: 10.021377s
  Max: 10.131838s
Results for 'worker-6':
Duration:
  Avg: 10.054322888s
  Min: 10.027499s
  Max: 10.108621s
Results for 'worker-8':
Duration:
  Avg: 10.054438s
  Min: 10.028355s
  Max: 10.110242s
```
