### PR TITLE
Fix API gateway to follow the same function syntax that worker service expets

### DIFF
--- a/golem-common/src/model/function_name.rs
+++ b/golem-common/src/model/function_name.rs
@@ -379,9 +379,11 @@ impl ParsedFunctionName {
                     ParsedFunctionName { site, function }
                 }),
         )
-        .or(identifier().map(|id| ParsedFunctionName {
-            site: ParsedFunctionSite::Global,
-            function: ParsedFunctionReference::Function { function: id },
+        .or(identifier().map(|id| {
+            ParsedFunctionName {
+                site: ParsedFunctionSite::Global,
+                function: ParsedFunctionReference::Function { function: id },
+            }
         }));
 
         let result: Result<(ParsedFunctionName, &str), easy::ParseError<&str>> =
@@ -440,7 +442,7 @@ mod tests {
         let parsed = ParsedFunctionName::parse("ns:name/interface.{fn1}").expect("Parsing failed");
         assert_eq!(
             parsed.site().interface_name(),
-            Some("ns:name/interface".to_string())
+            Some("ns:name/interace".to_string())
         );
         assert_eq!(parsed.function().function_name(), "fn1".to_string());
     }

--- a/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
+++ b/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
@@ -102,7 +102,6 @@ mod internal {
     }
 
     pub(crate) fn get_routes(paths: Paths) -> Result<Vec<Route>, String> {
-        dbg!("here???");
         let mut routes: Vec<Route> = vec![];
 
         for (path, path_item) in paths.iter() {

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -322,7 +322,7 @@ mod tests {
         api_specification: &HttpApiDefinition,
     ) -> TestResponse {
         let evaluator = get_test_evaluator();
-        let worker_metadata_fetcher = get_test_metadata_fetcher("golem:it/api/get-cart-contents");
+        let worker_metadata_fetcher = get_test_metadata_fetcher("golem:it/api.{get-cart-contents}");
 
         let resolved_route = api_request
             .resolve(vec![api_specification.clone()])
@@ -338,7 +338,7 @@ mod tests {
     async fn test_end_to_end_evaluation_simple() {
         let empty_headers = HeaderMap::new();
         let api_request = get_api_request("foo/1", None, &empty_headers, serde_json::Value::Null);
-        let expression = r#"let response = golem:it/api/get-cart-contents("a", "b"); response"#;
+        let expression = r#"let response = golem:it/api.{get-cart-contents}("a", "b"); response"#;
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
@@ -351,7 +351,7 @@ mod tests {
         let result = (test_response.function_name, test_response.function_params);
 
         let expected = (
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::String("a".to_string()),
                 Value::String("b".to_string()),
@@ -367,7 +367,7 @@ mod tests {
         let api_request = get_api_request("foo/1", None, &empty_headers, serde_json::Value::Null);
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents({x : "y"});
+          let response = golem:it/api.{get-cart-contents}({x : "y"});
           response
         "#;
 
@@ -391,7 +391,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Object(expected_map)]),
         );
 
@@ -404,7 +404,7 @@ mod tests {
         let api_request = get_api_request("foo/1", None, &empty_headers, serde_json::Value::Null);
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents({x : request.path.user-id});
+          let response = golem:it/api.{get-cart-contents}({x : request.path.user-id});
           response
         "#;
 
@@ -428,7 +428,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Object(expected_map)]),
         );
 
@@ -445,7 +445,7 @@ mod tests {
             serde_json::Value::Null,
         );
 
-        let expression = r#"let response = golem:it/api/get-cart-contents(request.path.user-id, request.path.token-id); response"#;
+        let expression = r#"let response = golem:it/api.{get-cart-contents}(request.path.user-id, request.path.token-id); response"#;
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}?{token-id}",
@@ -463,7 +463,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::Number(serde_json::Number::from(1)),
                 Value::Number(serde_json::Number::from(2)),
@@ -491,7 +491,7 @@ mod tests {
         );
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents(request.path.user-id, request.path.token-id, "age-${request.body.age}");
+          let response = golem:it/api.{get-cart-contents}(request.path.user-id, request.path.token-id, "age-${request.body.age}");
           response
         "#;
 
@@ -511,7 +511,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::Number(serde_json::Number::from(1)),
                 Value::Number(serde_json::Number::from(2)),
@@ -546,7 +546,7 @@ mod tests {
         );
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents({ user-id : request.path.user-id }, request.path.token-id, "age-${request.body.age}", {user-name : request.headers.username});
+          let response = golem:it/api.{get-cart-contents}({ user-id : request.path.user-id }, request.path.token-id, "age-${request.body.age}", {user-name : request.headers.username});
           response
         "#;
 
@@ -577,7 +577,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::Object(user_id_map),
                 Value::Number(serde_json::Number::from(2)),
@@ -593,7 +593,7 @@ mod tests {
     async fn test_worker_request_cond_expr_resolution() {
         let empty_headers = HeaderMap::new();
         let api_request = get_api_request("foo/2", None, &empty_headers, Value::Null);
-        let expression = r#"let response = golem:it/api/get-cart-contents("a", "b"); response"#;
+        let expression = r#"let response = golem:it/api.{get-cart-contents}("a", "b"); response"#;
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
@@ -611,7 +611,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::String("a".to_string()),
                 Value::String("b".to_string()),
@@ -632,7 +632,8 @@ mod tests {
             Value::String("address".to_string()),
         );
 
-        let expression = r#"let response = golem:it/api/get-cart-contents(request.body); response"#;
+        let expression =
+            r#"let response = golem:it/api.{get-cart-contents}(request.body); response"#;
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
@@ -650,7 +651,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::String("address".to_string())]),
         );
 
@@ -668,7 +669,7 @@ mod tests {
             Value::String("address".to_string()),
         );
 
-        let expression = r#"let response = golem:it/api/get-cart-contents(1 == 1); response"#;
+        let expression = r#"let response = golem:it/api.{get-cart-contents}(1 == 1); response"#;
 
         let api_specification: HttpApiDefinition =
             get_api_spec("foo/{user-id}", "shopping-cart", expression);
@@ -683,7 +684,7 @@ mod tests {
 
         let expected = (
             "shopping-cart".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Bool(true)]),
         );
 
@@ -701,7 +702,7 @@ mod tests {
             Value::String("address".to_string()),
         );
 
-        let expression = r#"let response = golem:it/api/get-cart-contents(2 > 1); response"#;
+        let expression = r#"let response = golem:it/api.{get-cart-contents}(2 > 1); response"#;
 
         let api_specification: HttpApiDefinition =
             get_api_spec("foo/{user-id}", "shopping-cart", expression);
@@ -716,7 +717,7 @@ mod tests {
 
         let expected = (
             "shopping-cart".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Bool(true)]),
         );
 
@@ -735,7 +736,7 @@ mod tests {
         );
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents(if (2 < 1) then 0 else 1);
+          let response = golem:it/api.{get-cart-contents}(if (2 < 1) then 0 else 1);
           response
         "#;
 
@@ -752,7 +753,7 @@ mod tests {
 
         let expected = (
             "shopping-cart".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Number(serde_json::Number::from(1))]),
         );
 
@@ -774,7 +775,7 @@ mod tests {
         );
 
         let expression = r#"
-          let response = golem:it/api/get-cart-contents(if (request.body.number < 11) then 0 else 1);
+          let response = golem:it/api.{get-cart-contents}(if (request.body.number < 11) then 0 else 1);
           response
         "#;
 
@@ -791,7 +792,7 @@ mod tests {
 
         let expected = (
             "shopping-cart".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Number(serde_json::Number::from(0))]),
         );
 
@@ -815,7 +816,7 @@ mod tests {
         let expression = r#"
           let condition1 = if (request.body.number < 11) then request.path.user-id else 1;
           let condition2 = if (request.body.number < 5) then request.path.user-id else 1;
-          let response = golem:it/api/get-cart-contents(condition1, condition2);
+          let response = golem:it/api.{get-cart-contents}(condition1, condition2);
           response
         "#;
 
@@ -832,7 +833,7 @@ mod tests {
 
         let expected = (
             "shopping-cart".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::Number(serde_json::Number::from(2)),
                 Value::Number(serde_json::Number::from(1)),
@@ -868,7 +869,7 @@ mod tests {
         let expression = r#"
           let param1 = request.body.foo_key;
           let param2 = request.body.bar_key[0];
-          let response = golem:it/api/get-cart-contents(param1, param2);
+          let response = golem:it/api.{get-cart-contents}(param1, param2);
           response
         "#;
 
@@ -888,7 +889,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![
                 Value::String("foo_value".to_string()),
                 Value::String("bar_value".to_string()),
@@ -923,7 +924,7 @@ mod tests {
 
         let expression = r#"
           let param = request.body;
-          let response = golem:it/api/get-cart-contents(param);
+          let response = golem:it/api.{get-cart-contents}(param);
           response
         "#;
 
@@ -943,7 +944,7 @@ mod tests {
 
         let expected = (
             "shopping-cart-1".to_string(),
-            "golem:it/api/get-cart-contents".to_string(),
+            "golem:it/api.{get-cart-contents}".to_string(),
             Value::Array(vec![Value::Object(request_body)]),
         );
 

--- a/golem-worker-service-base/src/parser/expr/expr_parser.rs
+++ b/golem-worker-service-base/src/parser/expr/expr_parser.rs
@@ -198,7 +198,12 @@ pub(crate) fn parse_code(input: impl AsRef<str>) -> Result<Expr, ParseError> {
             Token::Dot => {
                 let expr = previous_expression
                     .clone()
-                    .final_expr()?
+                    .final_expr()
+                    .or_else(|_| {
+                        previous_expression
+                            .get_concatenated_str()
+                            .map(|opt| opt.map(|str| Expr::Literal(str)))
+                    })?
                     .ok_or::<ParseError>(
                         "Selection of field is applied to a non existing left expression".into(),
                     )?;
@@ -333,6 +338,12 @@ mod internal {
                     let str = match i {
                         Expr::Identifier(str) => Ok(str.to_string()),
                         Expr::Literal(str) => Ok(str.to_string()),
+                        // TODO; https://www.notion.so/golemcloud/Rib-Supporting-New-Function-Syntax-ed92a3f1b92e4dd2a768402127f9aa7f
+                        // This needs to be done better and is documented above
+                        // The reasoning here is, we consider a previous expression to be a string only if they are actually string,
+                        // but by the time we decided its an invocation of a function/variant call the possible name of the function or variant
+                        // was parsed a selection-field, and revert it back to Str
+                        Expr::SelectField(expr, field) => Ok(format!("{}.{}", expr, field)),
                         expr => Err(ParseError::Message(format!(
                             "Invalid expression: {}",
                             expression::to_string(expr).unwrap()

--- a/golem-worker-service-base/src/parser/expr/selection.rs
+++ b/golem-worker-service-base/src/parser/expr/selection.rs
@@ -42,6 +42,10 @@ pub fn get_select_field(tokenizer: &mut Tokenizer, selection_on: Expr) -> Result
     let possible_field = match next_token {
         Some(Token::MultiChar(MultiCharTokens::StringLiteral(field))) => field,
         Some(Token::MultiChar(MultiCharTokens::Identifier(field))) => field,
+        Some(Token::LCurly) => {
+            let possible_str = tokenizer.capture_string_until_and_skip_end(&Token::RCurly);
+            possible_str.map_or("{}".to_string(), |str| format!("{{{}}}", str))
+        }
         Some(token) => {
             return Err(ParseError::Message(format!(
                 "Expecting a valid field selection after dot instead of {}",

--- a/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
@@ -138,13 +138,20 @@ impl ResolvedWorkerBinding {
                     functions,
                 );
 
-                let result = evaluator
-                    .evaluate(&self.response_mapping.clone().0, &runtime)
-                    .await;
+                match runtime {
+                    Ok(context) => {
+                        let result = evaluator
+                            .evaluate(&self.response_mapping.clone().0, &context)
+                            .await;
 
-                match result {
-                    Ok(worker_response) => worker_response.to_response(&self.request_details),
-                    Err(err) => err.to_response(&self.request_details),
+                        match result {
+                            Ok(worker_response) => {
+                                worker_response.to_response(&self.request_details)
+                            }
+                            Err(err) => err.to_response(&self.request_details),
+                        }
+                    }
+                    Err(err) => MetadataFetchError(err).to_response(&self.request_details),
                 }
             }
             Err(err) => err.to_response(&self.request_details),

--- a/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
@@ -40,6 +40,14 @@ impl ToResponse<poem::Response> for MetadataFetchError {
     }
 }
 
+impl ToResponse<poem::Response> for String {
+    fn to_response(&self, _request_details: &RequestDetails) -> poem::Response {
+        poem::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from_string(self.to_string()))
+    }
+}
+
 mod internal {
     use crate::evaluator::{EvaluationError, EvaluationResult};
     use crate::primitive::{GetPrimitive, Primitive};


### PR DESCRIPTION
Please note, the sole purpose of this PR to get as minimal changes as possible into the API Gateway's Rib, and unblock dynamic-resource-allocation feature, and have the existing function calls tested with Rib to follow the new syntax.  

I gave it some thoughts if I could do it in the best possible way within a day of time, before deciding to make this particular PR (which is not the best possible way).  The thoughts are tangible, but very raw documentations here mainly for myself: https://www.notion.so/golemcloud/Rib-Supporting-New-Function-Syntax-ed92a3f1b92e4dd2a768402127f9aa7f. I would like to continue with this as a separate work

## More details
The only function syntax Rib tested ever was of the structure `namespace:package/interface/function-name(param1, param2)`, or simple `function-name(param1, param2)`.

I have made just enough changes to change all these structures in tests to follow the new syntax which is `namespace:package/interface.{function-name}(param1, param2)`

## Summary

* we will document in Rib that the only supported function calls are only of the form `namespace:package/interface/function-name(param1, param2)` and that syntax consistent with rest of the `worker-service`, `cli` etc.
* For supporting the newer syntax properly for all possible functions with Rib, with cleaner changes, I would like it to be a separate work as mentioned above