### PR TITLE
Fix script in benchmark file

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -147,7 +147,7 @@ jobs:
                 fi
              done
           else
-            for file in "${files[@]}"; do
+            for file in ${files[@]}; do
                 absent_files+=("$file")
                 get_report_command="$get_report_command --files $file=$(pwd)/benchmark-data-current/$file"
              done

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -137,7 +137,7 @@ jobs:
           
           if git fetch origin main:main && [[ ! "$COMMENT_BODY" =~ refresh ]]; then                              
              # Check each file
-             for file in "${files[@]}"; do
+             for file in ${files[@]}; do
                 if git checkout master -- "benchmark-data/$file"; then
                   present_files+=("$file")
                   compare_command="$compare_command --files $file=$(pwd)/benchmark-data/$file,$(pwd)/benchmark-data-current/$file"


### PR DESCRIPTION
There was a difference between the script that tested vs what's deployed with golem.
Difference was looping through the files was listing directory in benchmark directory, vs hardcoded in the test-script.

It's hard to test shell script. In future, I will find some ways to move this back to Rust.