### PR TITLE
518 golem URI

### DIFF
--- a/golem-cli/src/clients/component.rs
+++ b/golem-cli/src/clients/component.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use crate::model::component::Component;
-use crate::model::{ComponentId, ComponentName, GolemError, PathBufOrStdin};
+use crate::model::{ComponentName, GolemError, PathBufOrStdin};
 use async_trait::async_trait;
+use golem_common::uri::oss::urn::ComponentUrn;
 
 #[async_trait]
 pub trait ComponentClient {
@@ -22,12 +23,12 @@ pub trait ComponentClient {
 
     async fn get_metadata(
         &self,
-        component_id: &ComponentId,
+        component_urn: &ComponentUrn,
         version: u64,
     ) -> Result<Component, GolemError>;
     async fn get_latest_metadata(
         &self,
-        component_id: &ComponentId,
+        component_urn: &ComponentUrn,
     ) -> Result<Component, GolemError>;
     async fn find(
         &self,
@@ -40,5 +41,9 @@ pub trait ComponentClient {
         file: PathBufOrStdin,
         project: &Option<Self::ProjectContext>,
     ) -> Result<Component, GolemError>;
-    async fn update(&self, id: ComponentId, file: PathBufOrStdin) -> Result<Component, GolemError>;
+    async fn update(
+        &self,
+        urn: ComponentUrn,
+        file: PathBufOrStdin,
+    ) -> Result<Component, GolemError>;
 }

--- a/golem-cli/src/clients/worker.rs
+++ b/golem-cli/src/clients/worker.rs
@@ -13,26 +13,26 @@
 // limitations under the License.
 
 use crate::model::{
-    ComponentId, GolemError, IdempotencyKey, WorkerMetadata, WorkerName, WorkerUpdateMode,
+    GolemError, IdempotencyKey, WorkerMetadata, WorkerName, WorkerUpdateMode,
     WorkersMetadataResponse,
 };
 use async_trait::async_trait;
 use golem_client::model::{InvokeParameters, InvokeResult, ScanCursor, WorkerFilter, WorkerId};
+use golem_common::uri::oss::urn::{ComponentUrn, WorkerUrn};
 
 #[async_trait]
 pub trait WorkerClient {
     async fn new_worker(
         &self,
         name: WorkerName,
-        component_id: ComponentId,
+        component_urn: ComponentUrn,
         args: Vec<String>,
         env: Vec<(String, String)>,
     ) -> Result<WorkerId, GolemError>;
 
     async fn invoke_and_await(
         &self,
-        name: WorkerName,
-        component_id: ComponentId,
+        worker_urn: WorkerUrn,
         function: String,
         parameters: InvokeParameters,
         idempotency_key: Option<IdempotencyKey>,
@@ -40,32 +40,19 @@ pub trait WorkerClient {
 
     async fn invoke(
         &self,
-        name: WorkerName,
-        component_id: ComponentId,
+        worker_urn: WorkerUrn,
         function: String,
         parameters: InvokeParameters,
         idempotency_key: Option<IdempotencyKey>,
     ) -> Result<(), GolemError>;
 
-    async fn interrupt(
-        &self,
-        name: WorkerName,
-        component_id: ComponentId,
-    ) -> Result<(), GolemError>;
-    async fn simulated_crash(
-        &self,
-        name: WorkerName,
-        component_id: ComponentId,
-    ) -> Result<(), GolemError>;
-    async fn delete(&self, name: WorkerName, component_id: ComponentId) -> Result<(), GolemError>;
-    async fn get_metadata(
-        &self,
-        name: WorkerName,
-        component_id: ComponentId,
-    ) -> Result<WorkerMetadata, GolemError>;
+    async fn interrupt(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
+    async fn simulated_crash(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
+    async fn delete(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
+    async fn get_metadata(&self, worker_urn: WorkerUrn) -> Result<WorkerMetadata, GolemError>;
     async fn find_metadata(
         &self,
-        component_id: ComponentId,
+        component_urn: ComponentUrn,
         filter: Option<WorkerFilter>,
         cursor: Option<ScanCursor>,
         count: Option<u64>,
@@ -73,18 +60,17 @@ pub trait WorkerClient {
     ) -> Result<WorkersMetadataResponse, GolemError>;
     async fn list_metadata(
         &self,
-        component_id: ComponentId,
+        component_urn: ComponentUrn,
         filter: Option<Vec<String>>,
         cursor: Option<ScanCursor>,
         count: Option<u64>,
         precise: Option<bool>,
     ) -> Result<WorkersMetadataResponse, GolemError>;
-    async fn connect(&self, name: WorkerName, component_id: ComponentId) -> Result<(), GolemError>;
+    async fn connect(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
 
     async fn update(
         &self,
-        name: WorkerName,
-        component_id: ComponentId,
+        worker_urn: WorkerUrn,
         mode: WorkerUpdateMode,
         target_version: u64,
     ) -> Result<(), GolemError>;

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::model::ComponentIdOrName;
+use crate::model::ComponentUriArg;
 use crate::oss::model::OssContext;
+use golem_common::uri::oss::uri::ComponentUri;
 
 pub mod api_definition;
 pub mod api_deployment;
@@ -22,11 +23,11 @@ pub mod profile;
 pub mod worker;
 
 pub trait ComponentRefSplit<ProjectRef> {
-    fn split(self) -> (ComponentIdOrName, Option<ProjectRef>);
+    fn split(self) -> (ComponentUri, Option<ProjectRef>);
 }
 
-impl ComponentRefSplit<OssContext> for ComponentIdOrName {
-    fn split(self) -> (ComponentIdOrName, Option<OssContext>) {
-        (self, None)
+impl ComponentRefSplit<OssContext> for ComponentUriArg {
+    fn split(self) -> (ComponentUri, Option<OssContext>) {
+        (self.uri, None)
     }
 }

--- a/golem-cli/src/command/component.rs
+++ b/golem-cli/src/command/component.rs
@@ -40,9 +40,9 @@ pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
     /// Updates an existing component by uploading a new version of its WASM
     #[command()]
     Update {
-        /// The component name or identifier to update
+        /// The component to update
         #[command(flatten)]
-        component_id_or_name: ComponentRef,
+        component_name_or_uri: ComponentRef,
 
         /// The WASM file to be used as a new version of the Golem component
         #[arg(value_name = "component-file", value_hint = clap::ValueHint::FilePath)]
@@ -63,9 +63,9 @@ pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
     /// Get component
     #[command()]
     Get {
-        /// The Golem component id or name
+        /// The Golem component
         #[command(flatten)]
-        component_id_or_name: ComponentRef,
+        component_name_or_uri: ComponentRef,
 
         /// The version of the component
         #[arg(short = 't', long)]
@@ -95,13 +95,13 @@ impl<
                     .await
             }
             ComponentSubCommand::Update {
-                component_id_or_name,
+                component_name_or_uri,
                 component_file,
             } => {
-                let (component_id_or_name, project_ref) = component_id_or_name.split();
+                let (component_name_or_uri, project_ref) = component_name_or_uri.split();
                 let project_id = projects.resolve_id_or_default_opt(project_ref).await?;
                 service
-                    .update(component_id_or_name, component_file, project_id)
+                    .update(component_name_or_uri, component_file, project_id)
                     .await
             }
             ComponentSubCommand::List {
@@ -112,12 +112,14 @@ impl<
                 service.list(component_name, Some(project_id)).await
             }
             ComponentSubCommand::Get {
-                component_id_or_name,
+                component_name_or_uri,
                 version,
             } => {
-                let (component_id_or_name, project_ref) = component_id_or_name.split();
+                let (component_name_or_uri, project_ref) = component_name_or_uri.split();
                 let project_id = projects.resolve_id_or_default_opt(project_ref).await?;
-                service.get(component_id_or_name, version, project_id).await
+                service
+                    .get(component_name_or_uri, version, project_id)
+                    .await
             }
         }
     }

--- a/golem-cli/src/model/component.rs
+++ b/golem-cli/src/model/component.rs
@@ -5,6 +5,8 @@ use golem_client::model::{
     NameTypePair, ProtectedComponentId, ResourceMode, Type, TypeEnum, TypeFlags, TypeRecord,
     TypeTuple, TypeVariant, UserComponentId, VersionedComponentId,
 };
+use golem_common::model::ComponentId;
+use golem_common::uri::oss::urn::ComponentUrn;
 use golem_wasm_ast::wave::DisplayNamedFunc;
 use rib::{ParsedFunctionName, ParsedFunctionSite};
 use serde::{Deserialize, Serialize};
@@ -49,7 +51,7 @@ impl From<golem_client::model::Component> for Component {
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentView {
-    pub component_id: String,
+    pub component_urn: ComponentUrn,
     pub component_version: u64,
     pub component_name: String,
     pub component_size: u64,
@@ -68,7 +70,9 @@ impl From<Component> for ComponentView {
 impl From<&Component> for ComponentView {
     fn from(value: &Component) -> Self {
         ComponentView {
-            component_id: value.versioned_component_id.component_id.to_string(),
+            component_urn: ComponentUrn {
+                id: ComponentId(value.versioned_component_id.component_id),
+            },
             component_version: value.versioned_component_id.version,
             component_name: value.component_name.to_string(),
             component_size: value.component_size,

--- a/golem-cli/src/oss/command.rs
+++ b/golem-cli/src/oss/command.rs
@@ -16,11 +16,12 @@ use crate::command::api_definition::ApiDefinitionSubcommand;
 use crate::command::api_deployment::ApiDeploymentSubcommand;
 use crate::command::component::ComponentSubCommand;
 use crate::command::profile::ProfileSubCommand;
-use crate::command::worker::WorkerSubcommand;
-use crate::model::{ComponentIdOrName, Format};
+use crate::command::worker::{OssWorkerUriArg, WorkerSubcommand};
+use crate::model::{ComponentUriArg, Format};
 use crate::oss::model::OssContext;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;
+use golem_common::uri::oss::uri::ResourceUri;
 use golem_examples::model::{ExampleName, GuestLanguage, GuestLanguageTier, PackageName};
 
 #[derive(Subcommand, Debug)]
@@ -30,14 +31,23 @@ pub enum OssCommand<ProfileAdd: clap::Args> {
     #[command()]
     Component {
         #[command(subcommand)]
-        subcommand: ComponentSubCommand<OssContext, ComponentIdOrName>,
+        subcommand: ComponentSubCommand<OssContext, ComponentUriArg>,
     },
 
     /// Manage Golem workers
     #[command()]
     Worker {
         #[command(subcommand)]
-        subcommand: WorkerSubcommand<ComponentIdOrName>,
+        subcommand: WorkerSubcommand<ComponentUriArg, OssWorkerUriArg>,
+    },
+
+    /// Get resource by URI
+    ///
+    /// Use resource URN or URL to get resource metadata.
+    #[command()]
+    Get {
+        #[arg(value_name = "URI")]
+        uri: ResourceUri,
     },
 
     /// Create a new Golem component from built-in examples

--- a/golem-cli/tests/api_definition.rs
+++ b/golem-cli/tests/api_definition.rs
@@ -213,11 +213,12 @@ fn api_definition_import(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_import{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let path = make_open_api_file(&component_name, &component.component_id)?;
+    let component_id = component.component_urn.id.0.to_string();
+    let path = make_open_api_file(&component_name, &component_id)?;
 
     let res: HttpApiDefinition = cli.run(&["api-definition", "import", path.to_str().unwrap()])?;
 
-    let expected = golem_def(&component_name, &component.component_id);
+    let expected = golem_def(&component_name, &component_id);
 
     assert_eq!(res, expected);
 
@@ -233,7 +234,8 @@ fn api_definition_add(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_add{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let def = golem_def(&component_name, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let res: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -252,14 +254,15 @@ fn api_definition_update(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_update{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
+    let component_id = component.component_urn.id.0.to_string();
 
-    let def = golem_def(&component_name, &component.component_id);
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
 
     let updated = golem_def_with_response(
         &component_name,
-        &component.component_id,
+        &component_id,
         "${{headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: 200}}"
             .to_string(),
     );
@@ -280,13 +283,14 @@ fn api_definition_update_immutable(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_update_immutable{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
+    let component_id = component.component_urn.id.0.to_string();
 
-    let mut def = golem_def(&component_name, &component.component_id);
+    let mut def = golem_def(&component_name, &component_id);
     def.draft = false;
     let path = make_golem_file(&def)?;
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
 
-    let updated = golem_def_with_response(&component_name, &component.component_id, "${{headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: 200}}".to_string());
+    let updated = golem_def_with_response(&component_name, &component_id, "${{headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: 200}}".to_string());
     let path = make_golem_file(&updated)?;
     let res = cli.run_string(&["api-definition", "update", path.to_str().unwrap()]);
 
@@ -304,7 +308,8 @@ fn api_definition_list(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_list{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let def = golem_def(&component_name, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -325,7 +330,8 @@ fn api_definition_list_versions(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_list_versions{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let def = golem_def(&component_name, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
     let cfg = &cli.config;
 
@@ -353,7 +359,8 @@ fn api_definition_get(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_get{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let def = golem_def(&component_name, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -383,7 +390,8 @@ fn api_definition_delete(
 ) -> Result<(), Failed> {
     let component_name = format!("api_definition_delete{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
-    let def = golem_def(&component_name, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;

--- a/golem-cli/tests/api_deployment.rs
+++ b/golem-cli/tests/api_deployment.rs
@@ -66,7 +66,8 @@ pub fn make_definition(
     id: &str,
 ) -> Result<HttpApiDefinition, Failed> {
     let component = make_shopping_cart_component(deps, id, cli)?;
-    let def = golem_def(id, &component.component_id);
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(id, &component_id);
     let path = make_golem_file(&def)?;
 
     cli.run(&["api-definition", "add", path.to_str().unwrap()])

--- a/golem-cli/tests/cli.rs
+++ b/golem-cli/tests/cli.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct CliConfig {
-    short_args: bool,
+    pub short_args: bool,
 }
 
 impl CliConfig {
@@ -27,11 +27,11 @@ impl CliConfig {
 }
 
 pub trait Cli {
-    fn run<T: DeserializeOwned>(&self, args: &[&str]) -> Result<T, Failed>;
-    fn run_string(&self, args: &[&str]) -> Result<String, Failed>;
-    fn run_json(&self, args: &[&str]) -> Result<Value, Failed>;
-    fn run_unit(&self, args: &[&str]) -> Result<(), Failed>;
-    fn run_stdout(&self, args: &[&str]) -> Result<Child, Failed>;
+    fn run<T: DeserializeOwned, S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<T, Failed>;
+    fn run_string<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<String, Failed>;
+    fn run_json<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<Value, Failed>;
+    fn run_unit<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<(), Failed>;
+    fn run_stdout<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<Child, Failed>;
 }
 
 #[derive(Debug, Clone)]
@@ -156,28 +156,31 @@ impl CliLive {
 }
 
 impl Cli for CliLive {
-    fn run<'a, T: DeserializeOwned>(&self, args: &[&str]) -> Result<T, Failed> {
+    fn run<'a, T: DeserializeOwned, S: AsRef<OsStr> + Debug>(
+        &self,
+        args: &[S],
+    ) -> Result<T, Failed> {
         let stdout = self.run_inner(args)?;
 
         Ok(serde_json::from_str(&stdout)?)
     }
 
-    fn run_string(&self, args: &[&str]) -> Result<String, Failed> {
+    fn run_string<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<String, Failed> {
         self.run_inner(args)
     }
 
-    fn run_json(&self, args: &[&str]) -> Result<Value, Failed> {
+    fn run_json<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<Value, Failed> {
         let stdout = self.run_inner(args)?;
 
         Ok(serde_json::from_str(&stdout)?)
     }
 
-    fn run_unit(&self, args: &[&str]) -> Result<(), Failed> {
+    fn run_unit<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<(), Failed> {
         let _ = self.run_inner(args)?;
         Ok(())
     }
 
-    fn run_stdout(&self, args: &[&str]) -> Result<Child, Failed> {
+    fn run_stdout<S: AsRef<OsStr> + Debug>(&self, args: &[S]) -> Result<Child, Failed> {
         println!(
             "Executing Golem CLI command: {} {args:?}",
             self.golem_cli_path.to_str().unwrap_or("")

--- a/golem-cli/tests/component.rs
+++ b/golem-cli/tests/component.rs
@@ -1,5 +1,6 @@
 use crate::cli::{Cli, CliLive};
 use golem_cli::model::component::ComponentView;
+use golem_common::uri::oss::url::ComponentUrl;
 use golem_test_framework::config::TestDependencies;
 use libtest_mimic::{Failed, Trial};
 use std::sync::Arc;
@@ -28,9 +29,29 @@ fn make(
             component_add_and_get,
         ),
         Trial::test_in_context(
+            format!("component_add_and_get_urn{suffix}"),
+            ctx.clone(),
+            component_add_and_get_urn,
+        ),
+        Trial::test_in_context(
+            format!("component_add_and_get_url{suffix}"),
+            ctx.clone(),
+            component_add_and_get_url,
+        ),
+        Trial::test_in_context(
             format!("component_update{suffix}"),
             ctx.clone(),
             component_update,
+        ),
+        Trial::test_in_context(
+            format!("component_update_urn{suffix}"),
+            ctx.clone(),
+            component_update_urn,
+        ),
+        Trial::test_in_context(
+            format!("component_update_url{suffix}"),
+            ctx.clone(),
+            component_update_url,
         ),
     ]
 }
@@ -137,8 +158,68 @@ fn component_update(
     let _: ComponentView = cli.run(&[
         "component",
         "update",
-        &cfg.arg('C', "component-id"),
-        &component.component_id,
+        &cfg.arg('c', "component-name"),
+        &component.component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+    Ok(())
+}
+
+fn component_update_urn(
+    (deps, name, cli): (
+        Arc<dyn TestDependencies + Send + Sync + 'static>,
+        String,
+        CliLive,
+    ),
+) -> Result<(), Failed> {
+    let component_name = format!("{name} component update urn");
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        &component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let _: ComponentView = cli.run(&[
+        "component",
+        "update",
+        &cfg.arg('C', "component"),
+        &component.component_urn.to_string(),
+        env_service.to_str().unwrap(),
+    ])?;
+    Ok(())
+}
+
+fn component_update_url(
+    (deps, name, cli): (
+        Arc<dyn TestDependencies + Send + Sync + 'static>,
+        String,
+        CliLive,
+    ),
+) -> Result<(), Failed> {
+    let component_name = format!("{name} component update url");
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        &component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let component_url = ComponentUrl {
+        name: component.component_name.to_string(),
+    };
+
+    let _: ComponentView = cli.run(&[
+        "component",
+        "update",
+        &cfg.arg('C', "component"),
+        &component_url.to_string(),
         env_service.to_str().unwrap(),
     ])?;
     Ok(())
@@ -166,6 +247,66 @@ fn component_add_and_get(
         "get",
         &cfg.arg('c', "component-name"),
         &component_name,
+    ])?;
+    assert!(res == component, "{res:?} = ({component:?})");
+    Ok(())
+}
+
+fn component_add_and_get_urn(
+    (deps, name, cli): (
+        Arc<dyn TestDependencies + Send + Sync + 'static>,
+        String,
+        CliLive,
+    ),
+) -> Result<(), Failed> {
+    let component_name = format!("{name} component add and get urn");
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        &component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let res: ComponentView = cli.run(&[
+        "component",
+        "get",
+        &cfg.arg('C', "component"),
+        &component.component_urn.to_string(),
+    ])?;
+    assert!(res == component, "{res:?} = ({component:?})");
+    Ok(())
+}
+
+fn component_add_and_get_url(
+    (deps, name, cli): (
+        Arc<dyn TestDependencies + Send + Sync + 'static>,
+        String,
+        CliLive,
+    ),
+) -> Result<(), Failed> {
+    let component_name = format!("{name} component add and get url");
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        &component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let component_url = ComponentUrl {
+        name: component.component_name.to_string(),
+    };
+
+    let res: ComponentView = cli.run(&[
+        "component",
+        "get",
+        &cfg.arg('C', "component"),
+        &component_url.to_string(),
     ])?;
     assert!(res == component, "{res:?} = ({component:?})");
     Ok(())

--- a/golem-cli/tests/get.rs
+++ b/golem-cli/tests/get.rs
@@ -1,0 +1,187 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::api_definition::{golem_def, make_golem_file, make_shopping_cart_component};
+use crate::api_deployment::make_definition;
+use crate::cli::{Cli, CliLive};
+use crate::worker::make_component;
+use golem_cli::model::component::ComponentView;
+use golem_cli::model::WorkerMetadataView;
+use golem_client::model::{ApiDeployment, HttpApiDefinition};
+use golem_common::uri::oss::url::{ApiDefinitionUrl, ApiDeploymentUrl, ComponentUrl, WorkerUrl};
+use golem_common::uri::oss::urn::{ApiDefinitionUrn, ApiDeploymentUrn, WorkerUrn};
+use golem_test_framework::config::TestDependencies;
+use libtest_mimic::{Failed, Trial};
+use std::sync::Arc;
+
+fn make(cli: CliLive, deps: Arc<dyn TestDependencies + Send + Sync + 'static>) -> Vec<Trial> {
+    let ctx = (deps, cli);
+    vec![
+        Trial::test_in_context(
+            "top_level_get_api_definition".to_string(),
+            ctx.clone(),
+            top_level_get_api_definition,
+        ),
+        Trial::test_in_context(
+            "top_level_get_api_deployment".to_string(),
+            ctx.clone(),
+            top_level_get_api_deployment,
+        ),
+        Trial::test_in_context(
+            "top_level_get_component".to_string(),
+            ctx.clone(),
+            top_level_get_component,
+        ),
+        Trial::test_in_context(
+            "top_level_get_worker".to_string(),
+            ctx.clone(),
+            top_level_get_worker,
+        ),
+    ]
+}
+
+pub fn all(deps: Arc<dyn TestDependencies + Send + Sync + 'static>) -> Vec<Trial> {
+    make(
+        CliLive::make("top_level_get", deps.clone())
+            .unwrap()
+            .with_long_args(),
+        deps,
+    )
+}
+
+fn top_level_get_api_definition(
+    (deps, cli): (Arc<dyn TestDependencies + Send + Sync + 'static>, CliLive),
+) -> Result<(), Failed> {
+    let component_name = "top_level_get_api_definition";
+    let component = make_shopping_cart_component(deps, component_name, &cli)?;
+    let component_id = component.component_urn.id.0.to_string();
+    let def = golem_def(component_name, &component_id);
+    let path = make_golem_file(&def)?;
+
+    let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
+
+    let url = ApiDefinitionUrl {
+        name: component_name.to_string(),
+        version: "0.1.0".to_string(),
+    };
+
+    let res: HttpApiDefinition = cli.run(&["get", &url.to_string()])?;
+
+    assert_eq!(res, def);
+
+    let urn = ApiDefinitionUrn {
+        id: component_name.to_string(),
+        version: "0.1.0".to_string(),
+    };
+
+    let res: HttpApiDefinition = cli.run(&["get", &urn.to_string()])?;
+
+    assert_eq!(res, def);
+
+    Ok(())
+}
+
+fn top_level_get_api_deployment(
+    (deps, cli): (Arc<dyn TestDependencies + Send + Sync + 'static>, CliLive),
+) -> Result<(), Failed> {
+    let definition = make_definition(deps, &cli, "top_level_get_api_deployment")?;
+    let host = "get-host-top-level-get";
+    let cfg = &cli.config;
+
+    let created: ApiDeployment = cli.run(&[
+        "api-deployment",
+        "deploy",
+        &cfg.arg('d', "definition"),
+        &format!("{}/{}", definition.id, definition.version),
+        &cfg.arg('H', "host"),
+        host,
+        &cfg.arg('s', "subdomain"),
+        "sdomain",
+    ])?;
+
+    let site = format!("sdomain.{host}");
+
+    let url = ApiDeploymentUrl { site: site.clone() };
+
+    let res: ApiDeployment = cli.run(&["get", &url.to_string()])?;
+
+    assert_eq!(created, res);
+
+    let urn = ApiDeploymentUrn { site: site.clone() };
+
+    let res: ApiDeployment = cli.run(&["get", &urn.to_string()])?;
+
+    assert_eq!(created, res);
+
+    Ok(())
+}
+
+fn top_level_get_component(
+    (deps, cli): (Arc<dyn TestDependencies + Send + Sync + 'static>, CliLive),
+) -> Result<(), Failed> {
+    let component_name = "top_level_get_component";
+    let env_service = deps.component_directory().join("environment-service.wasm");
+    let cfg = &cli.config;
+    let component: ComponentView = cli.run(&[
+        "component",
+        "add",
+        &cfg.arg('c', "component-name"),
+        component_name,
+        env_service.to_str().unwrap(),
+    ])?;
+
+    let url = ComponentUrl {
+        name: component.component_name.to_string(),
+    };
+
+    let res: ComponentView = cli.run(&["get", &url.to_string()])?;
+    assert_eq!(res, component);
+
+    let res: ComponentView = cli.run(&["get", &component.component_urn.to_string()])?;
+    assert_eq!(res, component);
+
+    Ok(())
+}
+
+fn top_level_get_worker(
+    (deps, cli): (Arc<dyn TestDependencies + Send + Sync + 'static>, CliLive),
+) -> Result<(), Failed> {
+    let component = make_component(deps, "top_level_get_worker", &cli)?;
+    let worker_name = "top_level_get_worker";
+    let cfg = &cli.config;
+
+    let worker_urn: WorkerUrn = cli.run(&[
+        "worker",
+        "add",
+        &cfg.arg('w', "worker-name"),
+        worker_name,
+        "--component",
+        &component.component_urn.to_string(),
+    ])?;
+
+    let url = WorkerUrl {
+        component_name: component.component_name.to_string(),
+        worker_name: worker_name.to_string(),
+    };
+
+    let worker: WorkerMetadataView = cli.run(&["get", &url.to_string()])?;
+
+    assert_eq!(worker.worker_urn, worker_urn);
+
+    let worker: WorkerMetadataView = cli.run(&["get", &worker_urn.to_string()])?;
+
+    assert_eq!(worker.worker_urn, worker_urn);
+
+    Ok(())
+}

--- a/golem-cli/tests/main.rs
+++ b/golem-cli/tests/main.rs
@@ -1,6 +1,8 @@
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
 use libtest_mimic::{Arguments, Conclusion, Failed};
+use strum_macros::EnumIter;
 use tracing::info;
 
 use golem_test_framework::config::{
@@ -11,9 +13,27 @@ mod api_definition;
 mod api_deployment;
 pub mod cli;
 mod component;
+mod get;
 mod profile;
 mod text;
 mod worker;
+
+#[derive(Debug, Copy, Clone, EnumIter)]
+pub enum RefKind {
+    Name,
+    Url,
+    Urn,
+}
+
+impl Display for RefKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefKind::Name => write!(f, "name"),
+            RefKind::Url => write!(f, "url"),
+            RefKind::Urn => write!(f, "urn"),
+        }
+    }
+}
 
 fn run(deps: Arc<dyn TestDependencies + Send + Sync + 'static>) -> Conclusion {
     let args = Arguments::from_args();
@@ -25,7 +45,8 @@ fn run(deps: Arc<dyn TestDependencies + Send + Sync + 'static>) -> Conclusion {
     tests.append(&mut text::all(deps.clone()));
     tests.append(&mut api_definition::all(deps.clone()));
     tests.append(&mut api_deployment::all(deps.clone()));
-    tests.append(&mut profile::all(deps));
+    tests.append(&mut profile::all(deps.clone()));
+    tests.append(&mut get::all(deps));
 
     libtest_mimic::run(&args, tests)
 }

--- a/golem-common/src/uri/mod.rs
+++ b/golem-common/src/uri/mod.rs
@@ -1,0 +1,720 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use url::Url;
+
+pub mod oss;
+
+pub const COMPONENT_TYPE_NAME: &str = "component";
+pub const WORKER_TYPE_NAME: &str = "worker";
+pub const API_DEFINITION_TYPE_NAME: &str = "api-definition";
+pub const API_DEPLOYMENT_TYPE_NAME: &str = "api-deployment";
+
+/// Reference to a Golem resource
+/// Resolving such reference might require additional queries to multiple Golem services.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum GolemUri {
+    URL(GolemUrl),
+    URN(GolemUrn),
+}
+
+#[derive(Debug, Clone)]
+pub enum GolemUriParseError {
+    URN(GolemUrnParseError),
+    URL(GolemUrlParseError),
+}
+
+impl Display for GolemUriParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUriParseError::URN(err) => {
+                write!(f, "Failed to parse Golem URI: {err}")
+            }
+            GolemUriParseError::URL(err) => {
+                write!(f, "Failed to parse Golem URI: {err}")
+            }
+        }
+    }
+}
+
+impl FromStr for GolemUri {
+    type Err = GolemUriParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("urn:") {
+            let urn = GolemUrn::from_str(s).map_err(GolemUriParseError::URN)?;
+            Ok(GolemUri::URN(urn))
+        } else {
+            let url = GolemUrl::from_str(s).map_err(GolemUriParseError::URL)?;
+            Ok(GolemUri::URL(url))
+        }
+    }
+}
+
+impl Display for GolemUri {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUri::URL(url) => {
+                write!(f, "{}", url)
+            }
+            GolemUri::URN(urn) => {
+                write!(f, "{}", urn)
+            }
+        }
+    }
+}
+
+impl Serialize for GolemUri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GolemUri {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Fully resolved Golem resource name
+/// This name is enough to locate Golem resource in a service without additional queries to different Golem services.
+///
+/// User should not try to create such URN manually.
+///
+/// All user facing APIs should return URN for created resources.
+/// All user facing APIs should return URN for resource search.
+/// User facing APIs should avoid resource IDs - use URN instead.
+///
+/// The other way to get resource GolemUrn is to resolve a GolemUrl.
+///
+/// URN format is `urn:{resource_type}:{resource_name}`
+/// `resource_type` is case-insensitive
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct GolemUrn {
+    resource_type: String,
+    resource_name: String,
+}
+
+impl Display for GolemUrn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "urn:{}:{}", self.resource_type, self.resource_name)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum GolemUrnParseError {
+    NoUrnPrefix,
+    NoResourceName,
+    EmptyResourceType,
+    InvalidResourceType(char),
+}
+
+impl Display for GolemUrnParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUrnParseError::NoUrnPrefix => {
+                write!(f, "Failed to parse Golem URN: 'urn:' prefix expected.")
+            }
+            GolemUrnParseError::NoResourceName => {
+                write!(f, "Failed to parse Golem URN: resource name expected.")
+            }
+            GolemUrnParseError::EmptyResourceType => {
+                write!(f, "Failed to parse Golem URN: empty resource type.")
+            }
+            GolemUrnParseError::InvalidResourceType(c) => {
+                write!(
+                    f,
+                    "Failed to parse Golem URN: unexpected character '{c}' in resource type."
+                )
+            }
+        }
+    }
+}
+
+impl FromStr for GolemUrn {
+    type Err = GolemUrnParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(no_prefix) = s.strip_prefix("urn:") {
+            if let Some((resource_type, resource_name)) = no_prefix.split_once(':') {
+                if resource_type.is_empty() {
+                    Err(GolemUrnParseError::EmptyResourceType)
+                } else if resource_name.is_empty() {
+                    Err(GolemUrnParseError::NoResourceName)
+                } else {
+                    Ok(GolemUrn {
+                        resource_type: resource_type.to_lowercase(),
+                        resource_name: resource_name.to_string(),
+                    })
+                }
+            } else {
+                Err(GolemUrnParseError::NoResourceName)
+            }
+        } else {
+            Err(GolemUrnParseError::NoUrnPrefix)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GolemUrnTransformError {
+    InvalidName {
+        target_type: &'static str,
+        err: String,
+    },
+    UnexpectedType {
+        expected_types: Vec<&'static str>,
+        actual_type: String,
+    },
+    UrnParseError {
+        err: GolemUrnParseError,
+    },
+}
+
+impl Error for GolemUrnTransformError {}
+
+impl GolemUrnTransformError {
+    pub fn invalid_name(target_type: &'static str, err: String) -> GolemUrnTransformError {
+        GolemUrnTransformError::InvalidName { target_type, err }
+    }
+}
+
+impl Display for GolemUrnTransformError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUrnTransformError::InvalidName { target_type, err } => {
+                write!(f, "Failed to parse URN of type {target_type}: {err}")
+            }
+            GolemUrnTransformError::UnexpectedType {
+                expected_types,
+                actual_type,
+            } => {
+                if expected_types.len() == 1 {
+                    let expected_type = expected_types.first().unwrap();
+                    write!(
+                        f,
+                        "URN of type {expected_type} expected, but got {actual_type}"
+                    )
+                } else {
+                    let expected = expected_types.join(", ");
+
+                    write!(f, "Unexpected resource type in URN: {actual_type}. Expected one of: {expected}")
+                }
+            }
+            GolemUrnTransformError::UrnParseError { err } => {
+                write!(f, "Failed to parse URN: {err}")
+            }
+        }
+    }
+}
+
+pub trait TypedGolemUrn {
+    fn resource_type() -> &'static str;
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError>
+    where
+        Self: Sized;
+    fn to_name(&self) -> String;
+}
+
+fn try_from_golem_urn<T: TypedGolemUrn>(urn: &GolemUrn) -> Result<T, GolemUrnTransformError> {
+    let expected_type = T::resource_type();
+
+    if urn.resource_type != expected_type {
+        Err(GolemUrnTransformError::UnexpectedType {
+            expected_types: vec![expected_type],
+            actual_type: urn.resource_type.to_string(),
+        })
+    } else {
+        T::try_from_name(&urn.resource_name)
+    }
+}
+
+impl GolemUrn {
+    /// Create GolemUrn from type and name
+    ///
+    /// Should be used for `From` implementations - see `urn_from_example` test
+    pub fn try_from_parts<N: Into<String>>(
+        resource_type: &str,
+        resource_name: N,
+    ) -> Result<Self, GolemUrnParseError> {
+        validate_resource_type(resource_type).map_err(GolemUrnParseError::InvalidResourceType)?;
+
+        Ok(Self {
+            resource_type: resource_type.to_string(),
+            resource_name: resource_name.into(),
+        })
+    }
+}
+
+impl Serialize for GolemUrn {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GolemUrn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+fn validate_resource_type(resource_type: &str) -> Result<(), char> {
+    for c in resource_type.chars() {
+        match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '-' | '.' => {}
+            _ => {
+                return Err(c);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub enum GolemUrlTransformError {
+    InvalidPath {
+        target_type: &'static str,
+        err: String,
+    },
+    InvalidQuery {
+        target_type: &'static str,
+        key: &'static str,
+        err: String,
+    },
+    UnexpectedQuery {
+        target_type: &'static str,
+        key: String,
+    },
+    UnexpectedType {
+        expected_types: Vec<&'static str>,
+        actual_type: String,
+    },
+    UrlParseError {
+        err: GolemUrlParseError,
+    },
+}
+
+impl Error for GolemUrlTransformError {}
+
+impl Display for GolemUrlTransformError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUrlTransformError::InvalidPath { target_type, err } => {
+                write!(
+                    f,
+                    "Failed to parse URL of type {target_type}, invalid path: {err}"
+                )
+            }
+            GolemUrlTransformError::InvalidQuery {
+                target_type,
+                key,
+                err,
+            } => {
+                write!(
+                    f,
+                    "Failed to parse URL of type {target_type}, invalid query key '{key}': {err}"
+                )
+            }
+            GolemUrlTransformError::UnexpectedQuery { target_type, key } => {
+                write!(
+                    f,
+                    "Failed to parse URL of type {target_type}: unexpected query key '{key}'"
+                )
+            }
+            GolemUrlTransformError::UnexpectedType {
+                expected_types,
+                actual_type,
+            } => {
+                if expected_types.len() == 1 {
+                    let expected_type = expected_types.first().unwrap();
+                    write!(
+                        f,
+                        "URL of type {expected_type} expected, but got {actual_type}"
+                    )
+                } else {
+                    let expected = expected_types.join(", ");
+
+                    write!(f, "Unexpected resource type in URL: {actual_type}. Expected one of: {expected}")
+                }
+            }
+            GolemUrlTransformError::UrlParseError { err } => {
+                write!(f, "Failed to parse URL: {err}")
+            }
+        }
+    }
+}
+
+impl GolemUrlTransformError {
+    pub fn invalid_path<S: Into<String>>(target_type: &'static str, err: S) -> Self {
+        Self::InvalidPath {
+            target_type,
+            err: err.into(),
+        }
+    }
+
+    pub fn invalid_query(target_type: &'static str, key: &'static str, err: String) -> Self {
+        Self::InvalidQuery {
+            target_type,
+            key,
+            err,
+        }
+    }
+}
+
+pub trait TypedGolemUrl {
+    fn resource_type() -> &'static str;
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized;
+    fn to_parts(&self) -> (String, Option<String>);
+
+    fn invalid_path<S: Into<String>>(err: S) -> GolemUrlTransformError {
+        GolemUrlTransformError::invalid_path(Self::resource_type(), err)
+    }
+
+    fn expect_path1(path: &str) -> Result<String, GolemUrlTransformError> {
+        let path = path
+            .strip_prefix('/')
+            .ok_or(Self::invalid_path("path is not started with '/'"))?;
+
+        if path.contains('/') {
+            Err(Self::invalid_path(format!(
+                "1 segment expected, but got {} segments",
+                path.split('/').count()
+            )))
+        } else {
+            Ok(urldecode(path))
+        }
+    }
+
+    fn make_path1(elem1: &str) -> String {
+        format!("/{}", urlencode(elem1))
+    }
+
+    fn expect_path2(path: &str) -> Result<(String, String), GolemUrlTransformError> {
+        let path = path
+            .strip_prefix('/')
+            .ok_or(Self::invalid_path("path is not started with '/'"))?;
+
+        let segments = path.split('/').collect::<Vec<_>>();
+
+        if segments.len() != 2 {
+            Err(Self::invalid_path(format!(
+                "2 segments expected, but got {} segments",
+                segments.len()
+            )))
+        } else {
+            let segment1 = segments.first().unwrap();
+            let segment2 = segments.get(1).unwrap();
+
+            Ok((urldecode(segment1), urldecode(segment2)))
+        }
+    }
+
+    fn make_path2(elem1: &str, elem2: &str) -> String {
+        format!("/{}/{}", urlencode(elem1), urlencode(elem2))
+    }
+
+    fn expect_empty_query(
+        query: Option<&str>,
+        cloud_keys: &'static [&'static str],
+    ) -> Result<(), GolemUrlTransformError> {
+        let pairs = url::form_urlencoded::parse(query.unwrap_or("").as_bytes()).collect::<Vec<_>>();
+
+        if let Some((key, _)) = pairs.first() {
+            let cloud_key = cloud_keys.iter().find(|&&k| k == key);
+
+            if let Some(&key) = cloud_key {
+                Err(GolemUrlTransformError::InvalidQuery {
+                    target_type: Self::resource_type(),
+                    key,
+                    err: "Cloud context is not supported in current profile".to_string(),
+                })
+            } else {
+                Err(GolemUrlTransformError::UnexpectedQuery {
+                    target_type: Self::resource_type(),
+                    key: key.to_string(),
+                })
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn try_from_golem_url<T: TypedGolemUrl>(url: &GolemUrl) -> Result<T, GolemUrlTransformError> {
+    let expected_type = T::resource_type();
+
+    if url.resource_type != expected_type {
+        Err(GolemUrlTransformError::UnexpectedType {
+            expected_types: vec![expected_type],
+            actual_type: url.resource_type.to_string(),
+        })
+    } else {
+        T::try_from_parts(&url.path, url.query.as_deref())
+    }
+}
+
+/// Human-readable location for a Golem resource
+/// Resolving such reference requires additional queries to Golem services.
+///
+/// Golem URL is a subset or URL
+///
+/// You can use query parameters for optional context.
+///
+/// URL authority is not supported.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct GolemUrl {
+    resource_type: String,
+    path: String,
+    query: Option<String>,
+}
+
+impl Display for GolemUrl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}://{}", self.resource_type, self.path)?;
+        if let Some(query) = &self.query {
+            write!(f, "&{query}")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GolemUrlParseError {
+    UnexpectedAuthority,
+    NoResourceType,
+    InvalidResourceType(char),
+    InvalidUrl(url::ParseError),
+}
+
+impl Error for GolemUrlParseError {
+    fn cause(&self) -> Option<&dyn Error> {
+        match self {
+            GolemUrlParseError::InvalidUrl(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<url::ParseError> for GolemUrlParseError {
+    fn from(value: url::ParseError) -> Self {
+        GolemUrlParseError::InvalidUrl(value)
+    }
+}
+
+impl Display for GolemUrlParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUrlParseError::UnexpectedAuthority => {
+                write!(f, "Failed to parse Golem URL: authority is not supported.")
+            }
+            GolemUrlParseError::NoResourceType => {
+                write!(f, "Failed to parse Golem URL: resource type expected.")
+            }
+            GolemUrlParseError::InvalidResourceType(c) => write!(
+                f,
+                "Failed to parse Golem URL: unexpected character '{c}' in resource type."
+            ),
+            GolemUrlParseError::InvalidUrl(err) => write!(f, "Failed to parse Golem URL: {err}"),
+        }
+    }
+}
+
+impl TryFrom<Url> for GolemUrl {
+    type Error = GolemUrlParseError;
+
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        if value.has_authority() && !value.authority().is_empty() {
+            return Err(GolemUrlParseError::UnexpectedAuthority);
+        }
+
+        let resource_type = value.scheme();
+        let path = value.path();
+        let query = value.query();
+
+        GolemUrl::from_parts(resource_type, path, query)
+    }
+}
+
+impl FromStr for GolemUrl {
+    type Err = GolemUrlParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Url::try_from(s)?.try_into()
+    }
+}
+
+impl GolemUrl {
+    pub fn from_parts<P: Into<String>, Q: Into<String>>(
+        resource_type: &str,
+        path: P,
+        query: Option<Q>,
+    ) -> Result<Self, GolemUrlParseError> {
+        validate_resource_type(resource_type).map_err(GolemUrlParseError::InvalidResourceType)?;
+
+        Ok(Self {
+            resource_type: resource_type.to_string(),
+            path: path.into(),
+            query: query.map(|q| q.into()),
+        })
+    }
+}
+
+fn urldecode(s: &str) -> String {
+    fn join(k: Cow<str>, v: Cow<str>) -> String {
+        if v.is_empty() {
+            k.into_owned()
+        } else {
+            [k, v].join("=")
+        }
+    }
+
+    url::form_urlencoded::parse(s.as_bytes())
+        .map(|(k, v)| join(k, v))
+        .collect()
+}
+
+fn urlencode(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
+impl Serialize for GolemUrl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GolemUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::uri::{GolemUri, GolemUrl, GolemUrn};
+    use std::str::FromStr;
+    use url::Url;
+
+    #[test]
+    pub fn parse_from_json() {
+        let urn_json = "\"urn:type:name\"";
+        let url_json = "\"type:///path&k=v\"";
+
+        let urn: GolemUrn = serde_json::from_str(urn_json).unwrap();
+        let url: GolemUrl = serde_json::from_str(url_json).unwrap();
+        let uri: GolemUri = serde_json::from_str(urn_json).unwrap();
+
+        assert_eq!(urn.to_string(), "urn:type:name");
+        assert_eq!(uri.to_string(), "urn:type:name");
+        assert_eq!(url.to_string(), "type:///path&k=v");
+
+        let urn_res = serde_json::to_string(&urn).unwrap();
+        let url_res = serde_json::to_string(&url).unwrap();
+        let uri_res = serde_json::to_string(&uri).unwrap();
+
+        assert_eq!(urn_res, urn_json);
+        assert_eq!(uri_res, urn_json);
+        assert_eq!(url_res, url_json);
+    }
+
+    #[test]
+    pub fn parse_uri() {
+        let uri_urn = GolemUri::from_str("urn:type:name").unwrap();
+        let uri_url = GolemUri::from_str("type:///path&k=v").unwrap();
+        assert_eq!(uri_urn.to_string(), "urn:type:name");
+        assert_eq!(uri_url.to_string(), "type:///path&k=v");
+    }
+
+    #[test]
+    pub fn parse_urn() {
+        let res = GolemUrn::from_str("urn:my-type:my: name").unwrap();
+        assert_eq!(res.to_string(), "urn:my-type:my: name");
+    }
+
+    #[test]
+    pub fn parse_urn_case_insensitive() {
+        let res = GolemUrn::from_str("urn:My-Type:my name").unwrap();
+        assert_eq!(res.to_string(), "urn:my-type:my name");
+    }
+
+    #[test]
+    pub fn urn_from_example() {
+        struct CoolUrn(String);
+        impl From<CoolUrn> for GolemUrn {
+            fn from(value: CoolUrn) -> Self {
+                GolemUrn::try_from_parts("cool", value.0).unwrap()
+            }
+        }
+
+        assert_eq!(
+            GolemUrn::from(CoolUrn("abc".to_string())).to_string(),
+            "urn:cool:abc"
+        );
+    }
+
+    #[test]
+    pub fn golem_url_from_url() {
+        let url = Url::parse("worker:///679ae459-8700-41d9-920c-7e2887459c94/worker1").unwrap();
+        let golem_url: GolemUrl = url.try_into().unwrap();
+
+        assert_eq!(
+            golem_url.to_string(),
+            "worker:///679ae459-8700-41d9-920c-7e2887459c94/worker1"
+        );
+    }
+
+    #[test]
+    pub fn url_query() {
+        let golem_url = GolemUrl::from_str("cool:///id&context=value").unwrap();
+
+        assert_eq!(golem_url.to_string(), "cool:///id&context=value");
+    }
+
+    #[test]
+    pub fn url_no_authority() {
+        let res = GolemUrl::from_str("cool://localhost/id");
+
+        assert!(res.is_err());
+    }
+}

--- a/golem-common/src/uri/oss/mod.rs
+++ b/golem-common/src/uri/oss/mod.rs
@@ -12,17 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod cache;
-pub mod client;
-pub mod config;
-
-pub mod grpc;
-pub mod metrics;
-pub mod model;
-pub mod newtype;
-pub mod redis;
-pub mod retriable_error;
-pub mod retries;
-pub mod serialization;
-pub mod tracing;
 pub mod uri;
+pub mod url;
+pub mod urn;

--- a/golem-common/src/uri/oss/uri.rs
+++ b/golem-common/src/uri/oss/uri.rs
@@ -1,0 +1,585 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::uri::oss::url::{
+    ApiDefinitionUrl, ApiDeploymentUrl, ComponentOrVersionUrl, ComponentUrl, ComponentVersionUrl,
+    ResourceUrl, WorkerUrl,
+};
+use crate::uri::oss::urn::{
+    ApiDefinitionUrn, ApiDeploymentUrn, ComponentOrVersionUrn, ComponentUrn, ComponentVersionUrn,
+    ResourceUrn, WorkerUrn,
+};
+use crate::uri::{GolemUri, GolemUriParseError, GolemUrlTransformError, GolemUrnTransformError};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum GolemUriTransformError {
+    URN(GolemUrnTransformError),
+    URL(GolemUrlTransformError),
+}
+
+impl Error for GolemUriTransformError {}
+
+impl Display for GolemUriTransformError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GolemUriTransformError::URN(err) => {
+                write!(f, "{err}")
+            }
+            GolemUriTransformError::URL(err) => {
+                write!(f, "{err}")
+            }
+        }
+    }
+}
+
+macro_rules! uri_from_into {
+    ($name:ident) => {
+        impl TryFrom<&GolemUri> for $name {
+            type Error = GolemUriTransformError;
+
+            fn try_from(value: &GolemUri) -> Result<Self, Self::Error> {
+                match value {
+                    GolemUri::URL(url) => Ok($name::URL(
+                        url.try_into().map_err(GolemUriTransformError::URL)?,
+                    )),
+                    GolemUri::URN(urn) => Ok($name::URN(
+                        urn.try_into().map_err(GolemUriTransformError::URN)?,
+                    )),
+                }
+            }
+        }
+
+        impl TryFrom<GolemUri> for $name {
+            type Error = GolemUriTransformError;
+
+            fn try_from(value: GolemUri) -> Result<Self, Self::Error> {
+                (&value).try_into()
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = GolemUriTransformError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let uri = GolemUri::from_str(s).map_err(|err| match err {
+                    GolemUriParseError::URN(err) => {
+                        GolemUriTransformError::URN(GolemUrnTransformError::UrnParseError { err })
+                    }
+                    GolemUriParseError::URL(err) => {
+                        GolemUriTransformError::URL(GolemUrlTransformError::UrlParseError { err })
+                    }
+                })?;
+
+                uri.try_into()
+            }
+        }
+
+        impl From<&$name> for GolemUri {
+            fn from(value: &$name) -> Self {
+                match value {
+                    $name::URN(urn) => GolemUri::URN(urn.into()),
+                    $name::URL(url) => GolemUri::URL(url.into()),
+                }
+            }
+        }
+
+        impl From<$name> for GolemUri {
+            fn from(value: $name) -> Self {
+                GolemUri::from(&value)
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", GolemUri::from(self))
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                FromStr::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+/// Typed Golem URI for component
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentUri {
+    URN(ComponentUrn),
+    URL(ComponentUrl),
+}
+
+uri_from_into!(ComponentUri);
+
+/// Typed Golem URI for component version
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentVersionUri {
+    URN(ComponentVersionUrn),
+    URL(ComponentVersionUrl),
+}
+
+uri_from_into!(ComponentVersionUri);
+
+/// Typed Golem URI for component or component version
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentOrVersionUri {
+    URN(ComponentOrVersionUrn),
+    URL(ComponentOrVersionUrl),
+}
+
+uri_from_into!(ComponentOrVersionUri);
+
+/// Typed Golem URI for worker
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum WorkerUri {
+    URN(WorkerUrn),
+    URL(WorkerUrl),
+}
+
+uri_from_into!(WorkerUri);
+
+/// Typed Golem URI for API definition
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ApiDefinitionUri {
+    URN(ApiDefinitionUrn),
+    URL(ApiDefinitionUrl),
+}
+
+uri_from_into!(ApiDefinitionUri);
+
+/// Typed Golem URI for API definition
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ApiDeploymentUri {
+    URN(ApiDeploymentUrn),
+    URL(ApiDeploymentUrl),
+}
+
+uri_from_into!(ApiDeploymentUri);
+
+/// Any valid URI for a known Golem resource
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ResourceUri {
+    URN(ResourceUrn),
+    URL(ResourceUrl),
+}
+
+uri_from_into!(ResourceUri);
+
+#[cfg(test)]
+mod tests {
+    use crate::model::{ComponentId, WorkerId};
+    use crate::uri::oss::uri::{
+        ApiDefinitionUri, ApiDeploymentUri, ComponentOrVersionUri, ComponentUri,
+        ComponentVersionUri, ResourceUri, WorkerUri,
+    };
+    use crate::uri::oss::url::{
+        ApiDefinitionUrl, ApiDeploymentUrl, ComponentOrVersionUrl, ComponentUrl,
+        ComponentVersionUrl, WorkerUrl,
+    };
+    use crate::uri::oss::urn::{
+        ApiDefinitionUrn, ApiDeploymentUrn, ComponentOrVersionUrn, ComponentUrn,
+        ComponentVersionUrn, WorkerUrn,
+    };
+    use crate::uri::GolemUri;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    #[test]
+    pub fn component_uri_to_uri() {
+        let typed_url = ComponentUri::URL(ComponentUrl {
+            name: "some  name".to_string(),
+        });
+        let typed_urn = ComponentUri::URN(ComponentUrn {
+            id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+        });
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+
+        assert_eq!(untyped_url.to_string(), "component:///some++name");
+        assert_eq!(
+            untyped_urn.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("component:///some++name").unwrap();
+        let untyped_urn =
+            GolemUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94").unwrap();
+        let typed_url: ComponentUri = untyped_url.try_into().unwrap();
+        let typed_urn: ComponentUri = untyped_urn.try_into().unwrap();
+        let ComponentUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ComponentUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "some  name");
+        assert_eq!(
+            typed_urn.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_uri_from_str() {
+        let typed_url = ComponentUri::from_str("component:///some++name").unwrap();
+        let typed_urn =
+            ComponentUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94").unwrap();
+        let ComponentUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ComponentUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "some  name");
+        assert_eq!(
+            typed_urn.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_version_uri_to_uri() {
+        let typed_url = ComponentVersionUri::URL(ComponentVersionUrl {
+            name: "some  name".to_string(),
+            version: 13,
+        });
+        let typed_urn = ComponentVersionUri::URN(ComponentVersionUrn {
+            id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+            version: 15,
+        });
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+        assert_eq!(untyped_url.to_string(), "component:///some++name/13");
+        assert_eq!(
+            untyped_urn.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/15"
+        );
+    }
+
+    #[test]
+    pub fn component_version_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("component:///some++name/13").unwrap();
+        let untyped_urn =
+            GolemUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/15").unwrap();
+        let typed_url: ComponentVersionUri = untyped_url.try_into().unwrap();
+        let typed_urn: ComponentVersionUri = untyped_urn.try_into().unwrap();
+        let ComponentVersionUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ComponentVersionUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "some  name");
+        assert_eq!(typed_url.version, 13);
+        assert_eq!(
+            typed_urn.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed_urn.version, 15);
+    }
+
+    #[test]
+    pub fn component_version_uri_from_str() {
+        let typed_url = ComponentVersionUri::from_str("component:///some++name/13").unwrap();
+        let typed_urn =
+            ComponentVersionUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/15")
+                .unwrap();
+        let ComponentVersionUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ComponentVersionUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "some  name");
+        assert_eq!(typed_url.version, 13);
+        assert_eq!(
+            typed_urn.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed_urn.version, 15);
+    }
+
+    #[test]
+    pub fn component_or_version_uri_to_uri() {
+        let typed_url =
+            ComponentOrVersionUri::URL(ComponentOrVersionUrl::Version(ComponentVersionUrl {
+                name: "some  name".to_string(),
+                version: 13,
+            }));
+        let typed_urn =
+            ComponentOrVersionUri::URN(ComponentOrVersionUrn::Component(ComponentUrn {
+                id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+            }));
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+        assert_eq!(untyped_url.to_string(), "component:///some++name/13");
+        assert_eq!(
+            untyped_urn.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_or_version_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("component:///some++name/13").unwrap();
+        let untyped_urn =
+            GolemUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94").unwrap();
+        let typed_url: ComponentOrVersionUri = untyped_url.try_into().unwrap();
+        let typed_urn: ComponentOrVersionUri = untyped_urn.try_into().unwrap();
+
+        assert_eq!(typed_url.to_string(), "component:///some++name/13");
+        assert_eq!(
+            typed_urn.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_or_version_uri_from_str() {
+        let typed_url = ComponentOrVersionUri::from_str("component:///some++name/13").unwrap();
+        let typed_urn =
+            ComponentOrVersionUri::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94")
+                .unwrap();
+
+        assert_eq!(typed_url.to_string(), "component:///some++name/13");
+        assert_eq!(
+            typed_urn.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn worker_uri_to_uri() {
+        let typed_url = WorkerUri::URL(WorkerUrl {
+            component_name: "my comp".to_string(),
+            worker_name: "my worker".to_string(),
+        });
+        let typed_urn = WorkerUri::URN(WorkerUrn {
+            id: WorkerId {
+                component_id: ComponentId(
+                    Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap(),
+                ),
+                worker_name: "my worker".to_string(),
+            },
+        });
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+        assert_eq!(untyped_url.to_string(), "worker:///my+comp/my+worker");
+        assert_eq!(
+            untyped_urn.to_string(),
+            "urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my+worker"
+        );
+    }
+
+    #[test]
+    pub fn worker_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("worker:///my+comp/my+worker").unwrap();
+        let untyped_urn =
+            GolemUri::from_str("urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my+worker")
+                .unwrap();
+        let typed_url: WorkerUri = untyped_url.try_into().unwrap();
+        let typed_urn: WorkerUri = untyped_urn.try_into().unwrap();
+        let WorkerUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let WorkerUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.component_name, "my comp");
+        assert_eq!(typed_url.worker_name, "my worker");
+        assert_eq!(
+            typed_urn.id.component_id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed_urn.id.worker_name, "my worker");
+    }
+
+    #[test]
+    pub fn worker_uri_from_str() {
+        let typed_url = WorkerUri::from_str("worker:///my+comp/my+worker").unwrap();
+        let typed_urn =
+            WorkerUri::from_str("urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my+worker")
+                .unwrap();
+        let WorkerUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let WorkerUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.component_name, "my comp");
+        assert_eq!(typed_url.worker_name, "my worker");
+        assert_eq!(
+            typed_urn.id.component_id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed_urn.id.worker_name, "my worker");
+    }
+
+    #[test]
+    pub fn api_definition_uri_to_uri() {
+        let typed_url = ApiDefinitionUri::URL(ApiDefinitionUrl {
+            name: "my def".to_string(),
+            version: "1.2.3".to_string(),
+        });
+        let typed_urn = ApiDefinitionUri::URN(ApiDefinitionUrn {
+            id: "my def".to_string(),
+            version: "1.2.3".to_string(),
+        });
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+        assert_eq!(untyped_url.to_string(), "api-definition:///my+def/1.2.3");
+        assert_eq!(untyped_urn.to_string(), "urn:api-definition:my+def/1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("api-definition:///my+def/1.2.3").unwrap();
+        let untyped_urn = GolemUri::from_str("urn:api-definition:my+def/1.2.3").unwrap();
+        let typed_url: ApiDefinitionUri = untyped_url.try_into().unwrap();
+        let typed_urn: ApiDefinitionUri = untyped_urn.try_into().unwrap();
+        let ApiDefinitionUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ApiDefinitionUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "my def");
+        assert_eq!(typed_url.version, "1.2.3");
+        assert_eq!(typed_urn.id, "my def");
+        assert_eq!(typed_urn.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_uri_from_str() {
+        let typed_url = ApiDefinitionUri::from_str("api-definition:///my+def/1.2.3").unwrap();
+        let typed_urn = ApiDefinitionUri::from_str("urn:api-definition:my+def/1.2.3").unwrap();
+        let ApiDefinitionUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ApiDefinitionUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.name, "my def");
+        assert_eq!(typed_url.version, "1.2.3");
+        assert_eq!(typed_urn.id, "my def");
+        assert_eq!(typed_urn.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_deployment_uri_to_uri() {
+        let typed_url = ApiDeploymentUri::URL(ApiDeploymentUrl {
+            site: "example.com".to_string(),
+        });
+        let typed_urn = ApiDeploymentUri::URN(ApiDeploymentUrn {
+            site: "example.com".to_string(),
+        });
+
+        let untyped_url: GolemUri = typed_url.into();
+        let untyped_urn: GolemUri = typed_urn.into();
+        assert_eq!(untyped_url.to_string(), "api-deployment:///example.com");
+        assert_eq!(untyped_urn.to_string(), "urn:api-deployment:example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_uri_from_uri() {
+        let untyped_url = GolemUri::from_str("api-deployment:///example.com").unwrap();
+        let untyped_urn = GolemUri::from_str("urn:api-deployment:example.com").unwrap();
+        let typed_url: ApiDeploymentUri = untyped_url.try_into().unwrap();
+        let typed_urn: ApiDeploymentUri = untyped_urn.try_into().unwrap();
+        let ApiDeploymentUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ApiDeploymentUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.site, "example.com");
+        assert_eq!(typed_urn.site, "example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_uri_from_str() {
+        let typed_url = ApiDeploymentUri::from_str("api-deployment:///example.com").unwrap();
+        let typed_urn = ApiDeploymentUri::from_str("urn:api-deployment:example.com").unwrap();
+        let ApiDeploymentUri::URL(typed_url) = typed_url else {
+            panic!()
+        };
+        let ApiDeploymentUri::URN(typed_urn) = typed_urn else {
+            panic!()
+        };
+
+        assert_eq!(typed_url.site, "example.com");
+        assert_eq!(typed_urn.site, "example.com");
+    }
+
+    #[test]
+    pub fn resource_uri_from_uri() {
+        let untyped_cv = GolemUri::from_str("component:///comp_name/11").unwrap();
+        let untyped_ad = GolemUri::from_str("urn:api-deployment:example.com").unwrap();
+        let typed_cv: ResourceUri = untyped_cv.try_into().unwrap();
+        let typed_ad: ResourceUri = untyped_ad.try_into().unwrap();
+
+        assert_eq!(
+            GolemUri::from(typed_cv).to_string(),
+            "component:///comp_name/11"
+        );
+        assert_eq!(
+            GolemUri::from(typed_ad).to_string(),
+            "urn:api-deployment:example.com"
+        );
+    }
+
+    #[test]
+    pub fn resource_uri_from_str() {
+        let typed_cv = ResourceUri::from_str("component:///comp_name/11").unwrap();
+        let typed_ad = ResourceUri::from_str("urn:api-deployment:example.com").unwrap();
+
+        assert_eq!(typed_cv.to_string(), "component:///comp_name/11");
+        assert_eq!(typed_ad.to_string(), "urn:api-deployment:example.com");
+    }
+}

--- a/golem-common/src/uri/oss/url.rs
+++ b/golem-common/src/uri/oss/url.rs
@@ -1,0 +1,591 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::ComponentVersion;
+use crate::uri::{
+    try_from_golem_url, GolemUrl, GolemUrlTransformError, TypedGolemUrl, API_DEFINITION_TYPE_NAME,
+    API_DEPLOYMENT_TYPE_NAME, COMPONENT_TYPE_NAME, WORKER_TYPE_NAME,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+macro_rules! url_from_into {
+    ($name:ident) => {
+        impl TryFrom<&GolemUrl> for $name {
+            type Error = GolemUrlTransformError;
+
+            fn try_from(value: &GolemUrl) -> Result<Self, Self::Error> {
+                try_from_golem_url(value)
+            }
+        }
+
+        impl TryFrom<GolemUrl> for $name {
+            type Error = GolemUrlTransformError;
+
+            fn try_from(value: GolemUrl) -> Result<Self, Self::Error> {
+                try_from_golem_url(&value)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = GolemUrlTransformError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let url = GolemUrl::from_str(s)
+                    .map_err(|err| GolemUrlTransformError::UrlParseError { err })?;
+
+                url.try_into()
+            }
+        }
+
+        impl From<&$name> for GolemUrl {
+            fn from(value: &$name) -> Self {
+                let (path, query) = value.to_parts();
+
+                GolemUrl {
+                    resource_type: $name::resource_type().to_string(),
+                    path,
+                    query,
+                }
+            }
+        }
+
+        impl From<$name> for GolemUrl {
+            fn from(value: $name) -> Self {
+                GolemUrl::from(&value)
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", GolemUrl::from(self))
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                FromStr::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+/// Typed Golem URL for component
+///
+/// Format: `component:///{name}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ComponentUrl {
+    pub name: String,
+}
+
+const CLOUD_CONTEXT_ACCOUNT: &str = "account";
+const CLOUD_CONTEXT_PROJECT: &str = "project";
+const CLOUD_CONTEXT: &[&str] = &[CLOUD_CONTEXT_ACCOUNT, CLOUD_CONTEXT_PROJECT];
+
+impl TypedGolemUrl for ComponentUrl {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        let name = Self::expect_path1(path)?;
+        Self::expect_empty_query(query, CLOUD_CONTEXT)?;
+
+        Ok(Self { name })
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        (Self::make_path1(&self.name), None)
+    }
+}
+
+url_from_into!(ComponentUrl);
+
+/// Typed Golem URL for component version
+///
+/// Format: `component:///{name}/{version}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ComponentVersionUrl {
+    pub name: String,
+    pub version: ComponentVersion,
+}
+
+impl TypedGolemUrl for ComponentVersionUrl {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        let (name, version) = Self::expect_path2(path)?;
+        let version: ComponentVersion = version
+            .parse()
+            .map_err(|err| Self::invalid_path(format!("Failed to parse version: {err}")))?;
+
+        Self::expect_empty_query(query, CLOUD_CONTEXT)?;
+
+        Ok(Self { name, version })
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        (
+            Self::make_path2(&self.name, &self.version.to_string()),
+            None,
+        )
+    }
+}
+
+url_from_into!(ComponentVersionUrl);
+
+/// Typed Golem URL for component or component version
+///
+/// Format: `component:///{name}` or `component:///{name}/{version}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentOrVersionUrl {
+    Component(ComponentUrl),
+    Version(ComponentVersionUrl),
+}
+
+impl TypedGolemUrl for ComponentOrVersionUrl {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        if path.strip_prefix('/').unwrap_or("").contains('/') {
+            Ok(ComponentOrVersionUrl::Version(
+                ComponentVersionUrl::try_from_parts(path, query)?,
+            ))
+        } else {
+            Ok(ComponentOrVersionUrl::Component(
+                ComponentUrl::try_from_parts(path, query)?,
+            ))
+        }
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        match self {
+            ComponentOrVersionUrl::Component(c) => c.to_parts(),
+            ComponentOrVersionUrl::Version(v) => v.to_parts(),
+        }
+    }
+}
+
+url_from_into!(ComponentOrVersionUrl);
+
+/// Typed Golem URL for worker
+///
+/// Format: `worker:///{component_name}/{worker_name}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorkerUrl {
+    pub component_name: String,
+    pub worker_name: String,
+}
+
+impl TypedGolemUrl for WorkerUrl {
+    fn resource_type() -> &'static str {
+        WORKER_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        let (component_name, worker_name) = Self::expect_path2(path)?;
+
+        Self::expect_empty_query(query, CLOUD_CONTEXT)?;
+
+        Ok(Self {
+            component_name,
+            worker_name,
+        })
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        (
+            Self::make_path2(&self.component_name, &self.worker_name),
+            None,
+        )
+    }
+}
+
+url_from_into!(WorkerUrl);
+
+/// Typed Golem URL for API definition
+///
+/// Format: `api-definition:///{name}/{version}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ApiDefinitionUrl {
+    pub name: String,
+    pub version: String,
+}
+
+impl TypedGolemUrl for ApiDefinitionUrl {
+    fn resource_type() -> &'static str {
+        API_DEFINITION_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        let (name, version) = Self::expect_path2(path)?;
+
+        Self::expect_empty_query(query, CLOUD_CONTEXT)?;
+
+        Ok(Self { name, version })
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        (Self::make_path2(&self.name, &self.version), None)
+    }
+}
+
+url_from_into!(ApiDefinitionUrl);
+
+/// Typed Golem URL for API deployment
+///
+/// Format: `api-deployment:///{site}`
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ApiDeploymentUrl {
+    pub site: String,
+}
+
+impl TypedGolemUrl for ApiDeploymentUrl {
+    fn resource_type() -> &'static str {
+        API_DEPLOYMENT_TYPE_NAME
+    }
+
+    fn try_from_parts(path: &str, query: Option<&str>) -> Result<Self, GolemUrlTransformError>
+    where
+        Self: Sized,
+    {
+        let site = Self::expect_path1(path)?;
+
+        Self::expect_empty_query(query, CLOUD_CONTEXT)?;
+
+        Ok(Self { site })
+    }
+
+    fn to_parts(&self) -> (String, Option<String>) {
+        (Self::make_path1(&self.site), None)
+    }
+}
+
+url_from_into!(ApiDeploymentUrl);
+
+/// Any valid URL for a known Golem resource
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ResourceUrl {
+    Component(ComponentUrl),
+    ComponentVersion(ComponentVersionUrl),
+    Worker(WorkerUrl),
+    ApiDefinition(ApiDefinitionUrl),
+    ApiDeployment(ApiDeploymentUrl),
+}
+
+impl TryFrom<&GolemUrl> for ResourceUrl {
+    type Error = GolemUrlTransformError;
+
+    fn try_from(value: &GolemUrl) -> Result<Self, Self::Error> {
+        match value.resource_type.as_str() {
+            COMPONENT_TYPE_NAME => match ComponentOrVersionUrl::try_from(value)? {
+                ComponentOrVersionUrl::Component(c) => Ok(ResourceUrl::Component(c)),
+                ComponentOrVersionUrl::Version(v) => Ok(ResourceUrl::ComponentVersion(v)),
+            },
+            WORKER_TYPE_NAME => Ok(ResourceUrl::Worker(WorkerUrl::try_from(value)?)),
+            API_DEFINITION_TYPE_NAME => Ok(ResourceUrl::ApiDefinition(ApiDefinitionUrl::try_from(
+                value,
+            )?)),
+            API_DEPLOYMENT_TYPE_NAME => Ok(ResourceUrl::ApiDeployment(ApiDeploymentUrl::try_from(
+                value,
+            )?)),
+            typ => Err(GolemUrlTransformError::UnexpectedType {
+                expected_types: vec![
+                    COMPONENT_TYPE_NAME,
+                    WORKER_TYPE_NAME,
+                    API_DEFINITION_TYPE_NAME,
+                    API_DEPLOYMENT_TYPE_NAME,
+                ],
+                actual_type: typ.to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<GolemUrl> for ResourceUrl {
+    type Error = GolemUrlTransformError;
+
+    fn try_from(value: GolemUrl) -> Result<Self, Self::Error> {
+        ResourceUrl::try_from(&value)
+    }
+}
+
+impl From<&ResourceUrl> for GolemUrl {
+    fn from(value: &ResourceUrl) -> Self {
+        match value {
+            ResourceUrl::Component(c) => c.into(),
+            ResourceUrl::ComponentVersion(v) => v.into(),
+            ResourceUrl::Worker(w) => w.into(),
+            ResourceUrl::ApiDefinition(d) => d.into(),
+            ResourceUrl::ApiDeployment(d) => d.into(),
+        }
+    }
+}
+
+impl From<ResourceUrl> for GolemUrl {
+    fn from(value: ResourceUrl) -> Self {
+        GolemUrl::from(&value)
+    }
+}
+
+impl FromStr for ResourceUrl {
+    type Err = GolemUrlTransformError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let url =
+            GolemUrl::from_str(s).map_err(|err| GolemUrlTransformError::UrlParseError { err })?;
+
+        url.try_into()
+    }
+}
+
+impl Display for ResourceUrl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", GolemUrl::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::uri::oss::url::{
+        ApiDefinitionUrl, ApiDeploymentUrl, ComponentOrVersionUrl, ComponentUrl,
+        ComponentVersionUrl, ResourceUrl, WorkerUrl,
+    };
+    use crate::uri::GolemUrl;
+    use std::str::FromStr;
+
+    #[test]
+    pub fn component_url_to_url() {
+        let typed = ComponentUrl {
+            name: "some  name".to_string(),
+        };
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "component:///some++name");
+    }
+
+    #[test]
+    pub fn component_url_from_url() {
+        let untyped = GolemUrl::from_str("component:///some++name").unwrap();
+        let typed: ComponentUrl = untyped.try_into().unwrap();
+
+        assert_eq!(typed.name, "some  name");
+    }
+
+    #[test]
+    pub fn component_url_from_str() {
+        let typed = ComponentUrl::from_str("component:///some++name").unwrap();
+
+        assert_eq!(typed.name, "some  name");
+    }
+
+    #[test]
+    pub fn component_version_url_to_url() {
+        let typed = ComponentVersionUrl {
+            name: "some  name".to_string(),
+            version: 8,
+        };
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "component:///some++name/8");
+    }
+
+    #[test]
+    pub fn component_version_url_from_url() {
+        let untyped = GolemUrl::from_str("component:///some++name/8").unwrap();
+        let typed: ComponentVersionUrl = untyped.try_into().unwrap();
+
+        assert_eq!(typed.name, "some  name");
+        assert_eq!(typed.version, 8);
+    }
+
+    #[test]
+    pub fn component_version_url_from_str() {
+        let typed = ComponentVersionUrl::from_str("component:///some++name/8").unwrap();
+
+        assert_eq!(typed.name, "some  name");
+        assert_eq!(typed.version, 8);
+    }
+
+    #[test]
+    pub fn component_or_version_url_to_url() {
+        let typed = ComponentOrVersionUrl::Version(ComponentVersionUrl {
+            name: "some  name".to_string(),
+            version: 8,
+        });
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "component:///some++name/8");
+    }
+
+    #[test]
+    pub fn component_or_version_url_from_url() {
+        let untyped_version = GolemUrl::from_str("component:///some++name/8").unwrap();
+        let untyped_no_version = GolemUrl::from_str("component:///some++name").unwrap();
+        let typed_version: ComponentOrVersionUrl = untyped_version.try_into().unwrap();
+        let typed_no_version: ComponentOrVersionUrl = untyped_no_version.try_into().unwrap();
+
+        assert_eq!(typed_version.to_string(), "component:///some++name/8");
+        assert_eq!(typed_no_version.to_string(), "component:///some++name");
+    }
+
+    #[test]
+    pub fn component_or_version_url_from_str() {
+        let typed_version = ComponentOrVersionUrl::from_str("component:///some++name/8").unwrap();
+        let typed_no_version = ComponentOrVersionUrl::from_str("component:///some++name").unwrap();
+
+        assert_eq!(typed_version.to_string(), "component:///some++name/8");
+        assert_eq!(typed_no_version.to_string(), "component:///some++name");
+    }
+
+    #[test]
+    pub fn worker_url_to_url() {
+        let typed = WorkerUrl {
+            component_name: "my component".to_string(),
+            worker_name: "my worker".to_string(),
+        };
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "worker:///my+component/my+worker");
+    }
+
+    #[test]
+    pub fn worker_url_from_url() {
+        let untyped = GolemUrl::from_str("worker:///my+component/my+worker").unwrap();
+        let typed: WorkerUrl = untyped.try_into().unwrap();
+
+        assert_eq!(typed.component_name, "my component");
+        assert_eq!(typed.worker_name, "my worker");
+    }
+
+    #[test]
+    pub fn worker_url_from_str() {
+        let typed = WorkerUrl::from_str("worker:///my+component/my+worker").unwrap();
+
+        assert_eq!(typed.component_name, "my component");
+        assert_eq!(typed.worker_name, "my worker");
+    }
+
+    #[test]
+    pub fn api_definition_url_to_url() {
+        let typed = ApiDefinitionUrl {
+            name: "my def".to_string(),
+            version: "1.2.3".to_string(),
+        };
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "api-definition:///my+def/1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_url_from_url() {
+        let untyped = GolemUrl::from_str("api-definition:///my+def/1.2.3").unwrap();
+        let typed: ApiDefinitionUrl = untyped.try_into().unwrap();
+
+        assert_eq!(typed.name, "my def");
+        assert_eq!(typed.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_url_from_str() {
+        let typed = ApiDefinitionUrl::from_str("api-definition:///my+def/1.2.3").unwrap();
+
+        assert_eq!(typed.name, "my def");
+        assert_eq!(typed.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_deployment_url_to_url() {
+        let typed = ApiDeploymentUrl {
+            site: "example.com".to_string(),
+        };
+
+        let untyped: GolemUrl = typed.into();
+        assert_eq!(untyped.to_string(), "api-deployment:///example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_url_from_url() {
+        let untyped = GolemUrl::from_str("api-deployment:///example.com").unwrap();
+        let typed: ApiDeploymentUrl = untyped.try_into().unwrap();
+
+        assert_eq!(typed.site, "example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_url_from_str() {
+        let typed = ApiDeploymentUrl::from_str("api-deployment:///example.com").unwrap();
+
+        assert_eq!(typed.site, "example.com");
+    }
+
+    #[test]
+    pub fn resource_url_from_url() {
+        let untyped_cv = GolemUrl::from_str("component:///comp_name/11").unwrap();
+        let untyped_ad = GolemUrl::from_str("api-deployment:///example.com").unwrap();
+        let typed_cv: ResourceUrl = untyped_cv.try_into().unwrap();
+        let typed_ad: ResourceUrl = untyped_ad.try_into().unwrap();
+
+        assert_eq!(
+            GolemUrl::from(typed_cv).to_string(),
+            "component:///comp_name/11"
+        );
+        assert_eq!(
+            GolemUrl::from(typed_ad).to_string(),
+            "api-deployment:///example.com"
+        );
+    }
+
+    #[test]
+    pub fn resource_url_from_str() {
+        let typed_cv = ResourceUrl::from_str("component:///comp_name/11").unwrap();
+        let typed_ad = ResourceUrl::from_str("api-deployment:///example.com").unwrap();
+
+        assert_eq!(typed_cv.to_string(), "component:///comp_name/11");
+        assert_eq!(typed_ad.to_string(), "api-deployment:///example.com");
+    }
+}

--- a/golem-common/src/uri/oss/urn.rs
+++ b/golem-common/src/uri/oss/urn.rs
@@ -1,0 +1,668 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::{ComponentId, ComponentVersion, WorkerId};
+use crate::uri::{
+    try_from_golem_urn, urldecode, urlencode, GolemUrn, GolemUrnTransformError, TypedGolemUrn,
+    API_DEFINITION_TYPE_NAME, API_DEPLOYMENT_TYPE_NAME, COMPONENT_TYPE_NAME, WORKER_TYPE_NAME,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use uuid::Uuid;
+
+macro_rules! urn_from_into {
+    ($name:ident) => {
+        impl TryFrom<&GolemUrn> for $name {
+            type Error = GolemUrnTransformError;
+
+            fn try_from(value: &GolemUrn) -> Result<Self, Self::Error> {
+                try_from_golem_urn(value)
+            }
+        }
+
+        impl TryFrom<GolemUrn> for $name {
+            type Error = GolemUrnTransformError;
+
+            fn try_from(value: GolemUrn) -> Result<Self, Self::Error> {
+                try_from_golem_urn(&value)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = GolemUrnTransformError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let urn = GolemUrn::from_str(s)
+                    .map_err(|err| GolemUrnTransformError::UrnParseError { err })?;
+
+                urn.try_into()
+            }
+        }
+
+        impl From<&$name> for GolemUrn {
+            fn from(value: &$name) -> Self {
+                GolemUrn {
+                    resource_type: $name::resource_type().to_string(),
+                    resource_name: value.to_name(),
+                }
+            }
+        }
+
+        impl From<$name> for GolemUrn {
+            fn from(value: $name) -> Self {
+                GolemUrn::from(&value)
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", GolemUrn::from(self))
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                FromStr::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+/// Typed Golem URN for component
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ComponentUrn {
+    pub id: ComponentId,
+}
+
+impl TypedGolemUrn for ComponentUrn {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        let id = Uuid::parse_str(resource_name).map_err(|err| {
+            GolemUrnTransformError::invalid_name(
+                Self::resource_type(),
+                format!("Can't parse UUID: {err}"),
+            )
+        })?;
+
+        Ok(Self {
+            id: ComponentId(id),
+        })
+    }
+
+    fn to_name(&self) -> String {
+        self.id.0.to_string()
+    }
+}
+
+urn_from_into!(ComponentUrn);
+
+/// Typed Golem URN for component version
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ComponentVersionUrn {
+    pub id: ComponentId,
+    pub version: ComponentVersion,
+}
+
+impl TypedGolemUrn for ComponentVersionUrn {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        if let Some((id, version)) = resource_name.split_once('/') {
+            let id = Uuid::parse_str(id).map_err(|err| {
+                GolemUrnTransformError::invalid_name(
+                    Self::resource_type(),
+                    format!("Can't parse UUID: {err}"),
+                )
+            })?;
+            let version: ComponentVersion = version.parse().map_err(|err| {
+                GolemUrnTransformError::invalid_name(
+                    Self::resource_type(),
+                    format!("Can't parse component version: {err}"),
+                )
+            })?;
+
+            Ok(ComponentVersionUrn {
+                id: ComponentId(id),
+                version,
+            })
+        } else {
+            Err(GolemUrnTransformError::invalid_name(
+                Self::resource_type(),
+                "Component version expected".to_string(),
+            ))
+        }
+    }
+
+    fn to_name(&self) -> String {
+        format!("{}/{}", self.id.0, self.version)
+    }
+}
+
+urn_from_into!(ComponentVersionUrn);
+
+/// Typed Golem URN for component or component version
+///
+/// It can be used as component vis optional version.
+/// Absent version can be used to represent the current version.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentOrVersionUrn {
+    Component(ComponentUrn),
+    Version(ComponentVersionUrn),
+}
+
+impl TypedGolemUrn for ComponentOrVersionUrn {
+    fn resource_type() -> &'static str {
+        COMPONENT_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        if resource_name.contains('/') {
+            let res = ComponentVersionUrn::try_from_name(resource_name)?;
+
+            Ok(Self::Version(res))
+        } else {
+            let res = ComponentUrn::try_from_name(resource_name)?;
+
+            Ok(Self::Component(res))
+        }
+    }
+
+    fn to_name(&self) -> String {
+        match self {
+            ComponentOrVersionUrn::Component(c) => c.to_name(),
+            ComponentOrVersionUrn::Version(v) => v.to_name(),
+        }
+    }
+}
+
+urn_from_into!(ComponentOrVersionUrn);
+
+/// Typed Golem URN for worker
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WorkerUrn {
+    pub id: WorkerId,
+}
+
+impl TypedGolemUrn for WorkerUrn {
+    fn resource_type() -> &'static str {
+        WORKER_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        if let Some((id, worker_name)) = resource_name.split_once('/') {
+            let id = Uuid::parse_str(id).map_err(|err| {
+                GolemUrnTransformError::invalid_name(
+                    Self::resource_type(),
+                    format!("Can't parse UUID: {err}"),
+                )
+            })?;
+
+            let worker_name = urldecode(worker_name);
+
+            Ok(Self {
+                id: WorkerId {
+                    component_id: ComponentId(id),
+                    worker_name,
+                },
+            })
+        } else {
+            Err(GolemUrnTransformError::invalid_name(
+                Self::resource_type(),
+                "Worker name expected".to_string(),
+            ))
+        }
+    }
+
+    fn to_name(&self) -> String {
+        format!(
+            "{}/{}",
+            self.id.component_id.0,
+            urlencode(&self.id.worker_name)
+        )
+    }
+}
+
+urn_from_into!(WorkerUrn);
+
+/// Typed Golem URN for API definition
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ApiDefinitionUrn {
+    pub id: String,
+    pub version: String,
+}
+
+impl TypedGolemUrn for ApiDefinitionUrn {
+    fn resource_type() -> &'static str {
+        API_DEFINITION_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        if let Some((id, version)) = resource_name.split_once('/') {
+            let id = urldecode(id);
+            let version = urldecode(version);
+
+            Ok(Self { id, version })
+        } else {
+            Err(GolemUrnTransformError::invalid_name(
+                Self::resource_type(),
+                "Version expected".to_string(),
+            ))
+        }
+    }
+
+    fn to_name(&self) -> String {
+        let id: String = urlencode(&self.id);
+
+        format!("{id}/{}", urlencode(&self.version))
+    }
+}
+
+urn_from_into!(ApiDefinitionUrn);
+
+/// Typed Golem URN for API deployment
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ApiDeploymentUrn {
+    pub site: String,
+}
+
+impl TypedGolemUrn for ApiDeploymentUrn {
+    fn resource_type() -> &'static str {
+        API_DEPLOYMENT_TYPE_NAME
+    }
+
+    fn try_from_name(resource_name: &str) -> Result<Self, GolemUrnTransformError> {
+        Ok(ApiDeploymentUrn {
+            site: resource_name.to_string(),
+        })
+    }
+
+    fn to_name(&self) -> String {
+        self.site.to_string()
+    }
+}
+
+urn_from_into!(ApiDeploymentUrn);
+
+/// Any valid URN for a known Golem resource
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ResourceUrn {
+    Component(ComponentUrn),
+    ComponentVersion(ComponentVersionUrn),
+    Worker(WorkerUrn),
+    ApiDefinition(ApiDefinitionUrn),
+    ApiDeployment(ApiDeploymentUrn),
+}
+
+impl TryFrom<&GolemUrn> for ResourceUrn {
+    type Error = GolemUrnTransformError;
+
+    fn try_from(value: &GolemUrn) -> Result<Self, Self::Error> {
+        match value.resource_type.as_str() {
+            COMPONENT_TYPE_NAME => match ComponentOrVersionUrn::try_from(value)? {
+                ComponentOrVersionUrn::Component(c) => Ok(ResourceUrn::Component(c)),
+                ComponentOrVersionUrn::Version(v) => Ok(ResourceUrn::ComponentVersion(v)),
+            },
+            WORKER_TYPE_NAME => Ok(ResourceUrn::Worker(WorkerUrn::try_from(value)?)),
+            API_DEFINITION_TYPE_NAME => Ok(ResourceUrn::ApiDefinition(ApiDefinitionUrn::try_from(
+                value,
+            )?)),
+            API_DEPLOYMENT_TYPE_NAME => Ok(ResourceUrn::ApiDeployment(ApiDeploymentUrn::try_from(
+                value,
+            )?)),
+            typ => Err(GolemUrnTransformError::UnexpectedType {
+                expected_types: vec![
+                    COMPONENT_TYPE_NAME,
+                    WORKER_TYPE_NAME,
+                    API_DEFINITION_TYPE_NAME,
+                    API_DEPLOYMENT_TYPE_NAME,
+                ],
+                actual_type: typ.to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<GolemUrn> for ResourceUrn {
+    type Error = GolemUrnTransformError;
+
+    fn try_from(value: GolemUrn) -> Result<Self, Self::Error> {
+        ResourceUrn::try_from(&value)
+    }
+}
+
+impl From<&ResourceUrn> for GolemUrn {
+    fn from(value: &ResourceUrn) -> Self {
+        match value {
+            ResourceUrn::Component(c) => c.into(),
+            ResourceUrn::ComponentVersion(v) => v.into(),
+            ResourceUrn::Worker(w) => w.into(),
+            ResourceUrn::ApiDefinition(d) => d.into(),
+            ResourceUrn::ApiDeployment(d) => d.into(),
+        }
+    }
+}
+
+impl From<ResourceUrn> for GolemUrn {
+    fn from(value: ResourceUrn) -> Self {
+        GolemUrn::from(&value)
+    }
+}
+
+impl FromStr for ResourceUrn {
+    type Err = GolemUrnTransformError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let urn =
+            GolemUrn::from_str(s).map_err(|err| GolemUrnTransformError::UrnParseError { err })?;
+
+        urn.try_into()
+    }
+}
+
+impl Display for ResourceUrn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", GolemUrn::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::{ComponentId, WorkerId};
+    use crate::uri::oss::urn::{
+        ApiDefinitionUrn, ApiDeploymentUrn, ComponentOrVersionUrn, ComponentUrn,
+        ComponentVersionUrn, ResourceUrn, WorkerUrn,
+    };
+    use crate::uri::GolemUrn;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    #[test]
+    pub fn component_urn_to_urn() {
+        let typed = ComponentUrn {
+            id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+        };
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(
+            untyped.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_urn_from_urn() {
+        let untyped =
+            GolemUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94").unwrap();
+        let typed: ComponentUrn = untyped.try_into().unwrap();
+
+        assert_eq!(
+            typed.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_urn_from_str() {
+        let typed =
+            ComponentUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94").unwrap();
+
+        assert_eq!(
+            typed.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_version_urn_to_urn() {
+        let typed = ComponentVersionUrn {
+            id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+            version: 7,
+        };
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(
+            untyped.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/7"
+        );
+    }
+
+    #[test]
+    pub fn component_version_urn_from_urn() {
+        let untyped =
+            GolemUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/9").unwrap();
+        let typed: ComponentVersionUrn = untyped.try_into().unwrap();
+
+        assert_eq!(
+            typed.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed.version, 9);
+    }
+
+    #[test]
+    pub fn component_version_urn_from_str() {
+        let typed =
+            ComponentVersionUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/9")
+                .unwrap();
+
+        assert_eq!(
+            typed.id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed.version, 9);
+    }
+
+    #[test]
+    pub fn component_or_version_urn_to_urn() {
+        let typed = ComponentOrVersionUrn::Component(ComponentUrn {
+            id: ComponentId(Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap()),
+        });
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(
+            untyped.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_or_version_urn_from_urn() {
+        let typed_version: ComponentOrVersionUrn =
+            GolemUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/9")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let typed_no_version: ComponentOrVersionUrn =
+            GolemUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        assert_eq!(
+            GolemUrn::from(typed_version).to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/9"
+        );
+        assert_eq!(
+            GolemUrn::from(typed_no_version).to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn component_or_version_urn_from_str() {
+        let typed_version =
+            ComponentOrVersionUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/9")
+                .unwrap();
+        let typed_no_version =
+            ComponentOrVersionUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94")
+                .unwrap();
+
+        assert_eq!(
+            typed_version.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/9"
+        );
+        assert_eq!(
+            typed_no_version.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94"
+        );
+    }
+
+    #[test]
+    pub fn worker_urn_to_urn() {
+        let typed = WorkerUrn {
+            id: WorkerId {
+                component_id: ComponentId(
+                    Uuid::parse_str("679ae459-8700-41d9-920c-7e2887459c94").unwrap(),
+                ),
+                worker_name: "my:worker/1".to_string(),
+            },
+        };
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(
+            untyped.to_string(),
+            "urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my%3Aworker%2F1"
+        );
+    }
+
+    #[test]
+    pub fn worker_urn_from_urn() {
+        let untyped =
+            GolemUrn::from_str("urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my%3Aworker%2F1")
+                .unwrap();
+        let typed: WorkerUrn = untyped.try_into().unwrap();
+
+        assert_eq!(
+            typed.id.component_id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed.id.worker_name, "my:worker/1");
+    }
+
+    #[test]
+    pub fn worker_urn_from_str() {
+        let typed =
+            WorkerUrn::from_str("urn:worker:679ae459-8700-41d9-920c-7e2887459c94/my%3Aworker%2F1")
+                .unwrap();
+
+        assert_eq!(
+            typed.id.component_id.0.to_string(),
+            "679ae459-8700-41d9-920c-7e2887459c94"
+        );
+        assert_eq!(typed.id.worker_name, "my:worker/1");
+    }
+
+    #[test]
+    pub fn api_definition_urn_to_urn() {
+        let typed = ApiDefinitionUrn {
+            id: "a:b.c".to_string(),
+            version: "1.2.3".to_string(),
+        };
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(untyped.to_string(), "urn:api-definition:a%3Ab.c/1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_urn_from_urn() {
+        let untyped = GolemUrn::from_str("urn:api-definition:a%3Ab.c/1.2.3").unwrap();
+        let typed: ApiDefinitionUrn = untyped.try_into().unwrap();
+
+        assert_eq!(typed.id, "a:b.c");
+        assert_eq!(typed.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_definition_urn_from_str() {
+        let typed = ApiDefinitionUrn::from_str("urn:api-definition:a%3Ab.c/1.2.3").unwrap();
+
+        assert_eq!(typed.id, "a:b.c");
+        assert_eq!(typed.version, "1.2.3");
+    }
+
+    #[test]
+    pub fn api_deployment_urn_to_urn() {
+        let typed = ApiDeploymentUrn {
+            site: "example.com".to_string(),
+        };
+
+        let untyped: GolemUrn = typed.into();
+        assert_eq!(untyped.to_string(), "urn:api-deployment:example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_urn_from_urn() {
+        let untyped = GolemUrn::from_str("urn:api-deployment:example.com").unwrap();
+        let typed: ApiDeploymentUrn = untyped.try_into().unwrap();
+
+        assert_eq!(typed.site, "example.com");
+    }
+
+    #[test]
+    pub fn api_deployment_urn_from_str() {
+        let typed = ApiDeploymentUrn::from_str("urn:api-deployment:example.com").unwrap();
+
+        assert_eq!(typed.site, "example.com");
+    }
+
+    #[test]
+    pub fn resource_urn_from_urn() {
+        let untyped_cv =
+            GolemUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/7").unwrap();
+        let untyped_ad = GolemUrn::from_str("urn:api-deployment:example.com").unwrap();
+        let typed_cv: ResourceUrn = untyped_cv.try_into().unwrap();
+        let typed_ad: ResourceUrn = untyped_ad.try_into().unwrap();
+
+        assert_eq!(
+            GolemUrn::from(typed_cv).to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/7"
+        );
+        assert_eq!(
+            GolemUrn::from(typed_ad).to_string(),
+            "urn:api-deployment:example.com"
+        );
+    }
+
+    #[test]
+    pub fn resource_urn_from_str() {
+        let typed_cv =
+            ResourceUrn::from_str("urn:component:679ae459-8700-41d9-920c-7e2887459c94/7").unwrap();
+        let typed_ad = ResourceUrn::from_str("urn:api-deployment:example.com").unwrap();
+
+        assert_eq!(
+            typed_cv.to_string(),
+            "urn:component:679ae459-8700-41d9-920c-7e2887459c94/7"
+        );
+        assert_eq!(typed_ad.to_string(), "urn:api-deployment:example.com");
+    }
+}


### PR DESCRIPTION
New command - `top level get`:

```
golem-cli get component:///component_name
golem-cli get urn:component:c201c162-fd68-4750-9e7b-9aee8993beff
golem-cli get worker:///component_name/worker_name
golem-cli get urn:worker:c201c162-fd68-4750-9e7b-9aee8993beff/worker_name
golem-cli get api-definition:///definition_name/0.1.0
golem-cli get api-deployment:///example.com
```

This also works for consistency, but I'm not going to put it to the docs:

```
golem-cli get urn:api-definition:definition_name/0.1.0
golem-cli get urn:api-deployment:example.com
```

`component` and `worker` commands accept `URI` instead of ID:

```
golem-cli component get --component-name component_name
golem-cli component get --component component:///component_name
golem-cli component get --component urn:component:c201c162-fd68-4750-9e7b-9aee8993beff

golem-cli worker get --component-name component_name --worker-name worker_name
golem-cli worker get --worker worker:///component_name/worker_name
golem-cli worker get --worker urn:worker:c201c162-fd68-4750-9e7b-9aee8993beff/worker_name
```

`api-definition` and `api-deployment` command do not accept `URI` because there is no `ID` (i.e. ID and Name are the same), so `URI` would be just a verbose version of `name` option

Not implemented: `api-definition` accepts component ID intead of `URN` as part of `HttpApiDefinition` - `routes.binding.component_id` - fixing it would require either implementing `URN` support in HTTP API or introducing a copy of `HttpApiDefinition` format in CLI.

Resolves #518 