### PR TITLE
cargo make run task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ test-components/tinygo-wasi*/tinygo_wasi/
 golem-client/*
 !golem-client/Cargo.toml
 !golem-client/build.rs
+logs
+data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,31 +7,46 @@ cargo install --force cargo-make
 ```
 
 runs all unit tests, worker executor tests and integration tests
+
 ```shell
 cargo make test
 ```
 
 runs unit tests only
+
 ```shell
 cargo make unit-tests
 ```
 
 runs worker executor tests only
+
 ```shell
 cargo make integration-tests
 ```
 
 runs CLI tests only
+
 ```shell
 cargo make cli-tests
 ```
 
 runs sharding integration tests only
+
 ```shell
 cargo make sharding-tests
 ```
 
-## Local Testing
+## Starting all services locally
+
+There is a simple `cargo make run` task that starts all the debug executables of the services locally, using the default configuration. The prerequisites are:
+
+- `nginx` installed (on OSX can be installed with `brew install nginx`)
+- `redis` installed (on OSX can be installed with `brew install redis`)
+- `lnav` installed (on OSX can be installed with `brew install lnav`)
+
+The `cargo make run` command will start all the services and show a unified view of the logs using `lnav`. Quitting `lnav` kills the spawned processes.
+
+## Local Testing using Docker containers
 
 To spin up services using the latest code
 
@@ -45,6 +60,7 @@ cargo build --release --target x86_64-unknown-linux-gnu
 
 docker-compose -f docker-compose-sqlite.yaml up --build
 ```
+
 To start the service without a rebuild
 
 ```bash
@@ -90,6 +106,7 @@ Make sure to do `docker-compose pull` next time to make sure you are pulling the
 ### Cargo Build
 
 ### MAC
+
 If you are running ` cargo build --target ARCH-unknown-linux-gnu` (cross compiling to Linux) from MAC, you may encounter
 some missing dependencies. If interested, refer, https://github.com/messense/homebrew-macos-cross-toolchains
 
@@ -101,7 +118,7 @@ Typically, the following should allow you to run it successfully.
 brew tap messense/macos-cross-toolchains
 brew install messense/macos-cross-toolchains/x86_64-unknown-linux-gnu
 # If openssl is not in system
-# brew install openssl 
+# brew install openssl
 export OPENSSL_DIR=$(brew --prefix openssl)
 export CC_X86_64_UNKNOWN_LINUX_GNU=x86_64-unknown-linux-gnu-gcc
 export CXX_X86_64_UNKNOWN_LINUX_GNU=x86_64-unknown-linux-gnu-g++
@@ -128,7 +145,7 @@ Typically, the following should allow you to run it successfully.
 brew tap messense/macos-cross-toolchains
 brew install aarch64-unknown-linux-gnu
 # If openssl is not in system
-# brew install openssl 
+# brew install openssl
 export OPENSSL_DIR=$(brew --prefix openssl)
 export CC_AARCH64_UNKNOWN_LINUX_GNU=aarch64-unknown-linux-gnu-gcc
 export CXX_AARCH64_UNKNOWN_LINUX_GNU=aarch64-unknown-linux-gnu-g++

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,6 +14,7 @@
 # - `cargo make check-openapi`: generates openapi spec from the code and checks if it is the same as the one in the openapi directory (for CI)
 # - `cargo make generate-openapi`: generates openapi spec from the code and saves it to the openapi directory
 # - `cargo make publish`: publishes packages to crates.io
+# - `cargo make run`: runs all services locally, requires redis, lnav and nginx
 
 [config]
 default_to_workspace = false # by default, we run cargo commands on top level instead of per member
@@ -451,3 +452,69 @@ condition = { env = { "PLATFORM_OVERRIDE" = "linux/arm64" } }
 env = { "PLATFORM_TARGET" = "aarch64-unknown-linux-gnu" }
 extend = "package-release-base"
 dependencies = ["build-release-override-linux-arm64"]
+
+[tasks.run]
+description = "Runs all the services locally"
+dependencies = ["build"]
+
+condition = { fail_message = "Requires lnav, nginx and redis on path. Install them with your package manager." }
+condition_script = ["nginx -v", "lnav --version", "redis-server --version"]
+
+script = '''
+mkdir -pv logs
+
+redis-server --port 6380 --save "" --appendonly no &> logs/redis.log &
+redis_pid=$!
+
+export RUST_BACKTRACE=1
+
+pushd golem-shard-manager || exit
+RUST_LOG=info,h2=warn,hyper=warn,tower=warn GOLEM_SHARD_MANAGER_PORT=9002 ../target/debug/golem-shard-manager &> ../logs/shard-manager.log &
+shard_manager_pid=$!
+popd || exit
+
+pushd golem-component-compilation-service || exit
+RUST_LOG=info,h2=warn,hyper=warn,tower=warn ../target/debug/golem-component-compilation-service &> ../logs/component-compilation-service.log &
+component_compilation_service_pid=$!
+popd || exit
+
+pushd golem-component-service || exit
+RUST_LOG=info,h2=warn,hyper=warn,tower=warn ../target/debug/golem-component-service &> ../logs/component-service.log &
+component_service_pid=$!
+popd || exit
+
+pushd golem-worker-service || exit
+RUST_LOG=info,h2=warn,hyper=warn,tower=warn ../target/debug/golem-worker-service &> ../logs/worker-service.log &
+worker_service_pid=$!
+popd || exit
+
+pushd golem-worker-executor || exit
+RUST_LOG=info ../target/debug/worker-executor &> ../logs/worker-executor.log &
+worker_executor_pid=$!
+popd || exit
+
+nginx -c $CARGO_MAKE_WORKING_DIRECTORY/golem-router/golem-services.local.conf &> logs/nginx.log &
+router_pid=$!
+
+echo "Started services"
+echo " - worker executor:               $worker_executor_pid"
+echo " - worker service:                $worker_service_pid"
+echo " - component service:             $component_service_pid"
+echo " - component compilation service: $component_compilation_service_pid"
+echo " - shard manager:                 $shard_manager_pid"
+echo " - router:                        $router_pid"
+echo " - redis:                         $redis_pid"
+echo ""
+echo "Kill all manually:"
+echo "kill -9 $worker_executor_pid $worker_service_pid $component_service_pid $component_compilation_service_pid $shard_manager_pid $router_pid $redis_pid"
+
+lnav logs
+
+kill $worker_executor_pid || true
+kill $worker_service_pid || true
+kill $component_service_pid || true
+kill $component_compilation_service_pid || true
+kill $shard_manager_pid || true
+kill $router_pid || true
+kill $redis_pid || true
+'''

--- a/golem-component-compilation-service/config/component-compilation-service.toml
+++ b/golem-component-compilation-service/config/component-compilation-service.toml
@@ -2,10 +2,15 @@ enable_tracing_console = false
 enable_json_log = false
 
 grpc_host = "0.0.0.0"
-grpc_port = 9090
+grpc_port = 9091
 
-http_host= "0.0.0.0"
-http_port = 8080
+http_host = "0.0.0.0"
+http_port = 8084
+
+[component_service]
+host = "localhost"
+port = 9090
+access_token = "5C832D93-FF85-4A8F-9803-513950FDFDB1"
 
 [component_service.retries]
 max_attempts = 3
@@ -14,11 +19,12 @@ max_delay = "1s"
 multiplier = 3
 
 [blob_storage]
-type = "S3"
+type = "LocalFileSystem"
 
 [blob_storage.config]
-# region
-# aws_endpoint_url
+root = "../data/blob_storage"
+
+# defaults for S3 mode
 object_prefix = ""
 compilation_cache_bucket = "compilation-cache"
 custom_data_bucket = "custom-data"
@@ -32,6 +38,7 @@ multiplier = 3
 
 [compiled_component_service]
 type = "Enabled"
+
 [compiled_component_service.config]
 
 [upload_worker]

--- a/golem-component-compilation-service/src/config.rs
+++ b/golem-component-compilation-service/src/config.rs
@@ -101,23 +101,5 @@ impl ServerConfig {
 
 #[test]
 fn config_load() {
-    std::env::set_var("GOLEM__COMPONENT_SERVICE__HOST", "0.0.0.0");
-    std::env::set_var("GOLEM__COMPONENT_SERVICE__PORT", "9001");
-    std::env::set_var(
-        "GOLEM__COMPONENT_SERVICE__ACCESS_TOKEN",
-        "6778f06f-43ac-4e45-b501-6adb3253edf2",
-    );
-
-    std::env::set_var("GOLEM__BLOB_STORAGE__CONFIG__REGION", "us-east-1");
-    std::env::set_var(
-        "GOLEM__BLOB_STORAGE__CONFIG__COMPILATION_CACHE_BUCKET",
-        "golem-compiled-components",
-    );
-    std::env::set_var(
-        "GOLEM__BLOB_STORAGE__CONFIG__CUSTOM_DATA_BUCKET",
-        "golem-custom-data",
-    );
-    std::env::set_var("GOLEM__BLOB_STORAGE__CONFIG__OBJECT_PREFIX", "");
-
     let _ = ServerConfig::new();
 }

--- a/golem-component-service/config/component-service.toml
+++ b/golem-component-service/config/component-service.toml
@@ -1,28 +1,35 @@
 enable_tracing_console = false
 enable_json_log = false
 
-http_port = 8081
-grpc_port = 9091
+http_port = 8083
+grpc_port = 9090
 
 [db]
 type = "Sqlite"
 
 [db.config]
 max_connections = 10
-host = "localhost"
-port = 5432
-database = "golem"
-#username
-#password
-#schema
+database = "../data/golem.sqlite"
 
 [component_store]
+type = "Local"
+
+[component_store.config]
 object_prefix = ""
+root_path = "../data/component_store"
 
 [worker_executor_client_cache]
 max_capacity = 1000
 time_to_idle = "4h"
 
-
 [compilation]
-type = "Disabled"
+type = "Enabled"
+
+[compilation.config]
+host = "localhost"
+port = 9091
+
+[component_service]
+host = "localhost"
+port = 9090
+access_token = "5C832D93-FF85-4A8F-9803-513950FDFDB1"

--- a/golem-component-service/src/config.rs
+++ b/golem-component-service/src/config.rs
@@ -107,27 +107,6 @@ impl Default for ComponentServiceConfig {
 mod tests {
     #[test]
     pub fn config_is_loadable() {
-        std::env::set_var("GOLEM__DB__TYPE", "Postgres");
-        std::env::set_var("GOLEM__DB__CONFIG__USERNAME", "postgres");
-        std::env::set_var("GOLEM__DB__CONFIG__PASSWORD", "postgres");
-        std::env::set_var("GOLEM__ROUTING_TABLE__HOST", "localhost");
-        std::env::set_var("GOLEM__ROUTING_TABLE__PORT", "1234");
-
-        std::env::set_var("GOLEM__COMPONENT_STORE__TYPE", "Local");
-        std::env::set_var(
-            "GOLEM__COMPONENT_STORE__CONFIG__ROOT_PATH",
-            "component_store",
-        );
-        std::env::set_var("GOLEM__COMPONENT_STORE__CONFIG__OBJECT_PREFIX", "");
-
-        std::env::set_var("GOLEM__COMPILATION__TYPE", "Enabled");
-        std::env::set_var("GOLEM__COMPILATION__CONFIG__HOST", "localhost");
-        std::env::set_var("GOLEM__COMPILATION__CONFIG__PORT", "1234");
-
-        std::env::set_var("GOLEM__HTTP_PORT", "9001");
-        std::env::set_var("GOLEM__GRPC_PORT", "9002");
-
-        // The rest can be loaded from the toml
         let _ = super::ComponentServiceConfig::new();
     }
 }

--- a/golem-router/golem-services.local.conf
+++ b/golem-router/golem-services.local.conf
@@ -1,0 +1,38 @@
+daemon off;
+error_log /dev/stdout info;
+
+events {
+}
+
+http {
+    access_log /dev/stdout;
+    client_max_body_size 52428800; # Increase this especially if your component size is higher than this
+
+    server {
+        listen 9881;
+        server_name localhost;
+
+        location ~ /v2/components/[^/]+/workers/[^/]+/connect$ {
+            proxy_pass http://localhost:9005;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade "websocket";
+            proxy_set_header Connection "upgrade";
+        }
+
+        location /v1/api {
+            proxy_pass http://localhost:9005;
+        }
+
+        location ~ /v2/components/[^/]+/workers(.*)$ {
+            proxy_pass http://localhost:9005;
+        }
+
+        location /v2/components {
+            proxy_pass http://localhost:8083;
+        }
+
+        location / {
+            proxy_pass http://localhost:8083;
+        }
+    }
+}

--- a/golem-shard-manager/config/shard-manager.toml
+++ b/golem-shard-manager/config/shard-manager.toml
@@ -1,13 +1,13 @@
 enable_tracing_console = false
 enable_json_log = false
 number_of_shards = 1024
-http_port = 8080
+http_port = 8081
 
 rebalance_threshold = 0.1
 
 [redis]
-# host
-# port
+host = "localhost"
+port = 6380
 database = 0
 tracing = false
 pool_size = 8

--- a/golem-shard-manager/src/shard_manager_config.rs
+++ b/golem-shard-manager/src/shard_manager_config.rs
@@ -72,14 +72,6 @@ pub enum HealthCheckMode {
 mod tests {
     #[test]
     pub fn config_is_loadable() {
-        // The following settings are always coming through environment variables:
-        std::env::set_var("GOLEM__REDIS__HOST", "localhost");
-        std::env::set_var("GOLEM__REDIS__PORT", "1234");
-        std::env::set_var("GOLEM__REDIS__DATABASE", "1");
-        std::env::set_var("GOLEM__ENABLE_JSON_LOG", "true");
-        std::env::set_var("GOLEM__HTTP_PORT", "8080");
-
-        // The rest can be loaded from the toml
         let _ = super::ShardManagerConfig::new();
     }
 }

--- a/golem-worker-executor/config/worker-executor.toml
+++ b/golem-worker-executor/config/worker-executor.toml
@@ -4,12 +4,15 @@ enable_json_log = false
 grpc_address = "0.0.0.0"
 http_address = "0.0.0.0"
 
+http_port = 8082
+port = 9000
+
 [key_value_storage]
 type = "Redis"
 
 [key_value_storage.config]
-# host
-# port
+host = "localhost"
+port = 6380
 database = 0
 tracing = false
 pool_size = 8
@@ -25,9 +28,12 @@ multiplier = 2
 type = "KVStoreRedis"
 
 [blob_storage]
-type = "S3"
+type = "LocalFileSystem"
 
 [blob_storage.config]
+root = "../data/blob_storage"
+
+# S3 defaults
 # region
 # aws_endpoint_url
 object_prefix = ""
@@ -69,10 +75,10 @@ time_to_idle = "12h"
 type = "Grpc"
 
 [component_service.config]
-max_component_size = 52428800 # 50 Mb
-# host
-# port
-# access_token
+max_component_size = 52428800                         # 50 Mb
+host = "localhost"
+port = 9090
+access_token = "2A354594-7A63-4091-A46B-CC58D379F677"
 
 [component_service.config.retries]
 max_attempts = 3
@@ -88,8 +94,8 @@ type = "Enabled"
 type = "Grpc"
 
 [shard_manager_service.config]
-# host
-# port
+host = "localhost"
+port = 9002
 
 [shard_manager_service.config.retries]
 max_attempts = 5
@@ -112,6 +118,6 @@ pending_key_retention = "1m"
 confirm_queue_capacity = 1024
 
 [public_worker_api]
-# host
-# port
-# access_token
+host = "localhost"
+port = 9007
+access_token = "2A354594-7A63-4091-A46B-CC58D379F677"

--- a/golem-worker-executor/src/services/config.rs
+++ b/golem-worker-executor/src/services/config.rs
@@ -20,39 +20,12 @@ mod tests {
 
     #[test]
     pub fn config_is_loadable() {
-        // The following settings are always coming through environment variables:
-        std::env::set_var("GOLEM__KEY_VALUE_STORAGE__CONFIG__HOST", "localhost");
-        std::env::set_var("GOLEM__KEY_VALUE_STORAGE__CONFIG__PORT", "1234");
-        std::env::set_var("GOLEM__KEY_VALUE_STORAGE__CONFIG__DATABASE", "1");
-        std::env::set_var("GOLEM__COMPONENT_SERVICE__CONFIG__HOST", "localhost");
-        std::env::set_var("GOLEM__COMPONENT_SERVICE__CONFIG__PORT", "1234");
-        std::env::set_var("GOLEM__COMPONENT_SERVICE__CONFIG__ACCESS_TOKEN", "token");
-        std::env::set_var("GOLEM__BLOB_STORAGE__CONFIG__REGION", "us-east-1");
-        std::env::set_var(
-            "GOLEM__BLOB_STORAGE__CONFIG__COMPILATION_CACHE_BUCKET",
-            "golem-compiled-components",
-        );
-        std::env::set_var(
-            "GOLEM__BLOB_STORAGE__CONFIG__CUSTOM_DATA_BUCKET",
-            "golem-custom-data",
-        );
-        std::env::set_var("GOLEM__BLOB_STORAGE__CONFIG__OBJECT_PREFIX", "");
-        std::env::set_var("GOLEM__SHARD_MANAGER_SERVICE__CONFIG__HOST", "localhost");
-        std::env::set_var("GOLEM__SHARD_MANAGER_SERVICE__CONFIG__PORT", "4567");
-        std::env::set_var("GOLEM__PUBLIC_WORKER_API__HOST", "localhost");
-        std::env::set_var("GOLEM__PUBLIC_WORKER_API__PORT", "1234");
-        std::env::set_var("GOLEM__PUBLIC_WORKER_API__ACCESS_TOKEN", "token");
-        std::env::set_var("GOLEM__PORT", "1234");
-        std::env::set_var("GOLEM__HTTP_PORT", "1235");
-        std::env::set_var("GOLEM__ENABLE_JSON_LOG", "true");
-
-        // The rest can be loaded from the toml
         let golem_config = GolemConfig::new();
 
         let shard_manager_grpc_port = match &golem_config.shard_manager_service {
             ShardManagerServiceConfig::Grpc(config) => config.port,
             _ => panic!("Expected shard manager service to be grpc"),
         };
-        assert_eq!(shard_manager_grpc_port, 4567);
+        assert_eq!(shard_manager_grpc_port, 9002);
     }
 }

--- a/golem-worker-service/config/worker-service.toml
+++ b/golem-worker-service/config/worker-service.toml
@@ -1,16 +1,16 @@
 enable_tracing_console = false
 enable_json_log = false
 # workspace
-# environment
-port = 9000
-custom_request_port = 9001
-worker_grpc_port = 9092
+environment = "local"
 
+port = 9005
+custom_request_port = 9006
+worker_grpc_port = 9007
 
 [redis]
-# host
-# port
-database = 0
+host = "localhost"
+port = 6380
+database = 1
 tracing = false
 pool_size = 8
 key_prefix = ""
@@ -22,8 +22,9 @@ max_delay = "2s"
 multiplier = 2
 
 [component_service]
-# host
-# port
+host = "localhost"
+port = 9090
+access_token = "5C832D93-FF85-4A8F-9803-513950FDFDB1"
 
 [component_service.retries]
 max_attempts = 3
@@ -36,5 +37,5 @@ max_capacity = 1000
 time_to_idle = "4h"
 
 [routing_table]
-# host
-# port
+host = "localhost"
+port = 9002

--- a/golem-worker-service/src/config.rs
+++ b/golem-worker-service/src/config.rs
@@ -8,25 +8,6 @@ pub fn get_config() -> WorkerServiceBaseConfig {
 mod tests {
     #[test]
     pub fn config_is_loadable() {
-        // The following settings are always coming through environment variables:
-        std::env::set_var("GOLEM__REDIS__HOST", "localhost");
-        std::env::set_var("GOLEM__REDIS__PORT", "1234");
-        std::env::set_var("GOLEM__REDIS__DATABASE", "1");
-        std::env::set_var("GOLEM__ENVIRONMENT", "dev");
-        std::env::set_var("GOLEM__WORKSPACE", "release");
-        std::env::set_var("GOLEM__COMPONENT_SERVICE__HOST", "localhost");
-        std::env::set_var("GOLEM__COMPONENT_SERVICE__PORT", "1234");
-        std::env::set_var("GOLEM__CUSTOM_REQUEST_PORT", "1234");
-        std::env::set_var(
-            "GOLEM__COMPONENT_SERVICE__ACCESS_TOKEN",
-            "5C832D93-FF85-4A8F-9803-513950FDFDB1",
-        );
-        std::env::set_var("GOLEM__ROUTING_TABLE__HOST", "golem-shard-manager");
-        std::env::set_var("GOLEM__ROUTING_TABLE__PORT", "1234");
-
-        // The rest can be loaded from the toml
-        let config = super::get_config();
-
-        println!("config: {:?}", config);
+        let _ = super::get_config();
     }
 }


### PR DESCRIPTION
Resolves #525 

Provides a simple alternative to run all services locally, in a way it is ready to be tested with `golem-cli`. 

`cargo make run` builds and starts all the services, having only 3 external dependencies:

- `redis`
- `nginx`
- `lnav`

On OSX all 3 can be installed by `brew`.

Note: 

I made the service's default configurations, which were previously partial and containing confusing random ports etc, the default configuration for running them locally. This makes it convenient to test things (you can just start all services, then kill one and manually run without having to deal with env vars etc). And in prod / docker the config is overridden anyway.