### PR TITLE
Compiling on blocking thread pool

### DIFF
--- a/golem-worker-executor-base/src/services/compiled_component.rs
+++ b/golem-worker-executor-base/src/services/compiled_component.rs
@@ -16,6 +16,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::time::Instant;
+use tracing::debug;
 use wasmtime::component::Component;
 
 use golem_common::model::ComponentId;
@@ -76,6 +78,7 @@ impl CompiledComponentService for DefaultCompiledComponentService {
         {
             Ok(None) => Ok(None),
             Ok(Some(bytes)) => {
+                let start = Instant::now();
                 let component = unsafe {
                     Component::deserialize(engine, &bytes).map_err(|err| {
                         GolemError::component_download_failed(
@@ -85,6 +88,15 @@ impl CompiledComponentService for DefaultCompiledComponentService {
                         )
                     })?
                 };
+                let end = Instant::now();
+
+                let load_time = end.duration_since(start);
+                debug!(
+                    "Loaded precompiled image for {} in {}ms",
+                    component_id,
+                    load_time.as_millis(),
+                );
+
                 Ok(Some(component))
             }
             Err(err) => Err(GolemError::component_download_failed(


### PR DESCRIPTION
Note: Wanted to do the same for loading the precompiled binaries, but that's not easy because it requires an `&Engine` which we cannot move to the closure.