### PR TITLE
Fix worker infinite retry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -462,7 +462,7 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
         run: cargo make sharding-tests
-        timeout-minutes: 20
+        timeout-minutes: 30
   publish:
     needs:
       [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,8 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-ast"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/golem-wasm-ast?branch=analysis-type-features#4d1c8d6c21a62fd5379151f34300b5bf7b44388e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07bc0b7328974d964e47d8d107c53dae814b541643faf5e4c5039253a137205"
 dependencies = [
  "bincode",
  "leb128",
@@ -3750,8 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/wasm-rpc?branch=vigoo/type-annotated-value-json#d74c7f61f594c4472d7b34d3900becca9c7716ec"
+version = "0.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724537ba6da8e69b89439a583f26aed72718dc92a2280ee6697f7489a93deaba"
 dependencies = [
  "arbitrary",
  "async-recursion",
@@ -3773,8 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc-stubgen"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/wasm-rpc?branch=vigoo/type-annotated-value-json#d74c7f61f594c4472d7b34d3900becca9c7716ec"
+version = "0.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648daf25b18fe35fb5e824f50f352d8b09465df71f717aef64323e1f60262c12"
 dependencies = [
  "anyhow",
  "cargo-component",

--- a/golem-common/src/model/oplog.rs
+++ b/golem-common/src/model/oplog.rs
@@ -654,6 +654,7 @@ pub enum WrappedFunctionType {
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub enum WorkerError {
     Unknown(String),
+    InvalidRequest(String),
     StackOverflow,
     OutOfMemory,
 }
@@ -662,6 +663,7 @@ impl Display for WorkerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             WorkerError::Unknown(message) => write!(f, "{}", message),
+            WorkerError::InvalidRequest(message) => write!(f, "{}", message),
             WorkerError::StackOverflow => write!(f, "Stack overflow"),
             WorkerError::OutOfMemory => write!(f, "Out of memory"),
         }

--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -736,7 +736,8 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
                 } else {
                     WorkerStatus::Failed
                 };
-                (status, Some(OplogEntry::error(error.clone())), true)
+                let store_error = status == WorkerStatus::Failed;
+                (status, Some(OplogEntry::error(error.clone())), store_error)
             }
         };
 

--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -874,7 +874,7 @@ impl<Ctx: WorkerCtx> ResourceStore for DurableWorkerCtx<Ctx> {
                 self.update_worker_status(move |status| {
                     status.owned_resources.remove(&id);
                 })
-                    .await;
+                .await;
             }
         }
         result

--- a/golem-worker-executor-base/src/invocation.rs
+++ b/golem-worker-executor-base/src/invocation.rs
@@ -165,11 +165,6 @@ async fn invoke_or_fail<Ctx: WorkerCtx>(
 ) -> Result<InvokeResult, GolemError> {
     let mut store = store.as_context_mut();
 
-    let parsed = ParsedFunctionName::parse(&full_function_name)
-        .map_err(|err| GolemError::invalid_request(format!("Invalid function name: {}", err)))?;
-
-    let function = find_function(&mut store, instance, &parsed)?;
-
     if was_live_before {
         store
             .data_mut()
@@ -182,6 +177,11 @@ async fn invoke_or_fail<Ctx: WorkerCtx>(
         .data_mut()
         .store_worker_status(WorkerStatus::Running)
         .await;
+
+    let parsed = ParsedFunctionName::parse(&full_function_name)
+        .map_err(|err| GolemError::invalid_request(format!("Invalid function name: {}", err)))?;
+
+    let function = find_function(&mut store, instance, &parsed)?;
 
     let context = format!("{worker_id}/{full_function_name}");
     let mut extra_fuel = 0;

--- a/golem-worker-executor-base/src/worker.rs
+++ b/golem-worker-executor-base/src/worker.rs
@@ -1428,7 +1428,7 @@ impl RunningWorker {
                                                             .data_mut()
                                                             .on_invocation_failure(
                                                                 &TrapType::Error(
-                                                                    WorkerError::Unknown(
+                                                                    WorkerError::InvalidRequest(
                                                                         "Function not found"
                                                                             .to_string(),
                                                                     ),
@@ -2184,6 +2184,7 @@ pub fn is_worker_error_retriable(
 ) -> bool {
     match error {
         WorkerError::Unknown(_) => retry_count < (retry_config.max_attempts as u64),
+        WorkerError::InvalidRequest(_) => false,
         WorkerError::StackOverflow => false,
         WorkerError::OutOfMemory => true,
     }

--- a/golem-worker-executor-base/tests/wasi.rs
+++ b/golem-worker-executor-base/tests/wasi.rs
@@ -43,7 +43,7 @@ async fn write_stdout() {
 
     let mut rx = executor.capture_output(&worker_id).await;
 
-    let _result = executor.invoke_and_await(&worker_id, "run", vec![]).await;
+    let _result = executor.invoke_and_await(&worker_id, "runn", vec![]).await;
 
     tokio::time::sleep(Duration::from_secs(2)).await;
     let mut events = vec![];

--- a/golem-worker-executor-base/tests/wasi.rs
+++ b/golem-worker-executor-base/tests/wasi.rs
@@ -43,7 +43,7 @@ async fn write_stdout() {
 
     let mut rx = executor.capture_output(&worker_id).await;
 
-    let _result = executor.invoke_and_await(&worker_id, "runn", vec![]).await;
+    let _result = executor.invoke_and_await(&worker_id, "run", vec![]).await;
 
     tokio::time::sleep(Duration::from_secs(2)).await;
     let mut events = vec![];


### PR DESCRIPTION
Resolves #693 

- Skip hint entries when calculating retry count (the number of errors at the end of the oplog) as they can interleave the errors (example: new incoming invocation)
- Not writing resource create/describe/drop entries in reply mode (this with the lack of the first point caused the infinite retry loop)
- Fixes an issue where a worker ends up idle when invoked with a non-existing function, as the error was returned earlier than writing the bad invocation to the oplog.