### PR TITLE
Final touch before release - make headers, status back to optional fields (and upgrade wasm-rpc?)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ cargo make sharding-tests
     /run-benchmark
 ```
 
-3. If there are no other benchmarks to compare the following report should generate as a PR comment itself
+3. For all new benchmark types (meaning, those for which there is no baseline to compare), it should generate a report as below, as a PR comment
 
 ## Benchmark Report
 | Benchmark Type | Cluster Size | Size | Length | Avg Time |
@@ -63,8 +63,8 @@ cargo make sharding-tests
 
 RunID: 9435476881
 
-4. The underlying data used to created the above create will be automatically pushed back to the PR branch itself
-5. If there exists a baseline to compare for the benchmark type, then a comparison report will be generated for these benchmarks, and rest of them will be reported as above
+4. The underlying data used to created the above report will be automatically pushed back to the PR branch
+5. If there exists a baseline to compare for the benchmark type, then a comparison report will be generated for those benchmarks
 6. If there is no need to compare with any baseline, regardless of a baseline exist or not, then simply run
 
 ```bash
@@ -72,7 +72,7 @@ RunID: 9435476881
 /run-benchmark-refresh
 
 ```
-7. Refresh message can be useful in the event of comparison failures due to schema mismatches (especially when a developer refactor the benchmark code itself)
+7. Refresh message can be useful in the event of comparison failures (Example: A failure due to schema mismatch especially when a developer refactor the benchmark code itself)
 
 ## Starting all services locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,44 @@ runs sharding integration tests only
 cargo make sharding-tests
 ```
 
+## Running Benchmarks
+
+1. Raise PR
+2. Reviewer or author of PR can run benchmarks by typing in a PR comment as follows
+```shell
+    /run-benchmark
+```
+
+3. If there are no other benchmarks to compare the following report should generate as a PR comment itself
+
+## Benchmark Report
+| Benchmark Type | Cluster Size | Size | Length | Avg Time |
+|---------------|--------------|------|--------|----------|
+| benchmark_cold_start_large.json | 3 | 10 | 100 | 201.255108ms |
+| benchmark_cold_start_large_no_compilation.json | 3 | 10 | 100 | 123.000794122s |
+| benchmark_cold_start_medium.json | 3 | 10 | 100 | 121.566283ms |
+| benchmark_cold_start_medium_no_compilation.json | 3 | 10 | 100 | 178.508111048s |
+| benchmark_cold_start_small.json | 3 | 10 | 100 | 75.379351ms |
+| benchmark_cold_start_small_no_compilation.json | 3 | 10 | 100 | 423.142651ms |
+| benchmark_durability_overhead.json | 3 | 10 | 100 | 57.51445ms |
+| benchmark_latency_large.json | 3 | 10 | 100 | 61.586289ms |
+| benchmark_latency_medium.json | 3 | 10 | 100 | 60.646373ms |
+| benchmark_latency_small.json | 3 | 10 | 100 | 54.76123ms |
+| benchmark_suspend_worker.json | 3 | 10 | 100 | 10.03030193s |
+
+RunID: 9435476881
+
+4. The underlying data used to created the above create will be automatically pushed back to the PR branch itself
+5. If there exists a baseline to compare for the benchmark type, then a comparison report will be generated for these benchmarks, and rest of them will be reported as above
+6. If there is no need to compare with any baseline, regardless of a baseline exist or not, then simply run
+
+```bash
+
+/run-benchmark-refresh
+
+```
+7. Refresh message can be useful in the event of comparison failures due to schema mismatches (especially when a developer refactor the benchmark code itself)
+
 ## Starting all services locally
 
 There is a simple `cargo make run` task that starts all the debug executables of the services locally, using the default configuration. The prerequisites are:
@@ -58,14 +96,14 @@ cd golem-services
 # Target has to be x86_64-unknown-linux-gnu or aarch64-unknown-linux-gnu-gcc
 cargo build --release --target x86_64-unknown-linux-gnu
 
-docker-compose -f docker-compose-sqlite.yaml up --build
+docker compose -f docker-compose-sqlite.yaml up --build
 ```
 
 To start the service without a rebuild
 
 ```bash
 
-docker-compose -f docker-compose-sqlite.yaml up
+docker compose -f docker-compose-sqlite.yaml up
 
 ```
 
@@ -73,7 +111,7 @@ To compose down,
 
 ```bash
 
-docker-compose -f docker-compose-sqlite.yaml down
+docker compose -f docker-compose-sqlite.yaml down
 
 ```
 
@@ -81,7 +119,7 @@ To compose down including persistence volume
 
 ```bash
 
-docker-compose -f docker-compose-sqlite.yaml down -v
+docker compose -f docker-compose-sqlite.yaml down -v
 
 ```
 
@@ -177,6 +215,3 @@ cargo build --release --target x86_64-unknown-linux-gnu --package golem-componen
 cargo build --release --target x86_64-unknown-linux-gnu --package golem-worker-executor
 ```
 
-## Integration with existing API Gateways
-
-Please refer to [api-gateway-examples](api-gateway-examples) for more information.

--- a/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
+++ b/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
@@ -102,7 +102,6 @@ mod internal {
     }
 
     pub(crate) fn get_routes(paths: Paths) -> Result<Vec<Route>, String> {
-        dbg!("here???");
         let mut routes: Vec<Route> = vec![];
 
         for (path, path_item) in paths.iter() {

--- a/golem-worker-service-base/src/evaluator/getter.rs
+++ b/golem-worker-service-base/src/evaluator/getter.rs
@@ -81,11 +81,10 @@ pub trait GetterExt<T> {
 }
 
 impl<T: Getter<T>> GetterExt<T> for T {
-    fn get_optional(&self, key: &Path) -> Result<Option<T>, GetError> {
+    fn get_optional(&self, key: &Path) -> Option<T> {
         match self.get(key) {
-            Ok(value) => Ok(Some(value)),
-            Err(GetError::KeyNotFound(_)) => Ok(None),
-            Err(e) => Err(e),
+            Ok(value) => Some(value),
+            Err(_) => None,
         }
     }
 }

--- a/golem-worker-service-base/src/evaluator/getter.rs
+++ b/golem-worker-service-base/src/evaluator/getter.rs
@@ -77,7 +77,7 @@ fn get_array(value: &TypeAnnotatedValue) -> Option<Vec<TypeAnnotatedValue>> {
 }
 
 pub trait GetterExt<T> {
-    fn get_optional(&self, key: &Path) -> Result<Option<T>, GetError>;
+    fn get_optional(&self, key: &Path) -> Option<T>;
 }
 
 impl<T: Getter<T>> GetterExt<T> for T {

--- a/golem-worker-service-base/src/evaluator/getter.rs
+++ b/golem-worker-service-base/src/evaluator/getter.rs
@@ -75,3 +75,17 @@ fn get_array(value: &TypeAnnotatedValue) -> Option<Vec<TypeAnnotatedValue>> {
         _ => None,
     }
 }
+
+pub trait GetterExt<T> {
+    fn get_optional(&self, key: &Path) -> Result<Option<T>, GetError>;
+}
+
+impl<T: Getter<T>> GetterExt<T> for T {
+    fn get_optional(&self, key: &Path) -> Result<Option<T>, GetError> {
+        match self.get(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(GetError::KeyNotFound(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/golem-worker-service-base/src/evaluator/math_op_evaluator.rs
+++ b/golem-worker-service-base/src/evaluator/math_op_evaluator.rs
@@ -1,4 +1,4 @@
-use crate::evaluator::{EvaluationError, EvaluationResult};
+use crate::evaluator::{EvaluationError, ExprEvaluationResult};
 use crate::primitive::{GetPrimitive, Primitive};
 use golem_wasm_rpc::TypeAnnotatedValue;
 
@@ -22,10 +22,10 @@ where
 }
 
 pub(crate) fn compare_eval_result<F>(
-    left: &EvaluationResult,
-    right: &EvaluationResult,
+    left: &ExprEvaluationResult,
+    right: &ExprEvaluationResult,
     compare: F,
-) -> Result<EvaluationResult, EvaluationError>
+) -> Result<ExprEvaluationResult, EvaluationError>
 where
     F: Fn(Primitive, Primitive) -> bool,
 {
@@ -35,7 +35,7 @@ where
         match (left.get_value(), right.get_value()) {
             (Some(left), Some(right)) => {
                 let result = compare_typed_value(&left, &right, compare)?;
-                Ok(EvaluationResult::Value(result))
+                Ok(ExprEvaluationResult::Value(result))
             }
             _ => Err(EvaluationError::Message(
                 "Unsupported type to compare".to_string(),

--- a/golem-worker-service-base/src/evaluator/pattern_match_evaluator.rs
+++ b/golem-worker-service-base/src/evaluator/pattern_match_evaluator.rs
@@ -1,6 +1,6 @@
 use crate::evaluator::evaluator_context::EvaluationContext;
 use crate::evaluator::{DefaultEvaluator, Evaluator};
-use crate::evaluator::{EvaluationError, EvaluationResult};
+use crate::evaluator::{EvaluationError, ExprEvaluationResult};
 use crate::expression::{ArmPattern, ConstructorTypeName, Expr, InBuiltConstructorInner, MatchArm};
 use crate::worker_bridge_execution::WorkerRequestExecutor;
 use golem_wasm_ast::analysis::AnalysedType;
@@ -31,12 +31,12 @@ pub(crate) async fn evaluate_pattern_match(
     match_expr: &Expr,
     arms: &Vec<MatchArm>,
     input: &mut EvaluationContext,
-) -> Result<EvaluationResult, EvaluationError> {
+) -> Result<ExprEvaluationResult, EvaluationError> {
     let evaluator = DefaultEvaluator::from_worker_request_executor(worker_executor.clone());
 
     let match_evaluated = evaluator.evaluate(match_expr, input).await?;
 
-    let mut resolved: Option<EvaluationResult> = None;
+    let mut resolved: Option<ExprEvaluationResult> = None;
 
     for arm in arms {
         let constructor_pattern = &arm.0 .0;

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -119,7 +119,7 @@ mod tests {
     use crate::evaluator::getter::Getter;
     use crate::evaluator::path::Path;
     use crate::evaluator::{
-        DefaultEvaluator, EvaluationError, EvaluationResult, Evaluator, MetadataFetchError,
+        DefaultEvaluator, EvaluationError, Evaluator, ExprEvaluationResult, MetadataFetchError,
         WorkerMetadataFetcher, FQN,
     };
     use crate::http::http_request::{ApiInputPath, InputHttpRequest};
@@ -260,7 +260,7 @@ mod tests {
         function_params: Value,
     }
 
-    impl ToResponse<TestResponse> for EvaluationResult {
+    impl ToResponse<TestResponse> for ExprEvaluationResult {
         fn to_response(&self, _request_details: &RequestDetails) -> TestResponse {
             let function_name = self
                 .get_value()

--- a/golem-worker-service-base/src/worker_binding/golem_worker_binding.rs
+++ b/golem-worker-service-base/src/worker_binding/golem_worker_binding.rs
@@ -14,5 +14,6 @@ pub struct GolemWorkerBinding {
     pub response: ResponseMapping,
 }
 
+// ResponseMapping will consist of actual logic such as invoking worker functions
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct ResponseMapping(pub Expr);

--- a/golem-worker-service-base/src/worker_binding/request_details.rs
+++ b/golem-worker-service-base/src/worker_binding/request_details.rs
@@ -47,6 +47,18 @@ pub struct TypedHttRequestDetails {
 }
 
 impl TypedHttRequestDetails {
+    pub fn empty() -> TypedHttRequestDetails {
+        TypedHttRequestDetails {
+            typed_path_key_values: TypedPathKeyValues(TypedKeyValueCollection::default()),
+            typed_request_body: TypedRequestBody(TypeAnnotatedValue::Record {
+                value: vec![],
+                typ: vec![],
+            }),
+            typed_query_values: TypedQueryKeyValues(TypedKeyValueCollection::default()),
+            typed_header_values: TypedHeaderValues(TypedKeyValueCollection::default()),
+        }
+    }
+
     pub fn get_accept_content_type_header(&self) -> Option<String> {
         self.typed_header_values
             .0
@@ -105,7 +117,7 @@ impl TypedHttRequestDetails {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TypedPathKeyValues(pub TypedKeyValueCollection);
 
 impl TypedPathKeyValues {

--- a/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
@@ -1,6 +1,6 @@
 use crate::api_definition::http::{HttpApiDefinition, VarInfo};
 use crate::evaluator::{
-    DefaultEvaluator, EvaluationContext, EvaluationError, EvaluationResult, MetadataFetchError,
+    DefaultEvaluator, EvaluationContext, EvaluationError, ExprEvaluationResult, MetadataFetchError,
 };
 use crate::evaluator::{Evaluator, WorkerMetadataFetcher};
 use crate::http::http_request::router;
@@ -110,7 +110,7 @@ impl ResolvedWorkerBinding {
         worker_metadata_fetcher: &Arc<dyn WorkerMetadataFetcher + Sync + Send>,
     ) -> R
     where
-        EvaluationResult: ToResponse<R>,
+        ExprEvaluationResult: ToResponse<R>,
         EvaluationError: ToResponse<R>,
         MetadataFetchError: ToResponse<R>,
     {

--- a/golem-worker-service-base/src/worker_bridge_execution/content_type_mapper.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/content_type_mapper.rs
@@ -6,19 +6,20 @@ use poem::Body;
 use std::fmt::{Display, Formatter};
 
 pub trait HttpContentTypeResponseMapper {
-    fn to_http_response_body(
+    fn to_http_resp_with_content_type(
         &self,
         content_type_headers: ContentTypeHeaders,
     ) -> Result<WithContentType<Body>, ContentTypeMapError>;
 }
 
+#[derive(Debug, Clone)]
 pub enum ContentTypeHeaders {
     FromClientAccept(AcceptHeaders),
     FromUserDefinedResponseMapping(ContentType),
     Empty,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AcceptHeaders(Vec<String>);
 
 pub trait ContentTypeHeaderExt {
@@ -88,7 +89,7 @@ impl ContentTypeHeaders {
 }
 
 impl HttpContentTypeResponseMapper for TypeAnnotatedValue {
-    fn to_http_response_body(
+    fn to_http_resp_with_content_type(
         &self,
         content_type_headers: ContentTypeHeaders,
     ) -> Result<WithContentType<Body>, ContentTypeMapError> {

--- a/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
@@ -82,7 +82,7 @@ mod internal {
                     }?;
 
                     let body = typed_value
-                        .get_optional(&Path::from_key("body"))?
+                        .get_optional(&Path::from_key("body"))
                         .unwrap_or(typed_value.clone());
 
                     Ok(IntermediateHttpResponse {
@@ -121,7 +121,8 @@ mod internal {
 
                     match evaluation_result {
                         Some(type_annotated_value) => {
-                            match type_annotated_value.to_http_response_body(content_type) {
+                            match type_annotated_value.to_http_resp_with_content_type(content_type)
+                            {
                                 Ok(body_with_header) => {
                                     let mut response = body_with_header.into_response();
                                     response.set_status(*status);
@@ -304,7 +305,12 @@ mod test {
         let status = response_parts.status;
 
         let expected_body = "Healthy";
-        let expected_headers = poem::web::headers::HeaderMap::new();
+
+        // Deault content response is application/json. Refer HttpResponse
+        let expected_headers = poem::web::headers::HeaderMap::from_iter(vec![(
+            CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        )]);
         let expected_status = StatusCode::OK;
 
         assert_eq!(body, expected_body);


### PR DESCRIPTION
The main testing I wanted to do was upgrading wasm-rpc. I think the main contribution to wasm-rpc was wasm-rpc-stubgen (which is just my change allowing complex workflows)

Also also not sure whether we should release wasm-rpc before this [PR](https://github.com/golemcloud/wasm-rpc/pull/45) or simply give up on upgrading as such in this golem release


However, as part of the testing, I found the following behavior that got regressed in the API gateway.
This questioned the non existence of some unit tests. Therefore I added those tests.

The Rib expression always had optional headers etc when specifying response mapping. 
With Rib powerful in last couple of weeks, we also made it  mandatory (not quite intentional) to  specify status code, headers etc which can give horrible user experience with the next release. This is made back to being optional.