### PR TITLE
Gloem-cli perf opt and service factory refactor

### DIFF
--- a/golem-cli/src/lib.rs
+++ b/golem-cli/src/lib.rs
@@ -70,8 +70,11 @@ pub fn init_tracing(verbosity: &Verbosity) {
     }
 }
 
-pub async fn check_for_newer_server_version(version_service: &dyn VersionService) {
-    match version_service.check().await {
+pub async fn check_for_newer_server_version(
+    version_service: &dyn VersionService,
+    cli_version: &str,
+) {
+    match version_service.check(cli_version).await {
         Ok(VersionCheckResult::Ok) => { /* NOP */ }
         Ok(VersionCheckResult::NewerServerVersionAvailable {
             cli_version,

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -15,17 +15,15 @@
 extern crate derive_more;
 
 use clap::Parser;
-use clap_verbosity_flag::{Level, Verbosity};
 use golem_cli::command::profile::OssProfileAdd;
 use golem_cli::config::{Config, NamedProfile, Profile};
 use golem_cli::init::{CliKind, DummyProfileAuth, GolemInitCommand};
-use golem_cli::oss;
 use golem_cli::oss::command::GolemOssCommand;
 use golem_cli::oss::completion::PrintOssCompletion;
+use golem_cli::{init_tracing, oss};
 use indoc::eprintdoc;
 use std::path::PathBuf;
 use tracing::info;
-use tracing_subscriber::FmtSubscriber;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let home = dirs::home_dir().unwrap();

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -98,23 +98,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ))
     }
 }
-
-fn init_tracing(verbosity: &Verbosity) {
-    if let Some(level) = verbosity.log_level() {
-        let tracing_level = match level {
-            Level::Error => tracing::Level::ERROR,
-            Level::Warn => tracing::Level::WARN,
-            Level::Info => tracing::Level::INFO,
-            Level::Debug => tracing::Level::DEBUG,
-            Level::Trace => tracing::Level::TRACE,
-        };
-
-        let subscriber = FmtSubscriber::builder()
-            .with_max_level(tracing_level)
-            .with_writer(std::io::stderr)
-            .finish();
-
-        tracing::subscriber::set_global_default(subscriber)
-            .expect("setting default subscriber failed");
-    }
-}

--- a/golem-cli/src/oss/main.rs
+++ b/golem-cli/src/oss/main.rs
@@ -28,6 +28,8 @@ use golem_common::uri::oss::url::{ComponentUrl, ResourceUrl, WorkerUrl};
 use golem_common::uri::oss::urn::{ComponentUrn, ResourceUrn, WorkerUrn};
 use std::path::PathBuf;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub async fn async_main<ProfileAdd: Into<UniversalProfileAdd> + clap::Args>(
     cmd: GolemOssCommand<ProfileAdd>,
     profile: OssProfile,
@@ -39,7 +41,7 @@ pub async fn async_main<ProfileAdd: Into<UniversalProfileAdd> + clap::Args>(
     let format = cmd.format.unwrap_or(profile.config.default_format);
     let factory = || async {
         let factory = OssServiceFactory::from_profile(&profile)?;
-        check_for_newer_server_version(factory.version_service().as_ref()).await;
+        check_for_newer_server_version(factory.version_service().as_ref(), VERSION).await;
         Ok::<OssServiceFactory, GolemError>(factory)
     };
 


### PR DESCRIPTION
golem cli changes:
  - use the same reqwest client for all request to reuse tcp connections, and init them at factory creation -> no need for error handling during context and service creation
  - use Arc for reused clients / services, cleanup async usages and internal client builders
  - remove non used (in oss) auth parts
  - extract as public more common parts with cloud (make reqwest client, init tracing, version check)
  - version check cleanups
      - separate health check call errors and version mismatch
      - make cli_version an argument, so it is not tied to the oss lib / cli version
      - only do health check / version requests for unique urls, and do them in parallel
      - change the message from cargo install to point to binary releases and to docs
  - cleanup http config, separate env vars for normal and health check clients


