### PR TITLE
Support Enums in Rib, and add the ability to compile variants with hyphens in their names.

### DIFF
--- a/golem-api-grpc/proto/golem/rib/expr.proto
+++ b/golem-api-grpc/proto/golem/rib/expr.proto
@@ -156,6 +156,7 @@ message InvocationName {
    oneof name {
      golem.rib.ParsedFunctionName parsed = 1;
      string variant_constructor = 2;
+     string enum_constructor = 3;
    }
 }
 

--- a/golem-api-grpc/proto/golem/rib/ir.proto
+++ b/golem-api-grpc/proto/golem/rib/ir.proto
@@ -37,6 +37,7 @@ message RibIR {
         PushTupleInstruction push_tuple = 27;
         Negate negate = 28;
         ConcatInstruction concat = 29;
+        EnumConstructionInstruction enum_construction = 30;
     }
 }
 
@@ -89,6 +90,11 @@ message CallInstruction {
 message VariantConstructionInstruction {
     string variant_name = 1;
     wasm.ast.Type return_type = 3;
+}
+
+message EnumConstructionInstruction {
+    string enum_name = 1;
+    wasm.ast.Type return_type = 2;
 }
 
 message EqualTo {}

--- a/golem-rib/src/call_type.rs
+++ b/golem-rib/src/call_type.rs
@@ -21,6 +21,7 @@ use std::fmt::Display;
 pub enum CallType {
     Function(ParsedFunctionName),
     VariantConstructor(String),
+    EnumConstructor(String),
 }
 
 impl Display for CallType {
@@ -28,6 +29,7 @@ impl Display for CallType {
         match self {
             CallType::Function(parsed_fn_name) => write!(f, "{}", parsed_fn_name),
             CallType::VariantConstructor(name) => write!(f, "{}", name),
+            CallType::EnumConstructor(name) => write!(f, "{}", name),
         }
     }
 }
@@ -44,6 +46,9 @@ impl TryFrom<golem_api_grpc::proto::golem::rib::InvocationName> for CallType {
             }
             golem_api_grpc::proto::golem::rib::invocation_name::Name::VariantConstructor(name) => {
                 Ok(CallType::VariantConstructor(name))
+            }
+            golem_api_grpc::proto::golem::rib::invocation_name::Name::EnumConstructor(name) => {
+                Ok(CallType::EnumConstructor(name))
             }
         }
     }
@@ -62,6 +67,13 @@ impl From<CallType> for golem_api_grpc::proto::golem::rib::InvocationName {
             CallType::VariantConstructor(name) => {
                 golem_api_grpc::proto::golem::rib::InvocationName {
                     name: Some(golem_api_grpc::proto::golem::rib::invocation_name::Name::VariantConstructor(
+                        name,
+                    )),
+                }
+            }
+            CallType::EnumConstructor(name) => {
+                golem_api_grpc::proto::golem::rib::InvocationName {
+                    name: Some(golem_api_grpc::proto::golem::rib::invocation_name::Name::EnumConstructor(
                         name,
                     )),
                 }

--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -259,6 +259,12 @@ mod internal {
                             convert_to_analysed_type_for(expr, inferred_type)?,
                         ));
                     }
+                    CallType::EnumConstructor(enmum_name) => {
+                        instructions.push(RibIR::PushEnum(
+                            enmum_name.clone(),
+                            convert_to_analysed_type_for(expr, inferred_type)?,
+                        ));
+                    }
                 }
             }
 

--- a/golem-rib/src/inferred_type.rs
+++ b/golem-rib/src/inferred_type.rs
@@ -674,6 +674,8 @@ impl InferredType {
                     Ok(InferredType::Flags(a_flags.clone()))
                 }
                 (InferredType::Enum(a_variants), InferredType::Enum(b_variants)) => {
+                    dbg!(a_variants);
+                    dbg!(b_variants);
                     if a_variants != b_variants {
                         return Err(vec!["Enum variants do not match".to_string()]);
                     }

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -148,6 +148,10 @@ impl Interpreter {
                     .await?;
                 }
 
+                RibIR::PushEnum(enum_name, analysed_type) => {
+                    internal::run_push_enum_instruction(&mut self.stack, enum_name, analysed_type)?;
+                }
+
                 RibIR::Throw(message) => {
                     return Err(message);
                 }
@@ -456,6 +460,23 @@ mod internal {
             result => Err(format!(
                 "Expected a sequence value to select an index. But obtained {:?}",
                 result
+            )),
+        }
+    }
+
+    pub(crate) fn run_push_enum_instruction(
+        interpreter_stack: &mut InterpreterStack,
+        enum_name: String,
+        analysed_type: AnalysedType,
+    ) -> Result<(), String> {
+        match analysed_type {
+            AnalysedType::Enum(typed_enum) => {
+                interpreter_stack.push_enum(enum_name, typed_enum.cases);
+                Ok(())
+            }
+            _ => Err(format!(
+                "Expected a enum type for {}, but obtained {:?}",
+                enum_name, analysed_type
             )),
         }
     }

--- a/golem-rib/src/interpreter/stack.rs
+++ b/golem-rib/src/interpreter/stack.rs
@@ -16,7 +16,9 @@ use crate::interpreter::result::RibInterpreterResult;
 use golem_wasm_ast::analysis::protobuf::{NameTypePair, Type};
 use golem_wasm_ast::analysis::{AnalysedType, NameOptionTypePair};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
-use golem_wasm_rpc::protobuf::{TypedList, TypedOption, TypedRecord, TypedTuple, TypedVariant};
+use golem_wasm_rpc::protobuf::{
+    TypedEnum, TypedList, TypedOption, TypedRecord, TypedTuple, TypedVariant,
+};
 
 #[derive(Debug)]
 pub struct InterpreterStack {
@@ -105,6 +107,13 @@ impl InterpreterStack {
         }));
 
         self.push_val(value);
+    }
+
+    pub fn push_enum(&mut self, enum_name: String, typ: Vec<String>) {
+        self.push_val(TypeAnnotatedValue::Enum(TypedEnum {
+            typ,
+            value: enum_name,
+        }))
     }
 
     pub fn push_some(&mut self, inner_element: TypeAnnotatedValue, inner_type: &AnalysedType) {

--- a/golem-rib/src/parser/pattern_match.rs
+++ b/golem-rib/src/parser/pattern_match.rs
@@ -109,7 +109,7 @@ mod internal {
     use combine::attempt;
     use combine::error::StreamError;
     use combine::many1;
-    use combine::parser::char::{digit, letter};
+    use combine::parser::char::{char, digit, letter};
     use combine::parser::char::{spaces, string};
     use combine::sep_by;
 
@@ -154,7 +154,7 @@ mod internal {
     }
 
     fn constructor_type_name<'t>() -> impl Parser<easy::Stream<&'t str>, Output = String> {
-        many1(letter().or(digit()).or(char_('_')))
+        many1(letter().or(digit()).or(char_('_')).or(char('-')))
             .and_then(|s: Vec<char>| {
                 if s.first().map_or(false, |&c| c.is_alphabetic()) {
                     Ok(s)

--- a/golem-rib/src/type_inference/enum_resolution.rs
+++ b/golem-rib/src/type_inference/enum_resolution.rs
@@ -1,0 +1,85 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Expr, FunctionTypeRegistry};
+
+pub fn infer_enums(expr: &mut Expr, function_type_registry: &FunctionTypeRegistry) {
+    let eum_info = internal::get_enum_info(expr, function_type_registry);
+
+    internal::convert_identifiers_to_enum_function_calls(expr, &eum_info);
+}
+
+mod internal {
+    use crate::call_type::CallType;
+    use crate::{Expr, FunctionTypeRegistry, RegistryKey, RegistryValue};
+    use std::collections::VecDeque;
+
+    pub(crate) fn convert_identifiers_to_enum_function_calls(
+        expr: &mut Expr,
+        enum_info: &EnumInfo,
+    ) {
+        let enum_cases = enum_info.clone();
+
+        let mut queue = VecDeque::new();
+        queue.push_back(expr);
+
+        while let Some(expr) = queue.pop_back() {
+            match expr {
+                Expr::Identifier(variable_id, inferred_type) => {
+                    if enum_cases.cases.contains(&variable_id.name()) {
+                        *expr = Expr::Call(
+                            CallType::EnumConstructor(variable_id.name()),
+                            vec![],
+                            inferred_type.clone(),
+                        );
+                    }
+                }
+                _ => expr.visit_children_mut_bottom_up(&mut queue),
+            }
+        }
+    }
+
+    pub(crate) fn get_enum_info(
+        expr: &mut Expr,
+        function_type_registry: &FunctionTypeRegistry,
+    ) -> EnumInfo {
+        let mut enum_cases = vec![];
+        let mut queue = VecDeque::new();
+        queue.push_back(expr);
+
+        while let Some(expr) = queue.pop_back() {
+            match expr {
+                Expr::Identifier(variable_id, inferred_type) => {
+                    // Retrieve the possible no-arg variant from the registry
+                    let key = RegistryKey::EnumName(variable_id.name().clone());
+                    if let Some(RegistryValue::Value(analysed_type)) =
+                        function_type_registry.types.get(&key)
+                    {
+                        enum_cases.push(variable_id.name());
+                        *inferred_type = inferred_type.merge(analysed_type.clone().into());
+                    }
+                }
+
+                _ => expr.visit_children_mut_bottom_up(&mut queue),
+            }
+        }
+
+        EnumInfo { cases: enum_cases }
+    }
+
+    #[derive(Debug, Clone)]
+    pub(crate) struct EnumInfo {
+        cases: Vec<String>,
+    }
+}

--- a/golem-rib/src/type_inference/variant_resolution.rs
+++ b/golem-rib/src/type_inference/variant_resolution.rs
@@ -88,7 +88,6 @@ mod internal {
         while let Some(expr) = queue.pop_back() {
             match expr {
                 Expr::Identifier(variable_id, inferred_type) => {
-                    // Retrieve the possible no-arg variant from the registry
                     let key = RegistryKey::VariantName(variable_id.name().clone());
                     if let Some(RegistryValue::Value(analysed_type)) =
                         function_type_registry.types.get(&key)


### PR DESCRIPTION
Fixes #878  and #879 