### PR TITLE
Measure test component memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "prost",
+ "rand 0.8.5",
  "redis",
  "ringbuf",
  "rustls 0.23.10",

--- a/golem-worker-executor-base/Cargo.toml
+++ b/golem-worker-executor-base/Cargo.toml
@@ -93,6 +93,7 @@ ctor = { workspace = true }
 golem-wasm-ast = { workspace = true }
 once_cell = { workspace = true }
 proptest = { workspace = true }
+rand = { workspace = true }
 redis = { workspace = true }
 serde_json = { workspace = true }
 testcontainers = { workspace = true }

--- a/golem-worker-executor-base/config/worker-service.toml
+++ b/golem-worker-executor-base/config/worker-service.toml
@@ -54,6 +54,10 @@ multiplier = 3
 # host
 # port
 
+[component_cache]
+max_capacity = 0
+time_to_idle = "1h"
+
 [component_service.retries]
 max_attempts = 3
 min_delay = "100ms"

--- a/golem-worker-executor-base/config/worker-service.toml
+++ b/golem-worker-executor-base/config/worker-service.toml
@@ -54,10 +54,6 @@ multiplier = 3
 # host
 # port
 
-[component_cache]
-max_capacity = 0
-time_to_idle = "1h"
-
 [component_service.retries]
 max_attempts = 3
 min_delay = "100ms"

--- a/golem-worker-executor-base/src/services/golem_config.rs
+++ b/golem-worker-executor-base/src/services/golem_config.rs
@@ -341,7 +341,7 @@ impl Default for Limits {
 impl Default for ComponentCacheConfig {
     fn default() -> Self {
         Self {
-            max_capacity: 32,
+            max_capacity: 128,
             time_to_idle: Duration::from_secs(12 * 60 * 60),
         }
     }

--- a/golem-worker-executor-base/tests/lib.rs
+++ b/golem-worker-executor-base/tests/lib.rs
@@ -49,6 +49,7 @@ pub mod guest_languages;
 pub mod guest_languages2;
 pub mod hot_update;
 pub mod keyvalue;
+pub mod measure_test_component_mem;
 pub mod rpc;
 pub mod scalability;
 pub mod transactions;

--- a/golem-worker-executor-base/tests/measure_test_component_mem.rs
+++ b/golem-worker-executor-base/tests/measure_test_component_mem.rs
@@ -90,7 +90,7 @@ async fn measure_component(
 
     let component_id = executor
         .component_service()
-        .get_or_add_component(&path)
+        .get_or_add_component(path)
         .await;
 
     let data = std::fs::read(path)?;
@@ -143,7 +143,7 @@ async fn measure_component(
         }
     }
 
-    if results.len() > 0 {
+    if !results.is_empty() {
         let delta_memory = results.iter().map(|(d, _)| d).sum::<i64>() / results.len() as i64;
         let delta_vmemory = results.iter().map(|(_, d)| d).sum::<i64>() / results.len() as i64;
         Ok((delta_memory, delta_vmemory))

--- a/golem-worker-executor-base/tests/measure_test_component_mem.rs
+++ b/golem-worker-executor-base/tests/measure_test_component_mem.rs
@@ -1,0 +1,127 @@
+use crate::common::{start, TestContext, TestWorkerExecutor};
+use anyhow::anyhow;
+use golem_test_framework::config::TestDependencies;
+use golem_test_framework::dsl::TestDsl;
+use golem_wasm_ast::analysis::AnalysisContext;
+use golem_wasm_ast::component::Component;
+use golem_wasm_ast::IgnoreAllButMetadata;
+use humansize::{ISizeFormatter, BINARY};
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use std::path::Path;
+use sysinfo::{Pid, System};
+use tracing::{error, info};
+
+#[tokio::test]
+#[ignore]
+async fn measure() {
+    let mut system = System::new_all();
+    let ctx = TestContext::new();
+    let executor = start(&ctx).await.unwrap();
+
+    // measure
+    let mut read_dir = tokio::fs::read_dir(executor.component_directory())
+        .await
+        .unwrap();
+    let mut results = BTreeMap::new();
+    while let Some(entry) = read_dir.next_entry().await.unwrap() {
+        if entry.file_name().to_string_lossy().ends_with(".wasm") {
+            let component_size = tokio::fs::metadata(entry.path()).await.unwrap().len();
+            if let Ok(result) = measure_component(&mut system, &executor, &entry.path()).await {
+                results.insert(
+                    entry.file_name().to_string_lossy().to_string(),
+                    (component_size, result),
+                );
+            } else {
+                error!("Failed to measure {:?}", entry.path());
+            }
+        }
+    }
+
+    drop(executor);
+
+    let mut csv = String::new();
+    for (name, (component_size, (result, _vresult))) in results {
+        info!(
+            "{}: component size: {}, avg delta memory: {}",
+            name,
+            ISizeFormatter::new(component_size, BINARY),
+            ISizeFormatter::new(result, BINARY),
+            // ISizeFormatter::new(vresult, BINARY)
+        );
+        writeln!(csv, "{},{},{}", name, component_size, result).unwrap();
+    }
+    info!("{}", csv);
+}
+
+async fn measure_component(
+    system: &mut System,
+    executor: &TestWorkerExecutor,
+    path: &Path,
+) -> anyhow::Result<(i64, i64)> {
+    info!("Measuring {path:?}");
+
+    let component_id = executor
+        .component_service()
+        .get_or_add_component(&path)
+        .await;
+
+    let data = std::fs::read(path)?;
+    let component =
+        Component::<IgnoreAllButMetadata>::from_bytes(&data).map_err(|err| anyhow!(err))?;
+    let state = AnalysisContext::new(component);
+    let mems = state
+        .get_all_memories()
+        .map_err(|err| anyhow!(format!("{:?}", err)))?;
+
+    let mut results = Vec::new();
+
+    for idx in 0..6 {
+        let pid = Pid::from_u32(std::process::id());
+        system.refresh_process(pid);
+        let process = system.process(pid).unwrap();
+        let before_memory = process.memory();
+        let before_vmemory = process.virtual_memory();
+
+        let worker_id = executor.start_worker(&component_id, "measure").await;
+
+        system.refresh_process(pid);
+        let process = system.process(pid).unwrap();
+        let after_memory = process.memory();
+        let after_vmemory = process.virtual_memory();
+
+        executor.delete_worker(&worker_id).await;
+
+        // Not substracting total_initial_mem because it is only allocated runtime
+        let delta_memory = after_memory as i64 - before_memory as i64;
+        let delta_vmemory = after_vmemory as i64 - before_vmemory as i64;
+
+        info!(
+            "{:?} memory: {} -> {} ({:?})",
+            path, before_memory, after_memory, delta_memory
+        );
+
+        info!(
+            "{:?} virtual memory: {} -> {} ({:?})",
+            path, before_vmemory, after_vmemory, delta_vmemory
+        );
+        let total_initial_mem = mems
+            .iter()
+            .map(|mem| mem.mem_type.limits.min * 65536)
+            .sum::<u64>();
+        info!("{:?} initial memory: {}", path, total_initial_mem);
+
+        // first try is warmup
+        if idx > 0 && delta_memory > 0 {
+            results.push((delta_memory, delta_vmemory));
+        }
+    }
+
+    if results.len() > 0 {
+        let delta_memory = results.iter().map(|(d, _)| d).sum::<i64>() / results.len() as i64;
+        let delta_vmemory = results.iter().map(|(_, d)| d).sum::<i64>() / results.len() as i64;
+        Ok((delta_memory, delta_vmemory))
+    } else {
+        Err(anyhow!("No results"))
+    }
+}


### PR DESCRIPTION
Resolves #612 

Contains an ignored test that was used to gather measurement data. We should never run it as a test, but it may be useful for further experiments on our test components.

Plot:
<img width="1406" alt="image" src="https://github.com/golemcloud/golem/assets/2292489/741ef0cb-03be-4124-8355-010bbf71752b">

Results:
```
   auction.wasm: component size: 80.77 KiB, avg delta memory: 248 KiB
   auction_registry_composed.wasm: component size: 201.93 KiB, avg delta memory: 912 KiB
   blob-store-service.wasm: component size: 61.83 KiB, avg delta memory: 320 KiB
   c-1.wasm: component size: 59.56 KiB, avg delta memory: 141.33 KiB
   caller_composed.wasm: component size: 203.62 KiB, avg delta memory: 437.33 KiB
   child_component.wasm: component size: 2.56 MiB, avg delta memory: 8.16 MiB
   clock-service.wasm: component size: 59.36 KiB, avg delta memory: 216 KiB
   clocks.wasm: component size: 91.94 KiB, avg delta memory: 352 KiB
   counters.wasm: component size: 87.62 KiB, avg delta memory: 469.33 KiB
   csharp-1.wasm: component size: 8.55 MiB, avg delta memory: 67.72 MiB
   directories.wasm: component size: 112.40 KiB, avg delta memory: 437.33 KiB
   environment-service.wasm: component size: 70.44 KiB, avg delta memory: 298.67 KiB
   failing-component.wasm: component size: 151.10 KiB, avg delta memory: 160 KiB
   file-service.wasm: component size: 126.28 KiB, avg delta memory: 204 KiB
   file-write-read-delete.wasm: component size: 102.11 KiB, avg delta memory: 298.67 KiB
   flags-service.wasm: component size: 53.27 KiB, avg delta memory: 192 KiB
   golem-rust-tests.wasm: component size: 501.41 KiB, avg delta memory: 3.24 MiB
   grain-1.wasm: component size: 97.30 KiB, avg delta memory: 229.33 KiB
   http-client-2.wasm: component size: 705.20 KiB, avg delta memory: 1.60 MiB
   http-client.wasm: component size: 107.36 KiB, avg delta memory: 352 KiB
   interruption.wasm: component size: 72.99 KiB, avg delta memory: 397.33 KiB
   java-1.wasm: component size: 204.54 KiB, avg delta memory: 584 KiB
   java-2.wasm: component size: 288.16 KiB, avg delta memory: 1.40 MiB
   js-1.wasm: component size: 9.99 MiB, avg delta memory: 45.75 MiB
   js-2.wasm: component size: 9.99 MiB, avg delta memory: 44.01 MiB
   js-3.wasm: component size: 9.99 MiB, avg delta memory: 9.97 MiB
   js-4.wasm: component size: 10.18 MiB, avg delta memory: 64.85 MiB
   js-echo.wasm: component size: 9.98 MiB, avg delta memory: 17.56 MiB
   key-value-service.wasm: component size: 69.53 KiB, avg delta memory: 344 KiB
   large-dynamic-memory.wasm: component size: 74.65 KiB, avg delta memory: 210.67 KiB
   large-initial-memory.wasm: component size: 74.50 KiB, avg delta memory: 308 KiB
   networking.wasm: component size: 73.20 KiB, avg delta memory: 274.67 KiB
   option-service.wasm: component size: 52.67 KiB, avg delta memory: 234.67 KiB
   parent_component_composed.wasm: component size: 4.48 MiB, avg delta memory: 1.49 MiB
   promise.wasm: component size: 14.12 KiB, avg delta memory: 80 KiB
   py-echo.wasm: component size: 33.20 MiB, avg delta memory: 76.76 MiB
   python-1.wasm: component size: 33.20 MiB, avg delta memory: 143.36 MiB
   read-stdin.wasm: component size: 75.98 KiB, avg delta memory: 653.33 KiB
   runtime-service.wasm: component size: 515.08 KiB, avg delta memory: 1.72 MiB
   rust-echo.wasm: component size: 13.18 KiB, avg delta memory: 154.67 KiB
   rust_component_service.wasm: component size: 1.63 MiB, avg delta memory: 341.33 KiB
   shopping-cart-resource.wasm: component size: 115.13 KiB, avg delta memory: 1.11 MiB
   shopping-cart.wasm: component size: 113.69 KiB, avg delta memory: 386.67 KiB
   stdio-cc.wasm: component size: 85.66 KiB, avg delta memory: 205.33 KiB
   swift-1.wasm: component size: 8.67 MiB, avg delta memory: 86.16 MiB
   tinygo-wasi-http.wasm: component size: 6.04 MiB, avg delta memory: 504 KiB
   tinygo-wasi.wasm: component size: 652.59 KiB, avg delta memory: 3.34 MiB
   update-test-v1.wasm: component size: 99.75 KiB, avg delta memory: 845.33 KiB
   update-test-v2.wasm: component size: 91.10 KiB, avg delta memory: 506.67 KiB
   update-test-v3.wasm: component size: 57.64 KiB, avg delta memory: 176 KiB
   update-test-v4.wasm: component size: 52.13 KiB, avg delta memory: 208 KiB
   variant-service.wasm: component size: 13.29 KiB, avg delta memory: 74.67 KiB
   write-stderr.wasm: component size: 61.44 KiB, avg delta memory: 245.33 KiB
   write-stdout.wasm: component size: 65.51 KiB, avg delta memory: 226.67 KiB
   zig-1.wasm: component size: 684.47 KiB, avg delta memory: 1.49 MiB
   zig-3.wasm: component size: 172.63 KiB, avg delta memory: 146.67 KiB
```

in csv format:

```
name,component-size,delta-memory,language
auction.wasm,82705,253952,rust
auction_registry_composed.wasm,206775,933888,rust
blob-store-service.wasm,63318,327680,rust
c-1.wasm,60985,144725,c
caller_composed.wasm,208504,447829,rust
child_component.wasm,2686998,8555178,rust
clock-service.wasm,60782,221184,rust
clocks.wasm,94144,360448,rust
counters.wasm,89722,480597,rust
csharp-1.wasm,8964429,71013717,c#
directories.wasm,115094,447829,rust
environment-service.wasm,72129,305834,rust
failing-component.wasm,154725,163840,rust
file-service.wasm,129312,208896,rust
file-write-read-delete.wasm,104561,305834,rust
flags-service.wasm,54545,196608,rust
golem-rust-tests.wasm,513439,3394218,rust
grain-1.wasm,99632,234837,grain
http-client-2.wasm,722123,1679360,rust
http-client.wasm,109937,360448,rust
interruption.wasm,74739,406869,rust
java-1.wasm,209453,598016,java
java-2.wasm,295071,1471829,java
js-1.wasm,10474053,47968256,js
js-2.wasm,10475315,46145536,js
js-3.wasm,10474830,10452992,js
js-4.wasm,10677768,67999061,js
js-echo.wasm,10468620,18415616,js
key-value-service.wasm,71197,352256,rust
large-dynamic-memory.wasm,76446,215722,rust
large-initial-memory.wasm,76283,315392,rust
networking.wasm,74953,281258,rust
option-service.wasm,53935,240298,rust
parent_component_composed.wasm,4698441,1560576,rust
promise.wasm,14462,81920,rust
py-echo.wasm,34808660,80483669,python
python-1.wasm,34810252,150328661,python
read-stdin.wasm,77807,669013,rust
runtime-service.wasm,527446,1802240,rust
rust-echo.wasm,13492,158378,rust
rust_component_service.wasm,1709471,349525,rust
shopping-cart-resource.wasm,117895,1160533,rust
shopping-cart.wasm,116419,395946,rust
stdio-cc.wasm,87717,210261,rust
swift-1.wasm,9095683,90341376,swift
tinygo-wasi-http.wasm,6329673,516096,go
tinygo-wasi.wasm,668252,3497984,go
update-test-v1.wasm,102147,865621,rust
update-test-v2.wasm,93288,518826,rust
update-test-v3.wasm,59019,180224,rust
update-test-v4.wasm,53379,212992,rust
variant-service.wasm,13612,76458,rust
write-stderr.wasm,62913,251221,rust
write-stdout.wasm,67086,232106,rust
zig-1.wasm,700898,1567402,zig
zig-3.wasm,176773,150186,zig
```