### PR TITLE
component-service - default configuration

### DIFF
--- a/golem-component-service/config/component-service.toml
+++ b/golem-component-service/config/component-service.toml
@@ -23,13 +23,8 @@ max_capacity = 1000
 time_to_idle = "4h"
 
 [compilation]
-type = "Enabled"
+type = "Disabled"
 
-[compilation.config]
-host = "localhost"
-port = 9091
-
-[component_service]
-host = "localhost"
-port = 9090
-access_token = "5C832D93-FF85-4A8F-9803-513950FDFDB1"
+#[compilation.config]
+#host = "localhost"
+#port = 9091


### PR DESCRIPTION
if there is 

```toml
[compilation.config]
host = "localhost"
port = 9091
```
in configuration, then `GOLEM__COMPILATION__TYPE=Disabled` failing


```
./target/debug/benchmark_cold_start_small  --json spawned --component-compilation-disabled
```

```
2024-06-06T20:47:46.606458Z  INFO golem_test_framework::components: Waiting for golem-component-service start on host localhost:9091, timeout: 90s
2024-06-06T20:47:48.391827Z ERROR golem_test_framework::components: [componentsvc] thread 'main' panicked at golem-component-service/src/config.rs:88:14:
2024-06-06T20:47:48.391870Z ERROR golem_test_framework::components: [componentsvc] Failed to parse config: Error { tag: Tag(Default, 2), profile: Some(Profile(Uncased { string: "default" })), metadata: Some(Metadata { name: "`GOLEM__` environment variable(s)", source: None, provide_location: Some(Location { file: "golem-component-service/src/config.rs", line: 86, col: 14 }), interpolater:  }), path: ["compilation"], kind: InvalidType(Map, "unit variant ComponentCompilationConfig::Disabled"), prev: None }
2024-06-06T20:47:48.391888Z ERROR golem_test_framework::components: [componentsvc] stack backtrace:
2024-06-06T20:47:48.582234Z ERROR golem_test_framework::components: [componentsvc]    0: rust_begin_unwind
2024-06-06T20:47:48.582270Z ERROR golem_test_framework::components: [componentsvc]              at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
2024-06-06T20:47:48.582282Z ERROR golem_test_framework::components: [componentsvc]    1: core::panicking::panic_fmt
2024-06-06T20:47:48.582291Z ERROR golem_test_framework::components: [componentsvc]              at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
2024-06-06T20:47:48.582303Z ERROR golem_test_framework::components: [componentsvc]    2: core::result::unwrap_failed
2024-06-06T20:47:48.582312Z ERROR golem_test_framework::components: [componentsvc]              at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/result.rs:1654:5
2024-06-06T20:47:48.599388Z ERROR golem_test_framework::components: [componentsvc]    3: core::result::Result<T,E>::expect
2024-06-06T20:47:48.599426Z ERROR golem_test_framework::components: [componentsvc]              at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/result.rs:1034:23
2024-06-06T20:47:48.599833Z ERROR golem_test_framework::components: [componentsvc]    4: golem_component_service::config::ComponentServiceConfig::new
2024-06-06T20:47:48.599868Z ERROR golem_test_framework::components: [componentsvc]              at ./src/config.rs:84:9
2024-06-06T20:47:48.616826Z ERROR golem_test_framework::components: [componentsvc]    5: golem_component_service::main
2024-06-06T20:47:48.616857Z ERROR golem_test_framework::components: [componentsvc]              at ./src/server.rs:39:22
2024-06-06T20:47:48.647039Z ERROR golem_test_framework::components: [componentsvc]    6: core::ops::function::FnOnce::call_once
2024-06-06T20:47:48.647072Z ERROR golem_test_framework::components: [componentsvc]              at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
2024-06-06T20:47:48.649430Z ERROR golem_test_framework::components: [componentsvc] note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

related setup https://github.com/golemcloud/golem/blob/main/golem-test-framework/src/components/component_service/mod.rs#L349-L352

related config struct https://github.com/golemcloud/golem/blob/main/golem-component-service-base/src/config.rs
