### PR TITLE
Temporarily remove throughput benchmark

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -115,10 +115,10 @@ jobs:
           cat benchmark-data-current/benchmark_suspend_worker.json
           echo "Successfully ran suspend benchmark"
           
-          echo "Starting throughput benchmark"
-          ./target/debug/benchmark_throughput --quiet --json spawned > benchmark-data-current/benchmark_throughput.json
-          cat benchmark-data-current/benchmark_throughput.json
-          echo "Successfully ran throughput benchmark"
+          # echo "Starting throughput benchmark"
+          # ./target/debug/benchmark_throughput --quiet --json spawned > benchmark-data-current/benchmark_throughput.json
+          # cat benchmark-data-current/benchmark_throughput.json
+          # echo "Successfully ran throughput benchmark"
                 
           echo "Finished Running Benchmark Jobs"
           


### PR DESCRIPTION
I have to remove this to see a complete workflow of benchmark

* Throughput benchmark kept failing in my machine. Firstly we need to ensure its running as consistent as other benchmarks before having this as part of the CI workflow.
* I am currently looking at this. 
* This PR is to unblock rest of the benchmark jobs
* Also as I mentioned earlier, it was a good idea to keep the number of jobs minimal when we test a workflows, and that's why I didn't have all of these jobs and it wasn't accidental