### PR TITLE
Blob-store based oplog archive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,7 +349,7 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
         run: cargo make worker-executor-tests-${{ matrix.group.name }}
-        timeout-minutes: 20
+        timeout-minutes: 25
   integration-tests:
     runs-on: ubuntu-latest-large
     steps:

--- a/golem-api-grpc/proto/golem/workerexecutor/worker_executor.proto
+++ b/golem-api-grpc/proto/golem/workerexecutor/worker_executor.proto
@@ -25,12 +25,12 @@ service WorkerExecutor {
   rpc InvokeAndAwaitWorker(InvokeAndAwaitWorkerRequest) returns (InvokeAndAwaitWorkerResponse);
   rpc InvokeWorker(InvokeWorkerRequest) returns (InvokeWorkerResponse);
   rpc ConnectWorker(ConnectWorkerRequest) returns (stream golem.worker.LogEvent);
-  rpc DeleteWorker(golem.worker.WorkerId) returns (DeleteWorkerResponse);
+  rpc DeleteWorker(DeleteWorkerRequest) returns (DeleteWorkerResponse);
   rpc CompletePromise(CompletePromiseRequest) returns (CompletePromiseResponse);
   rpc InterruptWorker(InterruptWorkerRequest) returns (InterruptWorkerResponse);
   rpc RevokeShards(RevokeShardsRequest) returns (RevokeShardsResponse);
   rpc AssignShards(AssignShardsRequest) returns (AssignShardsResponse);
-  rpc GetWorkerMetadata(golem.worker.WorkerId) returns (GetWorkerMetadataResponse);
+  rpc GetWorkerMetadata(GetWorkerMetadataRequest) returns (GetWorkerMetadataResponse);
   rpc ResumeWorker(ResumeWorkerRequest) returns (ResumeWorkerResponse);
   rpc GetRunningWorkersMetadata(GetRunningWorkersMetadataRequest) returns (GetRunningWorkersMetadataResponse);
   rpc GetWorkersMetadata(GetWorkersMetadataRequest) returns (GetWorkersMetadataResponse);
@@ -44,6 +44,11 @@ message InvokeWorkerResponse {
   }
 }
 
+message DeleteWorkerRequest {
+  golem.worker.WorkerId worker_id = 1;
+  golem.common.AccountId account_id = 2;
+}
+
 message DeleteWorkerResponse {
   oneof result {
     golem.common.Empty success = 1;
@@ -54,6 +59,7 @@ message DeleteWorkerResponse {
 message CompletePromiseRequest {
   golem.worker.PromiseId promise_id = 1;
   bytes data = 2;
+  golem.common.AccountId account_id = 3;
 }
 
 message CompletePromiseResponse {
@@ -129,6 +135,7 @@ message ConnectWorkerRequest {
 message InterruptWorkerRequest {
   golem.worker.WorkerId worker_id = 1;
   bool recover_immediately = 2;
+  golem.common.AccountId account_id = 3;
 }
 
 message RevokeShardsRequest {
@@ -153,6 +160,11 @@ message AssignShardsResponse {
   }
 }
 
+message GetWorkerMetadataRequest {
+  golem.worker.WorkerId worker_id = 1;
+  golem.common.AccountId account_id = 2;
+}
+
 message GetWorkerMetadataResponse {
   oneof result {
     golem.worker.WorkerMetadata success = 1;
@@ -162,6 +174,7 @@ message GetWorkerMetadataResponse {
 
 message ResumeWorkerRequest {
   golem.worker.WorkerId worker_id = 1;
+  golem.common.AccountId account_id = 2;
 }
 
 message ResumeWorkerResponse {
@@ -194,6 +207,7 @@ message GetWorkersMetadataRequest {
   golem.worker.Cursor cursor = 3;
   uint64 count = 4;
   bool precise = 5;
+  golem.common.AccountId account_id = 6;
 }
 
 message GetWorkersMetadataResponse {
@@ -212,6 +226,7 @@ message UpdateWorkerRequest {
   golem.worker.WorkerId worker_id = 1;
   uint64 target_version = 2;
   golem.worker.UpdateMode mode = 3;
+  golem.common.AccountId account_id = 4;
 }
 
 message UpdateWorkerResponse {

--- a/golem-common/src/model/mod.rs
+++ b/golem-common/src/model/mod.rs
@@ -405,7 +405,7 @@ impl ScheduledAction {
             ScheduledAction::CompletePromise {
                 account_id,
                 promise_id,
-            } => OwnedWorkerId::new(&account_id, &promise_id.worker_id),
+            } => OwnedWorkerId::new(account_id, &promise_id.worker_id),
             ScheduledAction::ArchiveOplog {
                 owned_worker_id, ..
             } => owned_worker_id.clone(),

--- a/golem-component-compilation-service/config/component-compilation-service.toml
+++ b/golem-component-compilation-service/config/component-compilation-service.toml
@@ -29,6 +29,7 @@ object_prefix = ""
 compilation_cache_bucket = "compilation-cache"
 custom_data_bucket = "custom-data"
 oplog_payload_bucket = "oplog-payload"
+compressed_oplog_buckets = ["oplog-archive-1"]
 
 [blob_storage.config.retries]
 max_attempts = 3

--- a/golem-test-framework/src/components/worker_service/forwarding.rs
+++ b/golem-test-framework/src/components/worker_service/forwarding.rs
@@ -124,7 +124,15 @@ impl WorkerService for ForwardingWorkerService {
             .worker_executor
             .client()
             .await
-            .delete_worker(request.worker_id.expect("Worker ID is required"))
+            .delete_worker(workerexecutor::DeleteWorkerRequest {
+                worker_id: request.worker_id,
+                account_id: Some(
+                    AccountId {
+                        value: "test-account".to_string(),
+                    }
+                    .into(),
+                ),
+            })
             .await
             .expect("Failed to call golem-worker-executor")
             .into_inner();
@@ -156,7 +164,15 @@ impl WorkerService for ForwardingWorkerService {
             .worker_executor
             .client()
             .await
-            .get_worker_metadata(request.worker_id.expect("Worker ID is required"))
+            .get_worker_metadata(workerexecutor::GetWorkerMetadataRequest {
+                worker_id: Some(request.worker_id.expect("Worker ID is required")),
+                account_id: Some(
+                    AccountId {
+                        value: "test-account".to_string(),
+                    }
+                    .into(),
+                ),
+            })
             .await
             .expect("Failed to call golem-worker-executor")
             .into_inner();
@@ -308,6 +324,12 @@ impl WorkerService for ForwardingWorkerService {
             .await
             .resume_worker(workerexecutor::ResumeWorkerRequest {
                 worker_id: request.worker_id,
+                account_id: Some(
+                    AccountId {
+                        value: "test-account".to_string(),
+                    }
+                    .into(),
+                ),
             })
             .await
             .expect("Failed to call golem-worker-executor")
@@ -340,6 +362,12 @@ impl WorkerService for ForwardingWorkerService {
             .interrupt_worker(workerexecutor::InterruptWorkerRequest {
                 worker_id: request.worker_id,
                 recover_immediately: request.recover_immediately,
+                account_id: Some(
+                    AccountId {
+                        value: "test-account".to_string(),
+                    }
+                    .into(),
+                ),
             })
             .await
             .expect("Failed to call golem-worker-executor")
@@ -375,6 +403,12 @@ impl WorkerService for ForwardingWorkerService {
                 worker_id: request.worker_id,
                 target_version: request.target_version,
                 mode: request.mode,
+                account_id: Some(
+                    AccountId {
+                        value: "test-account".to_string(),
+                    }
+                    .into(),
+                ),
             })
             .await
             .expect("Failed to call golem-worker-executor")

--- a/golem-worker-executor-base/config/worker-service.toml
+++ b/golem-worker-executor-base/config/worker-service.toml
@@ -36,6 +36,7 @@ object_prefix = ""
 compilation_cache_bucket = "compilation-cache"
 custom_data_bucket = "custom-data"
 oplog_payload_bucket = "oplog-payload"
+compressed_oplog_buckets = ["oplog-archive-1"]
 
 [blob_storage.config.retries]
 max_attempts = 3

--- a/golem-worker-executor-base/src/durable_host/blobstore/container.rs
+++ b/golem-worker-executor-base/src/durable_host/blobstore/container.rs
@@ -68,7 +68,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         end: u64,
     ) -> anyhow::Result<Result<Resource<IncomingValue>, Error>> {
         record_host_function_call("blobstore::container::container", "get_data");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -108,7 +109,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         data: Resource<OutgoingValue>,
     ) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::container::container", "write_data");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -144,7 +146,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         container: Resource<Container>,
     ) -> anyhow::Result<Result<Resource<StreamObjectNames>, Error>> {
         record_host_function_call("blobstore::container::container", "list_objects");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -179,7 +182,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         name: ObjectName,
     ) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::container::container", "delete_object");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -210,7 +214,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         names: Vec<ObjectName>,
     ) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::container::container", "delete_objects");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -241,7 +246,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         name: ObjectName,
     ) -> anyhow::Result<Result<bool, Error>> {
         record_host_function_call("blobstore::container::container", "has_object");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -272,7 +278,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         name: ObjectName,
     ) -> anyhow::Result<Result<ObjectMetadata, Error>> {
         record_host_function_call("blobstore::container::container", "object_info");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()
@@ -311,7 +318,8 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
 
     async fn clear(&mut self, container: Resource<Container>) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::container::container", "clear");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
+
         let container_name = self
             .as_wasi_view()
             .table()

--- a/golem-worker-executor-base/src/durable_host/blobstore/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/blobstore/mod.rs
@@ -36,7 +36,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<Resource<Container>, Error>> {
         record_host_function_call("blobstore::blobstore", "create_container");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let name_clone = name.clone();
         let result: Result<u64, anyhow::Error> = Durability::<Ctx, u64, SerializableError>::wrap(
             self,
@@ -76,7 +76,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<Resource<Container>, Error>> {
         record_host_function_call("blobstore::blobstore", "get_container");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let result = Durability::<Ctx, Option<u64>, SerializableError>::wrap(
             self,
             WrappedFunctionType::ReadRemote,
@@ -103,7 +103,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
 
     async fn delete_container(&mut self, name: ContainerName) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::blobstore", "delete_container");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let result = Durability::<Ctx, (), SerializableError>::wrap(
             self,
             WrappedFunctionType::WriteRemote,
@@ -126,7 +126,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<bool, Error>> {
         record_host_function_call("blobstore::blobstore", "container_exists");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let result = Durability::<Ctx, bool, SerializableError>::wrap(
             self,
             WrappedFunctionType::ReadRemote,
@@ -150,7 +150,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         dest: ObjectId,
     ) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::blobstore", "copy_object");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let result = Durability::<Ctx, (), SerializableError>::wrap(
             self,
             WrappedFunctionType::WriteRemote,
@@ -178,7 +178,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         dest: ObjectId,
     ) -> anyhow::Result<Result<(), Error>> {
         record_host_function_call("blobstore::blobstore", "move_object");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.state.owned_worker_id.account_id();
         let result = Durability::<Ctx, (), SerializableError>::wrap(
             self,
             WrappedFunctionType::WriteRemote,

--- a/golem-worker-executor-base/src/durable_host/http/types.rs
+++ b/golem-worker-executor-base/src/durable_host/http/types.rs
@@ -592,7 +592,7 @@ impl<Ctx: WorkerCtx> HostFutureIncomingResponse for DurableWorkerCtx<Ctx> {
                             self.state.open_function_table.remove(&handle);
                         }
                         None => {
-                            warn!("No matching BeginRemoteWrite index was found when HTTP response arrived for {}. Handle: {}; open functions: {:?}", self.worker_id, handle, self.state.open_function_table);
+                            warn!("No matching BeginRemoteWrite index was found when HTTP response arrived. Handle: {}; open functions: {:?}", handle, self.state.open_function_table);
                         }
                     }
                 }
@@ -625,7 +625,7 @@ impl<Ctx: WorkerCtx> HostFutureIncomingResponse for DurableWorkerCtx<Ctx> {
                         self.state.open_function_table.remove(&handle);
                     }
                     None => {
-                        warn!("No matching BeginRemoteWrite index was found when HTTP response arrived for {}. Handle: {}; open functions: {:?}", self.worker_id, handle, self.state.open_function_table);
+                        warn!("No matching BeginRemoteWrite index was found when HTTP response arrived. Handle: {}; open functions: {:?}", handle, self.state.open_function_table);
                     }
                 }
             }

--- a/golem-worker-executor-base/src/durable_host/keyvalue/eventual.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/eventual.rs
@@ -35,7 +35,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         key: Key,
     ) -> anyhow::Result<Result<Option<Resource<IncomingValue>>, Resource<Error>>> {
         record_host_function_call("keyvalue::eventual", "get");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -79,7 +79,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         outgoing_value: Resource<OutgoingValue>,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
         record_host_function_call("keyvalue::eventual", "set");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -126,7 +126,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         key: Key,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
         record_host_function_call("keyvalue::eventual", "delete");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -162,7 +162,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         key: Key,
     ) -> anyhow::Result<Result<bool, Resource<Error>>> {
         record_host_function_call("keyvalue::eventual", "exists");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()

--- a/golem-worker-executor-base/src/durable_host/keyvalue/eventual_batch.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/eventual_batch.rs
@@ -35,7 +35,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         keys: Vec<Key>,
     ) -> anyhow::Result<Result<Vec<Option<Resource<IncomingValue>>>, Resource<Error>>> {
         record_host_function_call("keyvalue::eventual_batch", "get_many");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -90,7 +90,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         bucket: Resource<Bucket>,
     ) -> anyhow::Result<Result<Vec<Key>, Resource<Error>>> {
         record_host_function_call("keyvalue::eventual_batch", "get_keys");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -117,7 +117,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         key_values: Vec<(Key, Resource<OutgoingValue>)>,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
         record_host_function_call("keyvalue::eventual_batch", "set_many");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()
@@ -169,7 +169,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         keys: Vec<Key>,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
         record_host_function_call("keyvalue::eventual_batch", "delete_many");
-        let account_id = self.state.account_id.clone();
+        let account_id = self.owned_worker_id.account_id();
         let bucket = self
             .as_wasi_view()
             .table()

--- a/golem-worker-executor-base/src/services/blob_store.rs
+++ b/golem-worker-executor-base/src/services/blob_store.rs
@@ -288,7 +288,7 @@ impl BlobStoreService for DefaultBlobStoreService {
     ) -> anyhow::Result<Vec<u8>> {
         let data = self
             .blob_storage
-            .get_slice(
+            .get_raw_slice(
                 "blob_store",
                 "get_data",
                 BlobStorageNamespace::CustomStorage(account_id),
@@ -404,7 +404,7 @@ impl BlobStoreService for DefaultBlobStoreService {
         data: Vec<u8>,
     ) -> anyhow::Result<()> {
         self.blob_storage
-            .put(
+            .put_raw(
                 "blob_store",
                 "write_data",
                 BlobStorageNamespace::CustomStorage(account_id),

--- a/golem-worker-executor-base/src/services/compiled_component.rs
+++ b/golem-worker-executor-base/src/services/compiled_component.rs
@@ -66,7 +66,7 @@ impl CompiledComponentService for DefaultCompiledComponentService {
     ) -> Result<Option<Component>, GolemError> {
         match self
             .blob_storage
-            .get(
+            .get_raw(
                 "compiled_component",
                 "get",
                 BlobStorageNamespace::CompilationCache,
@@ -105,7 +105,7 @@ impl CompiledComponentService for DefaultCompiledComponentService {
             .serialize()
             .expect("Could not serialize component");
         self.blob_storage
-            .put(
+            .put_raw(
                 "compiled_component",
                 "put",
                 BlobStorageNamespace::CompilationCache,

--- a/golem-worker-executor-base/src/services/golem_config.rs
+++ b/golem-worker-executor-base/src/services/golem_config.rs
@@ -220,6 +220,7 @@ pub struct OplogConfig {
     pub max_operations_before_commit: u64,
     pub max_payload_size: usize,
     pub indexed_storage_layers: usize,
+    pub blob_storage_layers: usize,
     pub entry_count_limit: u64,
     #[serde(with = "humantime_serde")]
     pub archive_interval: Duration,
@@ -257,6 +258,7 @@ pub struct S3BlobStorageConfig {
     pub compilation_cache_bucket: String,
     pub custom_data_bucket: String,
     pub oplog_payload_bucket: String,
+    pub compressed_oplog_buckets: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -349,6 +351,7 @@ impl Default for S3BlobStorageConfig {
             oplog_payload_bucket: "oplog-payload".to_string(),
             object_prefix: "".to_string(),
             aws_endpoint_url: None,
+            compressed_oplog_buckets: vec!["oplog-archive-1".to_string()],
         }
     }
 }
@@ -375,6 +378,7 @@ impl Default for OplogConfig {
             max_operations_before_commit: 128,
             max_payload_size: 64 * 1024,
             indexed_storage_layers: 2,
+            blob_storage_layers: 1,
             entry_count_limit: 1024,
             archive_interval: Duration::from_secs(60 * 60 * 24), // 24 hours
         }

--- a/golem-worker-executor-base/src/services/invocation_queue.rs
+++ b/golem-worker-executor-base/src/services/invocation_queue.rs
@@ -614,9 +614,7 @@ impl<Ctx: WorkerCtx> RunningInvocationQueue<Ctx> {
                     }
                 }
             } else {
-                warn!(
-                    "Lost invocation message because the worker was dropped: {message:?}"
-                );
+                warn!("Lost invocation message because the worker was dropped: {message:?}");
                 break;
             }
         }

--- a/golem-worker-executor-base/src/services/oplog/blob.rs
+++ b/golem-worker-executor-base/src/services/oplog/blob.rs
@@ -65,7 +65,7 @@ impl OplogArchiveService for BlobOplogArchiveService {
 
     async fn delete(&self, owned_worker_id: &OwnedWorkerId) {
         self.blob_storage
-            .delete(
+            .delete_dir(
                 "blob_oplog",
                 "delete",
                 BlobStorageNamespace::CompressedOplog {

--- a/golem-worker-executor-base/src/services/oplog/blob.rs
+++ b/golem-worker-executor-base/src/services/oplog/blob.rs
@@ -1,0 +1,415 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::min;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use evicting_cache_map::EvictingCacheMap;
+use tokio::sync::RwLock;
+
+use golem_common::model::oplog::{OplogEntry, OplogIndex};
+use golem_common::model::{AccountId, ComponentId, OwnedWorkerId, ScanCursor, WorkerId};
+
+use crate::error::GolemError;
+use crate::services::oplog::multilayer::OplogArchive;
+use crate::services::oplog::{CompressedOplogChunk, OplogArchiveService};
+use crate::storage::blob::{
+    BlobStorage, BlobStorageLabelledApi, BlobStorageNamespace, ExistsResult,
+};
+
+/// An oplog archive implementation that uses the configured blob storage to store compressed
+/// chunks of the oplog.
+#[derive(Debug)]
+pub struct BlobOplogArchiveService {
+    blob_storage: Arc<dyn BlobStorage + Send + Sync>,
+    level: usize,
+}
+
+impl BlobOplogArchiveService {
+    const CACHE_SIZE: usize = 4096;
+
+    pub fn new(blob_storage: Arc<dyn BlobStorage + Send + Sync>, level: usize) -> Self {
+        BlobOplogArchiveService {
+            blob_storage,
+            level,
+        }
+    }
+}
+
+#[async_trait]
+impl OplogArchiveService for BlobOplogArchiveService {
+    async fn open(&self, owned_worker_id: &OwnedWorkerId) -> Arc<dyn OplogArchive + Send + Sync> {
+        Arc::new(
+            BlobOplogArchive::new(
+                owned_worker_id.clone(),
+                self.blob_storage.clone(),
+                self.level,
+            )
+            .await,
+        )
+    }
+
+    async fn delete(&self, owned_worker_id: &OwnedWorkerId) {
+        self.blob_storage
+            .delete(
+                "blob_oplog",
+                "delete",
+                BlobStorageNamespace::CompressedOplog {
+                    account_id: owned_worker_id.account_id(),
+                    component_id: owned_worker_id.component_id(),
+                    level: self.level,
+                },
+                Path::new(&owned_worker_id.worker_name()),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to drop compressed oplog for worker {} in blob storage: {err}",
+                    owned_worker_id.worker_id
+                )
+            });
+    }
+
+    async fn read(
+        &self,
+        owned_worker_id: &OwnedWorkerId,
+        idx: OplogIndex,
+        n: u64,
+    ) -> BTreeMap<OplogIndex, OplogEntry> {
+        let archive = self.open(owned_worker_id).await;
+        archive.read(idx, n).await
+    }
+
+    async fn exists(&self, owned_worker_id: &OwnedWorkerId) -> bool {
+        self.blob_storage
+            .with("blob_oplog", "exists")
+            .exists(
+                BlobStorageNamespace::CompressedOplog {
+                    account_id: owned_worker_id.account_id(),
+                    component_id: owned_worker_id.component_id(),
+                    level: self.level,
+                },
+                Path::new(&owned_worker_id.worker_name()),
+            )
+            .await
+            .map(|exists| exists == ExistsResult::Directory)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to check existence of compressed oplog for worker {} in blob storage: {err}",
+                    owned_worker_id.worker_id
+                )
+            })
+    }
+
+    async fn scan_for_component(
+        &self,
+        account_id: &AccountId,
+        component_id: &ComponentId,
+        cursor: ScanCursor,
+        _count: u64,
+    ) -> Result<(ScanCursor, Vec<OwnedWorkerId>), GolemError> {
+        if cursor.cursor == 0 {
+            let paths = self.blob_storage
+                .with("blob_oplog", "scan_for_component")
+                .list_dir(
+                    BlobStorageNamespace::CompressedOplog {
+                        account_id: account_id.clone(),
+                        component_id: component_id.clone(),
+                        level: self.level,
+                    },
+                    Path::new(""),
+                ).await.map_err(|err| {
+                    GolemError::unknown(format!("Failed to list entries of compressed oplog for component {component_id} in blob storage: {err}"))
+                })?;
+
+            let owned_worker_ids = paths
+                .into_iter()
+                .map(|path| {
+                    let worker_name = path.file_name().unwrap().to_str().unwrap();
+                    OwnedWorkerId {
+                        account_id: account_id.clone(),
+                        worker_id: WorkerId {
+                            component_id: component_id.clone(),
+                            worker_name: worker_name.to_string(),
+                        },
+                    }
+                })
+                .collect();
+
+            Ok((
+                ScanCursor {
+                    cursor: 0,
+                    layer: cursor.layer,
+                },
+                owned_worker_ids,
+            ))
+        } else {
+            Err(GolemError::unknown(
+                "Cannot use cursor with blob oplog archive",
+            ))
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BlobOplogArchive {
+    owned_worker_id: OwnedWorkerId,
+    blob_storage: Arc<dyn BlobStorage + Send + Sync>,
+    level: usize,
+    entries: Arc<RwLock<BTreeMap<OplogIndex, PathBuf>>>,
+    #[allow(clippy::type_complexity)]
+    cache: RwLock<
+        EvictingCacheMap<
+            OplogIndex,
+            OplogEntry,
+            { BlobOplogArchiveService::CACHE_SIZE },
+            fn(OplogIndex, OplogEntry) -> (),
+        >,
+    >,
+}
+
+impl BlobOplogArchive {
+    pub async fn new(
+        owned_worker_id: OwnedWorkerId,
+        blob_storage: Arc<dyn BlobStorage + Send + Sync>,
+        level: usize,
+    ) -> Self {
+        let paths = blob_storage.with("blob_oplog",
+                                      "new").list_dir(
+            BlobStorageNamespace::CompressedOplog {
+                account_id: owned_worker_id.account_id(),
+                component_id: owned_worker_id.component_id(),
+                level
+            },
+            Path::new(&owned_worker_id.worker_name()),
+        ).await.unwrap_or_else(|err| {
+                panic!(
+                    "failed to list entries of compressed oplog for worker {} in blob storage: {err}",
+                    owned_worker_id.worker_id
+                )
+            });
+
+        let entries = paths
+            .into_iter()
+            .map(|path| {
+                let idx = Self::path_to_oplog_index(&path);
+                (idx, path)
+            })
+            .collect::<BTreeMap<OplogIndex, PathBuf>>();
+        let entries = Arc::new(RwLock::new(entries));
+
+        BlobOplogArchive {
+            owned_worker_id,
+            blob_storage,
+            level,
+            entries,
+            cache: RwLock::new(EvictingCacheMap::new()),
+        }
+    }
+
+    pub(crate) fn path_to_oplog_index(path: &Path) -> OplogIndex {
+        path.file_name()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(OplogIndex::from_u64)
+            .unwrap_or_else(|| panic!("failed to parse oplog index from path: {path:?}"))
+    }
+
+    pub(crate) fn oplog_index_to_path(&self, idx: OplogIndex) -> PathBuf {
+        let mut path = PathBuf::new();
+        path.push(&self.owned_worker_id.worker_name());
+        path.push(idx.to_string());
+        path
+    }
+
+    async fn read_and_cache_chunk(&self, idx: OplogIndex) -> Result<Option<OplogIndex>, String> {
+        let entries = self.entries.read().await;
+        let last_idx = entries.keys().find(|k| **k >= idx);
+        if let Some(last_idx) = last_idx {
+            let chunk: CompressedOplogChunk = self
+                .blob_storage
+                .with("blob_oplog", "read")
+                .get(
+                    BlobStorageNamespace::CompressedOplog {
+                        account_id: self.owned_worker_id.account_id(),
+                        component_id: self.owned_worker_id.component_id(),
+                        level: self.level,
+                    },
+                    &self.oplog_index_to_path(idx),
+                )
+                .await?
+                .ok_or(format!("compressed chunk for {idx} not found"))?;
+
+            let entries = chunk.decompress()?;
+            let mut cache = self.cache.write().await;
+
+            let mut idx = Into::<u64>::into(*last_idx) - chunk.count + 1;
+            for entry in entries {
+                cache.insert(OplogIndex::from_u64(idx), entry);
+                idx += 1;
+            }
+
+            Ok(Some(*last_idx))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[async_trait]
+impl OplogArchive for BlobOplogArchive {
+    async fn read(&self, idx: OplogIndex, n: u64) -> BTreeMap<OplogIndex, OplogEntry> {
+        let owned_worker_id = &self.owned_worker_id;
+
+        let mut result = BTreeMap::new();
+        let mut last_idx = idx.range_end(n);
+        let mut before = OplogIndex::from_u64(u64::MAX);
+
+        while last_idx >= idx {
+            {
+                let mut cache = self.cache.write().await;
+
+                while let Some(entry) = cache.get(&last_idx) {
+                    result.insert(last_idx, entry.clone());
+                    if last_idx == idx {
+                        break;
+                    } else {
+                        last_idx = last_idx.previous();
+                    }
+                }
+                drop(cache);
+            }
+
+            if before == last_idx {
+                // No entries found in cache, even though fetch returned true. This means we reached the beginning of the stream
+                break;
+            }
+
+            if result.len() == (n as usize) {
+                // We are done fetching all the results
+                break;
+            }
+
+            let fetched_last_idx = self.read_and_cache_chunk(last_idx).await.unwrap_or_else(|err| {
+                panic!("failed to read compressed oplog for worker {owned_worker_id} in blob storage: {err}")
+            });
+            if fetched_last_idx.is_some() {
+                before = last_idx;
+            } else if result.is_empty() {
+                // We allow to have a gap on the right side of the query - as we cannot guarantee
+                // that the 'n' parameter is exactly matches the available number of elements. However,
+                // there must not be any gaps in the middle.
+                let entries = self.entries.read().await;
+                if let Some((idx, _)) = entries.last_key_value() {
+                    last_idx = min(last_idx, *idx);
+                } else {
+                    break;
+                }
+            } else {
+                // We never go towards older entries so if we didn't fetch the chunk we reached the
+                // boundary of this layer
+                break;
+            }
+        }
+
+        result
+    }
+
+    async fn append(&self, chunk: Vec<(OplogIndex, OplogEntry)>) {
+        if let Some(last) = chunk.last() {
+            let oplog_index = last.0;
+            let path = self.oplog_index_to_path(oplog_index);
+
+            let chunk = chunk.into_iter().map(|(_, entry)| entry).collect();
+            let compressed_chunk = CompressedOplogChunk::compress(chunk)
+                .unwrap_or_else(|err| panic!("failed to compress oplog chunk: {err}"));
+
+            let mut entries = self.entries.write().await;
+            self.blob_storage.with(
+                "blob_oplog",
+                "append").put(
+                BlobStorageNamespace::CompressedOplog {
+                    account_id: self.owned_worker_id.account_id(),
+                    component_id: self.owned_worker_id.component_id(),
+                    level: self.level
+                },
+                &path,
+                &compressed_chunk,
+            ).await.unwrap_or_else(|err| {
+                panic!(
+                    "failed to store compressed oplog chunk for worker {} in blob storage: {err}", self.owned_worker_id.worker_id
+                )
+            });
+            entries.insert(oplog_index, path);
+        }
+    }
+
+    async fn current_oplog_index(&self) -> OplogIndex {
+        let entries = self.entries.read().await;
+        entries
+            .keys()
+            .last()
+            .copied()
+            .unwrap_or_else(|| OplogIndex::from_u64(0))
+    }
+
+    async fn drop_prefix(&self, last_dropped_id: OplogIndex) {
+        let mut entries = self.entries.write().await;
+        let idx_to_drop = entries
+            .keys()
+            .filter(|key| **key <= last_dropped_id)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let to_drop = idx_to_drop
+            .iter()
+            .map(|idx| {
+                let mut path = PathBuf::new();
+                path.push(&self.owned_worker_id.worker_name());
+                path.push(idx.to_string());
+                path
+            })
+            .collect::<Vec<_>>();
+
+        self.blob_storage
+            .with("blob_oplog", "drop_prefix")
+            .delete_many(
+                BlobStorageNamespace::CompressedOplog {
+                    account_id: self.owned_worker_id.account_id(),
+                    component_id: self.owned_worker_id.component_id(),
+                    level: self.level,
+                },
+                &to_drop,
+            )
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to drop compressed oplog chunks for worker {} in blob storage: {err}",
+                    self.owned_worker_id.worker_id
+                )
+            });
+
+        for idx in idx_to_drop {
+            let _ = entries.remove(&idx);
+        }
+    }
+
+    async fn length(&self) -> u64 {
+        let entries = self.entries.read().await;
+        entries.len() as u64
+    }
+}

--- a/golem-worker-executor-base/src/services/oplog/mock.rs
+++ b/golem-worker-executor-base/src/services/oplog/mock.rs
@@ -16,7 +16,7 @@ use crate::error::GolemError;
 use crate::services::oplog::{Oplog, OplogService};
 use async_trait::async_trait;
 use golem_common::model::oplog::{OplogEntry, OplogIndex};
-use golem_common::model::{AccountId, ComponentId, ScanCursor, WorkerId};
+use golem_common::model::{AccountId, ComponentId, OwnedWorkerId, ScanCursor};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -43,52 +43,48 @@ impl OplogServiceMock {
 impl OplogService for OplogServiceMock {
     async fn create(
         &self,
-        _account_id: &AccountId,
-        _worker_id: &WorkerId,
+        _owned_worker_id: &OwnedWorkerId,
         _initial_entry: OplogEntry,
     ) -> Arc<dyn Oplog + Send + Sync> {
         unimplemented!()
     }
 
-    async fn open(
-        &self,
-        _account_id: &AccountId,
-        _worker_id: &WorkerId,
-    ) -> Arc<dyn Oplog + Send + Sync> {
+    async fn open(&self, _owned_worker_id: &OwnedWorkerId) -> Arc<dyn Oplog + Send + Sync> {
         unimplemented!()
     }
 
-    async fn get_first_index(&self, _worker_id: &WorkerId) -> OplogIndex {
+    async fn get_first_index(&self, _owned_worker_id: &OwnedWorkerId) -> OplogIndex {
         unimplemented!()
     }
 
-    async fn get_last_index(&self, _worker_id: &WorkerId) -> OplogIndex {
+    async fn get_last_index(&self, _owned_worker_id: &OwnedWorkerId) -> OplogIndex {
         unimplemented!()
     }
 
-    async fn delete(&self, _worker_id: &WorkerId) {
+    async fn delete(&self, _owned_worker_id: &OwnedWorkerId) {
         unimplemented!()
     }
 
     async fn read(
         &self,
-        _worker_id: &WorkerId,
+        _owned_worker_id: &OwnedWorkerId,
         _idx: OplogIndex,
         _n: u64,
     ) -> BTreeMap<OplogIndex, OplogEntry> {
         unimplemented!()
     }
 
-    async fn exists(&self, _worker_id: &WorkerId) -> bool {
+    async fn exists(&self, _owned_worker_id: &OwnedWorkerId) -> bool {
         unimplemented!()
     }
 
     async fn scan_for_component(
         &self,
+        _account_id: &AccountId,
         _component_id: &ComponentId,
         _cursor: ScanCursor,
         _count: u64,
-    ) -> Result<(ScanCursor, Vec<WorkerId>), GolemError> {
+    ) -> Result<(ScanCursor, Vec<OwnedWorkerId>), GolemError> {
         unimplemented!()
     }
 }

--- a/golem-worker-executor-base/src/services/oplog/mod.rs
+++ b/golem-worker-executor-base/src/services/oplog/mod.rs
@@ -30,7 +30,10 @@ use golem_common::cache::{BackgroundEvictionMode, Cache, FullCacheEvictionMode};
 use golem_common::model::oplog::{
     OplogEntry, OplogIndex, OplogPayload, UpdateDescription, WrappedFunctionType,
 };
-use golem_common::model::{AccountId, CallingConvention, ComponentId, ComponentVersion, IdempotencyKey, OwnedWorkerId, ScanCursor, Timestamp, WorkerId};
+use golem_common::model::{
+    AccountId, CallingConvention, ComponentId, ComponentVersion, IdempotencyKey, OwnedWorkerId,
+    ScanCursor, Timestamp, WorkerId,
+};
 use golem_common::serialization::{serialize, try_deserialize};
 pub use multilayer::{MultiLayerOplog, MultiLayerOplogService, OplogArchiveService};
 pub use primary::PrimaryOplogService;
@@ -68,10 +71,8 @@ pub trait OplogService: Debug {
         owned_worker_id: &OwnedWorkerId,
         initial_entry: OplogEntry,
     ) -> Arc<dyn Oplog + Send + Sync + 'static>;
-    async fn open(
-        &self,
-        owned_worker_id: &OwnedWorkerId,
-    ) -> Arc<dyn Oplog + Send + Sync + 'static>;
+    async fn open(&self, owned_worker_id: &OwnedWorkerId)
+        -> Arc<dyn Oplog + Send + Sync + 'static>;
 
     async fn get_first_index(&self, owned_worker_id: &OwnedWorkerId) -> OplogIndex;
     async fn get_last_index(&self, owned_worker_id: &OwnedWorkerId) -> OplogIndex;

--- a/golem-worker-executor-base/src/services/oplog/mod.rs
+++ b/golem-worker-executor-base/src/services/oplog/mod.rs
@@ -24,22 +24,20 @@ use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use bytes::Bytes;
 
-pub use compressed::CompressedOplogArchive;
-pub use compressed::CompressedOplogArchiveService;
+pub use blob::BlobOplogArchiveService;
+pub use compressed::{CompressedOplogArchive, CompressedOplogArchiveService, CompressedOplogChunk};
 use golem_common::cache::{BackgroundEvictionMode, Cache, FullCacheEvictionMode};
 use golem_common::model::oplog::{
     OplogEntry, OplogIndex, OplogPayload, UpdateDescription, WrappedFunctionType,
 };
-use golem_common::model::{
-    AccountId, CallingConvention, ComponentId, ComponentVersion, IdempotencyKey, ScanCursor,
-    Timestamp, WorkerId,
-};
+use golem_common::model::{AccountId, CallingConvention, ComponentId, ComponentVersion, IdempotencyKey, OwnedWorkerId, ScanCursor, Timestamp, WorkerId};
 use golem_common::serialization::{serialize, try_deserialize};
 pub use multilayer::{MultiLayerOplog, MultiLayerOplogService, OplogArchiveService};
 pub use primary::PrimaryOplogService;
 
 use crate::error::GolemError;
 
+mod blob;
 mod compressed;
 mod multilayer;
 mod primary;
@@ -67,24 +65,22 @@ mod tests;
 pub trait OplogService: Debug {
     async fn create(
         &self,
-        account_id: &AccountId,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         initial_entry: OplogEntry,
     ) -> Arc<dyn Oplog + Send + Sync + 'static>;
     async fn open(
         &self,
-        account_id: &AccountId,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
     ) -> Arc<dyn Oplog + Send + Sync + 'static>;
 
-    async fn get_first_index(&self, worker_id: &WorkerId) -> OplogIndex;
-    async fn get_last_index(&self, worker_id: &WorkerId) -> OplogIndex;
+    async fn get_first_index(&self, owned_worker_id: &OwnedWorkerId) -> OplogIndex;
+    async fn get_last_index(&self, owned_worker_id: &OwnedWorkerId) -> OplogIndex;
 
-    async fn delete(&self, worker_id: &WorkerId);
+    async fn delete(&self, owned_worker_id: &OwnedWorkerId);
 
     async fn read(
         &self,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         idx: OplogIndex,
         n: u64,
     ) -> BTreeMap<OplogIndex, OplogEntry>;
@@ -92,12 +88,12 @@ pub trait OplogService: Debug {
     /// Reads an inclusive range of entries from the oplog
     async fn read_range(
         &self,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         start_idx: OplogIndex,
         last_idx: OplogIndex,
     ) -> BTreeMap<OplogIndex, OplogEntry> {
         self.read(
-            worker_id,
+            owned_worker_id,
             start_idx,
             Into::<u64>::into(last_idx) - Into::<u64>::into(start_idx) + 1,
         )
@@ -106,25 +102,26 @@ pub trait OplogService: Debug {
 
     async fn read_prefix(
         &self,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         last_idx: OplogIndex,
     ) -> BTreeMap<OplogIndex, OplogEntry> {
-        self.read_range(worker_id, OplogIndex::INITIAL, last_idx)
+        self.read_range(owned_worker_id, OplogIndex::INITIAL, last_idx)
             .await
     }
 
     /// Checks whether the oplog exists in the oplog, without opening it
-    async fn exists(&self, worker_id: &WorkerId) -> bool;
+    async fn exists(&self, owned_worker_id: &OwnedWorkerId) -> bool;
 
     /// Scans the oplog for all workers belonging to the given component, in a paginated way.
     ///
     /// Pages can be empty. This operation is slow and is not locking the oplog.
     async fn scan_for_component(
         &self,
+        account_id: &AccountId,
         component_id: &ComponentId,
         cursor: ScanCursor,
         count: u64,
-    ) -> Result<(ScanCursor, Vec<WorkerId>), GolemError>;
+    ) -> Result<(ScanCursor, Vec<OwnedWorkerId>), GolemError>;
 }
 
 /// An open oplog providing write access

--- a/golem-worker-executor-base/src/services/oplog/tests.rs
+++ b/golem-worker-executor-base/src/services/oplog/tests.rs
@@ -731,6 +731,10 @@ async fn empty_layer_gets_deleted_impl(use_blob: bool) {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    let primary_exists = primary_oplog_service.exists(&owned_worker_id).await;
+    let secondary_exists = secondary_layer.exists(&owned_worker_id).await;
+    let tertiary_exists = tertiary_layer.exists(&owned_worker_id).await;
+
     let primary_length = primary_oplog_service
         .open(&owned_worker_id)
         .await
@@ -746,10 +750,6 @@ async fn empty_layer_gets_deleted_impl(use_blob: bool) {
     assert_eq!(primary_length, 0);
     assert_eq!(secondary_length, 0);
     assert_eq!(tertiary_length, 1);
-
-    let primary_exists = primary_oplog_service.exists(&owned_worker_id).await;
-    let secondary_exists = secondary_layer.exists(&owned_worker_id).await;
-    let tertiary_exists = tertiary_layer.exists(&owned_worker_id).await;
 
     assert!(!primary_exists);
     assert!(!secondary_exists);

--- a/golem-worker-executor-base/src/services/worker_activator.rs
+++ b/golem-worker-executor-base/src/services/worker_activator.rs
@@ -103,7 +103,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + Send + Sync + 'static> WorkerActivator
             Some(metadata) => {
                 Worker::activate(
                     &self.all,
-                    &owned_worker_id,
+                    owned_worker_id,
                     metadata.args,
                     metadata.env,
                     Some(metadata.last_known_status.component_version),

--- a/golem-worker-executor-base/src/services/worker_activator.rs
+++ b/golem-worker-executor-base/src/services/worker_activator.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use golem_common::model::WorkerId;
+use golem_common::model::OwnedWorkerId;
 #[cfg(any(feature = "mocks", test))]
 use tracing::info;
 use tracing::{error, warn};
@@ -29,12 +29,12 @@ use crate::workerctx::WorkerCtx;
 #[async_trait]
 pub trait WorkerActivator {
     /// Makes sure an already existing worker is active in a background task. Returns immediately
-    async fn activate_worker(&self, worker_id: &WorkerId);
+    async fn activate_worker(&self, owned_worker_id: &OwnedWorkerId);
 
     /// Makes sure an already existing worker is active in a background task. If
     /// it was already active, it deactivates it first, so it is guaranteed that its recovery
     /// runs. Returns immediately
-    async fn reactivate_worker(&self, worker_id: &WorkerId);
+    async fn reactivate_worker(&self, owned_worker_id: &OwnedWorkerId);
 }
 
 pub struct LazyWorkerActivator {
@@ -61,19 +61,19 @@ impl Default for LazyWorkerActivator {
 
 #[async_trait]
 impl WorkerActivator for LazyWorkerActivator {
-    async fn activate_worker(&self, worker_id: &WorkerId) {
+    async fn activate_worker(&self, owned_worker_id: &OwnedWorkerId) {
         let maybe_worker_activator = self.worker_activator.lock().unwrap().clone();
         match maybe_worker_activator {
-            Some(worker_activator) => worker_activator.activate_worker(worker_id).await,
-            None => warn!("WorkerActivator is disabled, not activating instance: {worker_id}"),
+            Some(worker_activator) => worker_activator.activate_worker(owned_worker_id).await,
+            None => warn!("WorkerActivator is disabled, not activating instance"),
         }
     }
 
-    async fn reactivate_worker(&self, worker_id: &WorkerId) {
+    async fn reactivate_worker(&self, owned_worker_id: &OwnedWorkerId) {
         let maybe_worker_activator = self.worker_activator.lock().unwrap().clone();
         match maybe_worker_activator {
-            Some(worker_activator) => worker_activator.reactivate_worker(worker_id).await,
-            None => warn!("WorkerActivator is disabled, not reactivating instance: {worker_id}"),
+            Some(worker_activator) => worker_activator.reactivate_worker(owned_worker_id).await,
+            None => warn!("WorkerActivator is disabled, not reactivating instance"),
         }
     }
 }
@@ -97,43 +97,41 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx>> DefaultWorkerActivator<Ctx, Svcs> {
 impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + Send + Sync + 'static> WorkerActivator
     for DefaultWorkerActivator<Ctx, Svcs>
 {
-    async fn activate_worker(&self, worker_id: &WorkerId) {
-        let metadata = self.all.worker_service().get(worker_id).await;
+    async fn activate_worker(&self, owned_worker_id: &OwnedWorkerId) {
+        let metadata = self.all.worker_service().get(owned_worker_id).await;
         match metadata {
             Some(metadata) => {
                 Worker::activate(
                     &self.all,
-                    worker_id,
+                    &owned_worker_id,
                     metadata.args,
                     metadata.env,
                     Some(metadata.last_known_status.component_version),
-                    metadata.account_id,
                 )
                 .await
             }
             None => {
-                error!("WorkerActivator::activate_worker: worker {worker_id} not found")
+                error!("WorkerActivator::activate_worker: worker not found")
             }
         }
     }
 
-    async fn reactivate_worker(&self, worker_id: &WorkerId) {
-        let metadata = self.all.worker_service().get(worker_id).await;
+    async fn reactivate_worker(&self, owned_worker_id: &OwnedWorkerId) {
+        let metadata = self.all.worker_service().get(owned_worker_id).await;
         match metadata {
             Some(metadata) => {
-                self.all.active_workers().remove(worker_id);
+                self.all.active_workers().remove(&owned_worker_id.worker_id);
                 Worker::activate(
                     &self.all,
-                    worker_id,
+                    owned_worker_id,
                     metadata.args,
                     metadata.env,
                     Some(metadata.last_known_status.component_version),
-                    metadata.account_id,
                 )
                 .await
             }
             None => {
-                error!("WorkerActivator::reactivate_worker: worker {worker_id} not found")
+                error!("WorkerActivator::reactivate_worker: worker not found")
             }
         }
     }
@@ -159,11 +157,11 @@ impl WorkerActivatorMock {
 #[cfg(any(feature = "mocks", test))]
 #[async_trait]
 impl WorkerActivator for WorkerActivatorMock {
-    async fn activate_worker(&self, worker_id: &WorkerId) {
-        info!("WorkerActivatorMock::activate_worker {worker_id}");
+    async fn activate_worker(&self, _owned_worker_id: &OwnedWorkerId) {
+        info!("WorkerActivatorMock::activate_worker");
     }
 
-    async fn reactivate_worker(&self, worker_id: &WorkerId) {
-        info!("WorkerActivatorMock::reactivate_worker {worker_id}");
+    async fn reactivate_worker(&self, _owned_worker_id: &OwnedWorkerId) {
+        info!("WorkerActivatorMock::reactivate_worker");
     }
 }

--- a/golem-worker-executor-base/src/storage/blob/fs.rs
+++ b/golem-worker-executor-base/src/storage/blob/fs.rs
@@ -75,7 +75,7 @@ impl FileSystemBlobStorage {
             BlobStorageNamespace::CompressedOplog {
                 account_id,
                 component_id,
-                level
+                level,
             } => {
                 result.push("compressed_oplog");
                 result.push(account_id.to_string());

--- a/golem-worker-executor-base/src/storage/blob/fs.rs
+++ b/golem-worker-executor-base/src/storage/blob/fs.rs
@@ -72,6 +72,16 @@ impl FileSystemBlobStorage {
                 result.push(account_id.to_string());
                 result.push(worker_id.to_string());
             }
+            BlobStorageNamespace::CompressedOplog {
+                account_id,
+                component_id,
+                level
+            } => {
+                result.push("compressed_oplog");
+                result.push(account_id.to_string());
+                result.push(component_id.to_string());
+                result.push(level.to_string());
+            }
         }
 
         result.push(path);
@@ -89,7 +99,7 @@ impl FileSystemBlobStorage {
 
 #[async_trait]
 impl BlobStorage for FileSystemBlobStorage {
-    async fn get(
+    async fn get_raw(
         &self,
         _target_label: &'static str,
         _op_label: &'static str,
@@ -135,7 +145,7 @@ impl BlobStorage for FileSystemBlobStorage {
         }
     }
 
-    async fn put(
+    async fn put_raw(
         &self,
         _target_label: &'static str,
         _op_label: &'static str,

--- a/golem-worker-executor-base/src/storage/blob/memory.rs
+++ b/golem-worker-executor-base/src/storage/blob/memory.rs
@@ -46,7 +46,7 @@ impl InMemoryBlobStorage {
 
 #[async_trait]
 impl BlobStorage for InMemoryBlobStorage {
-    async fn get(
+    async fn get_raw(
         &self,
         _target_label: &'static str,
         _op_label: &'static str,
@@ -92,7 +92,7 @@ impl BlobStorage for InMemoryBlobStorage {
         }))
     }
 
-    async fn put(
+    async fn put_raw(
         &self,
         _target_label: &'static str,
         _op_label: &'static str,

--- a/golem-worker-executor-base/src/storage/blob/mod.rs
+++ b/golem-worker-executor-base/src/storage/blob/mod.rs
@@ -12,19 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use bincode::{Decode, Encode};
+use bytes::Bytes;
+
+use golem_common::model::{AccountId, ComponentId, Timestamp, WorkerId};
+use golem_common::serialization::{deserialize, serialize};
+
 pub mod fs;
 pub mod memory;
 pub mod s3;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use golem_common::model::{AccountId, Timestamp, WorkerId};
-use std::fmt::Debug;
-use std::path::{Path, PathBuf};
-
 #[async_trait]
 pub trait BlobStorage: Debug {
-    async fn get(
+    async fn get_raw(
         &self,
         target_label: &'static str,
         op_label: &'static str,
@@ -32,7 +36,7 @@ pub trait BlobStorage: Debug {
         path: &Path,
     ) -> Result<Option<Bytes>, String>;
 
-    async fn get_slice(
+    async fn get_raw_slice(
         &self,
         target_label: &'static str,
         op_label: &'static str,
@@ -41,7 +45,9 @@ pub trait BlobStorage: Debug {
         start: u64,
         end: u64,
     ) -> Result<Option<Bytes>, String> {
-        let data = self.get(target_label, op_label, namespace, path).await?;
+        let data = self
+            .get_raw(target_label, op_label, namespace, path)
+            .await?;
         Ok(data.map(|data| data.slice((start as usize)..(end as usize))))
     }
 
@@ -53,7 +59,7 @@ pub trait BlobStorage: Debug {
         path: &Path,
     ) -> Result<Option<BlobMetadata>, String>;
 
-    async fn put(
+    async fn put_raw(
         &self,
         target_label: &'static str,
         op_label: &'static str,
@@ -125,10 +131,13 @@ pub trait BlobStorage: Debug {
         to: &Path,
     ) -> Result<(), String> {
         match self
-            .get(target_label, op_label, namespace.clone(), from)
+            .get_raw(target_label, op_label, namespace.clone(), from)
             .await?
         {
-            Some(data) => self.put(target_label, op_label, namespace, to, &data).await,
+            Some(data) => {
+                self.put_raw(target_label, op_label, namespace, to, &data)
+                    .await
+            }
             None => Err(format!("Entry not found: {:?}", from)),
         }
     }
@@ -147,6 +156,173 @@ pub trait BlobStorage: Debug {
     }
 }
 
+pub trait BlobStorageLabelledApi<S: BlobStorage + ?Sized + Sync> {
+    fn with(&self, svc_name: &'static str, api_name: &'static str) -> LabelledBlobStorage<S>;
+}
+
+impl<'a, S: BlobStorage + ?Sized + Sync> BlobStorageLabelledApi<S> for S {
+    fn with(&self, svc_name: &'static str, api_name: &'static str) -> LabelledBlobStorage<Self> {
+        LabelledBlobStorage::new(svc_name, api_name, self)
+    }
+}
+
+pub struct LabelledBlobStorage<'a, S: BlobStorage + ?Sized + Sync> {
+    svc_name: &'static str,
+    api_name: &'static str,
+    storage: &'a S,
+}
+
+impl<'a, S: BlobStorage + ?Sized + Sync> LabelledBlobStorage<'a, S> {
+    pub fn new(svc_name: &'static str, api_name: &'static str, storage: &'a S) -> Self {
+        Self {
+            svc_name,
+            api_name,
+            storage,
+        }
+    }
+
+    pub async fn get_raw(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<Option<Bytes>, String> {
+        self.storage
+            .get_raw(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn get_raw_slice(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+        start: u64,
+        end: u64,
+    ) -> Result<Option<Bytes>, String> {
+        self.storage
+            .get_raw_slice(self.svc_name, self.api_name, namespace, path, start, end)
+            .await
+    }
+
+    pub async fn get_metadata(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<Option<BlobMetadata>, String> {
+        self.storage
+            .get_metadata(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn put_raw(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+        data: &[u8],
+    ) -> Result<(), String> {
+        self.storage
+            .put_raw(self.svc_name, self.api_name, namespace, path, data)
+            .await
+    }
+
+    pub async fn delete(&self, namespace: BlobStorageNamespace, path: &Path) -> Result<(), String> {
+        self.storage
+            .delete(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn delete_many(
+        &self,
+        namespace: BlobStorageNamespace,
+        paths: &[PathBuf],
+    ) -> Result<(), String> {
+        self.storage
+            .delete_many(self.svc_name, self.api_name, namespace, paths)
+            .await
+    }
+
+    pub async fn create_dir(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<(), String> {
+        self.storage
+            .create_dir(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn list_dir(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<Vec<PathBuf>, String> {
+        self.storage
+            .list_dir(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn delete_dir(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<(), String> {
+        self.storage
+            .delete_dir(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn exists(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<ExistsResult, String> {
+        self.storage
+            .exists(self.svc_name, self.api_name, namespace, path)
+            .await
+    }
+
+    pub async fn copy(
+        &self,
+        namespace: BlobStorageNamespace,
+        from: &Path,
+        to: &Path,
+    ) -> Result<(), String> {
+        self.storage
+            .copy(self.svc_name, self.api_name, namespace, from, to)
+            .await
+    }
+
+    pub async fn r#move(
+        &self,
+        namespace: BlobStorageNamespace,
+        from: &Path,
+        to: &Path,
+    ) -> Result<(), String> {
+        self.storage
+            .r#move(self.svc_name, self.api_name, namespace, from, to)
+            .await
+    }
+
+    pub async fn get<T: Decode>(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+    ) -> Result<Option<T>, String> {
+        match self.get_raw(namespace, path).await? {
+            Some(data) => Ok(Some(deserialize(&data)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn put<T: Encode>(
+        &self,
+        namespace: BlobStorageNamespace,
+        path: &Path,
+        data: &T,
+    ) -> Result<(), String> {
+        self.put_raw(namespace, path, &serialize(data)?).await
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BlobStorageNamespace {
     CompilationCache,
@@ -155,9 +331,14 @@ pub enum BlobStorageNamespace {
         account_id: AccountId,
         worker_id: WorkerId,
     },
+    CompressedOplog {
+        account_id: AccountId,
+        component_id: ComponentId,
+        level: usize,
+    },
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExistsResult {
     File,
     Directory,

--- a/golem-worker-executor-base/src/storage/blob/mod.rs
+++ b/golem-worker-executor-base/src/storage/blob/mod.rs
@@ -160,7 +160,7 @@ pub trait BlobStorageLabelledApi<S: BlobStorage + ?Sized + Sync> {
     fn with(&self, svc_name: &'static str, api_name: &'static str) -> LabelledBlobStorage<S>;
 }
 
-impl<'a, S: BlobStorage + ?Sized + Sync> BlobStorageLabelledApi<S> for S {
+impl<S: BlobStorage + ?Sized + Sync> BlobStorageLabelledApi<S> for S {
     fn with(&self, svc_name: &'static str, api_name: &'static str) -> LabelledBlobStorage<Self> {
         LabelledBlobStorage::new(svc_name, api_name, self)
     }

--- a/golem-worker-executor-base/src/worker.rs
+++ b/golem-worker-executor-base/src/worker.rs
@@ -342,7 +342,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         )
         .await?;
 
-        let oplog = this.oplog_service().open(&owned_worker_id).await;
+        let oplog = this.oplog_service().open(owned_worker_id).await;
         let initial_pending_invocations = worker_metadata
             .last_known_status
             .pending_invocations
@@ -423,7 +423,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         )
         .await?;
 
-        let oplog = this.oplog_service().open(&owned_worker_id).await;
+        let oplog = this.oplog_service().open(owned_worker_id).await;
         let initial_pending_invocations = worker_metadata
             .last_known_status
             .pending_invocations
@@ -505,7 +505,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         )
         .await?;
 
-        let oplog = this.oplog_service().open(&owned_worker_id).await;
+        let oplog = this.oplog_service().open(owned_worker_id).await;
         let initial_pending_invocations = worker_metadata
             .last_known_status
             .pending_invocations

--- a/golem-worker-executor-base/src/workerctx.rs
+++ b/golem-worker-executor-base/src/workerctx.rs
@@ -21,8 +21,8 @@ use golem_wasm_rpc::Value;
 use wasmtime::{AsContextMut, ResourceLimiterAsync};
 
 use golem_common::model::{
-    AccountId, CallingConvention, ComponentVersion, IdempotencyKey, WorkerId, WorkerMetadata,
-    WorkerStatus, WorkerStatusRecord,
+    AccountId, CallingConvention, ComponentVersion, IdempotencyKey, OwnedWorkerId, WorkerId,
+    WorkerMetadata, WorkerStatus, WorkerStatusRecord,
 };
 
 use crate::error::GolemError;
@@ -91,8 +91,7 @@ pub trait WorkerCtx:
     /// - `execution_status`: Lock created to store the execution status
     #[allow(clippy::too_many_arguments)]
     async fn create(
-        worker_id: WorkerId,
-        account_id: AccountId,
+        owned_worker_id: OwnedWorkerId,
         promise_service: Arc<dyn PromiseService + Send + Sync>,
         events: Arc<Events>,
         worker_service: Arc<dyn WorkerService + Send + Sync>,
@@ -328,7 +327,7 @@ pub trait ExternalOperations<Ctx: WorkerCtx> {
     /// Sets the current worker status without activating the worker
     async fn set_worker_status<T: HasAll<Ctx> + Send + Sync>(
         this: &T,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         status: WorkerStatus,
     ) -> Result<(), GolemError>;
 
@@ -336,13 +335,13 @@ pub trait ExternalOperations<Ctx: WorkerCtx> {
     /// error was stored in the last entry.
     async fn get_last_error_and_retry_count<T: HasAll<Ctx> + Send + Sync>(
         this: &T,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
     ) -> Option<LastError>;
 
     /// Gets a best-effort current worker status without activating the worker
     async fn compute_latest_worker_status<T: HasAll<Ctx> + Send + Sync>(
         this: &T,
-        worker_id: &WorkerId,
+        owned_worker_id: &OwnedWorkerId,
         metadata: &Option<WorkerMetadata>,
     ) -> Result<WorkerStatusRecord, GolemError>;
 

--- a/golem-worker-executor-base/tests/api.rs
+++ b/golem-worker-executor-base/tests/api.rs
@@ -300,6 +300,12 @@ async fn promise() {
                 .into(),
             ),
             data: vec![42],
+            account_id: Some(
+                AccountId {
+                    value: "test-account".to_string(),
+                }
+                .into(),
+            ),
         })
         .await
         .unwrap();

--- a/golem-worker-executor/config/worker-executor.toml
+++ b/golem-worker-executor/config/worker-executor.toml
@@ -40,6 +40,7 @@ object_prefix = ""
 compilation_cache_bucket = "compilation-cache"
 custom_data_bucket = "custom-data"
 oplog_payload_bucket = "oplog-payload"
+compressed_oplog_buckets = ["oplog-archive-1"]
 
 [blob_storage.config.retries]
 max_attempts = 3
@@ -51,6 +52,7 @@ multiplier = 3
 max_operations_before_commit = 128
 max_payload_size = 65536
 indexed_storage_layers = 2
+blob_storage_layers = 1
 entry_count_limit = 1024
 archive_interval = "24h"
 

--- a/golem-worker-service/src/api/worker.rs
+++ b/golem-worker-service/src/api/worker.rs
@@ -83,7 +83,7 @@ impl WorkerApi {
         let worker_id = make_worker_id(component_id.0, worker_name.0)?;
 
         self.worker_service
-            .delete(&worker_id, &EmptyAuthCtx {})
+            .delete(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(Json(DeleteWorkerResponse {}))
@@ -168,7 +168,13 @@ impl WorkerApi {
 
         let result = self
             .worker_service
-            .complete_promise(&worker_id, oplog_idx, data, &EmptyAuthCtx {})
+            .complete_promise(
+                &worker_id,
+                oplog_idx,
+                data,
+                empty_worker_metadata(),
+                &EmptyAuthCtx {},
+            )
             .await?;
 
         Ok(Json(result))
@@ -191,6 +197,7 @@ impl WorkerApi {
             .interrupt(
                 &worker_id,
                 recover_immediately.0.unwrap_or(false),
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;
@@ -211,7 +218,7 @@ impl WorkerApi {
         let worker_id = make_worker_id(component_id.0, worker_name.0)?;
         let result = self
             .worker_service
-            .get_metadata(&worker_id, &EmptyAuthCtx {})
+            .get_metadata(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(Json(result))
@@ -254,6 +261,7 @@ impl WorkerApi {
                 cursor.unwrap_or_default(),
                 count.0.unwrap_or(50),
                 precise.0.unwrap_or(false),
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;
@@ -279,6 +287,7 @@ impl WorkerApi {
                 params.cursor.clone().unwrap_or_default(),
                 params.count.unwrap_or(50),
                 params.precise.unwrap_or(false),
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;
@@ -299,7 +308,7 @@ impl WorkerApi {
         let worker_id = make_worker_id(component_id.0, worker_name.0)?;
 
         self.worker_service
-            .resume(&worker_id, &EmptyAuthCtx {})
+            .resume(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(Json(ResumeResponse {}))
@@ -323,6 +332,7 @@ impl WorkerApi {
                 &worker_id,
                 params.mode.clone().into(),
                 params.target_version,
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;

--- a/golem-worker-service/src/grpcapi/worker.rs
+++ b/golem-worker-service/src/grpcapi/worker.rs
@@ -267,7 +267,7 @@ impl WorkerGrpcApi {
         let worker_id = make_crate_worker_id(request.worker_id)?;
 
         self.worker_service
-            .delete(&worker_id, &EmptyAuthCtx {})
+            .delete(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(())
@@ -289,6 +289,7 @@ impl WorkerGrpcApi {
                 &worker_id,
                 parameters.oplog_idx,
                 parameters.data,
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;
@@ -304,7 +305,7 @@ impl WorkerGrpcApi {
 
         let metadata = self
             .worker_service
-            .get_metadata(&worker_id, &EmptyAuthCtx {})
+            .get_metadata(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(metadata.into())
@@ -336,6 +337,7 @@ impl WorkerGrpcApi {
                 request.cursor.map(|c| c.into()).unwrap_or_default(),
                 request.count,
                 request.precise,
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;
@@ -352,7 +354,12 @@ impl WorkerGrpcApi {
         let worker_id = make_crate_worker_id(request.worker_id)?;
 
         self.worker_service
-            .interrupt(&worker_id, request.recover_immediately, &EmptyAuthCtx {})
+            .interrupt(
+                &worker_id,
+                request.recover_immediately,
+                empty_worker_metadata(),
+                &EmptyAuthCtx {},
+            )
             .await?;
 
         Ok(())
@@ -414,7 +421,7 @@ impl WorkerGrpcApi {
         let worker_id = make_crate_worker_id(request.worker_id)?;
 
         self.worker_service
-            .resume(&worker_id, &EmptyAuthCtx {})
+            .resume(&worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await?;
 
         Ok(())
@@ -441,6 +448,7 @@ impl WorkerGrpcApi {
                 &worker_id,
                 request.mode(),
                 request.target_version,
+                empty_worker_metadata(),
                 &EmptyAuthCtx {},
             )
             .await?;

--- a/golem-worker-service/src/worker_component_metadata_fetcher.rs
+++ b/golem-worker-service/src/worker_component_metadata_fetcher.rs
@@ -1,3 +1,4 @@
+use crate::empty_worker_metadata;
 use async_trait::async_trait;
 use golem_service_base::model::{Export, WorkerId};
 use golem_wasm_ast::analysis::AnalysedFunction;
@@ -24,7 +25,7 @@ impl WorkerMetadataFetcher for DefaultWorkerComponentMetadataFetcher {
     ) -> Result<Vec<AnalysedFunction>, MetadataFetchError> {
         let result = self
             .worker_service
-            .get_component_for_worker(worker_id, &EmptyAuthCtx {})
+            .get_component_for_worker(worker_id, empty_worker_metadata(), &EmptyAuthCtx {})
             .await
             .map_err(|e| MetadataFetchError(e.to_string()))?;
 


### PR DESCRIPTION
Resolves #216 

Contains refactorings related to #502 

Introduces `OwnedWorkerId`, a combination of `WorkerId` and `AccountId` and uses it in most places in the worker executor where previously worker and account IDs were passed separately. Also the number of places where this type is needed (the additional account ID) increased because now the _oplog_ requires to have an associated account ID for each operation. Although this change increases the required information to be transferred in many cases, it unified the API a bit as now everything requires a combination of worker id and account id: this can be explained by worker executor needs to know who owns the worker, but it does not want to query an external service to determine so - so this information must be passed from the outer layers where authorization already calculated the information anyway (or in case all worker belongs to the same account, it is passed as a constant value).

The primary reason for passing this ownership information down to the oplog service is to be able to store oplog archives grouped by accounts, similarly how custom blobs are already stored grouped by accounts. This is good for various security and privacy reasons and can support some planned features.