### PR TITLE
Hot fix: Remove empty check as it is not done in wasm rpc code

### DIFF
--- a/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
@@ -56,28 +56,32 @@ impl RefinedWorkerResponse {
 
 #[cfg(test)]
 mod tests {
+    use crate::service::worker::TypedResult;
+    use golem_service_base::model::{FunctionResult, Type, TypeU32};
     use golem_wasm_ast::analysis::AnalysedType;
     use golem_wasm_rpc::TypeAnnotatedValue;
-    use golem_service_base::model::{FunctionResult, Type, TypeU32};
-    use crate::service::worker::TypedResult;
 
-    use crate::worker_bridge_execution::WorkerResponse;
     use crate::worker_bridge_execution::refined_worker_response::RefinedWorkerResponse;
+    use crate::worker_bridge_execution::WorkerResponse;
 
     #[test]
     fn test_refined_worker_response_from_worker_response() {
         let worker_response = WorkerResponse {
             result: TypedResult {
                 result: TypeAnnotatedValue::U32(1),
-                function_result_types: vec![FunctionResult{
+                function_result_types: vec![FunctionResult {
                     name: None,
-                    typ: Type::U32(TypeU32)
+                    typ: Type::U32(TypeU32),
                 }],
             },
         };
 
-        let refined_worker_response = RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
-        assert_eq!(refined_worker_response, RefinedWorkerResponse::SingleResult(TypeAnnotatedValue::U32(1)));
+        let refined_worker_response =
+            RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
+        assert_eq!(
+            refined_worker_response,
+            RefinedWorkerResponse::SingleResult(TypeAnnotatedValue::U32(1))
+        );
 
         let worker_response = WorkerResponse {
             result: TypedResult {
@@ -86,10 +90,11 @@ mod tests {
                     typ: vec![],
                 },
                 function_result_types: vec![],
-            }
+            },
         };
 
-        let refined_worker_response = RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
+        let refined_worker_response =
+            RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
         assert_eq!(refined_worker_response, RefinedWorkerResponse::Unit);
 
         let worker_response = WorkerResponse {
@@ -98,18 +103,21 @@ mod tests {
                     typ: vec![("foo".to_string(), AnalysedType::U32)],
                     value: vec![("foo".to_string(), TypeAnnotatedValue::U32(1))],
                 },
-                function_result_types: vec![FunctionResult{
+                function_result_types: vec![FunctionResult {
                     name: Some("name".to_string()),
-                    typ: Type::U32(TypeU32)
+                    typ: Type::U32(TypeU32),
                 }],
             },
         };
 
-
-        let refined_worker_response = RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
-        assert_eq!(refined_worker_response, RefinedWorkerResponse::MultipleResults(TypeAnnotatedValue::Record {
-            typ: vec![("foo".to_string(), AnalysedType::U32)],
-            value: vec![("foo".to_string(), TypeAnnotatedValue::U32(1))],
-        }));
+        let refined_worker_response =
+            RefinedWorkerResponse::from_worker_response(&worker_response).unwrap();
+        assert_eq!(
+            refined_worker_response,
+            RefinedWorkerResponse::MultipleResults(TypeAnnotatedValue::Record {
+                typ: vec![("foo".to_string(), AnalysedType::U32)],
+                value: vec![("foo".to_string(), TypeAnnotatedValue::U32(1))],
+            })
+        );
     }
 }

--- a/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
@@ -6,7 +6,7 @@ use crate::worker_bridge_execution::WorkerResponse;
 // Refined Worker response is different from WorkerResponse, because,
 // it ensures that we are not returning a vector of result if they are not named results
 // or unit
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RefinedWorkerResponse {
     Unit,
     SingleResult(TypeAnnotatedValue),
@@ -68,7 +68,10 @@ mod tests {
     fn test_refined_worker_response_from_worker_response() {
         let worker_response = WorkerResponse {
             result: TypedResult {
-                result: TypeAnnotatedValue::U32(1),
+                result: TypeAnnotatedValue::Tuple {
+                    value: vec![TypeAnnotatedValue::U32(1)],
+                    typ: vec![AnalysedType::U32],
+                },
                 function_result_types: vec![FunctionResult {
                     name: None,
                     typ: Type::U32(TypeU32),

--- a/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/refined_worker_response.rs
@@ -28,9 +28,7 @@ impl RefinedWorkerResponse {
         let result = &worker_response.result.result;
         let function_result_types = &worker_response.result.function_result_types;
 
-        if function_result_types.iter().all(|r| r.name.is_none())
-            && !function_result_types.is_empty()
-        {
+        if function_result_types.iter().all(|r| r.name.is_none()) {
             match result {
                 TypeAnnotatedValue::Tuple { value, .. } => {
                     if value.len() == 1 {


### PR DESCRIPTION
A hot fix to remove the following issue #641 


```
Internal Error. WorkerBridge expects the result from worker to be a Record if results are named
```

I am sorry I can't figure out why there was an empty check that existed before. By removing this it aligns with what wasm-rpc code base is doing
https://github.com/golemcloud/wasm-rpc/blob/main/wasm-rpc/src/json.rs#L118

This is mainly around avoid responses that are always wrapped in a vector. 
