### PR TITLE
Fix external oplog payload blobstore path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,7 @@ dependencies = [
  "golem-wasm-ast",
  "golem-wasm-rpc",
  "golem-wit",
+ "hex",
  "http 0.2.12",
  "http 1.1.0",
  "http-body 1.0.1",

--- a/golem-worker-executor-base/Cargo.toml
+++ b/golem-worker-executor-base/Cargo.toml
@@ -47,6 +47,7 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 gethostname = "0.4.3"
 golem-wit = { version = "0.3.1" }
+hex = "0.4.3"
 http = { workspace = true }
 http_02 = { workspace = true }
 http-body = "1.0.0"                                 # keep in sync with wasmtime

--- a/golem-worker-executor-base/src/services/oplog/primary.rs
+++ b/golem-worker-executor-base/src/services/oplog/primary.rs
@@ -631,7 +631,7 @@ impl Oplog for PrimaryOplog {
                             account_id: owned_worker_id.account_id(),
                             worker_id: owned_worker_id.worker_id(),
                         },
-                        Path::new(&format!("{}/{}", hex::encode(&md5_hash), payload_id.0)),
+                        Path::new(&format!("{}/{}", hex::encode(md5_hash), payload_id.0)),
                     )
                     .await?
                     .ok_or(format!("Payload not found (worker: {owned_worker_id}, payload_id: {payload_id}, md5 hash: {md5_hash:02X?})"))

--- a/golem-worker-executor-base/src/services/oplog/primary.rs
+++ b/golem-worker-executor-base/src/services/oplog/primary.rs
@@ -598,7 +598,7 @@ impl Oplog for PrimaryOplog {
                         account_id: owned_worker_id.account_id(),
                         worker_id: owned_worker_id.worker_id(),
                     },
-                    Path::new(&format!("{:02X?}/{}", md5_hash, payload_id.0)),
+                    Path::new(&format!("{}/{}", hex::encode(&md5_hash), payload_id.0)),
                     data,
                 )
                 .await?;
@@ -631,7 +631,7 @@ impl Oplog for PrimaryOplog {
                             account_id: owned_worker_id.account_id(),
                             worker_id: owned_worker_id.worker_id(),
                         },
-                        Path::new(&format!("{:02X?}/{}", md5_hash, payload_id.0)),
+                        Path::new(&format!("{}/{}", hex::encode(&md5_hash), payload_id.0)),
                     )
                     .await?
                     .ok_or(format!("Payload not found (worker: {owned_worker_id}, payload_id: {payload_id}, md5 hash: {md5_hash:02X?})"))


### PR DESCRIPTION
Small fix for the path of external oplog payloads, the original intention was to use `md5hash-in-hex/uuid` but the implementation was creating paths like `[0C, 7B, 41, 17, C8, 01, 2C, 6D]/5AF2838B-B5A9-480E-BA6A-5610E32AA9E4`.