### PR TITLE
A set of CLI improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,12 +3563,13 @@ dependencies = [
 
 [[package]]
 name = "golem-examples"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37409e49376d86d7e7911617ae3c4634ff9304fdc9f215eb9f2925067e4a0a31"
+checksum = "59523e7c4989eecddbd0ac114cbd003c9b34122e7aaa4caa44c076834bd1a6aa"
 dependencies = [
  "Inflector",
  "cargo_metadata",
+ "clap 4.5.13",
  "copy_dir",
  "derive_more",
  "dir-diff",
@@ -3731,8 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-ast"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/golem-wasm-ast?branch=analysis-type-features#4d1c8d6c21a62fd5379151f34300b5bf7b44388e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07bc0b7328974d964e47d8d107c53dae814b541643faf5e4c5039253a137205"
 dependencies = [
  "bincode",
  "leb128",
@@ -3750,8 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/wasm-rpc?branch=vigoo/type-annotated-value-json#d74c7f61f594c4472d7b34d3900becca9c7716ec"
+version = "0.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724537ba6da8e69b89439a583f26aed72718dc92a2280ee6697f7489a93deaba"
 dependencies = [
  "arbitrary",
  "async-recursion",
@@ -3773,8 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc-stubgen"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/wasm-rpc?branch=vigoo/type-annotated-value-json#d74c7f61f594c4472d7b34d3900becca9c7716ec"
+version = "0.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648daf25b18fe35fb5e824f50f352d8b09465df71f717aef64323e1f60262c12"
 dependencies = [
  "anyhow",
  "cargo-component",

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -31,7 +31,7 @@ clap-verbosity-flag = "2.1.1"
 derive_more = { workspace = true }
 dirs = "5.0.1"
 futures-util = { workspace = true }
-golem-examples = "0.3.2"
+golem-examples = "0.3.3"
 golem-wasm-ast = { workspace = true }
 golem-wasm-rpc = { workspace = true }
 golem-wasm-rpc-stubgen = { version = "0.0.39", optional = true }

--- a/golem-cli/src/clients/worker.rs
+++ b/golem-cli/src/clients/worker.rs
@@ -47,6 +47,7 @@ pub trait WorkerClient {
     ) -> Result<(), GolemError>;
 
     async fn interrupt(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
+    async fn resume(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
     async fn simulated_crash(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
     async fn delete(&self, worker_urn: WorkerUrn) -> Result<(), GolemError>;
     async fn get_metadata(&self, worker_urn: WorkerUrn) -> Result<WorkerMetadata, GolemError>;

--- a/golem-cli/src/command/api_definition.rs
+++ b/golem-cli/src/command/api_definition.rs
@@ -37,7 +37,7 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
     /// Creates an api definition
     ///
     /// Golem API definition file format expected
-    #[command()]
+    #[command(alias="create")]
     Add {
         /// The newly created component's owner project
         #[command(flatten)]

--- a/golem-cli/src/command/api_definition.rs
+++ b/golem-cli/src/command/api_definition.rs
@@ -37,7 +37,7 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
     /// Creates an api definition
     ///
     /// Golem API definition file format expected
-    #[command(alias="create")]
+    #[command(alias = "create")]
     Add {
         /// The newly created component's owner project
         #[command(flatten)]

--- a/golem-cli/src/command/component.rs
+++ b/golem-cli/src/command/component.rs
@@ -22,7 +22,7 @@ use clap::Subcommand;
 #[command()]
 pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
     /// Creates a new component with a given name by uploading the component WASM
-    #[command(alias="create")]
+    #[command(alias = "create")]
     Add {
         /// The newly created component's owner project
         #[command(flatten)]

--- a/golem-cli/src/command/component.rs
+++ b/golem-cli/src/command/component.rs
@@ -22,7 +22,7 @@ use clap::Subcommand;
 #[command()]
 pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
     /// Creates a new component with a given name by uploading the component WASM
-    #[command()]
+    #[command(alias="create")]
     Add {
         /// The newly created component's owner project
         #[command(flatten)]

--- a/golem-cli/src/command/worker.rs
+++ b/golem-cli/src/command/worker.rs
@@ -274,6 +274,13 @@ pub enum WorkerSubcommand<ComponentRef: clap::Args, WorkerRef: clap::Args> {
         worker_ref: WorkerRef,
     },
 
+    /// Resume an interrupted worker
+    #[command()]
+    Resume {
+        #[command(flatten)]
+        worker_ref: WorkerRef,
+    },
+
     /// Simulates a crash on a worker for testing purposes.
     ///
     /// The worker starts recovering and resuming immediately.
@@ -424,6 +431,11 @@ impl<ComponentRef: clap::Args, WorkerRef: clap::Args> WorkerSubcommand<Component
                 let (worker_uri, project_ref) = worker_ref.split();
                 let project_id = projects.resolve_id_or_default_opt(project_ref).await?;
                 service.interrupt(worker_uri, project_id).await
+            }
+            WorkerSubcommand::Resume { worker_ref } => {
+                let (worker_uri, project_ref) = worker_ref.split();
+                let project_id = projects.resolve_id_or_default_opt(project_ref).await?;
+                service.resume(worker_uri, project_id).await
             }
             WorkerSubcommand::SimulatedCrash { worker_ref } => {
                 let (worker_uri, project_ref) = worker_ref.split();

--- a/golem-cli/src/command/worker.rs
+++ b/golem-cli/src/command/worker.rs
@@ -187,7 +187,7 @@ impl From<&OssWorkerUriArg> for OssWorkerNameOrUriArg {
 #[command()]
 pub enum WorkerSubcommand<ComponentRef: clap::Args, WorkerRef: clap::Args> {
     /// Creates a new idle worker
-    #[command()]
+    #[command(alias="start", alias="create")]
     Add {
         /// The Golem component to use for the worker
         #[command(flatten)]

--- a/golem-cli/src/command/worker.rs
+++ b/golem-cli/src/command/worker.rs
@@ -32,11 +32,23 @@ use crate::service::worker::WorkerService;
 #[derive(clap::Args, Debug, Clone)]
 pub struct OssWorkerNameOrUriArg {
     /// Worker URI. Either URN or URL.
-    #[arg(short = 'W', long, conflicts_with_all(["worker_name", "component", "component_name"]), required = true, value_name = "URI")]
+    #[arg(
+        short = 'W',
+        long,
+        conflicts_with_all(["worker_name", "component", "component_name"]),
+        required = true,
+        value_name = "URI"
+    )]
     worker: Option<WorkerUri>,
 
     /// Component URI. Either URN or URL.
-    #[arg(short = 'C', long, conflicts_with_all(["component_name", "worker"]), required = true, value_name = "URI")]
+    #[arg(
+        short = 'C',
+        long,
+        conflicts_with_all(["component_name", "worker"]),
+        required = true,
+        value_name = "URI"
+    )]
     component: Option<ComponentUri>,
 
     #[arg(short, long, conflicts_with_all(["component", "worker"]), required = true)]
@@ -48,11 +60,13 @@ pub struct OssWorkerNameOrUriArg {
 }
 
 #[derive(clap::Args, Debug, Clone)]
-#[group(required = true, multiple = false)]
+#[group(required = false, multiple = false)]
 pub struct InvokeParameterList {
     /// JSON array representing the parameters to be passed to the function
-    #[arg(short = 'j', long, value_name = "json", value_parser = ValueParser::new(JsonValueParser), group="param")]
-    json: Option<serde_json::value::Value>,
+    #[arg(
+        short = 'j', long, value_name = "json", value_parser = ValueParser::new(JsonValueParser), group = "param"
+    )]
+    parameters: Option<serde_json::value::Value>,
 
     /// Function parameter in WAVE format
     ///
@@ -397,7 +411,7 @@ impl<ComponentRef: clap::Args, WorkerRef: clap::Args> WorkerSubcommand<Component
                         worker_uri,
                         idempotency_key,
                         function,
-                        parameters.json,
+                        parameters.parameters,
                         parameters.wave,
                         project_id,
                     )
@@ -416,7 +430,7 @@ impl<ComponentRef: clap::Args, WorkerRef: clap::Args> WorkerSubcommand<Component
                         worker_uri,
                         idempotency_key,
                         function,
-                        parameters.json,
+                        parameters.parameters,
                         parameters.wave,
                         project_id,
                     )

--- a/golem-cli/src/model.rs
+++ b/golem-cli/src/model.rs
@@ -216,18 +216,20 @@ impl clap::Args for ComponentUriArg {
 }
 
 #[derive(clap::Args, Debug, Clone)]
+#[group(required = true, multiple = false)]
 struct ComponentUriOrNameArgs {
     /// Component URI. Either URN or URL.
     #[arg(
         short = 'C',
         long,
-        conflicts_with = "component_name",
+        group = "component_group",
         required = true,
         value_name = "URI"
     )]
     component: Option<ComponentUri>,
 
-    #[arg(short, long, conflicts_with = "component", required = true)]
+    /// Name of the component
+    #[arg(short, long, group = "component_group", required = true)]
     component_name: Option<String>,
 }
 

--- a/golem-cli/src/oss/clients/worker.rs
+++ b/golem-cli/src/oss/clients/worker.rs
@@ -125,6 +125,16 @@ impl<C: golem_client::api::WorkerClient + Sync + Send> WorkerClient for WorkerCl
         Ok(())
     }
 
+    async fn resume(&self, worker_urn: WorkerUrn) -> Result<(), GolemError> {
+        info!("Resuming {worker_urn}");
+
+        let _ = self
+            .client
+            .resume_worker(&worker_urn.id.component_id.0, &worker_urn.id.worker_name)
+            .await?;
+        Ok(())
+    }
+
     async fn simulated_crash(&self, worker_urn: WorkerUrn) -> Result<(), GolemError> {
         info!("Simulating crash of {worker_urn}");
 

--- a/golem-cli/src/oss/command.rs
+++ b/golem-cli/src/oss/command.rs
@@ -22,7 +22,6 @@ use crate::oss::model::OssContext;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;
 use golem_common::uri::oss::uri::ResourceUri;
-use golem_examples::model::{ExampleName, GuestLanguage, GuestLanguageTier, PackageName};
 
 #[derive(Subcommand, Debug)]
 #[command()]
@@ -51,32 +50,8 @@ pub enum OssCommand<ProfileAdd: clap::Args> {
     },
 
     /// Create a new Golem component from built-in examples
-    #[command()]
-    New {
-        /// Name of the example to use
-        #[arg(short, long)]
-        example: ExampleName,
-
-        /// The new component's name
-        #[arg(short, long)]
-        component_name: golem_examples::model::ComponentName,
-
-        /// The package name of the generated component (in namespace:name format)
-        #[arg(short, long)]
-        package_name: Option<PackageName>,
-    },
-
-    /// Lists the built-in examples available for creating new components
-    #[command()]
-    ListExamples {
-        /// The minimum language tier to include in the list
-        #[arg(short, long)]
-        min_tier: Option<GuestLanguageTier>,
-
-        /// Filter examples by a given guest language
-        #[arg(short, long)]
-        language: Option<GuestLanguage>,
-    },
+    #[command(flatten)]
+    Examples(golem_examples::cli::Command),
 
     /// WASM RPC stub generator
     #[cfg(feature = "stubgen")]

--- a/golem-cli/src/oss/main.rs
+++ b/golem-cli/src/oss/main.rs
@@ -84,12 +84,16 @@ pub async fn async_main<ProfileAdd: Into<UniversalProfileAdd> + clap::Args>(
                 )
                 .await
         }
-        OssCommand::New {
-            example,
+        OssCommand::Examples(golem_examples::cli::Command::New {
+            name_or_language,
             package_name,
             component_name,
-        } => examples::process_new(example, component_name, package_name),
-        OssCommand::ListExamples { min_tier, language } => {
+        }) => examples::process_new(
+            name_or_language.example_name(),
+            component_name,
+            package_name,
+        ),
+        OssCommand::Examples(golem_examples::cli::Command::ListExamples { min_tier, language }) => {
             examples::process_list_examples(min_tier, language)
         }
         #[cfg(feature = "stubgen")]

--- a/golem-cli/src/service/worker.rs
+++ b/golem-cli/src/service/worker.rs
@@ -95,6 +95,11 @@ pub trait WorkerService {
         worker_uri: WorkerUri,
         project: Option<Self::ProjectContext>,
     ) -> Result<GolemResult, GolemError>;
+    async fn resume(
+        &self,
+        worker_uri: WorkerUri,
+        project: Option<Self::ProjectContext>,
+    ) -> Result<GolemResult, GolemError>;
     async fn simulated_crash(
         &self,
         worker_uri: WorkerUri,
@@ -553,6 +558,18 @@ impl<ProjectContext: Send + Sync + 'static> WorkerService for WorkerServiceLive<
         self.client.interrupt(worker_urn).await?;
 
         Ok(GolemResult::Str("Interrupted".to_string()))
+    }
+
+    async fn resume(
+        &self,
+        worker_uri: WorkerUri,
+        project: Option<Self::ProjectContext>,
+    ) -> Result<GolemResult, GolemError> {
+        let worker_urn = self.resolve_uri(worker_uri, project).await?;
+
+        self.client.resume(worker_urn).await?;
+
+        Ok(GolemResult::Str("Resumed".to_string()))
     }
 
     async fn simulated_crash(


### PR DESCRIPTION
- Integrates the `new` command improvements implemented in https://github.com/golemcloud/golem-examples/pull/44
- Adds a few command aliases (Resolves #700)
- Uses clap argument groups where possible, which provides better `--help` output for alternatives
- Adds the missing `worker resume` command

Examples of how argument groups improve the help output:
```
Usage: golem-cli worker invoke [OPTIONS] --worker <URI> --component <URI> --component-name <COMPONENT_NAME> --worker-name <WORKER_NAME> --function <FUNCTION> <--json <json>|--arg <wave>>

Usage: golem-cli component update [OPTIONS] <--component <URI>|--component-name <COMPONENT_NAME>> <component-file>
```

Previously these alternatives (`<...|...>`) were not printed