### PR TITLE
golem-cli component get

### DIFF
--- a/golem-cli/src/component.rs
+++ b/golem-cli/src/component.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 
 use crate::clients::component::ComponentClient;
 use crate::model::component::ComponentView;
-use crate::model::text::{ComponentAddView, ComponentUpdateView};
+use crate::model::text::{ComponentAddView, ComponentGetView, ComponentUpdateView};
 use crate::model::{
     ComponentId, ComponentIdOrName, ComponentName, GolemError, GolemResult, PathBufOrStdin,
 };
@@ -133,7 +133,7 @@ impl<C: ComponentClient + Send + Sync> ComponentHandler for ComponentHandlerLive
                     None => self.get_latest_metadata(&component_id).await?,
                 };
                 let view: ComponentView = component.into();
-                Ok(GolemResult::Ok(Box::new(vec![view])))
+                Ok(GolemResult::Ok(Box::new(ComponentGetView(view))))
             }
         }
     }

--- a/golem-cli/src/model/text.rs
+++ b/golem-cli/src/model/text.rs
@@ -213,6 +213,29 @@ impl TextFormat for ComponentUpdateView {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentGetView(pub ComponentView);
+
+impl TextFormat for ComponentGetView {
+    fn print(&self) {
+        printdoc!(
+            "
+            Component with ID {}. Version: {}. Component size is {} bytes.
+            Component name: {}.
+            Exports:
+            ",
+            self.0.component_id,
+            self.0.component_version,
+            self.0.component_size,
+            self.0.component_name
+        );
+
+        for export in &self.0.exports {
+            println!("\t{export}")
+        }
+    }
+}
+
 #[derive(Table)]
 struct ComponentListView {
     #[table(title = "ID")]

--- a/golem-cli/tests/component.rs
+++ b/golem-cli/tests/component.rs
@@ -1,6 +1,5 @@
 use crate::cli::{Cli, CliLive};
 use golem_cli::model::component::ComponentView;
-use golem_cli::model::text::ComponentGetView;
 use golem_test_framework::config::TestDependencies;
 use libtest_mimic::{Failed, Trial};
 use std::sync::Arc;
@@ -148,7 +147,7 @@ fn component_add_and_get(
         CliLive,
     ),
 ) -> Result<(), Failed> {
-    let component_name = format!("{name} component add and find by name");
+    let component_name = format!("{name} component add and get");
     let env_service = deps.component_directory().join("environment-service.wasm");
     let cfg = &cli.config;
     let component: ComponentView = cli.run(&[
@@ -158,12 +157,12 @@ fn component_add_and_get(
         &component_name,
         env_service.to_str().unwrap(),
     ])?;
-    let res: ComponentGetView = cli.run(&[
+    let res: ComponentView = cli.run(&[
         "component",
         "get",
         &cfg.arg('c', "component-name"),
         &component_name,
     ])?;
-    assert!(res.0 == component, "{res:?} = ({component:?})");
+    assert!(res == component, "{res:?} = ({component:?})");
     Ok(())
 }

--- a/golem-cli/tests/text.rs
+++ b/golem-cli/tests/text.rs
@@ -240,7 +240,7 @@ fn text_component_get(
         env_service.to_str().unwrap(),
     ])?;
 
-    let update_res = cli.with_format(Format::Text).run_string(&[
+    let get_res = cli.with_format(Format::Text).run_string(&[
         "component",
         "get",
         &cfg.arg('C', "component-id"),
@@ -248,7 +248,7 @@ fn text_component_get(
         env_service.to_str().unwrap(),
     ])?;
 
-    let lines = update_res.lines().collect::<Vec<_>>();
+    let lines = get_res.lines().collect::<Vec<_>>();
 
     assert_eq!(
         *lines.first().unwrap(),

--- a/golem-cli/tests/text.rs
+++ b/golem-cli/tests/text.rs
@@ -31,6 +31,11 @@ fn make(
             text_component_update,
         ),
         Trial::test_in_context(
+            format!("text_component_get{suffix}"),
+            ctx.clone(),
+            text_component_get,
+        ),
+        Trial::test_in_context(
             format!("text_component_list{suffix}"),
             ctx.clone(),
             text_component_list,
@@ -197,6 +202,58 @@ fn text_component_update(
         *lines.first().unwrap(),
         format!(
             "Updated component with ID {}. New version: 1. Component size is 72309 bytes.",
+            component.component_id
+        )
+    );
+    assert_eq!(
+        *lines.get(1).unwrap(),
+        format!("Component name: {component_name}.")
+    );
+    assert_eq!(*lines.get(2).unwrap(), "Exports:");
+    assert_eq!(
+        *lines.get(3).unwrap(),
+        "\tgolem:it/api/get-environment() -> result<list<tuple<string, string>>, string>"
+    );
+    assert_eq!(
+        *lines.get(4).unwrap(),
+        "\tgolem:it/api/get-arguments() -> result<list<string>, string>"
+    );
+
+    Ok(())
+}
+
+fn text_component_get(
+    (deps, name, cli): (
+        Arc<dyn TestDependencies + Send + Sync + 'static>,
+        String,
+        CliLive,
+    ),
+) -> Result<(), Failed> {
+    let component_name = format!("{name} text component get");
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        &component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let update_res = cli.with_format(Format::Text).run_string(&[
+        "component",
+        "get",
+        &cfg.arg('C', "component-id"),
+        &component.component_id,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let lines = update_res.lines().collect::<Vec<_>>();
+
+    assert_eq!(
+        *lines.first().unwrap(),
+        format!(
+            "Component with ID {}. Version: 1. Component size is 72309 bytes.",
             component.component_id
         )
     );

--- a/golem-cli/tests/text.rs
+++ b/golem-cli/tests/text.rs
@@ -243,9 +243,8 @@ fn text_component_get(
     let get_res = cli.with_format(Format::Text).run_string(&[
         "component",
         "get",
-        &cfg.arg('C', "component-id"),
-        &component.component_id,
-        env_service.to_str().unwrap(),
+        &cfg.arg('c', "component-name"),
+        &component_name,
     ])?;
 
     let lines = get_res.lines().collect::<Vec<_>>();
@@ -253,7 +252,7 @@ fn text_component_get(
     assert_eq!(
         *lines.first().unwrap(),
         format!(
-            "Component with ID {}. Version: 1. Component size is 72309 bytes.",
+            "Component with ID {}. Version: 0. Component size is 72309 bytes.",
             component.component_id
         )
     );


### PR DESCRIPTION
fixes: #487 


```
% golem-cli component -h
Upload and manage Golem components

Usage: golem-cli component [OPTIONS] <COMMAND>

Commands:
  add     Creates a new component with a given name by uploading the component WASM
  update  Updates an existing component by uploading a new version of its WASM
  list    Lists the existing components
  get     Get component
  help    Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Increase logging verbosity
  -q, --quiet...    Decrease logging verbosity
  -h, --help        Print help
% golem-cli component get --component-id 78b55b39-7f62-4c20-90e2-9e5f27c6f7a5
Component with ID 78b55b39-7f62-4c20-90e2-9e5f27c6f7a5. Version: 2. Component size is 117009 bytes.
Component name: cart.
Exports:
	golem:it/api/initialize-cart(user-id: string)
	golem:it/api/add-item(item: record { product-id: string, name: string, price: float32, quantity: u32 })
	golem:it/api/remove-item(product-id: string)
	golem:it/api/update-item-quantity(product-id: string, quantity: u32)
	golem:it/api/checkout() -> variant { error(string), success(record { order-id: string }) }
	golem:it/api/get-cart-contents() -> list<record { product-id: string, name: string, price: float32, quantity: u32 }>
	golem:it/api/not-durable()
% golem-cli component get --component-id 78b55b39-7f62-4c20-90e2-9e5f27c6f7a5 -t 1
Component with ID 78b55b39-7f62-4c20-90e2-9e5f27c6f7a5. Version: 1. Component size is 117009 bytes.
Component name: cart.
Exports:
	golem:it/api/initialize-cart(user-id: string)
	golem:it/api/add-item(item: record { product-id: string, name: string, price: float32, quantity: u32 })
	golem:it/api/remove-item(product-id: string)
	golem:it/api/update-item-quantity(product-id: string, quantity: u32)
	golem:it/api/checkout() -> variant { error(string), success(record { order-id: string }) }
	golem:it/api/get-cart-contents() -> list<record { product-id: string, name: string, price: float32, quantity: u32 }>
	golem:it/api/not-durable()
% golem-cli component get --component-id 78b55b39-7f62-4c20-90e2-9e5f27c6f7a5 --help
Get component

Usage: golem-cli component get [OPTIONS] --component-id <COMPONENT_ID> --component-name <COMPONENT_NAME>

Options:
  -C, --component-id <COMPONENT_ID>
  -v, --verbose...                       Increase logging verbosity
  -c, --component-name <COMPONENT_NAME>
  -q, --quiet...                         Decrease logging verbosity
  -t, --version <VERSION>                The version of the component
  -h, --help                             Print help
```