### PR TITLE
bench - component-compilation-disabled

### DIFF
--- a/golem-test-framework/src/components/component_service/docker.rs
+++ b/golem-test-framework/src/components/component_service/docker.rs
@@ -34,8 +34,7 @@ impl DockerComponentService {
     const GRPC_PORT: u16 = 9091;
 
     pub fn new(
-        component_compilation_service_host: &str,
-        component_compilation_service_port: u16,
+        component_compilation_service: Option<(&str, u16)>,
         rdb: Arc<dyn Rdb + Send + Sync + 'static>,
         verbosity: Level,
     ) -> Self {
@@ -44,8 +43,7 @@ impl DockerComponentService {
         let env_vars = env_vars(
             Self::HTTP_PORT,
             Self::GRPC_PORT,
-            component_compilation_service_host,
-            component_compilation_service_port,
+            component_compilation_service,
             rdb,
             verbosity,
         );

--- a/golem-test-framework/src/components/component_service/k8s.rs
+++ b/golem-test-framework/src/components/component_service/k8s.rs
@@ -47,8 +47,7 @@ impl K8sComponentService {
         namespace: &K8sNamespace,
         routing_type: &K8sRoutingType,
         verbosity: Level,
-        component_compilation_service_host: &str,
-        component_compilation_service_port: u16,
+        component_compilation_service: Option<(&str, u16)>,
         rdb: Arc<dyn Rdb + Send + Sync + 'static>,
         timeout: Duration,
         service_annotations: Option<std::collections::BTreeMap<String, String>>,
@@ -58,8 +57,7 @@ impl K8sComponentService {
         let env_vars = env_vars(
             Self::HTTP_PORT,
             Self::GRPC_PORT,
-            component_compilation_service_host,
-            component_compilation_service_port,
+            component_compilation_service,
             rdb,
             verbosity,
         );

--- a/golem-test-framework/src/components/component_service/mod.rs
+++ b/golem-test-framework/src/components/component_service/mod.rs
@@ -312,8 +312,7 @@ async fn wait_for_startup(host: &str, grpc_port: u16, timeout: Duration) {
 fn env_vars(
     http_port: u16,
     grpc_port: u16,
-    component_compilation_service_host: &str,
-    component_compilation_service_port: u16,
+    component_compilation_service: Option<(&str, u16)>,
     rdb: Arc<dyn Rdb + Send + Sync + 'static>,
     verbosity: Level,
 ) -> HashMap<String, String> {
@@ -321,9 +320,6 @@ fn env_vars(
     let vars: &[(&str, &str)] = &[
         ("RUST_LOG"                     , &format!("{log_level},cranelift_codegen=warn,wasmtime_cranelift=warn,wasmtime_jit=warn,h2=warn,hyper=warn,tower=warn")),
         ("RUST_BACKTRACE"               , "1"),
-        ("GOLEM__COMPILATION__TYPE", "Enabled"),
-        ("GOLEM__COMPILATION__CONFIG__HOST", component_compilation_service_host),
-        ("GOLEM__COMPILATION__CONFIG__PORT", &component_compilation_service_port.to_string()),
         ("GOLEM__COMPONENT_STORE__TYPE", "Local"),
         ("GOLEM__COMPONENT_STORE__CONFIG__OBJECT_PREFIX", ""),
         ("GOLEM__COMPONENT_STORE__CONFIG__ROOT_PATH", "/tmp/ittest-local-object-store/golem"),
@@ -333,6 +329,30 @@ fn env_vars(
 
     let mut vars: HashMap<String, String> =
         HashMap::from_iter(vars.iter().map(|(k, v)| (k.to_string(), v.to_string())));
+
+    match component_compilation_service {
+        Some((host, port)) => {
+            vars.insert(
+                "GOLEM__COMPILATION__TYPE".to_string(),
+                "Enabled".to_string(),
+            );
+            vars.insert(
+                "GOLEM__COMPILATION__CONFIG__HOST".to_string(),
+                host.to_string(),
+            );
+            vars.insert(
+                "GOLEM__COMPILATION__CONFIG__PORT".to_string(),
+                port.to_string(),
+            );
+        }
+        _ => {
+            vars.insert(
+                "GOLEM__COMPILATION__TYPE".to_string(),
+                "Disabled".to_string(),
+            );
+        }
+    };
+
     vars.extend(rdb.info().env().clone());
     vars
 }

--- a/golem-test-framework/src/components/component_service/spawned.rs
+++ b/golem-test-framework/src/components/component_service/spawned.rs
@@ -38,7 +38,7 @@ impl SpawnedComponentService {
         working_directory: &Path,
         http_port: u16,
         grpc_port: u16,
-        component_compilation_service_port: u16,
+        component_compilation_service_port: Option<u16>,
         rdb: Arc<dyn Rdb + Send + Sync + 'static>,
         verbosity: Level,
         out_level: Level,
@@ -55,8 +55,7 @@ impl SpawnedComponentService {
             .envs(env_vars(
                 http_port,
                 grpc_port,
-                "localhost",
-                component_compilation_service_port,
+                component_compilation_service_port.map(|p| ("localhost", p)),
                 rdb,
                 verbosity,
             ))

--- a/golem-test-framework/src/config/cli.rs
+++ b/golem-test-framework/src/config/cli.rs
@@ -280,6 +280,30 @@ pub enum TestMode {
     },
 }
 
+impl TestMode {
+    pub fn component_compilation_disabled(&self) -> bool {
+        match self {
+            TestMode::Provided { .. } => false,
+            TestMode::Docker {
+                component_compilation_disabled,
+                ..
+            } => *component_compilation_disabled,
+            TestMode::Minikube {
+                component_compilation_disabled,
+                ..
+            } => *component_compilation_disabled,
+            TestMode::Aws {
+                component_compilation_disabled,
+                ..
+            } => *component_compilation_disabled,
+            TestMode::Spawned {
+                component_compilation_disabled,
+                ..
+            } => *component_compilation_disabled,
+        }
+    }
+}
+
 impl CliTestDependencies {
     pub fn init_logging(params: &CliParams) {
         let ansi_layer = tracing_subscriber::fmt::layer()

--- a/golem-test-framework/src/config/env.rs
+++ b/golem-test-framework/src/config/env.rs
@@ -136,8 +136,10 @@ impl EnvBasedTestDependencies {
             let component_service: Arc<dyn ComponentService + Send + Sync + 'static> =
                 if Self::use_docker() {
                     Arc::new(DockerComponentService::new(
-                        DockerComponentCompilationService::NAME,
-                        DockerComponentCompilationService::GRPC_PORT,
+                        Some((
+                            DockerComponentCompilationService::NAME,
+                            DockerComponentCompilationService::GRPC_PORT,
+                        )),
                         rdb.clone(),
                         Self::default_verbosity(),
                     ))
@@ -148,7 +150,7 @@ impl EnvBasedTestDependencies {
                             Path::new("../golem-component-service"),
                             8081,
                             9091,
-                            9094,
+                            Some(9094),
                             rdb.clone(),
                             Self::default_verbosity(),
                             Self::default_stdout_level(),

--- a/integration-tests/src/benchmarks/cold_start_medium.rs
+++ b/integration-tests/src/benchmarks/cold_start_medium.rs
@@ -24,6 +24,7 @@ use integration_tests::benchmarks::{
 
 struct ColdStartEchoMedium {
     config: RunConfig,
+    params: CliParams,
 }
 
 #[async_trait]
@@ -46,8 +47,8 @@ impl Benchmark for ColdStartEchoMedium {
         benchmark_context.deps.kill_all()
     }
 
-    async fn create(_params: CliParams, config: RunConfig) -> Self {
-        Self { config }
+    async fn create(params: CliParams, config: RunConfig) -> Self {
+        Self { config, params }
     }
 
     async fn setup_iteration(
@@ -62,13 +63,15 @@ impl Benchmark for ColdStartEchoMedium {
         benchmark_context: &Self::BenchmarkContext,
         context: &Self::IterationContext,
     ) {
-        // warmup with other workers
-        if let Some(WorkerId { component_id, .. }) = context.worker_ids.clone().first() {
-            start(
-                get_worker_ids(context.worker_ids.len(), component_id, "warmup-worker"),
-                benchmark_context.deps.clone(),
-            )
-            .await
+        if !self.params.mode.component_compilation_disabled() {
+            // warmup with other workers
+            if let Some(WorkerId { component_id, .. }) = context.worker_ids.clone().first() {
+                start(
+                    get_worker_ids(context.worker_ids.len(), component_id, "warmup-worker"),
+                    benchmark_context.deps.clone(),
+                )
+                .await
+            }
         }
     }
 

--- a/integration-tests/src/benchmarks/cold_start_small.rs
+++ b/integration-tests/src/benchmarks/cold_start_small.rs
@@ -24,6 +24,7 @@ use integration_tests::benchmarks::{
 
 struct ColdStartEchoSmall {
     config: RunConfig,
+    params: CliParams,
 }
 
 #[async_trait]
@@ -46,8 +47,8 @@ impl Benchmark for ColdStartEchoSmall {
         benchmark_context.deps.kill_all()
     }
 
-    async fn create(_params: CliParams, config: RunConfig) -> Self {
-        Self { config }
+    async fn create(params: CliParams, config: RunConfig) -> Self {
+        Self { config, params }
     }
 
     async fn setup_iteration(
@@ -62,13 +63,15 @@ impl Benchmark for ColdStartEchoSmall {
         benchmark_context: &Self::BenchmarkContext,
         context: &Self::IterationContext,
     ) {
-        // warmup with other workers
-        if let Some(WorkerId { component_id, .. }) = context.worker_ids.clone().first() {
-            start(
-                get_worker_ids(context.worker_ids.len(), component_id, "warmup-worker"),
-                benchmark_context.deps.clone(),
-            )
-            .await
+        if !self.params.mode.component_compilation_disabled() {
+            // warmup with other workers
+            if let Some(WorkerId { component_id, .. }) = context.worker_ids.clone().first() {
+                start(
+                    get_worker_ids(context.worker_ids.len(), component_id, "warmup-worker"),
+                    benchmark_context.deps.clone(),
+                )
+                .await
+            }
         }
     }
 

--- a/integration-tests/src/benchmarks/mod.rs
+++ b/integration-tests/src/benchmarks/mod.rs
@@ -75,7 +75,7 @@ pub async fn start(worker_ids: Vec<WorkerId>, deps: CliTestDependencies) {
 
 pub async fn setup_benchmark(params: CliParams, cluster_size: usize) -> BenchmarkContext {
     // Initialize infrastructure
-    let deps = CliTestDependencies::new(params.clone(), cluster_size).await;
+    let deps = CliTestDependencies::new(params.clone(), cluster_size, true).await;
 
     BenchmarkContext { deps }
 }

--- a/integration-tests/src/benchmarks/mod.rs
+++ b/integration-tests/src/benchmarks/mod.rs
@@ -75,7 +75,7 @@ pub async fn start(worker_ids: Vec<WorkerId>, deps: CliTestDependencies) {
 
 pub async fn setup_benchmark(params: CliParams, cluster_size: usize) -> BenchmarkContext {
     // Initialize infrastructure
-    let deps = CliTestDependencies::new(params.clone(), cluster_size, true).await;
+    let deps = CliTestDependencies::new(params.clone(), cluster_size).await;
 
     BenchmarkContext { deps }
 }


### PR DESCRIPTION
fixes: #381 

```
./target/debug/benchmark_cold_start_large --length 3  spawned --component-compilation-disabled
```

```
Results for 'invocation':
Duration:
  Avg: 71.051333033s
  Min: 70.671997s
  Max: 71.675313s
Results for 'worker-0':
Duration:
  Avg: 71.050806333s
  Min: 70.674088s
  Max: 71.674405s
Results for 'worker-1':
Duration:
  Avg: 71.054380333s
  Min: 70.674286s
  Max: 71.673069s
Results for 'worker-2':
Duration:
  Avg: 71.048819333s
  Min: 70.674116s
  Max: 71.673054s
Results for 'worker-3':
Duration:
  Avg: 71.047746333s
  Min: 70.673957s
  Max: 71.672844s
Results for 'worker-4':
Duration:
  Avg: 71.054834s
  Min: 70.673949s
  Max: 71.673285s
Results for 'worker-5':
Duration:
  Avg: 71.056509666s
  Min: 70.67404s
  Max: 71.675313s
Results for 'worker-6':
Duration:
  Avg: 71.0505s
  Min: 70.673959s
  Max: 71.674384s
Results for 'worker-7':
Duration:
  Avg: 71.049962666s
  Min: 70.673985s
  Max: 71.674395s
Results for 'worker-8':
Duration:
  Avg: 71.049907333s
  Min: 70.673219s
  Max: 71.672741s
Results for 'worker-9':
Duration:
  Avg: 71.049864333s
  Min: 70.671997s
  Max: 71.672143s
```

```
./target/debug/benchmark_cold_start_large --length 3  spawned
```

```
Results for 'invocation':
Duration:
  Avg: 331.923833ms
  Min: 112.219ms
  Max: 454.711ms
Results for 'worker-0':
Duration:
  Avg: 337.124333ms
  Min: 227.459ms
  Max: 451.013ms
Results for 'worker-1':
Duration:
  Avg: 342.133666ms
  Min: 229.632ms
  Max: 451.662ms
Results for 'worker-2':
Duration:
  Avg: 346.044666ms
  Min: 232.381ms
  Max: 452.317ms
Results for 'worker-3':
Duration:
  Avg: 339.024333ms
  Min: 227.71ms
  Max: 441.789ms
Results for 'worker-4':
Duration:
  Avg: 342.577ms
  Min: 231.946ms
  Max: 454.711ms
Results for 'worker-5':
Duration:
  Avg: 342.96ms
  Min: 228.802ms
  Max: 446.069ms
Results for 'worker-6':
Duration:
  Avg: 344.971333ms
  Min: 231.93ms
  Max: 453.775ms
Results for 'worker-7':
Duration:
  Avg: 346.204333ms
  Min: 229.722ms
  Max: 449.532ms
Results for 'worker-8':
Duration:
  Avg: 341.894ms
  Min: 226.824ms
  Max: 453.193ms
Results for 'worker-9':
Duration:
  Avg: 236.304666ms
  Min: 112.219ms
  Max: 365.387ms
```