### PR TITLE
Fix unit returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "golem-examples"
-version = "1.0.0-rc2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac60c107db14e5f91abe5d68bbf02349f2cb856de14bd9c76b18ae5f9f9e58e"
+checksum = "cdf804c2fba657a45213ab5d3e2460c9ed7dfd4d0e74d4472e4a1aa04c25afa2"
 dependencies = [
  "Inflector",
  "cargo_metadata",
@@ -3747,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-ast"
-version = "1.0.0-rc1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770844a7ec2727fcef6dad6f11283a99682f10c81985f1ec2c75828316076b94"
+checksum = "eb5a7ea3b63c2b1bc04c7de835d1c74bb40343211879af4d1d866cb8a7b51a61"
 dependencies = [
  "bincode",
  "leb128",
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc"
-version = "1.0.0-rc1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91951471a6504b3649e9687a32971dbd768f2027dcab052145809502f31454fc"
+checksum = "ae6a6fc80c3ad7bf4849f104a7614e5216890f48d131fa799aba5be639713d45"
 dependencies = [
  "arbitrary",
  "async-recursion",
@@ -3791,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wasm-rpc-stubgen"
-version = "1.0.0-rc1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491cf02dde768a310d7ba4907b072bbbcb93ed7bb703146733d3e3a908635676"
+checksum = "ac8729de93db67776d2b6c75d987eff101de891e8f167087eb53d32402183eb0"
 dependencies = [
  "anyhow",
  "cargo-component",
@@ -3824,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "golem-wit"
-version = "1.0.0-rc1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44357f9814854f8f672c77c63a1fce2b0258ad6f36115a3773a189976848635e"
+checksum = "419a91ba9038ca4b0d18378d5f3d4631377df436b3982dae0891503b86b2914e"
 
 [[package]]
 name = "golem-worker-executor"

--- a/golem-rib/src/compiler/type_with_unit.rs
+++ b/golem-rib/src/compiler/type_with_unit.rs
@@ -1,11 +1,13 @@
 use crate::InferredType;
+use bincode::{Decode, Encode};
 use golem_wasm_ast::analysis::{
     AnalysedType, NameOptionTypePair, NameTypePair, TypeBool, TypeChr, TypeEnum, TypeF32, TypeF64,
     TypeFlags, TypeHandle, TypeList, TypeOption, TypeRecord, TypeResult, TypeS16, TypeS32, TypeS64,
     TypeS8, TypeStr, TypeTuple, TypeU16, TypeU32, TypeU64, TypeU8, TypeVariant,
 };
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub enum AnalysedTypeWithUnit {
     Unit,
     Type(AnalysedType),

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -51,6 +51,12 @@ pub enum InferredType {
 pub struct TypeErrorMessage(pub String);
 
 impl InferredType {
+    pub fn is_unit(&self) -> bool {
+        match self {
+            InferredType::Sequence(types) => types.is_empty(),
+            _ => false,
+        }
+    }
     pub fn is_unknown(&self) -> bool {
         matches!(self, InferredType::Unknown)
     }

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -511,7 +511,6 @@ mod internal {
             .invoke_worker_function_async(parsed_function_name, type_anntoated_values)
             .await?;
 
-        // TODO refactor
         let interpreter_result = match result {
             TypeAnnotatedValue::Tuple(TypedTuple { value, .. }) if value.is_empty() => {
                 Ok(RibInterpreterResult::Unit)

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -1053,6 +1053,7 @@ mod tests {
         assert_eq!(&value1, &expected);
     }
 
+
     #[tokio::test]
     async fn test_evaluation_for_function_returning_unit() {
         let noop_executor = DefaultEvaluator::noop();
@@ -1088,8 +1089,9 @@ mod tests {
             get_analysed_export_for_unit_function("foo", vec![request_type.clone()]);
 
         let expr_str = r#"${
-              foo( { id: "bId", name: "bName", titles: request.body.titles, address: request.body.address });
-              "foo executed"
+              foo( { id: "bId", name: "bName" });
+              let result = foo( { id: "bId", name: "bName" });
+              result
             }"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
@@ -1103,9 +1105,9 @@ mod tests {
             .await
             .unwrap();
 
-        let expected = TypeAnnotatedValue::Str("bStreet".to_string());
+        let json = TypeAnnotatedValue::to_json_value(&value1);
 
-        assert_eq!(&value1, &expected);
+        assert_eq!(json, serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -239,7 +239,6 @@ mod tests {
             let mut type_info = HashMap::new();
             type_info.insert("worker".to_string(), worker_response_analysed_type);
 
-
             let mut rib_input = HashMap::new();
 
             if let Some(worker_response) = worker_response.clone() {
@@ -264,27 +263,21 @@ mod tests {
             }
 
             let invoke_result = match worker_response {
-                Some(result) => {
-                    TypeAnnotatedValue::Tuple(TypedTuple {
-                        value: vec![golem_wasm_rpc::protobuf::TypeAnnotatedValue {
-                            type_annotated_value: Some(result),
-                        }],
-                        typ: vec![],
-                    })
-                }
-                None => {
-                    TypeAnnotatedValue::Tuple(TypedTuple {
-                        value: vec![],
-                        typ: vec![],
-                    })
-                }
+                Some(result) => TypeAnnotatedValue::Tuple(TypedTuple {
+                    value: vec![golem_wasm_rpc::protobuf::TypeAnnotatedValue {
+                        type_annotated_value: Some(result),
+                    }],
+                    typ: vec![],
+                }),
+                None => TypeAnnotatedValue::Tuple(TypedTuple {
+                    value: vec![],
+                    typ: vec![],
+                }),
             };
 
             let worker_invoke_function: RibFunctionInvoke = Arc::new(move |_, _| {
                 let worker_response_clone = worker_response.clone();
-                Box::pin(async move {
-                    Ok(invoke_result)
-                })
+                Box::pin(async move { Ok(invoke_result) })
             });
 
             let eval_result =
@@ -1007,8 +1000,7 @@ mod tests {
     async fn test_evaluation_for_no_arg_unit_function() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let component_metadata =
-            get_analysed_export_for_no_arg_unit_function("foo");
+        let component_metadata = get_analysed_export_for_no_arg_unit_function("foo");
 
         let expr_str = r#"${
               foo();
@@ -1017,12 +1009,7 @@ mod tests {
 
         let expr1 = rib::from_string(expr_str).unwrap();
         let value1 = noop_executor
-            .evaluate_with_worker_response(
-                &expr1,
-                None,
-                component_metadata.clone(),
-                None
-            )
+            .evaluate_with_worker_response(&expr1, None, component_metadata.clone(), None)
             .await
             .unwrap();
 
@@ -1035,16 +1022,14 @@ mod tests {
     async fn test_evaluation_for_no_arg_function() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let worker_response =
-            create_none(Some(&AnalysedType::Str(TypeStr)));
+        let worker_response = create_none(Some(&AnalysedType::Str(TypeStr)));
 
         // Output from worker
         let return_type = AnalysedType::Option(TypeOption {
             inner: Box::new(AnalysedType::try_from(&worker_response).unwrap()),
         });
 
-        let component_metadata =
-            get_analysed_export_for_no_arg_function("foo", return_type);
+        let component_metadata = get_analysed_export_for_no_arg_function("foo", return_type);
 
         let expr_str = r#"${
               let result = foo();
@@ -1057,7 +1042,7 @@ mod tests {
                 &expr1,
                 Some(worker_response.clone()),
                 component_metadata.clone(),
-                None
+                None,
             )
             .await
             .unwrap();
@@ -2523,7 +2508,12 @@ mod tests {
             let expr2_string = expr1.to_string();
             let expr2 = rib::from_string(expr2_string.as_str()).unwrap();
             let value2 = noop_executor
-                .evaluate_with_worker_response(&expr2, Some(worker_response), component_metadata, None)
+                .evaluate_with_worker_response(
+                    &expr2,
+                    Some(worker_response),
+                    component_metadata,
+                    None,
+                )
                 .await
                 .unwrap();
 


### PR DESCRIPTION
Making sure, given a function `foo` that returns `unit`, it responds with a http response with empty body.

Handling `Unit` was done before, and therefore this is more of a bug fix,  with more tests at worker-service side which decides what to do with a result from `golem-rib` that can either be a `Unit` or `TypeAnnotatedValue`

Following is possible

```scala
// foo returns unit
let x = foo("bar");
x

```

This will return a response with empty response body. I think we cannot expect the user to never use the result from a function which was `Unit`. Intuitively,

```scala
foo("bar")
```

is isomorphic to

```
let x = foo("bar");
x
```

