### PR TITLE
Fix config error handling

### DIFF
--- a/golem-component-compilation-service/src/config.rs
+++ b/golem-component-compilation-service/src/config.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
-use std::net::{Ipv4Addr, SocketAddrV4};
-
 use http::Uri;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::path::Path;
 use uuid::Uuid;
 
 use golem_common::config::{ConfigExample, ConfigLoader, HasConfigExamples, RetryConfig};
@@ -128,7 +128,7 @@ impl Default for CompileWorkerConfig {
 }
 
 pub fn make_config_loader() -> ConfigLoader<ServerConfig> {
-    ConfigLoader::new_with_examples("config/component-compilation-service.toml".to_owned())
+    ConfigLoader::new_with_examples(Path::new("config/component-compilation-service.toml"))
 }
 
 #[cfg(test)]

--- a/golem-component-service/src/config.rs
+++ b/golem-component-service/src/config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 use golem_common::config::{ConfigExample, ConfigLoader, HasConfigExamples};
 use golem_common::tracing::TracingConfig;
@@ -70,7 +71,7 @@ impl HasConfigExamples<ComponentServiceConfig> for ComponentServiceConfig {
 }
 
 pub fn make_config_loader() -> ConfigLoader<ComponentServiceConfig> {
-    ConfigLoader::new_with_examples("config/component-service.toml".to_owned())
+    ConfigLoader::new_with_examples(Path::new("config/component-service.toml"))
 }
 
 #[cfg(test)]

--- a/golem-shard-manager/src/shard_manager_config.rs
+++ b/golem-shard-manager/src/shard_manager_config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -124,7 +125,7 @@ pub struct HealthCheckK8sConfig {
 }
 
 pub fn make_config_loader() -> ConfigLoader<ShardManagerConfig> {
-    ConfigLoader::new_with_examples("config/shard-manager.toml".to_string())
+    ConfigLoader::new_with_examples(Path::new("config/shard-manager.toml"))
 }
 
 #[cfg(test)]

--- a/golem-worker-executor-base/src/services/golem_config.rs
+++ b/golem-worker-executor-base/src/services/golem_config.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -575,5 +575,5 @@ impl Default for MemoryConfig {
 }
 
 pub fn make_config_loader() -> ConfigLoader<GolemConfig> {
-    ConfigLoader::new_with_examples("config/worker-executor.toml".to_string())
+    ConfigLoader::new_with_examples(Path::new("config/worker-executor.toml"))
 }

--- a/golem-worker-service/src/config.rs
+++ b/golem-worker-service/src/config.rs
@@ -1,8 +1,9 @@
 use golem_common::config::ConfigLoader;
 use golem_worker_service_base::app_config::WorkerServiceBaseConfig;
+use std::path::Path;
 
 pub fn make_config_loader() -> ConfigLoader<WorkerServiceBaseConfig> {
-    ConfigLoader::new_with_examples("config/worker-service.toml".to_owned())
+    ConfigLoader::new_with_examples(Path::new("config/worker-service.toml"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #571 

- Fixes how config errors are displayed
- Makes sure to fail if the service's `toml` config is not found

Before:
```
thread 'main' panicked at /Users/vigoo/projects/ziverge/golem-services/golem-common/src/config.rs:122:38:
Failed to load config: Error { tag: Tag(Default, 2), profile: Some(Profile(Uncased { string: "default" })), metadata: Some(Metadata { name: "TOML file", source: Some(File("/Users/vigoo/projects/ziverge/golem-services/golem-worker-executor/config/worker-executor.toml")), provide_location: Some(Location { file: "/Users/vigoo/projects/ziverge/golem-services/golem-common/src/config.rs", line: 83, col: 14 }), interpolater:  }), path: ["active_workers", "drop_when_full"], kind: InvalidType(Str("xx"), "f64"), prev: None }
stack backtrace:
   0: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   2: core::result::unwrap_failed
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/result.rs:1654:5
   3: core::result::Result<T,E>::expect
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/result.rs:1034:23
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

after:
```
Failed to load config: invalid type: found string "xx", expected f64 for key "default.active_workers.drop_when_full" in config/worker-executor.toml TOML file
```