### PR TITLE
Type binding

### DIFF
--- a/golem-api-grpc/build.rs
+++ b/golem-api-grpc/build.rs
@@ -16,6 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compile(
             &[
                 "proto/golem/rib/function_name.proto",
+                "proto/golem/rib/type_name.proto",
                 "proto/golem/rib/expr.proto",
                 "proto/golem/rib/rib_input.proto",
                 "proto/golem/rib/ir.proto",

--- a/golem-api-grpc/proto/golem/rib/expr.proto
+++ b/golem-api-grpc/proto/golem/rib/expr.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package golem.rib;
 
 import "golem/rib/function_name.proto";
+import "golem/rib/type_name.proto";
 
 message Expr {
   oneof expr {
@@ -36,6 +37,7 @@ message Expr {
 message LetExpr {
   string name = 1;
   Expr expr = 2;
+  optional TypeName type_name = 3;
 }
 
 message SelectFieldExpr {

--- a/golem-api-grpc/proto/golem/rib/type_name.proto
+++ b/golem-api-grpc/proto/golem/rib/type_name.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package golem.rib;
+
+// Define the TypeName enum to represent simple types.
+enum BasicTypeName {
+    BOOL = 0;
+    S8 = 1;
+    U8 = 2;
+    S16 = 3;
+    U16 = 4;
+    S32 = 5;
+    U32 = 6;
+    S64 = 7;
+    U64 = 8;
+    F32 = 9;
+    F64 = 10;
+    CHR = 11;
+    STR = 12;
+}
+
+message TypeName {
+    oneof kind {
+        BasicTypeName basic_type = 1;
+        ListType list_type = 2;
+        TupleType tuple_type = 3;
+        OptionType option_type = 4;
+    }
+}
+
+message ListType {
+    TypeName inner_type = 1;
+}
+
+message TupleType {
+    repeated TypeName types = 1;
+}
+
+message OptionType {
+    TypeName inner_type = 1;
+}

--- a/golem-cli/tests/api_definition.rs
+++ b/golem-cli/tests/api_definition.rs
@@ -167,7 +167,7 @@ pub fn make_open_api_file(
                 "worker-name": "worker-${request.path.user-id}",
                 "component-id": component_id,
                 "component-version": component_version,
-                "response" : "${{headers : {ContentType: \"json\", userid: \"foo\"}, body: \"foo\", status: 200}}"
+                "response" : "${let status: u64 = 200; {headers : {ContentType: \"json\", userid: \"foo\"}, body: \"foo\", status: status}}"
               },
               "get": {
                 "summary": "Get Cart Contents",
@@ -299,7 +299,7 @@ fn api_definition_update(
     let updated = golem_def_with_response(
         &component_name,
         &component_id,
-        "${{headers: {ContentType: \"json\", userid: \"bar\"}, body: \"baz\", status: 200}}"
+        "${let status: u64 = 200; {headers: {ContentType: \"json\", userid: \"bar\"}, body: \"baz\", status: status}}"
             .to_string(),
     );
     let path = make_golem_file(&updated)?;
@@ -328,7 +328,7 @@ fn api_definition_update_immutable(
     let path = make_golem_file(&def)?;
     let _: HttpApiDefinition = cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
 
-    let updated = golem_def_with_response(&component_name, &component_id, "${{headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: 200}}".to_string());
+    let updated = golem_def_with_response(&component_name, &component_id, "${let status: u64 = 200; {headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: status}}".to_string());
     let path = make_golem_file(&updated)?;
     let res = cli.run_string(&["api-definition", "update", path.to_str().unwrap()]);
 

--- a/golem-cli/tests/api_definition.rs
+++ b/golem-cli/tests/api_definition.rs
@@ -136,7 +136,7 @@ pub fn golem_def(id: &str, component_id: &str) -> HttpApiDefinitionRequest {
     golem_def_with_response(
         id,
         component_id,
-        "${{headers: {ContentType: \"json\", userid: \"foo\"}, body: \"foo\", status: 200}}"
+        "${let status: u64 = 200; {headers: {ContentType: \"json\", userid: \"foo\"}, body: \"foo\", status: status}}"
             .to_string(),
     )
 }

--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -158,7 +158,7 @@ mod internal {
                     stack.push(ExprState::from_expr(expr));
                 }
             }
-            Expr::Let(variable_id, inner_expr, _) => {
+            Expr::Let(variable_id, _, inner_expr, _) => {
                 stack.push(ExprState::from_expr(inner_expr.deref()));
                 instructions.push(RibIR::AssignVar(variable_id.clone()));
             }
@@ -401,6 +401,7 @@ mod compiler_tests {
 
         let expr = Expr::Let(
             variable_id.clone(),
+            None,
             Box::new(literal),
             InferredType::Unknown,
         );

--- a/golem-rib/src/compiler/desugar.rs
+++ b/golem-rib/src/compiler/desugar.rs
@@ -318,10 +318,7 @@ mod internal {
 
 #[cfg(test)]
 mod desugar_tests {
-    use crate::compiler::desugar::desugar_tests::expectations::{
-        expected_condition_simple, expected_condition_with_identifiers,
-        expected_condition_with_literals,
-    };
+    use crate::compiler::desugar::desugar_tests::expectations::expected_condition_with_identifiers;
     use crate::type_registry::FunctionTypeRegistry;
     use crate::Expr;
     use golem_wasm_ast::analysis::{
@@ -389,58 +386,7 @@ mod desugar_tests {
         }
     }
     mod expectations {
-        use crate::{Expr, InferredType, Number, VariableId};
-
-        pub(crate) fn expected_condition_simple() -> Expr {
-            Expr::cond(
-                Expr::equal_to(
-                    Expr::Number(Number { value: 1f64 }, InferredType::U64),
-                    Expr::Number(Number { value: 1f64 }, InferredType::U64),
-                ),
-                Expr::boolean(true),
-                Expr::cond(
-                    Expr::equal_to(
-                        Expr::Number(Number { value: 1f64 }, InferredType::U64),
-                        Expr::Number(Number { value: 2f64 }, InferredType::U64),
-                    ),
-                    Expr::boolean(false),
-                    Expr::Throw("No match found".to_string(), InferredType::Unknown),
-                )
-                .add_infer_type(InferredType::Bool),
-            )
-            .add_infer_type(InferredType::Bool)
-        }
-        pub(crate) fn expected_condition_with_literals() -> Expr {
-            Expr::cond(
-                Expr::equal_to(
-                    Expr::Unwrap(
-                        Box::new(Expr::option(Some(Expr::Number(
-                            Number { value: 1f64 },
-                            InferredType::U64,
-                        )))),
-                        InferredType::Unknown,
-                    ),
-                    Expr::Number(Number { value: 2f64 }, InferredType::U64),
-                ),
-                Expr::boolean(true),
-                Expr::cond(
-                    Expr::equal_to(
-                        Expr::Unwrap(
-                            Box::new(Expr::option(Some(Expr::Number(
-                                Number { value: 1f64 },
-                                InferredType::U64,
-                            )))),
-                            InferredType::Unknown,
-                        ),
-                        Expr::Number(Number { value: 3f64 }, InferredType::U64),
-                    ),
-                    Expr::boolean(false),
-                    Expr::Throw("No match found".to_string(), InferredType::Unknown),
-                )
-                .add_infer_type(InferredType::Bool),
-            )
-            .add_infer_type(InferredType::Bool)
-        }
+        use crate::{Expr, InferredType, VariableId};
         pub(crate) fn expected_condition_with_identifiers() -> Expr {
             Expr::Cond(
                 Box::new(Expr::EqualTo(

--- a/golem-rib/src/compiler/desugar.rs
+++ b/golem-rib/src/compiler/desugar.rs
@@ -190,6 +190,7 @@ mod internal {
             Expr::Identifier(identifier, inferred_type) => {
                 let assign_var = Expr::Let(
                     identifier.clone(),
+                    None,
                     Box::new(pred_expr.clone()),
                     inferred_type.clone(),
                 );
@@ -302,6 +303,7 @@ mod internal {
     ) -> Option<IfElseBranch> {
         let binding = Expr::Let(
             VariableId::global(name.to_string()),
+            None,
             Box::new(pred_expr.clone()),
             pred_expr.inferred_type(),
         );
@@ -404,6 +406,7 @@ mod desugar_tests {
                     vec![
                         Expr::Let(
                             VariableId::match_identifier("x".to_string(), 1),
+                            None,
                             Box::new(Expr::Unwrap(
                                 Box::new(Expr::Identifier(
                                     VariableId::local("x", 0),
@@ -436,6 +439,7 @@ mod desugar_tests {
                         vec![
                             Expr::Let(
                                 VariableId::match_identifier("y".to_string(), 2),
+                                None,
                                 Box::new(Expr::Unwrap(
                                     Box::new(Expr::Identifier(
                                         VariableId::local("x", 0),

--- a/golem-rib/src/compiler/desugar.rs
+++ b/golem-rib/src/compiler/desugar.rs
@@ -449,7 +449,7 @@ mod desugar_tests {
                             VariableId::local("x", 0),
                             InferredType::Option(Box::new(InferredType::U64)),
                         )),
-                        InferredType::Unknown
+                        InferredType::Unknown,
                     )),
                     Box::new(Expr::Literal("some".to_string(), InferredType::Str)),
                     InferredType::Bool,

--- a/golem-rib/src/compiler/mod.rs
+++ b/golem-rib/src/compiler/mod.rs
@@ -22,6 +22,7 @@ pub fn compile(
         .infer_types(&type_registry)
         .map_err(|e| e.join("\n"))?;
 
+    dbg!(expr_cloned.clone());
     // Inferring input is not done properly, however, worse case is run-time error asking user to pass these info
     let rib_input =
         RibInputTypeInfo::from_expr(&mut expr_cloned).unwrap_or(RibInputTypeInfo::empty());

--- a/golem-rib/src/compiler/mod.rs
+++ b/golem-rib/src/compiler/mod.rs
@@ -22,7 +22,6 @@ pub fn compile(
         .infer_types(&type_registry)
         .map_err(|e| e.join("\n"))?;
 
-    dbg!(expr_cloned.clone());
     // Inferring input is not done properly, however, worse case is run-time error asking user to pass these info
     let rib_input =
         RibInputTypeInfo::from_expr(&mut expr_cloned).unwrap_or(RibInputTypeInfo::empty());

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -424,7 +424,7 @@ impl Expr {
         self.infer_all_identifiers().map_err(|x| vec![x])?;
         self.pull_types_up().map_err(|x| vec![x])?;
         self.infer_all_identifiers().map_err(|x| vec![x])?;
-       // dbg!(self.clone());
+        // dbg!(self.clone());
         self.unify_types()?;
 
         dbg!(self.clone());

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -424,10 +424,7 @@ impl Expr {
         self.infer_all_identifiers().map_err(|x| vec![x])?;
         self.pull_types_up().map_err(|x| vec![x])?;
         self.infer_all_identifiers().map_err(|x| vec![x])?;
-        // dbg!(self.clone());
         self.unify_types()?;
-
-        dbg!(self.clone());
         Ok(())
     }
 

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -771,7 +771,7 @@ impl TryFrom<golem_api_grpc::proto::golem::rib::Expr> for Expr {
         let expr = match expr {
             golem_api_grpc::proto::golem::rib::expr::Expr::Let(expr) => {
                 let name = expr.name;
-                let type_name = expr.type_name.map(|t| TypeName::try_from(t)).transpose()?;
+                let type_name = expr.type_name.map(TypeName::try_from).transpose()?;
                 let expr = *expr.expr.ok_or("Missing expr")?;
                 Expr::Let(
                     VariableId::global(name.as_str().to_string()),

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -424,7 +424,10 @@ impl Expr {
         self.infer_all_identifiers().map_err(|x| vec![x])?;
         self.pull_types_up().map_err(|x| vec![x])?;
         self.infer_all_identifiers().map_err(|x| vec![x])?;
+       // dbg!(self.clone());
         self.unify_types()?;
+
+        dbg!(self.clone());
         Ok(())
     }
 
@@ -521,7 +524,9 @@ impl Expr {
                     // We are only interested in global variables
                     if variable_id.is_global() {
                         if let Some(types) = global_variables_dictionary.get(&variable_id.name()) {
-                            inferred_type.update(InferredType::AllOf(types.clone()));
+                            if let Some(all_of) = InferredType::all_of(types.clone()) {
+                                inferred_type.update(all_of);
+                            }
                         }
                     }
                 }

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -14,6 +14,7 @@
 
 use crate::function_name::ParsedFunctionName;
 use crate::parser::rib_expr::rib_program;
+use crate::parser::type_binding::bind;
 use crate::parser::type_name::TypeName;
 use crate::type_registry::FunctionTypeRegistry;
 use crate::{text, type_inference, InferredType, VariableId};
@@ -27,7 +28,6 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Display;
 use std::ops::Deref;
 use std::str::FromStr;
-use crate::parser::type_binding::bind;
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub enum Expr {
@@ -773,7 +773,8 @@ impl TryFrom<golem_api_grpc::proto::golem::rib::Expr> for Expr {
             golem_api_grpc::proto::golem::rib::expr::Expr::Let(expr) => {
                 let name = expr.name;
                 let type_name = expr.type_name.map(TypeName::try_from).transpose()?;
-                let expr_: golem_api_grpc::proto::golem::rib::Expr = *expr.expr.ok_or("Missing expr")?;
+                let expr_: golem_api_grpc::proto::golem::rib::Expr =
+                    *expr.expr.ok_or("Missing expr")?;
                 let expr = expr_.try_into()?;
                 let binded = bind(&expr, type_name.clone());
                 Expr::Let(

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -173,6 +173,7 @@ impl InferredType {
 
     pub fn unify_types_and_verify(&self) -> Result<InferredType, Vec<String>> {
         let unified = self.unify_types()?;
+        dbg!(unified.clone());
         if let Some(unresolved) = unified.un_resolved() {
             return Err(vec![unresolved]);
         }

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -343,10 +343,6 @@ impl InferredType {
         one_of_types
     }
 
-    fn all_numbers(types: &[InferredType]) -> bool {
-        types.iter().all(|t| t.is_number())
-    }
-
     fn unify_all_alternative_types(types: &Vec<InferredType>) -> Result<InferredType, Vec<String>> {
         let mut unified_type = InferredType::Unknown;
 
@@ -357,7 +353,7 @@ impl InferredType {
                 Ok(t) => {
                     unified_type = t.clone();
                 }
-                Err(e) => {
+                Err(_) => {
                     if !unified_type.is_unknown() {
                         unified_type = InferredType::OneOf(Self::flatten_one_of_list(&vec![
                             unified_type.clone(),
@@ -1098,12 +1094,8 @@ impl InferredType {
                 if new_types.contains(current_type) || current_type.is_unknown() {
                     *current_type = InferredType::AllOf(new_types);
                 } else {
-                    if current_type.is_unknown() {
-                        *current_type = InferredType::AllOf(new_types);
-                    } else {
-                        new_types.push(current_type.clone());
-                        *current_type = InferredType::AllOf(new_types);
-                    }
+                    new_types.push(current_type.clone());
+                    *current_type = InferredType::AllOf(new_types);
                 }
             }
 
@@ -1216,8 +1208,6 @@ mod internal {
 
 #[cfg(test)]
 mod test {
-    use wasm_wave::lex::Keyword::Inf;
-
     #[test]
     fn test_flatten_one_of() {
         use super::InferredType;

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -1204,8 +1204,10 @@ mod internal {
 
 #[cfg(test)]
 mod test {
+    use wasm_wave::lex::Keyword::Inf;
+
     #[test]
-    fn test_flatte_one_of() {
+    fn test_flatten_one_of() {
         use super::InferredType;
         let one_of = vec![
             InferredType::U8,
@@ -1223,7 +1225,27 @@ mod test {
         ];
 
         let flattened = InferredType::flatten_one_of_list(&one_of);
-        dbg!(flattened);
-        assert!(false)
+
+        let expected = vec![
+           InferredType::U8,
+           InferredType::U16,
+           InferredType::U32,
+           InferredType::U8,
+           InferredType::U16,
+           InferredType::U32,
+           InferredType::AllOf(
+                vec![
+                    InferredType::U64,
+                    InferredType::OneOf(
+                       vec![
+                            InferredType::U64,
+                            InferredType::U8,
+                        ],
+                    ),
+                ],
+            ),
+        ];
+
+        assert_eq!(flattened, expected)
     }
 }

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -1239,23 +1239,16 @@ mod test {
         let flattened = InferredType::flatten_one_of_list(&one_of);
 
         let expected = vec![
-           InferredType::U8,
-           InferredType::U16,
-           InferredType::U32,
-           InferredType::U8,
-           InferredType::U16,
-           InferredType::U32,
-           InferredType::AllOf(
-                vec![
-                    InferredType::U64,
-                    InferredType::OneOf(
-                       vec![
-                            InferredType::U64,
-                            InferredType::U8,
-                        ],
-                    ),
-                ],
-            ),
+            InferredType::U8,
+            InferredType::U16,
+            InferredType::U32,
+            InferredType::U8,
+            InferredType::U16,
+            InferredType::U32,
+            InferredType::AllOf(vec![
+                InferredType::U64,
+                InferredType::OneOf(vec![InferredType::U64, InferredType::U8]),
+            ]),
         ];
 
         assert_eq!(flattened, expected)

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -185,7 +185,6 @@ impl InferredType {
 
     pub fn unify_types_and_verify(&self) -> Result<InferredType, Vec<String>> {
         let unified = self.unify_types()?;
-        dbg!(unified.clone());
         if let Some(unresolved) = unified.un_resolved() {
             return Err(vec![unresolved]);
         }
@@ -605,7 +604,6 @@ impl InferredType {
                     if a == b {
                         Ok(a.clone())
                     } else {
-                        dbg!("here?");
                         Err(vec![format!(
                             "Types do not match. Inferred to be both {:?} and {:?}",
                             a, b

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::inferred_type::internal::sort_and_convert;
 use bincode::{Decode, Encode};
 use golem_wasm_ast::analysis::*;
 

--- a/golem-rib/src/parser/let_binding.rs
+++ b/golem-rib/src/parser/let_binding.rs
@@ -24,6 +24,7 @@ use crate::expr::Expr;
 use crate::parser::rib_expr::rib_expr;
 use crate::parser::type_name::parse_type_name;
 use combine::stream::easy;
+use crate::parser::type_binding;
 
 pub fn let_binding<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
     spaces().with(
@@ -60,56 +61,6 @@ fn let_variable<'t>() -> impl Parser<easy::Stream<&'t str>, Output = String> {
         })
         .map(|s: Vec<char>| s.into_iter().collect())
         .message("Unable to parse let binding variable")
-}
-
-// TODO; Revisit and clean up
-mod type_binding {
-    use crate::parser::type_name::TypeName;
-    use crate::{Expr, InferredType};
-
-    pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
-        if let Some(type_name) = type_name {
-            let mut expr = expr.clone();
-            override_type(&mut expr, type_name.into());
-            expr
-        } else {
-            expr.clone()
-        }
-    }
-
-    pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
-        match expr {
-            Expr::Identifier(_, inferred_type)
-            | Expr::Let(_, _, inferred_type)
-            | Expr::SelectField(_, _, inferred_type)
-            | Expr::SelectIndex(_, _, inferred_type)
-            | Expr::Sequence(_, inferred_type)
-            | Expr::Record(_, inferred_type)
-            | Expr::Tuple(_, inferred_type)
-            | Expr::Literal(_, inferred_type)
-            | Expr::Number(_, inferred_type)
-            | Expr::Flags(_, inferred_type)
-            | Expr::Boolean(_, inferred_type)
-            | Expr::Concat(_, inferred_type)
-            | Expr::Multiple(_, inferred_type)
-            | Expr::Not(_, inferred_type)
-            | Expr::GreaterThan(_, _, inferred_type)
-            | Expr::GreaterThanOrEqualTo(_, _, inferred_type)
-            | Expr::LessThanOrEqualTo(_, _, inferred_type)
-            | Expr::EqualTo(_, _, inferred_type)
-            | Expr::LessThan(_, _, inferred_type)
-            | Expr::Cond(_, _, _, inferred_type)
-            | Expr::PatternMatch(_, _, inferred_type)
-            | Expr::Option(_, inferred_type)
-            | Expr::Result(_, inferred_type)
-            | Expr::Unwrap(_, inferred_type)
-            | Expr::Throw(_, inferred_type)
-            | Expr::Tag(_, inferred_type)
-            | Expr::Call(_, _, inferred_type) => {
-                *inferred_type = new_type;
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/let_binding.rs
+++ b/golem-rib/src/parser/let_binding.rs
@@ -15,13 +15,14 @@
 use combine::error::StreamError;
 use combine::parser::char::digit;
 use combine::{
-    many1,
+    many1, optional,
     parser::char::{char as char_, letter, spaces, string},
     Parser,
 };
 
 use crate::expr::Expr;
 use crate::parser::rib_expr::rib_expr;
+use crate::parser::type_name::parse_type_name;
 use combine::stream::easy;
 
 pub fn let_binding<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
@@ -29,10 +30,20 @@ pub fn let_binding<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
         (
             string("let").skip(spaces()),
             let_variable().skip(spaces()),
+            optional(
+                // Optionally match and parse the type annotation
+                char_(':')
+                    .skip(spaces()) // Match the colon
+                    .with(parse_type_name()) // Parse the type
+                    .skip(spaces()), // Consume any trailing spaces
+            ),
             char_('=').skip(spaces()),
             rib_expr(),
         )
-            .map(|(_, var, _, expr)| Expr::let_binding(var.as_str(), expr)),
+            .map(|(_, var, optional_type, _, expr)| {
+                let new_expr = type_binding::bind(&expr, optional_type);
+                Expr::let_binding(var.as_str(), new_expr)
+            }),
     )
 }
 
@@ -51,9 +62,60 @@ fn let_variable<'t>() -> impl Parser<easy::Stream<&'t str>, Output = String> {
         .message("Unable to parse let binding variable")
 }
 
+// TODO; Revisit and clean up
+mod type_binding {
+    use crate::parser::type_name::TypeName;
+    use crate::{Expr, InferredType};
+
+    pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
+        if let Some(type_name) = type_name {
+            let mut expr = expr.clone();
+            override_type(&mut expr, type_name.into());
+            expr
+        } else {
+            expr.clone()
+        }
+    }
+
+    pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
+        match expr {
+            Expr::Identifier(_, inferred_type)
+            | Expr::Let(_, _, inferred_type)
+            | Expr::SelectField(_, _, inferred_type)
+            | Expr::SelectIndex(_, _, inferred_type)
+            | Expr::Sequence(_, inferred_type)
+            | Expr::Record(_, inferred_type)
+            | Expr::Tuple(_, inferred_type)
+            | Expr::Literal(_, inferred_type)
+            | Expr::Number(_, inferred_type)
+            | Expr::Flags(_, inferred_type)
+            | Expr::Boolean(_, inferred_type)
+            | Expr::Concat(_, inferred_type)
+            | Expr::Multiple(_, inferred_type)
+            | Expr::Not(_, inferred_type)
+            | Expr::GreaterThan(_, _, inferred_type)
+            | Expr::GreaterThanOrEqualTo(_, _, inferred_type)
+            | Expr::LessThanOrEqualTo(_, _, inferred_type)
+            | Expr::EqualTo(_, _, inferred_type)
+            | Expr::LessThan(_, _, inferred_type)
+            | Expr::Cond(_, _, _, inferred_type)
+            | Expr::PatternMatch(_, _, inferred_type)
+            | Expr::Option(_, inferred_type)
+            | Expr::Result(_, inferred_type)
+            | Expr::Unwrap(_, inferred_type)
+            | Expr::Throw(_, inferred_type)
+            | Expr::Tag(_, inferred_type)
+            | Expr::Call(_, _, inferred_type) => {
+                *inferred_type = new_type;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{InferredType, VariableId};
     use combine::EasyParser;
 
     #[test]
@@ -144,6 +206,214 @@ mod tests {
                 Expr::let_binding(
                     "foo",
                     Expr::record(vec![("bar".to_string(), Expr::identifier("baz"))])
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_u8() {
+        let input = "let foo: u8 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U8)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_u16() {
+        let input = "let foo: u16 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U16)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_u32() {
+        let input = "let foo: u32 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U32)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_u64() {
+        let input = "let foo: u64 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U64)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_s8() {
+        let input = "let foo: s8 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S8)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_s16() {
+        let input = "let foo: s16 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S16)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_s32() {
+        let input = "let foo: s32 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S32)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_s64() {
+        let input = "let foo: s64 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S64)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_f32() {
+        let input = "let foo: f32 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::F32)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_f64() {
+        let input = "let foo: f64 = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::F64)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_chr() {
+        let input = "let foo: chr = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::Chr)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_str() {
+        let input = "let foo: str = bar";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Identifier(VariableId::global("bar".to_string()), InferredType::Str)
+                ),
+                ""
+            ))
+        );
+    }
+
+    #[test]
+    fn test_let_binding_with_type_name_list_u8() {
+        let input = "let foo: list<u8> = []";
+        let result = let_binding().easy_parse(input);
+        assert_eq!(
+            result,
+            Ok((
+                Expr::let_binding(
+                    "foo",
+                    Expr::Sequence(vec![], InferredType::List(Box::new(InferredType::U8)))
                 ),
                 ""
             ))

--- a/golem-rib/src/parser/let_binding.rs
+++ b/golem-rib/src/parser/let_binding.rs
@@ -22,9 +22,9 @@ use combine::{
 
 use crate::expr::Expr;
 use crate::parser::rib_expr::rib_expr;
+use crate::parser::type_binding;
 use crate::parser::type_name::parse_type_name;
 use combine::stream::easy;
-use crate::parser::type_binding;
 
 pub fn let_binding<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
     spaces().with(

--- a/golem-rib/src/parser/let_binding.rs
+++ b/golem-rib/src/parser/let_binding.rs
@@ -42,8 +42,12 @@ pub fn let_binding<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
             rib_expr(),
         )
             .map(|(_, var, optional_type, _, expr)| {
-                let new_expr = type_binding::bind(&expr, optional_type);
-                Expr::let_binding(var.as_str(), new_expr)
+                let new_expr = type_binding::bind(&expr, optional_type.clone());
+                if let Some(type_name) = optional_type {
+                    Expr::let_binding_with_type(var, type_name, new_expr)
+                } else {
+                    Expr::let_binding(var.as_str(), new_expr)
+                }
             }),
     )
 }
@@ -66,6 +70,7 @@ fn let_variable<'t>() -> impl Parser<easy::Stream<&'t str>, Output = String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::type_name::TypeName;
     use crate::{InferredType, VariableId};
     use combine::EasyParser;
 
@@ -170,8 +175,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::U8,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U8)
                 ),
                 ""
@@ -186,8 +192,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::U16,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U16)
                 ),
                 ""
@@ -202,8 +209,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::U32,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U32)
                 ),
                 ""
@@ -218,8 +226,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::U64,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::U64)
                 ),
                 ""
@@ -234,8 +243,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::S8,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S8)
                 ),
                 ""
@@ -250,8 +260,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::S16,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S16)
                 ),
                 ""
@@ -266,8 +277,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::S32,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S32)
                 ),
                 ""
@@ -282,8 +294,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::S64,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::S64)
                 ),
                 ""
@@ -298,8 +311,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::F32,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::F32)
                 ),
                 ""
@@ -314,8 +328,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::F64,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::F64)
                 ),
                 ""
@@ -330,8 +345,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::Chr,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::Chr)
                 ),
                 ""
@@ -346,8 +362,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::Str,
                     Expr::Identifier(VariableId::global("bar".to_string()), InferredType::Str)
                 ),
                 ""
@@ -362,8 +379,9 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::let_binding(
+                Expr::let_binding_with_type(
                     "foo",
+                    TypeName::List(Box::new(TypeName::U8)),
                     Expr::Sequence(vec![], InferredType::List(Box::new(InferredType::U8)))
                 ),
                 ""

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -19,3 +19,4 @@ mod select_index;
 mod sequence;
 mod tuple;
 mod type_name;
+pub(crate) mod type_binding;

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -18,5 +18,5 @@ mod select_field;
 mod select_index;
 mod sequence;
 mod tuple;
-mod type_name;
 pub(crate) mod type_binding;
+mod type_name;

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -18,3 +18,4 @@ mod select_field;
 mod select_index;
 mod sequence;
 mod tuple;
+mod type_name;

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -19,4 +19,4 @@ mod select_index;
 mod sequence;
 mod tuple;
 pub(crate) mod type_binding;
-mod type_name;
+pub(crate) mod type_name;

--- a/golem-rib/src/parser/type_binding.rs
+++ b/golem-rib/src/parser/type_binding.rs
@@ -14,7 +14,7 @@ pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
 pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
     match expr {
         Expr::Identifier(_, inferred_type)
-        | Expr::Let(_, _, inferred_type)
+        | Expr::Let(_, _, _, inferred_type)
         | Expr::SelectField(_, _, inferred_type)
         | Expr::SelectIndex(_, _, inferred_type)
         | Expr::Sequence(_, inferred_type)

--- a/golem-rib/src/parser/type_binding.rs
+++ b/golem-rib/src/parser/type_binding.rs
@@ -1,4 +1,3 @@
-
 use crate::parser::type_name::TypeName;
 use crate::{Expr, InferredType};
 

--- a/golem-rib/src/parser/type_binding.rs
+++ b/golem-rib/src/parser/type_binding.rs
@@ -1,46 +1,47 @@
-    use crate::parser::type_name::TypeName;
-    use crate::{Expr, InferredType};
 
-    pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
-        if let Some(type_name) = type_name {
-            let mut expr = expr.clone();
-            override_type(&mut expr, type_name.into());
-            expr
-        } else {
-            expr.clone()
+use crate::parser::type_name::TypeName;
+use crate::{Expr, InferredType};
+
+pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
+    if let Some(type_name) = type_name {
+        let mut expr = expr.clone();
+        override_type(&mut expr, type_name.into());
+        expr
+    } else {
+        expr.clone()
+    }
+}
+
+pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
+    match expr {
+        Expr::Identifier(_, inferred_type)
+        | Expr::Let(_, _, inferred_type)
+        | Expr::SelectField(_, _, inferred_type)
+        | Expr::SelectIndex(_, _, inferred_type)
+        | Expr::Sequence(_, inferred_type)
+        | Expr::Record(_, inferred_type)
+        | Expr::Tuple(_, inferred_type)
+        | Expr::Literal(_, inferred_type)
+        | Expr::Number(_, inferred_type)
+        | Expr::Flags(_, inferred_type)
+        | Expr::Boolean(_, inferred_type)
+        | Expr::Concat(_, inferred_type)
+        | Expr::Multiple(_, inferred_type)
+        | Expr::Not(_, inferred_type)
+        | Expr::GreaterThan(_, _, inferred_type)
+        | Expr::GreaterThanOrEqualTo(_, _, inferred_type)
+        | Expr::LessThanOrEqualTo(_, _, inferred_type)
+        | Expr::EqualTo(_, _, inferred_type)
+        | Expr::LessThan(_, _, inferred_type)
+        | Expr::Cond(_, _, _, inferred_type)
+        | Expr::PatternMatch(_, _, inferred_type)
+        | Expr::Option(_, inferred_type)
+        | Expr::Result(_, inferred_type)
+        | Expr::Unwrap(_, inferred_type)
+        | Expr::Throw(_, inferred_type)
+        | Expr::Tag(_, inferred_type)
+        | Expr::Call(_, _, inferred_type) => {
+            *inferred_type = new_type;
         }
     }
-
-    pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
-        match expr {
-            Expr::Identifier(_, inferred_type)
-            | Expr::Let(_, _, inferred_type)
-            | Expr::SelectField(_, _, inferred_type)
-            | Expr::SelectIndex(_, _, inferred_type)
-            | Expr::Sequence(_, inferred_type)
-            | Expr::Record(_, inferred_type)
-            | Expr::Tuple(_, inferred_type)
-            | Expr::Literal(_, inferred_type)
-            | Expr::Number(_, inferred_type)
-            | Expr::Flags(_, inferred_type)
-            | Expr::Boolean(_, inferred_type)
-            | Expr::Concat(_, inferred_type)
-            | Expr::Multiple(_, inferred_type)
-            | Expr::Not(_, inferred_type)
-            | Expr::GreaterThan(_, _, inferred_type)
-            | Expr::GreaterThanOrEqualTo(_, _, inferred_type)
-            | Expr::LessThanOrEqualTo(_, _, inferred_type)
-            | Expr::EqualTo(_, _, inferred_type)
-            | Expr::LessThan(_, _, inferred_type)
-            | Expr::Cond(_, _, _, inferred_type)
-            | Expr::PatternMatch(_, _, inferred_type)
-            | Expr::Option(_, inferred_type)
-            | Expr::Result(_, inferred_type)
-            | Expr::Unwrap(_, inferred_type)
-            | Expr::Throw(_, inferred_type)
-            | Expr::Tag(_, inferred_type)
-            | Expr::Call(_, _, inferred_type) => {
-                *inferred_type = new_type;
-            }
-        }
-    }
+}

--- a/golem-rib/src/parser/type_binding.rs
+++ b/golem-rib/src/parser/type_binding.rs
@@ -1,0 +1,46 @@
+    use crate::parser::type_name::TypeName;
+    use crate::{Expr, InferredType};
+
+    pub(crate) fn bind(expr: &Expr, type_name: Option<TypeName>) -> Expr {
+        if let Some(type_name) = type_name {
+            let mut expr = expr.clone();
+            override_type(&mut expr, type_name.into());
+            expr
+        } else {
+            expr.clone()
+        }
+    }
+
+    pub(crate) fn override_type(expr: &mut Expr, new_type: InferredType) {
+        match expr {
+            Expr::Identifier(_, inferred_type)
+            | Expr::Let(_, _, inferred_type)
+            | Expr::SelectField(_, _, inferred_type)
+            | Expr::SelectIndex(_, _, inferred_type)
+            | Expr::Sequence(_, inferred_type)
+            | Expr::Record(_, inferred_type)
+            | Expr::Tuple(_, inferred_type)
+            | Expr::Literal(_, inferred_type)
+            | Expr::Number(_, inferred_type)
+            | Expr::Flags(_, inferred_type)
+            | Expr::Boolean(_, inferred_type)
+            | Expr::Concat(_, inferred_type)
+            | Expr::Multiple(_, inferred_type)
+            | Expr::Not(_, inferred_type)
+            | Expr::GreaterThan(_, _, inferred_type)
+            | Expr::GreaterThanOrEqualTo(_, _, inferred_type)
+            | Expr::LessThanOrEqualTo(_, _, inferred_type)
+            | Expr::EqualTo(_, _, inferred_type)
+            | Expr::LessThan(_, _, inferred_type)
+            | Expr::Cond(_, _, _, inferred_type)
+            | Expr::PatternMatch(_, _, inferred_type)
+            | Expr::Option(_, inferred_type)
+            | Expr::Result(_, inferred_type)
+            | Expr::Unwrap(_, inferred_type)
+            | Expr::Throw(_, inferred_type)
+            | Expr::Tag(_, inferred_type)
+            | Expr::Call(_, _, inferred_type) => {
+                *inferred_type = new_type;
+            }
+        }
+    }

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -44,13 +44,13 @@ impl From<TypeName> for InferredType {
             TypeName::Chr => InferredType::Chr,
             TypeName::Str => InferredType::Str,
             TypeName::List(inner_type) => {
-                InferredType::List(Box::new((inner_type.deref().clone().into())))
+                InferredType::Option(Box::new((type_name.deref().clone().into())))
             }
             TypeName::Tuple(inner_types) => {
                 InferredType::Tuple(inner_types.into_iter().map(|t| t.into()).collect())
             }
             TypeName::Option(type_name) => {
-                InferredType::Option(Box::new((type_name.deref().clone().into())))
+                InferredType::Option(Box::new(type_name.deref().clone().into()))
             }
         }
     }

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -5,7 +5,6 @@ use combine::parser::choice::choice;
 use combine::{attempt, between, easy, Parser, sep_by, Stream};
 use combine::{parser};
 
-// TODO; Support more
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Encode, Decode)]
 pub enum TypeName {
     Bool,
@@ -26,7 +25,7 @@ pub enum TypeName {
 }
 
 pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
-    choice((
+   spaces().with(choice((
         attempt(string("bool").map(|_| TypeName::Bool)),
         attempt(string("s8").map(|_| TypeName::S8)),
         attempt(string("u8").map(|_| TypeName::U8)),
@@ -40,7 +39,7 @@ pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Typ
         attempt(string("f64").map(|_| TypeName::F64)),
         attempt(string("chr").map(|_| TypeName::Chr)),
         attempt(string("str").map(|_| TypeName::Str)),
-    ))
+    ))).skip(spaces())
 }
 
 pub fn parse_list_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
@@ -111,7 +110,7 @@ mod type_name_parser_tests {
     }
 
     #[test]
-    fn test_list_type() {
+    fn test_list_type_name() {
         parse_and_compare("list<u8>", TypeName::List(Box::new(TypeName::U8)));
         parse_and_compare("list<list<f32>>", TypeName::List(Box::new(TypeName::List(Box::new(TypeName::F32)))));
     }

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -1,9 +1,11 @@
+use crate::InferredType;
 use bincode::{Decode, Encode};
+use combine::parser;
 use combine::parser::char;
 use combine::parser::char::{char, spaces, string};
 use combine::parser::choice::choice;
-use combine::{attempt, between, easy, Parser, sep_by, Stream};
-use combine::{parser};
+use combine::{attempt, between, easy, sep_by, Parser, Stream};
+use std::ops::Deref;
 
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Encode, Decode)]
 pub enum TypeName {
@@ -24,22 +26,50 @@ pub enum TypeName {
     Tuple(Vec<TypeName>),
 }
 
+impl From<TypeName> for InferredType {
+    fn from(type_name: TypeName) -> Self {
+        match type_name {
+            TypeName::Bool => InferredType::Bool,
+            TypeName::S8 => InferredType::S8,
+            TypeName::U8 => InferredType::U8,
+            TypeName::S16 => InferredType::S16,
+            TypeName::U16 => InferredType::U16,
+            TypeName::S32 => InferredType::S32,
+            TypeName::U32 => InferredType::U32,
+            TypeName::S64 => InferredType::S64,
+            TypeName::U64 => InferredType::U64,
+            TypeName::F32 => InferredType::F32,
+            TypeName::F64 => InferredType::F64,
+            TypeName::Chr => InferredType::Chr,
+            TypeName::Str => InferredType::Str,
+            TypeName::List(inner_type) => {
+                InferredType::List(Box::new((inner_type.deref().clone().into())))
+            }
+            TypeName::Tuple(inner_types) => {
+                InferredType::Tuple(inner_types.into_iter().map(|t| t.into()).collect())
+            }
+        }
+    }
+}
+
 pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
-   spaces().with(choice((
-        attempt(string("bool").map(|_| TypeName::Bool)),
-        attempt(string("s8").map(|_| TypeName::S8)),
-        attempt(string("u8").map(|_| TypeName::U8)),
-        attempt(string("s16").map(|_| TypeName::S16)),
-        attempt(string("u16").map(|_| TypeName::U16)),
-        attempt(string("s32").map(|_| TypeName::S32)),
-        attempt(string("u32").map(|_| TypeName::U32)),
-        attempt(string("s64").map(|_| TypeName::S64)),
-        attempt(string("u64").map(|_| TypeName::U64)),
-        attempt(string("f32").map(|_| TypeName::F32)),
-        attempt(string("f64").map(|_| TypeName::F64)),
-        attempt(string("chr").map(|_| TypeName::Chr)),
-        attempt(string("str").map(|_| TypeName::Str)),
-    ))).skip(spaces())
+    spaces()
+        .with(choice((
+            attempt(string("bool").map(|_| TypeName::Bool)),
+            attempt(string("s8").map(|_| TypeName::S8)),
+            attempt(string("u8").map(|_| TypeName::U8)),
+            attempt(string("s16").map(|_| TypeName::S16)),
+            attempt(string("u16").map(|_| TypeName::U16)),
+            attempt(string("s32").map(|_| TypeName::S32)),
+            attempt(string("u32").map(|_| TypeName::U32)),
+            attempt(string("s64").map(|_| TypeName::S64)),
+            attempt(string("u64").map(|_| TypeName::U64)),
+            attempt(string("f32").map(|_| TypeName::F32)),
+            attempt(string("f64").map(|_| TypeName::F64)),
+            attempt(string("chr").map(|_| TypeName::Chr)),
+            attempt(string("str").map(|_| TypeName::Str)),
+        )))
+        .skip(spaces())
 }
 
 pub fn parse_list_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
@@ -85,7 +115,7 @@ parser! {
 #[cfg(test)]
 mod type_name_parser_tests {
     use super::*;
-    use combine::{EasyParser};
+    use combine::EasyParser;
 
     fn parse_and_compare(input: &str, expected: TypeName) {
         let result = parse_type_name().easy_parse(input);
@@ -112,41 +142,53 @@ mod type_name_parser_tests {
     #[test]
     fn test_list_type_name() {
         parse_and_compare("list<u8>", TypeName::List(Box::new(TypeName::U8)));
-        parse_and_compare("list<list<f32>>", TypeName::List(Box::new(TypeName::List(Box::new(TypeName::F32)))));
+        parse_and_compare(
+            "list<list<f32>>",
+            TypeName::List(Box::new(TypeName::List(Box::new(TypeName::F32)))),
+        );
     }
 
     #[test]
     fn test_tuple_type() {
-        parse_and_compare("tuple<u8, u16>", TypeName::Tuple(vec![TypeName::U8, TypeName::U16]));
-        parse_and_compare("tuple<s32, list<u8>>", TypeName::Tuple(vec![
-            TypeName::S32,
-            TypeName::List(Box::new(TypeName::U8))
-        ]));
-        parse_and_compare("tuple<tuple<s8, s16>, u32>", TypeName::Tuple(vec![
-            TypeName::Tuple(vec![TypeName::S8, TypeName::S16]),
-            TypeName::U32
-        ]));
+        parse_and_compare(
+            "tuple<u8, u16>",
+            TypeName::Tuple(vec![TypeName::U8, TypeName::U16]),
+        );
+        parse_and_compare(
+            "tuple<s32, list<u8>>",
+            TypeName::Tuple(vec![TypeName::S32, TypeName::List(Box::new(TypeName::U8))]),
+        );
+        parse_and_compare(
+            "tuple<tuple<s8, s16>, u32>",
+            TypeName::Tuple(vec![
+                TypeName::Tuple(vec![TypeName::S8, TypeName::S16]),
+                TypeName::U32,
+            ]),
+        );
     }
 
     #[test]
     fn test_nested_types() {
-        parse_and_compare("list<tuple<u8, s8>>", TypeName::List(Box::new(TypeName::Tuple(vec![
-            TypeName::U8,
-            TypeName::S8
-        ]))));
-        parse_and_compare("tuple<list<u16>, list<f64>>", TypeName::Tuple(vec![
-            TypeName::List(Box::new(TypeName::U16)),
-            TypeName::List(Box::new(TypeName::F64))
-        ]));
+        parse_and_compare(
+            "list<tuple<u8, s8>>",
+            TypeName::List(Box::new(TypeName::Tuple(vec![TypeName::U8, TypeName::S8]))),
+        );
+        parse_and_compare(
+            "tuple<list<u16>, list<f64>>",
+            TypeName::Tuple(vec![
+                TypeName::List(Box::new(TypeName::U16)),
+                TypeName::List(Box::new(TypeName::F64)),
+            ]),
+        );
     }
 
     #[test]
     fn test_spaces_around_types() {
         parse_and_compare("  u8  ", TypeName::U8);
         parse_and_compare("list< u8 >", TypeName::List(Box::new(TypeName::U8)));
-        parse_and_compare("tuple< s32 , list< u8 > >", TypeName::Tuple(vec![
-            TypeName::S32,
-            TypeName::List(Box::new(TypeName::U8))
-        ]));
+        parse_and_compare(
+            "tuple< s32 , list< u8 > >",
+            TypeName::Tuple(vec![TypeName::S32, TypeName::List(Box::new(TypeName::U8))]),
+        );
     }
 }

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -1,0 +1,153 @@
+use bincode::{Decode, Encode};
+use combine::parser::char;
+use combine::parser::char::{char, spaces, string};
+use combine::parser::choice::choice;
+use combine::{attempt, between, easy, Parser, sep_by, Stream};
+use combine::{parser};
+
+// TODO; Support more
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Encode, Decode)]
+pub enum TypeName {
+    Bool,
+    S8,
+    U8,
+    S16,
+    U16,
+    S32,
+    U32,
+    S64,
+    U64,
+    F32,
+    F64,
+    Chr,
+    Str,
+    List(Box<TypeName>),
+    Tuple(Vec<TypeName>),
+}
+
+pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+    choice((
+        attempt(string("bool").map(|_| TypeName::Bool)),
+        attempt(string("s8").map(|_| TypeName::S8)),
+        attempt(string("u8").map(|_| TypeName::U8)),
+        attempt(string("s16").map(|_| TypeName::S16)),
+        attempt(string("u16").map(|_| TypeName::U16)),
+        attempt(string("s32").map(|_| TypeName::S32)),
+        attempt(string("u32").map(|_| TypeName::U32)),
+        attempt(string("s64").map(|_| TypeName::S64)),
+        attempt(string("u64").map(|_| TypeName::U64)),
+        attempt(string("f32").map(|_| TypeName::F32)),
+        attempt(string("f64").map(|_| TypeName::F64)),
+        attempt(string("chr").map(|_| TypeName::Chr)),
+        attempt(string("str").map(|_| TypeName::Str)),
+    ))
+}
+
+pub fn parse_list_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+    string("list")
+        .skip(spaces())
+        .with(between(
+            char('<').skip(spaces()),
+            char('>').skip(spaces()),
+            parse_type_name(),
+        ))
+        .map(|inner_type| TypeName::List(Box::new(inner_type)))
+}
+
+pub fn parse_tuple_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+    string("tuple")
+        .skip(spaces())
+        .with(between(
+            char('<').skip(spaces()),
+            char('>').skip(spaces()),
+            sep_by(parse_type_name(), char(',').skip(spaces())),
+        ))
+        .map(TypeName::Tuple)
+}
+
+pub fn parse_type_name_<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+    spaces().with(choice((
+        attempt(parse_basic_type()),
+        attempt(parse_list_type()),
+        attempt(parse_tuple_type()),
+    )))
+}
+
+parser! {
+    pub fn parse_type_name['t]()(easy::Stream<&'t str>) -> TypeName
+    where [
+        easy::Stream<&'t str>: Stream<Token = char>,
+    ]
+    {
+       parse_type_name_()
+    }
+}
+
+#[cfg(test)]
+mod type_name_parser_tests {
+    use super::*;
+    use combine::{EasyParser};
+
+    fn parse_and_compare(input: &str, expected: TypeName) {
+        let result = parse_type_name().easy_parse(input);
+        assert_eq!(result, Ok((expected, "")));
+    }
+
+    #[test]
+    fn test_basic_types() {
+        parse_and_compare("bool", TypeName::Bool);
+        parse_and_compare("s8", TypeName::S8);
+        parse_and_compare("u8", TypeName::U8);
+        parse_and_compare("s16", TypeName::S16);
+        parse_and_compare("u16", TypeName::U16);
+        parse_and_compare("s32", TypeName::S32);
+        parse_and_compare("u32", TypeName::U32);
+        parse_and_compare("s64", TypeName::S64);
+        parse_and_compare("u64", TypeName::U64);
+        parse_and_compare("f32", TypeName::F32);
+        parse_and_compare("f64", TypeName::F64);
+        parse_and_compare("chr", TypeName::Chr);
+        parse_and_compare("str", TypeName::Str);
+    }
+
+    #[test]
+    fn test_list_type() {
+        parse_and_compare("list<u8>", TypeName::List(Box::new(TypeName::U8)));
+        parse_and_compare("list<list<f32>>", TypeName::List(Box::new(TypeName::List(Box::new(TypeName::F32)))));
+    }
+
+    #[test]
+    fn test_tuple_type() {
+        parse_and_compare("tuple<u8, u16>", TypeName::Tuple(vec![TypeName::U8, TypeName::U16]));
+        parse_and_compare("tuple<s32, list<u8>>", TypeName::Tuple(vec![
+            TypeName::S32,
+            TypeName::List(Box::new(TypeName::U8))
+        ]));
+        parse_and_compare("tuple<tuple<s8, s16>, u32>", TypeName::Tuple(vec![
+            TypeName::Tuple(vec![TypeName::S8, TypeName::S16]),
+            TypeName::U32
+        ]));
+    }
+
+    #[test]
+    fn test_nested_types() {
+        parse_and_compare("list<tuple<u8, s8>>", TypeName::List(Box::new(TypeName::Tuple(vec![
+            TypeName::U8,
+            TypeName::S8
+        ]))));
+        parse_and_compare("tuple<list<u16>, list<f64>>", TypeName::Tuple(vec![
+            TypeName::List(Box::new(TypeName::U16)),
+            TypeName::List(Box::new(TypeName::F64))
+        ]));
+    }
+
+    #[test]
+    fn test_spaces_around_types() {
+        parse_and_compare("  u8  ", TypeName::U8);
+        parse_and_compare("list< u8 >", TypeName::List(Box::new(TypeName::U8)));
+        parse_and_compare("tuple< s32 , list< u8 > >", TypeName::Tuple(vec![
+            TypeName::S32,
+            TypeName::List(Box::new(TypeName::U8))
+        ]));
+    }
+}

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -44,7 +44,7 @@ impl From<TypeName> for InferredType {
             TypeName::Chr => InferredType::Chr,
             TypeName::Str => InferredType::Str,
             TypeName::List(inner_type) => {
-                InferredType::Option(Box::new((type_name.deref().clone().into())))
+                InferredType::List(Box::new(inner_type.deref().clone().into()))
             }
             TypeName::Tuple(inner_types) => {
                 InferredType::Tuple(inner_types.into_iter().map(|t| t.into()).collect())

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -845,7 +845,9 @@ mod simple_values_test {
 #[cfg(test)]
 mod let_tests {
     use crate::expr::Expr;
+    use crate::parser::type_name::TypeName;
     use crate::text::{from_string, to_string};
+    use crate::{InferredType, Number, VariableId};
 
     #[test]
     fn test_round_trip_read_write_let() {
@@ -855,6 +857,182 @@ mod let_tests {
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "${let x = \"hello\";\nlet y = \"bar\"}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_str() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::Str),
+                Box::new(Expr::literal("hello")),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::Str),
+                Box::new(Expr::literal("bar")),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str = "${let x: str = \"hello\";\nlet y: str = \"bar\"}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_u8() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::U8),
+                Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U8)),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::U8),
+                Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U8)),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str = "${let x: u8 = 1;\nlet y: u8 = 2}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_u16() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::U16),
+                Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U16)),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::U16),
+                Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U16)),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str = "${let x: u16 = 1;\nlet y: u16 = 2}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_u32() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::U32),
+                Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U32)),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::U32),
+                Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U32)),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str = "${let x: u32 = 1;\nlet y: u32 = 2}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_option() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::Option(Box::new(TypeName::Str))),
+                Box::new(Expr::Option(
+                    Some(Box::new(Expr::literal("foo"))),
+                    InferredType::Option(Box::new(InferredType::Str)),
+                )),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::Option(Box::new(TypeName::Str))),
+                Box::new(Expr::Option(
+                    Some(Box::new(Expr::literal("bar"))),
+                    InferredType::Option(Box::new(InferredType::Str)),
+                )),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str =
+            "${let x: option<str> = some(\"foo\");\nlet y: option<str> = some(\"bar\")}"
+                .to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_list() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::List(Box::new(TypeName::Str))),
+                Box::new(Expr::Sequence(
+                    vec![Expr::literal("foo")],
+                    InferredType::List(Box::new(InferredType::Str)),
+                )),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::List(Box::new(TypeName::Str))),
+                Box::new(Expr::Sequence(
+                    vec![Expr::literal("bar")],
+                    InferredType::List(Box::new(InferredType::Str)),
+                )),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str =
+            "${let x: list<str> = [\"foo\"];\nlet y: list<str> = [\"bar\"]}".to_string();
+        let output_expr = from_string(expr_str.as_str()).unwrap();
+        assert_eq!((expr_str, input_expr), (expected_str, output_expr));
+    }
+
+    #[test]
+    fn test_round_trip_read_write_let_with_type_binding_tuple() {
+        let input_expr = Expr::multiple(vec![
+            Expr::Let(
+                VariableId::global("x".to_string()),
+                Some(TypeName::Tuple(vec![TypeName::Str])),
+                Box::new(Expr::Tuple(
+                    vec![Expr::literal("foo")],
+                    InferredType::Tuple(vec![InferredType::Str]),
+                )),
+                InferredType::Unknown,
+            ),
+            Expr::Let(
+                VariableId::global("y".to_string()),
+                Some(TypeName::Tuple(vec![TypeName::Str])),
+                Box::new(Expr::Tuple(
+                    vec![Expr::literal("bar")],
+                    InferredType::Tuple(vec![InferredType::Str]),
+                )),
+                InferredType::Unknown,
+            ),
+        ]);
+        let expr_str = to_string(&input_expr).unwrap();
+        let expected_str =
+            "${let x: tuple<str> = (\"foo\");\nlet y: tuple<str> = (\"bar\")}".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
         assert_eq!((expr_str, input_expr), (expected_str, output_expr));
     }

--- a/golem-rib/src/text/writer.rs
+++ b/golem-rib/src/text/writer.rs
@@ -86,9 +86,13 @@ impl<W: Write> Writer<W> {
             }
             Expr::Identifier(identifier, _) => self.write_str(identifier.name()),
 
-            Expr::Let(variable_id, expr, _) => {
+            Expr::Let(variable_id, type_name, expr, _) => {
                 self.write_str("let ")?;
                 self.write_str(variable_id.name())?;
+                if let Some(type_name) = type_name {
+                    self.write_str(": ")?;
+                    self.write_display(type_name)?;
+                };
                 self.write_str(" = ")?;
                 self.write_expr(expr)
             }

--- a/golem-rib/src/type_inference/expr_visitor.rs
+++ b/golem-rib/src/type_inference/expr_visitor.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 // Visits each children of the expression and push them to the back of the queue
 pub fn visit_children_bottom_up_mut<'a>(expr: &'a mut Expr, queue: &mut VecDeque<&'a mut Expr>) {
     match expr {
-        Expr::Let(_, expr, _) => queue.push_back(&mut *expr),
+        Expr::Let(_, _, expr, _) => queue.push_back(&mut *expr),
         Expr::SelectField(expr, _, _) => queue.push_back(&mut *expr),
         Expr::SelectIndex(expr, _, _) => queue.push_back(&mut *expr),
         Expr::Sequence(exprs, _) => queue.extend(exprs.iter_mut()),
@@ -65,7 +65,7 @@ pub fn visit_children_bottom_up_mut<'a>(expr: &'a mut Expr, queue: &mut VecDeque
 
 pub fn visit_children_bottom_up<'a>(expr: &'a Expr, queue: &mut VecDeque<&'a Expr>) {
     match expr {
-        Expr::Let(_, expr, _) => queue.push_back(expr),
+        Expr::Let(_, _, expr, _) => queue.push_back(expr),
         Expr::SelectField(expr, _, _) => queue.push_back(expr),
         Expr::SelectIndex(expr, _, _) => queue.push_back(expr),
         Expr::Sequence(exprs, _) => queue.extend(exprs.iter()),
@@ -125,7 +125,7 @@ pub fn visit_children_bottom_up<'a>(expr: &'a Expr, queue: &mut VecDeque<&'a Exp
 
 pub fn visit_children_mut_top_down<'a>(expr: &'a mut Expr, queue: &mut VecDeque<&'a mut Expr>) {
     match expr {
-        Expr::Let(_, expr, _) => queue.push_front(&mut *expr),
+        Expr::Let(_, _, expr, _) => queue.push_front(&mut *expr),
         Expr::SelectField(expr, _, _) => queue.push_front(&mut *expr),
         Expr::SelectIndex(expr, _, _) => queue.push_front(&mut *expr),
         Expr::Sequence(exprs, _) => {

--- a/golem-rib/src/type_inference/identifier_inference.rs
+++ b/golem-rib/src/type_inference/identifier_inference.rs
@@ -21,7 +21,7 @@ pub fn infer_all_identifiers_bottom_up(expr: &mut Expr) -> Result<(), String> {
                     identifier_lookup.update(variable_id.clone(), inferred_type.clone());
                 }
             }
-            Expr::Let(variable_id, expr, _) => {
+            Expr::Let(variable_id, _, expr, _) => {
                 if let Some(inferred_type) = identifier_lookup.lookup(variable_id) {
                     if inferred_type.is_unknown() {
                         identifier_lookup.update(variable_id.clone(), expr.inferred_type())
@@ -51,7 +51,7 @@ pub fn infer_all_identifiers_top_down(expr: &mut Expr) -> Result<(), String> {
     // We start from the end and pick the identifiers type
     while let Some(expr) = queue.pop_front() {
         match expr {
-            Expr::Let(variable_id, expr, _) => {
+            Expr::Let(variable_id, _, expr, _) => {
                 if let Some(inferred_type) = identifier_lookup.lookup(variable_id) {
                     if inferred_type.is_unknown() {
                         identifier_lookup.update(variable_id.clone(), expr.inferred_type())

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -612,7 +612,8 @@ mod type_inference_tests {
         #[test]
         fn test_select_field_type_inference() {
             let rib_expr = r#"
-          let x = { foo : 1 };
+          let n: u64 = 1;
+          let x = { foo : n };
           x.foo
 
           "#;
@@ -624,11 +625,19 @@ mod type_inference_tests {
             let expected = Expr::Multiple(
                 vec![
                     Expr::Let(
+                        VariableId::local("n", 0),
+                        Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
+                        InferredType::Unknown,
+                    ),
+                    Expr::Let(
                         VariableId::local("x", 0),
                         Box::new(Expr::Record(
                             vec![(
                                 "foo".to_string(),
-                                Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
+                                Box::new(Expr::Identifier(
+                                    VariableId::local("n", 0),
+                                    InferredType::U64,
+                                )),
                             )],
                             InferredType::Record(vec![("foo".to_string(), InferredType::U64)]),
                         )),

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -665,7 +665,7 @@ mod type_inference_tests {
         #[test]
         fn test_tuple_type_inference() {
             let rib_expr = r#"
-          let x = (1, "2");
+          let x: tuple<u64, str> = (1, "2");
           x
 
           "#;

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -993,7 +993,7 @@ mod type_inference_tests {
         fn test_pattern_match_with_record_with_select_index() {
             let expr_str = r#"
               let x = { foo : "bar" };
-              let y = [1, 2, 3];
+              let y: list<u64> = [1, 2, 3];
 
               match some(x) {
                 some(x) => x.foo

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -719,7 +719,6 @@ mod type_inference_tests {
 
             expr.infer_types(&FunctionTypeRegistry::empty()).unwrap();
 
-            dbg!(expr.clone());
             let expected = Expr::Multiple(
                 vec![
                     Expr::Let(
@@ -1220,8 +1219,6 @@ mod type_inference_tests {
             let function_type_registry = internal::get_function_type_registry();
             let mut expr = Expr::from_text(rib_expr).unwrap();
             expr.infer_types(&function_type_registry).unwrap();
-
-            dbg!(expr.clone());
 
             let expected = Expr::Multiple(
                 vec![

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -567,7 +567,7 @@ mod type_inference_tests {
         #[test]
         fn test_select_index_type_inference() {
             let rib_expr = r#"
-          let x = [1, 2, 3];
+          let x: list<u64> = [1, 2, 3];
           x[0]
 
           "#;
@@ -706,7 +706,7 @@ mod type_inference_tests {
         #[test]
         fn test_variable_conflict_case() {
             let expr_str = r#"
-              let y = 1;
+              let y: u64 = 1;
               let z = some(y);
 
               match z {

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -1154,7 +1154,8 @@ mod type_inference_tests {
         #[test]
         fn test_record_type_inference() {
             let rib_expr = r#"
-          let x = { foo : 1 };
+          let number: u64 = 1;
+          let x = { foo : number };
           x
 
           "#;
@@ -1166,11 +1167,16 @@ mod type_inference_tests {
             let expected = Expr::Multiple(
                 vec![
                     Expr::Let(
+                        VariableId::local("number", 0),
+                        Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
+                        InferredType::Unknown,
+                    ),
+                    Expr::Let(
                         VariableId::local("x", 0),
                         Box::new(Expr::Record(
                             vec![(
                                 "foo".to_string(),
-                                Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
+                                Box::new(Expr::Identifier( VariableId::local("number", 0), InferredType::U64)),
                             )],
                             InferredType::Record(vec![("foo".to_string(), InferredType::U64)]),
                         )),

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -142,9 +142,9 @@ mod type_inference_tests {
         }
     }
     mod literal_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_number_literal_type_inference() {
@@ -203,9 +203,9 @@ mod type_inference_tests {
         }
     }
     mod comparison_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_comparison_type_inference() {
@@ -376,9 +376,9 @@ mod type_inference_tests {
         }
     }
     mod cond_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_cond_type_inference() {
@@ -450,9 +450,9 @@ mod type_inference_tests {
         }
     }
     mod identifier_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_identifier_type_inference() {
@@ -543,9 +543,9 @@ mod type_inference_tests {
         }
     }
     mod list_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_list_type_inference() {
@@ -586,9 +586,9 @@ mod type_inference_tests {
         }
     }
     mod select_index_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_select_index_type_inference() {
@@ -633,9 +633,9 @@ mod type_inference_tests {
         }
     }
     mod select_field_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_select_field_type_inference() {
@@ -689,9 +689,9 @@ mod type_inference_tests {
         }
     }
     mod tuple_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_tuple_type_inference() {
@@ -731,10 +731,10 @@ mod type_inference_tests {
         }
     }
     mod variable_conflict_tests {
+        use crate::parser::type_name::TypeName;
         use crate::{
             ArmPattern, Expr, FunctionTypeRegistry, InferredType, MatchArm, Number, VariableId,
         };
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_variable_conflict_case() {
@@ -812,12 +812,12 @@ mod type_inference_tests {
         }
     }
     mod pattern_match_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{
             ArmPattern, Expr, FunctionTypeRegistry, InferredType, InvocationName, MatchArm, Number,
             ParsedFunctionName, ParsedFunctionReference, ParsedFunctionSite, VariableId,
         };
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_simple_pattern_match_type_inference() {
@@ -1158,9 +1158,9 @@ mod type_inference_tests {
         }
     }
     mod option_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_option_type_inference() {
@@ -1200,9 +1200,9 @@ mod type_inference_tests {
         }
     }
     mod record_tests {
+        use crate::parser::type_name::TypeName;
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
-        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_record_type_inference() {

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -1185,7 +1185,10 @@ mod type_inference_tests {
                         Box::new(Expr::Record(
                             vec![(
                                 "foo".to_string(),
-                                Box::new(Expr::Identifier( VariableId::local("number", 0), InferredType::U64)),
+                                Box::new(Expr::Identifier(
+                                    VariableId::local("number", 0),
+                                    InferredType::U64,
+                                )),
                             )],
                             InferredType::Record(vec![("foo".to_string(), InferredType::U64)]),
                         )),

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -145,7 +145,7 @@ mod type_inference_tests {
         #[test]
         fn test_number_literal_type_inference() {
             let rib_expr = r#"
-          let x = 1;
+          let x: u64 = 1;
           x
 
           "#;
@@ -526,7 +526,7 @@ mod type_inference_tests {
         #[test]
         fn test_list_type_inference() {
             let rib_expr = r#"
-          let x = [1, 2, 3];
+          let x: list<u64> = [1, 2, 3];
           x
 
           "#;
@@ -1114,7 +1114,7 @@ mod type_inference_tests {
         #[test]
         fn test_option_type_inference() {
             let rib_expr = r#"
-          let x = some(1);
+          let x: option<u64> = some(1);
           x
 
           "#;

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -203,8 +203,8 @@ mod type_inference_tests {
         #[test]
         fn test_comparison_type_inference() {
             let rib_expr = r#"
-          let x = 1;
-          let y = 2;
+          let x: u64 = 1;
+          let y: u64 = 2;
           x > y;
           x >= y;
           x < y;
@@ -370,8 +370,8 @@ mod type_inference_tests {
         #[test]
         fn test_cond_type_inference() {
             let rib_expr = r#"
-          let x = 1;
-          let y = 2;
+          let x: u64 = 1;
+          let y: u64 = 2;
           let res1 = "foo";
           let res2 = "bar";
           if x > y then res1 else res2
@@ -477,7 +477,7 @@ mod type_inference_tests {
         #[test]
         fn test_identifier_type_inference_multiple_re_assign() {
             let rib_expr = r#"
-          let x = 1;
+          let x: u64 = 1;
           let y = x;
           let z = y;
           z

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -467,8 +467,6 @@ mod type_inference_tests {
             let mut expr = Expr::from_text(rib_expr).unwrap();
             expr.infer_types(&function_type_registry).unwrap();
 
-            dbg!(expr.clone());
-
             let expected = Expr::Multiple(
                 vec![
                     Expr::Let(

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -51,6 +51,7 @@ mod type_inference_tests {
 
             let let_binding = Expr::Let(
                 VariableId::local("x", 0),
+                None,
                 Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)), // The number in let expression is identified to be a U64
                 InferredType::Unknown, // Type of a let expression can be unit, we are not updating this part
             );
@@ -92,12 +93,14 @@ mod type_inference_tests {
 
             let let_binding1 = Expr::Let(
                 VariableId::local("x", 0),
+                None,
                 Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)), // The number in let expression is identified to be a U64
                 InferredType::Unknown, // Type of a let expression can be unit, we are not updating this part
             );
 
             let let_binding2 = Expr::Let(
                 VariableId::local("y", 0),
+                None,
                 Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U32)), // The number in let expression is identified to be a U64
                 InferredType::Unknown, // Type of a let expression can be unit, we are not updating this part
             );
@@ -141,6 +144,7 @@ mod type_inference_tests {
     mod literal_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_number_literal_type_inference() {
@@ -158,6 +162,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
@@ -185,6 +190,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::literal("1")),
                         InferredType::Unknown,
                     ),
@@ -199,6 +205,7 @@ mod type_inference_tests {
     mod comparison_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_comparison_type_inference() {
@@ -220,11 +227,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
@@ -310,11 +319,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::literal("1")),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        None,
                         Box::new(Expr::literal("2")),
                         InferredType::Unknown,
                     ),
@@ -352,6 +363,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::boolean(true)),
                         InferredType::Unknown,
                     ),
@@ -366,6 +378,7 @@ mod type_inference_tests {
     mod cond_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_cond_type_inference() {
@@ -385,21 +398,25 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("res1", 0),
+                        None,
                         Box::new(Expr::literal("foo")),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("res2", 0),
+                        None,
                         Box::new(Expr::literal("bar")),
                         InferredType::Unknown,
                     ),
@@ -435,6 +452,7 @@ mod type_inference_tests {
     mod identifier_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_identifier_type_inference() {
@@ -455,11 +473,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::literal("1")),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        None,
                         Box::new(Expr::Identifier(
                             VariableId::local("x", 0),
                             InferredType::Str,
@@ -492,11 +512,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        None,
                         Box::new(Expr::Identifier(
                             VariableId::local("x", 0),
                             InferredType::U64,
@@ -505,6 +527,7 @@ mod type_inference_tests {
                     ),
                     Expr::Let(
                         VariableId::local("z", 0),
+                        None,
                         Box::new(Expr::Identifier(
                             VariableId::local("y", 0),
                             InferredType::U64,
@@ -522,6 +545,7 @@ mod type_inference_tests {
     mod list_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_list_type_inference() {
@@ -539,6 +563,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
                                 Expr::Number(Number { value: 1f64 }, InferredType::U64),
@@ -563,6 +588,7 @@ mod type_inference_tests {
     mod select_index_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_select_index_type_inference() {
@@ -580,6 +606,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
                                 Expr::Number(Number { value: 1f64 }, InferredType::U64),
@@ -608,6 +635,7 @@ mod type_inference_tests {
     mod select_field_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_select_field_type_inference() {
@@ -626,11 +654,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("n", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::Record(
                             vec![(
                                 "foo".to_string(),
@@ -661,6 +691,7 @@ mod type_inference_tests {
     mod tuple_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_tuple_type_inference() {
@@ -678,6 +709,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::Tuple(vec![TypeName::U64, TypeName::Str])),
                         Box::new(Expr::Tuple(
                             vec![
                                 Expr::Number(Number { value: 1f64 }, InferredType::U64),
@@ -702,6 +734,7 @@ mod type_inference_tests {
         use crate::{
             ArmPattern, Expr, FunctionTypeRegistry, InferredType, MatchArm, Number, VariableId,
         };
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_variable_conflict_case() {
@@ -723,11 +756,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("y", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("z", 0),
+                        None,
                         Box::new(Expr::Option(
                             Some(Box::new(Expr::Identifier(
                                 VariableId::local("y", 0),
@@ -782,6 +817,7 @@ mod type_inference_tests {
             ArmPattern, Expr, FunctionTypeRegistry, InferredType, InvocationName, MatchArm, Number,
             ParsedFunctionName, ParsedFunctionReference, ParsedFunctionSite, VariableId,
         };
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_simple_pattern_match_type_inference() {
@@ -800,12 +836,14 @@ mod type_inference_tests {
 
             let let_binding1 = Expr::Let(
                 VariableId::local("x", 0),
+                None,
                 Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                 InferredType::Unknown,
             );
 
             let let_binding2 = Expr::Let(
                 VariableId::local("y", 0),
+                None,
                 Box::new(Expr::Number(Number { value: 2f64 }, InferredType::U32)),
                 InferredType::Unknown,
             );
@@ -883,6 +921,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::Record(
                             vec![("foo".to_string(), Box::new(Expr::literal("bar")))],
                             InferredType::Record(vec![("foo".to_string(), InferredType::Str)]),
@@ -945,6 +984,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::Record(
                             vec![("foo".to_string(), Box::new(Expr::literal("bar")))],
                             InferredType::Record(vec![("foo".to_string(), InferredType::Str)]),
@@ -1020,6 +1060,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::Record(
                             vec![("foo".to_string(), Box::new(Expr::literal("bar")))],
                             InferredType::Record(vec![("foo".to_string(), InferredType::Str)]),
@@ -1028,6 +1069,7 @@ mod type_inference_tests {
                     ),
                     Expr::Let(
                         VariableId::local("y", 0),
+                        Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
                                 Expr::Number(Number { value: 1f64 }, InferredType::U64),
@@ -1118,6 +1160,7 @@ mod type_inference_tests {
     mod option_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_option_type_inference() {
@@ -1135,6 +1178,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("x", 0),
+                        Some(TypeName::Option(Box::new(TypeName::U64))),
                         Box::new(Expr::Option(
                             Some(Box::new(Expr::Number(
                                 Number { value: 1f64 },
@@ -1158,6 +1202,7 @@ mod type_inference_tests {
     mod record_tests {
         use crate::type_inference::type_inference_tests::internal;
         use crate::{Expr, InferredType, Number, VariableId};
+        use crate::parser::type_name::TypeName;
 
         #[test]
         fn test_record_type_inference() {
@@ -1176,11 +1221,13 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("number", 0),
+                        Some(TypeName::U64),
                         Box::new(Expr::Number(Number { value: 1f64 }, InferredType::U64)),
                         InferredType::Unknown,
                     ),
                     Expr::Let(
                         VariableId::local("x", 0),
+                        None,
                         Box::new(Expr::Record(
                             vec![(
                                 "foo".to_string(),
@@ -1224,6 +1271,7 @@ mod type_inference_tests {
                 vec![
                     Expr::Let(
                         VariableId::local("p", 0),
+                        None,
                         Box::new(Expr::Result(
                             Err(Box::new(Expr::literal("foo"))),
                             InferredType::Result {
@@ -1235,6 +1283,7 @@ mod type_inference_tests {
                     ),
                     Expr::Let(
                         VariableId::local("q", 0),
+                        None,
                         Box::new(Expr::Result(
                             Ok(Box::new(Expr::literal("bar"))),
                             InferredType::Result {

--- a/golem-rib/src/type_inference/name_binding.rs
+++ b/golem-rib/src/type_inference/name_binding.rs
@@ -9,7 +9,7 @@ pub fn name_binding_local_variables(expr: &mut Expr) {
     // Start from the end
     while let Some(expr) = queue.pop_front() {
         match expr {
-            Expr::Let(variable_id, expr, _) => {
+            Expr::Let(variable_id, _, expr, _) => {
                 let field_name = variable_id.name();
                 identifier_id_state.update_variable_id(&field_name); // Increment the variable_id
                 *variable_id = identifier_id_state.lookup(&field_name).unwrap();
@@ -78,6 +78,7 @@ mod name_binding_tests {
 
         let let_binding = Expr::Let(
             VariableId::local("x", 0),
+            None,
             Box::new(Expr::number(1f64)),
             InferredType::Unknown,
         );
@@ -117,12 +118,14 @@ mod name_binding_tests {
 
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
+            None,
             Box::new(Expr::number(1f64)),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("y", 0),
+            None,
             Box::new(Expr::number(2f64)),
             InferredType::Unknown,
         );
@@ -176,12 +179,14 @@ mod name_binding_tests {
 
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
+            None,
             Box::new(Expr::number(1f64)),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("x", 1),
+            None,
             Box::new(Expr::number(2f64)),
             InferredType::Unknown,
         );

--- a/golem-rib/src/type_inference/pattern_match_binding.rs
+++ b/golem-rib/src/type_inference/pattern_match_binding.rs
@@ -51,7 +51,7 @@ mod internal {
                         index = latest
                     }
                 }
-                Expr::Let(variable_id, expr, _) => {
+                Expr::Let(variable_id, _, expr, _) => {
                     queue.push_front(expr);
                     shadowed_let_binding.push(variable_id.name());
                 }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -74,8 +74,9 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
             if then_type == else_type {
                 inferred_type.update(then_type);
             } else {
-                let cond_then_else_type = InferredType::AllOf(vec![then_type, else_type]);
-                inferred_type.update(cond_then_else_type)
+                if let Some(cond_then_else_type) = InferredType::all_of(vec![then_type, else_type]) {
+                    inferred_type.update(cond_then_else_type);
+                }
             }
         }
 
@@ -97,7 +98,9 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
                 if possible_inference_types.iter().all(|t| t == &first_type) {
                     inferred_type.update(first_type);
                 } else {
-                    inferred_type.update(InferredType::AllOf(possible_inference_types));
+                    if let Some(all_of) = InferredType::all_of(possible_inference_types) {
+                        inferred_type.update(all_of);
+                    }
                 }
             }
         }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -45,6 +45,7 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
             inferred_type.update(record_type)
         }
         Expr::Option(Some(expr), inferred_type) => {
+            expr.pull_types_up()?;
             let option_type = InferredType::Option(Box::new(expr.inferred_type()));
             inferred_type.update(option_type)
         }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -74,7 +74,8 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
             if then_type == else_type {
                 inferred_type.update(then_type);
             } else {
-                if let Some(cond_then_else_type) = InferredType::all_of(vec![then_type, else_type]) {
+                if let Some(cond_then_else_type) = InferredType::all_of(vec![then_type, else_type])
+                {
                     inferred_type.update(cond_then_else_type);
                 }
             }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -73,11 +73,10 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
 
             if then_type == else_type {
                 inferred_type.update(then_type);
-            } else {
-                if let Some(cond_then_else_type) = InferredType::all_of(vec![then_type, else_type])
-                {
-                    inferred_type.update(cond_then_else_type);
-                }
+            } else if let Some(cond_then_else_type) =
+                InferredType::all_of(vec![then_type, else_type])
+            {
+                inferred_type.update(cond_then_else_type);
             }
         }
 
@@ -98,10 +97,8 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
                 let first_type = possible_inference_types[0].clone();
                 if possible_inference_types.iter().all(|t| t == &first_type) {
                     inferred_type.update(first_type);
-                } else {
-                    if let Some(all_of) = InferredType::all_of(possible_inference_types) {
-                        inferred_type.update(all_of);
-                    }
+                } else if let Some(all_of) = InferredType::all_of(possible_inference_types) {
+                    inferred_type.update(all_of);
                 }
             }
         }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -103,7 +103,7 @@ pub fn pull_types_up(expr: &mut Expr) -> Result<(), String> {
                 }
             }
         }
-        Expr::Let(_, expr, _) => expr.pull_types_up()?,
+        Expr::Let(_, _, expr, _) => expr.pull_types_up()?,
         Expr::SelectField(expr, field, inferred_type) => {
             expr.pull_types_up()?;
             let expr_type = expr.inferred_type();

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -204,20 +204,20 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
 
-            Expr::Let(_, expr, inferred_type) => {
+            Expr::Let(_, expr, _) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types_and_verify();
-
-                match unified_inferred_type {
-                    Ok(unified_type) => *inferred_type = unified_type,
-                    Err(e) => {
-                        errors.push(format!(
-                            "Unable to resolve the type of let binding {}",
-                            expr_str
-                        ));
-                        errors.extend(e);
-                    }
-                }
+                // let unified_inferred_type = inferred_type.unify_types_and_verify();
+                //
+                // match unified_inferred_type {
+                //     Ok(unified_type) => *inferred_type = unified_type,
+                //     Err(e) => {
+                //         errors.push(format!(
+                //             "Unable to resolve the type of let binding {}",
+                //             expr_str
+                //         ));
+                //         errors.extend(e);
+                //     }
+                // }
             }
             Expr::Literal(_, inferred_type) => {
                 let unified_inferred_type = inferred_type.unify_types_and_verify();

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -375,4 +375,5 @@ mod internal {
             ArmPattern::WildCard => {}
         }
     }
+
 }

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -10,7 +10,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
 
         match expr {
             Expr::Number(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -23,7 +23,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             Expr::Record(vec, inferred_type) => {
                 queue.extend(vec.iter_mut().map(|(_, expr)| &mut **expr));
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -36,7 +36,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             Expr::Tuple(vec, inferred_type) => {
                 queue.extend(vec.iter_mut());
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -48,7 +48,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::Sequence(vec, inferred_type) => {
                 queue.extend(vec.iter_mut());
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -63,7 +63,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::Option(Some(expr), inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -75,7 +75,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
 
             Expr::Option(None, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -88,7 +88,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
 
             Expr::Result(Ok(expr), inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -104,7 +104,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             Expr::Result(Err(expr), inferred_type) => {
                 queue.push(expr);
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -122,7 +122,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 queue.push(then);
                 queue.push(else_);
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -144,7 +144,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                     internal::push_arm_pattern_expr(arm_pattern, &mut queue);
                     queue.push(arm_resolution_expr);
                 }
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -160,7 +160,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             Expr::Call(function_call, vec, inferred_type) => {
                 queue.extend(vec.iter_mut());
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -175,7 +175,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::SelectField(expr, _, inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -190,7 +190,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::SelectIndex(expr, _, inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -206,7 +206,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
 
             Expr::Let(_, expr, inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -220,7 +220,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
             Expr::Literal(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -230,7 +230,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
             Expr::Flags(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -241,7 +241,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
             Expr::Identifier(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -261,7 +261,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             Expr::Multiple(expr, inferred_type) => {
                 queue.extend(expr);
 
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -276,7 +276,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::Not(expr, inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -288,7 +288,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
             Expr::Unwrap(expr, inferred_type) => {
                 queue.push(expr);
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -299,7 +299,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
             Expr::Throw(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,
@@ -311,7 +311,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
             }
 
             Expr::Tag(_, inferred_type) => {
-                let unified_inferred_type = inferred_type.unify_types();
+                let unified_inferred_type = inferred_type.unify_types_and_verify();
 
                 match unified_inferred_type {
                     Ok(unified_type) => *inferred_type = unified_type,

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -204,20 +204,8 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
 
-            Expr::Let(_, expr, _) => {
+            Expr::Let(_, _, expr, _) => {
                 queue.push(expr);
-                // let unified_inferred_type = inferred_type.unify_types_and_verify();
-                //
-                // match unified_inferred_type {
-                //     Ok(unified_type) => *inferred_type = unified_type,
-                //     Err(e) => {
-                //         errors.push(format!(
-                //             "Unable to resolve the type of let binding {}",
-                //             expr_str
-                //         ));
-                //         errors.extend(e);
-                //     }
-                // }
             }
             Expr::Literal(_, inferred_type) => {
                 let unified_inferred_type = inferred_type.unify_types_and_verify();

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -375,5 +375,4 @@ mod internal {
             ArmPattern::WildCard => {}
         }
     }
-
 }

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -536,7 +536,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${if request.body.age>100 then 0 else 1}",
+            "${let n: u64 = 100; let age: u64 = request.body.age; let zero: u64 = 0; let one: u64 = 1; let res = if age > n then zero else one; \"shopping-cart-${res}\"}",
             expression,
         );
 
@@ -815,9 +815,17 @@ mod tests {
           response
         "#;
 
+        // r#"${
+        //     let userid: u64 = request.path.user-id;
+        //     let max: u64 = 100;
+        //     let zero: u64 = 0;
+        //     let one: u64 = 1;
+        //     let res = if userid>max then zero else one;
+        //     "shopping-cart-${res}"
+
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
+            "${let userid: u64 = request.path.user-id; let max: u64 = 100; let zero: u64 = 0; let one: u64 = 1;  let res = if userid>max then zero else one; \"shopping-cart-${res}\"}",
             expression,
         );
 
@@ -896,7 +904,7 @@ mod tests {
 
             let api_specification: HttpApiDefinition = get_api_spec(
                 "getcartcontent/{cart-id}",
-                "shopping-cart-${request.path.cart-id}",
+                "${let x: u64 = request.path.cart-id; \"shopping-cart-${x}\"}",
                 expression,
             );
 

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -422,7 +422,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${request.path.user-id}",
+            "${let x: u64 = request.path.user-id; \"shopping-cart-${x}\"}",
             expression,
         );
 
@@ -496,7 +496,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}?{token-id}",
-            "shopping-cart-${request.path.user-id}",
+            "${let x: u64 = request.path.user-id; \"shopping-cart-${x}\"}",
             expression,
         );
 
@@ -575,7 +575,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
+            "${let userid: u64 = request.path.user-id; let max: u64 = 100; let zero: u64 = 0; let one: u64 = 1;  let res = if userid>max then zero else one; \"shopping-cart-${res}\"}",
             expression,
         );
 
@@ -763,7 +763,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
+            "${let userid: u64 = request.path.user-id; let max: u64 = 100; let zero: u64 = 0; let one: u64 = 1;  let res = if userid>max then zero else one; \"shopping-cart-${res}\"}",
             expression,
         );
 
@@ -815,14 +815,6 @@ mod tests {
           response
         "#;
 
-        // r#"${
-        //     let userid: u64 = request.path.user-id;
-        //     let max: u64 = 100;
-        //     let zero: u64 = 0;
-        //     let one: u64 = 1;
-        //     let res = if userid>max then zero else one;
-        //     "shopping-cart-${res}"
-
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
             "${let userid: u64 = request.path.user-id; let max: u64 = 100; let zero: u64 = 0; let one: u64 = 1;  let res = if userid>max then zero else one; \"shopping-cart-${res}\"}",
@@ -863,7 +855,7 @@ mod tests {
 
             let api_specification: HttpApiDefinition = get_api_spec(
                 definition_path,
-                "shopping-cart-${request.path.cart-id}",
+                "${let x: u64 = request.path.cart-id; \"shopping-cart-${x}\"}",
                 expression,
             );
 

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -458,7 +458,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${request.path.user-id}",
+            "${let x: u64 = request.path.user-id; \"shopping-cart-${x}\"}",
             expression,
         );
 
@@ -611,7 +611,9 @@ mod tests {
         );
 
         let expression = r#"
-           let input = if 2 < 1 then "foo" else "bar";
+           let left: u64 = 2;
+           let right: u64 = 1;
+           let input = if left < right then "foo" else "bar";
            let response = golem:it/api.{get-cart-contents}(input, input);
            response
         "#;
@@ -654,8 +656,14 @@ mod tests {
         );
 
         let expression = r#"
-          let number1 = if request.body.number < 11 then 0 else 1;
-          let number2 = if request.body.number > 11 then 0 else 1;
+          let request_number: u64 = request.body.number;
+          let userid: u64 = request.path.user-id;
+          let fall_back: u64 = 1;
+          let eleven: u64 = 11;
+          let zero: u64 = 0;
+
+          let number1 = if request_number < eleven then zero else fall_back;
+          let number2 = if request_number > eleven then zero else fall_back;
           let input1 = "foo-${number1}";
           let input2 = "bar-${number2}";
           let response = golem:it/api.{get-cart-contents}(input1, input2);
@@ -700,8 +708,14 @@ mod tests {
         );
 
         let expression = r#"
-          let condition1 = if request.body.number < 11 then request.path.user-id else 1;
-          let condition2 = if request.body.number < 5 then request.path.user-id else 1;
+          let request_number: u64 = request.body.number;
+          let userid: u64 = request.path.user-id;
+          let fall_back: u64 = 1;
+          let eleven: u64 = 11;
+          let five: u64 = 5;
+
+          let condition1 = if request_number < eleven then userid else fall_back;
+          let condition2 = if request_number < five then userid else fall_back;
           let param1 = "foo-${condition1}";
           let param2 = "bar-${condition2}";
           let response = golem:it/api.{get-cart-contents}(param1, param2);

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -391,7 +391,7 @@ mod tests {
 
         let api_specification: HttpApiDefinition = get_api_spec(
             "foo/{user-id}",
-            "shopping-cart-${request.path.user-id}",
+            "${let id: u64 = request.path.user-id; \"shopping-cart-${id}\"}",
             expression,
         );
 

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -435,10 +435,12 @@ mod tests {
         let component_metadata =
             get_analysed_exports("foo", vec![request_type.clone()], return_type);
 
+        // TODO; result2 should be automatically inferred
         let expr_str = r#"${
               let x = { body : { id: "bId", name: "bName", titles: request.body.titles, address: request.body.address } };
               let result = foo(x);
-              match result {  some(value) => "personal-id", none =>  request.body.id }
+              let result2: str = request.body.id;
+              match result {  some(value) => "personal-id", none => result2 }
             }"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
@@ -600,7 +602,7 @@ mod tests {
         );
 
         let expr =
-            rib::from_string(r#"${if request.headers.authorisation == "admin" then 200 else 401}"#)
+            rib::from_string(r#"${let input: str = request.headers.authorisation; let x: u64 = 200; let y: u64 = 401; if input == "admin" then x else y}"#)
                 .unwrap();
         let expected_evaluated_result = TypeAnnotatedValue::U64("200".parse().unwrap());
         let result = noop_executor
@@ -653,7 +655,10 @@ mod tests {
         let expr_str = r#"${
               let x = request;
               let result = foo(x);
-              if request.headers.authorisation == "admin" then 200 else 401
+              let success: u64 = 200;
+              let failure: u64 = 401;
+              let auth = request.headers.authorisation;
+              if auth == "admin" then success else failure
             }"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
@@ -1318,7 +1323,7 @@ mod tests {
         )])
         .unwrap();
 
-        let worker_response = create_ok_result(worker_response_inner, None).unwrap();
+        let worker_response = create_ok_result(worker_response_inner, Some(AnalysedType::Str(TypeStr))).unwrap();
 
         let return_type = AnalysedType::try_from(&worker_response).unwrap();
 
@@ -1331,11 +1336,13 @@ mod tests {
 
         let metadata = get_analysed_exports("foo", vec![request_type.clone()], return_type);
 
+        // TODO; inlining request.path.id all over should work too
         let expr1 = rib::from_string(
             r#"${
               let x = request;
               let foo_result = foo(x);
-              if request.path.id == "foo" then "bar" else match foo_result { ok(value) => request.path.id, err(msg) => "empty" }
+              let txt = request.path.id;
+              if txt == "foo" then "bar" else match foo_result { ok(value) => txt, err(msg) => "empty" }
              }"#,
         )
             .unwrap();
@@ -1349,11 +1356,13 @@ mod tests {
             )
             .await;
 
+        // TODO; inlining request.path.id all over should work too
         let expr2 = rib::from_string(
             r#"${
               let x = request;
               let foo_result = foo(x);
-              if request.path.id == "bar" then "foo" else match foo_result { ok(foo) => foo.id, err(msg) => "empty" }
+              let txt = request.path.id;
+              if txt == "bar" then "foo" else match foo_result { ok(foo) => foo.id, err(msg) => "empty" }
           }"#,
 
         ).unwrap();
@@ -1405,7 +1414,7 @@ mod tests {
 
         let record_value = create_singleton_record("id", &field_value).unwrap();
 
-        let worker_response = create_ok_result(record_value.clone(), None).unwrap();
+        let worker_response = create_ok_result(record_value.clone(), Some(AnalysedType::Str(TypeStr))).unwrap();
 
         // Output from worker
         let return_type = AnalysedType::try_from(&worker_response).unwrap();
@@ -1413,7 +1422,7 @@ mod tests {
         let component_metadata =
             get_analysed_exports("foo", vec![AnalysedType::U64(TypeU64)], return_type);
 
-        let expr_str = r#"${let result = foo(1); match result {  ok(value) => "personal-id", err(msg) => "not found" }}"#;
+        let expr_str = r#"${let n1: u64 = 1; let result = foo(n1); match result {  ok(value) => "personal-id", err(msg) => "not found" }}"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
         let value1 = noop_executor
@@ -1440,7 +1449,7 @@ mod tests {
 
         let record_value = create_singleton_record("id", &field_value).unwrap();
 
-        let worker_response = create_ok_result(record_value.clone(), None).unwrap();
+        let worker_response = create_ok_result(record_value.clone(), Some(AnalysedType::Str(TypeStr))).unwrap();
 
         // Output from worker
         let return_type = AnalysedType::try_from(&worker_response).unwrap();
@@ -1481,7 +1490,7 @@ mod tests {
         let component_metadata =
             get_analysed_exports("foo", vec![AnalysedType::U64(TypeU64)], return_type);
 
-        let expr_str = r#"${let result = foo(1); match result { ok(value) => value.id, err(msg) => "not found" }}"#;
+        let expr_str = r#"${let result = foo(1); match result { ok(value) => value.id, err(_) => "not found" }}"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
         let value1 = noop_executor
@@ -1519,7 +1528,7 @@ mod tests {
         let component_metadata =
             get_analysed_exports("foo", vec![AnalysedType::U64(TypeU64)], return_type);
 
-        let expr_str = r#"${let result = foo(1); match result { ok(value) => value.ids[0], err(msg) => "not found" }}"#;
+        let expr_str = r#"${let result = foo(1); match result { ok(value) => value.ids[0], err(_) => "not found" }}"#;
 
         let expr1 = rib::from_string(expr_str).unwrap();
         let value1 = noop_executor
@@ -1549,7 +1558,7 @@ mod tests {
             get_analysed_exports("foo", vec![AnalysedType::U64(TypeU64)], return_type);
 
         let expr_str =
-            r#"${let result = foo(1); match result { ok(x) => some(1), err(msg) => none }}"#;
+            r#"${let n: u64 = 1; let result = foo(1); match result { ok(x) => some(n), err(_) => none }}"#;
         let expr1 = rib::from_string(expr_str).unwrap();
         let value1 = noop_executor
             .evaluate_with_worker_response(
@@ -1570,7 +1579,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr =
-            rib::from_string(r#"${match ok(1) { ok(value) => none, err(_) => some(1) }}"#).unwrap();
+            rib::from_string(r#"${let x:u64 = 1; match ok(x) { ok(value) => none, err(_) => some(x) }}"#).unwrap();
         let result = noop_executor
             .evaluate_pure_expr(&expr)
             .await
@@ -1588,7 +1597,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr =
-            rib::from_string("${match err(1) { ok(value) => none, err(msg) => some(some(1)) }}")
+            rib::from_string("${let x: u64 = 1; match err(x) { ok(_) => none, err(x) => some(some(x)) }}")
                 .unwrap();
         let result = noop_executor
             .evaluate_pure_expr(&expr)
@@ -1607,7 +1616,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr =
-            rib::from_string("${match ok(\"afsal\") { ok(value) => ok(1), err(msg) => err(2) }}")
+            rib::from_string("${let left: u64 = 1; let right: u64 = 2; match ok(\"afsal\") { ok(value) => ok(left), err(_) => err(right) }}")
                 .unwrap();
         let result = noop_executor
             .evaluate_pure_expr(&expr)
@@ -1623,7 +1632,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr = rib::from_string(
-            "${match err(\"afsal\") { ok(value) => ok(\"1\"), err(msg) => err(2) }}",
+            "${let err_n: u64 = 2; match err(\"afsal\") { ok(_) => ok(\"1\"), err(msg) => err(err_n) }}",
         )
         .unwrap();
 
@@ -1644,7 +1653,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr =
-            rib::from_string("${match err(10) { ok(_) => ok(1), err(_) => err(2) }}").unwrap();
+            rib::from_string("${let x: u64 = 10; let lef: u64 = 1; let rig: u64 = 2; match err(x) { ok(_) => ok(lef), err(_) => err(rig) }}").unwrap();
 
         let result = noop_executor
             .evaluate_pure_expr(&expr)
@@ -1959,7 +1968,7 @@ mod tests {
     async fn test_evaluation_with_wave_like_syntax_ok_record() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let expr = rib::from_string("${{a : ok(1)}}").unwrap();
+        let expr = rib::from_string("${let x: u64 = 1; {a : ok(x)}}").unwrap();
 
         let result = noop_executor.evaluate_pure_expr(&expr).await;
 
@@ -1974,7 +1983,7 @@ mod tests {
     async fn test_evaluation_with_wave_like_syntax_err_record() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let expr = rib::from_string("${{a : err(1)}}").unwrap();
+        let expr = rib::from_string("${let n: u64 = 1; {a : err(n)}}").unwrap();
 
         let result = noop_executor.evaluate_pure_expr(&expr).await;
 
@@ -1991,7 +2000,7 @@ mod tests {
     async fn test_evaluation_with_wave_like_syntax_simple_list() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let expr = rib::from_string("${[1,2,3]}").unwrap();
+        let expr = rib::from_string("${let x: list<u64> = [1,2,3]; x}").unwrap();
 
         let result = noop_executor.evaluate_pure_expr(&expr).await;
 
@@ -2011,7 +2020,7 @@ mod tests {
     async fn test_evaluation_with_wave_like_syntax_simple_tuple() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let expr = rib::from_string("${(some(1),2,3)}").unwrap();
+        let expr = rib::from_string("${let x: tuple<option<u64>, u64, u64> = (some(1),2,3); x}").unwrap();
 
         let result = noop_executor.evaluate_pure_expr(&expr).await;
 
@@ -2046,7 +2055,7 @@ mod tests {
     async fn test_evaluation_with_wave_like_syntax_result_list() {
         let noop_executor = DefaultEvaluator::noop();
 
-        let expr = rib::from_string("${[ok(1),ok(2)]}").unwrap();
+        let expr = rib::from_string("${let x: u64 = 1; let y: u64 = 2; [ok(x),ok(y)]}").unwrap();
 
         let result = noop_executor.evaluate_pure_expr(&expr).await;
 
@@ -2066,8 +2075,10 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let program = r"
-            let x = { a : 1 };
-            let y = { b : 2 };
+            let n1: u64 = 1;
+            let n2: u64 = 2;
+            let x = { a : n1 };
+            let y = { b : n2 };
             let z = x.a > y.b;
             z
           ";

--- a/golem-worker-service-base/tests/services_tests.rs
+++ b/golem-worker-service-base/tests/services_tests.rs
@@ -229,16 +229,16 @@ mod tests {
             &Uuid::new_v4().to_string(),
             "0.0.1",
             "/api/1/foo/{user-id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(request.body.foo); let status = if result == \"admin\" then 401 else 200; {status: status } }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; {status: status } }",
             false,
         );
         let def2draft = get_api_definition(
             &Uuid::new_v4().to_string(),
             "0.0.1",
             "/api/2/foo/{user-id}",
-            "shopping-cart-${if request.body.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(request.body.foo); let status = if result == \"admin\" then 401 else 200; {status: status } }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; {status: status } }",
             true,
         );
         let def2 = HttpApiDefinitionRequest {
@@ -249,16 +249,16 @@ mod tests {
             &Uuid::new_v4().to_string(),
             "0.0.1",
             "/api/3/foo/{user-id}?{id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(request.body.foo); let status = if result == \"admin\" then 401 else 200; {status: status } }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; {status: status } }",
             false,
         );
         let def4 = get_api_definition(
             &Uuid::new_v4().to_string(),
             "0.0.1",
             "/api/4/foo/{user-id}",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(\"doo\"); let status = if result == \"admin\" then 401 else 200; {status: status } }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; {status: status } }",
             false,
         );
 
@@ -435,7 +435,7 @@ mod tests {
             "0.0.1",
             "/api/get1",
             "worker1",
-            "${ { headers: { ContentType: \"json\", userid: \"foo\"}, body: golem:it/api.{get-cart-contents}(\"foo\"), status: 200 }  }",
+            "${ let status: u64 = 200; { headers: { ContentType: \"json\", userid: \"foo\"}, body: golem:it/api.{get-cart-contents}(\"foo\"), status: status }  }",
             false,
         );
         let def2 = get_api_definition(
@@ -523,24 +523,24 @@ mod tests {
             &Uuid::new_v4().to_string(),
             "0.0.1",
             "/api/get1",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then 401 else 200; status }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; status }",
             false,
         );
         let def1v1_upd = get_api_definition(
             &def1v1.id.0,
             "0.0.1",
             "/api/get1/1",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then 401 else 200; status }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; status }",
             false,
         );
         let def1v2 = get_api_definition(
             &def1v1.id.0,
             "0.0.2",
             "/api/get1/2",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then 401 else 200; status }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; status }",
             true,
         );
 
@@ -548,8 +548,8 @@ mod tests {
             &def1v1.id.0,
             "0.0.2",
             "/api/get1/22",
-            "shopping-cart-${if request.path.user-id>100 then 0 else 1}",
-            "${ let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then 401 else 200; status }",
+            "${let userid: u64 = request.path.user; let hun: u64 = 100; let zero: u64 = 0; let one: u64 = 1; let res = if userid>hun then zero else one; \"shopping-cart-${res}\"}",
+            "${ let not_found: u64 = 401; let success: u64 = 200; let result = golem:it/api.{get-cart-contents}(\"foo\"); let status = if result == \"admin\" then not_found else success; status }",
             true,
         );
 


### PR DESCRIPTION
The PR is not showing enough changes since the base branch is https://github.com/golemcloud/golem/pull/822, however shows the fundamental logic addition and test changes  (that verifies the change) for easier review.

* Able to specify if there is an ambiguity in types (type annotation), as our stack based interpreter needs to know the actual types and cannot guess (we made some hacks during release 1.0 such as fall back to u64 if user specified a number which can be u8, u16 etc but this leads to a lot of corner cases, and we decided to take this path). Example returning an `empty list` is never possible without this strategy.

```scala
let my_list: list<u8> = [];
{status: 200, body: my_list}
```

* There is no need to specify the type if it can infer from any function calls to worker. The following will work


```scala
let x = 1;
call_my_function(x) 

```

* Limited support, as you need to write a let binding to specify the types. But this PR will unblock users to a great extent. 

Obviously, it will be a bit more user friendly for simpler expressions to work without type annotation. Example, with this PR, we see we have to specify the type of x. 

```
let x : u8 = 1;
x
```
Avoiding u8 would make it sound user friendly, but making ways to allow such thing will introduce a lot of hacks into our type inference logic, and thereby the future maintainability of Rib will be in question, unless we find a non hacky structured solution to bring such user friendliness. Not to mention, Rib is mainly used to call worker functions and to a relatively good extent types will be inferred.

We had some flexibility in the code previously, to get release 1.0 going with whatever worker bridge used to do until then, but introduced corner cases.
