### PR TITLE
fix profile auth

### DIFF
--- a/golem-cli/src/command/profile.rs
+++ b/golem-cli/src/command/profile.rs
@@ -332,7 +332,8 @@ impl<ProfileAdd: Into<UniversalProfileAdd> + clap::Args> ProfileSubCommand<Profi
                 add.subcommand.handle(cli_kind, set_active, config_dir)
             }
             ProfileSubCommand::Init { name } => {
-                let res = crate::init::init_profile(cli_kind, name, config_dir).await?;
+                let res =
+                    crate::init::init_profile(cli_kind, name, config_dir, profile_auth).await?;
 
                 if res.auth_required {
                     profile_auth.auth(&res.profile_name, config_dir).await?

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli_kind,
                 config_dir,
                 Box::new(PrintOssCompletion()),
+                Box::new(DummyProfileAuth {}),
             ))
     } else {
         let command = GolemInitCommand::<OssProfileAdd>::parse();


### PR DESCRIPTION
Allow Golem Cloud to configure profile authentication process for `golem-cli init` command