### PR TITLE
Precise Rib Parsing & Errors

### DIFF
--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -19,6 +19,7 @@ use crate::parser::type_name::TypeName;
 use crate::type_registry::FunctionTypeRegistry;
 use crate::{text, type_inference, InferredType, VariableId};
 use bincode::{Decode, Encode};
+use combine::stream::position;
 use combine::EasyParser;
 use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
@@ -80,15 +81,9 @@ impl Expr {
     ///
     pub fn from_text(input: &str) -> Result<Expr, String> {
         rib_program()
-            .easy_parse(input.as_ref())
-            .map_err(|err| err.to_string())
-            .and_then(|(expr, remaining)| {
-                if remaining.is_empty() {
-                    Ok(expr)
-                } else {
-                    Err(format!("Failed to parse: {}", remaining))
-                }
-            })
+            .easy_parse(position::Stream::new(input))
+            .map(|t| t.0)
+            .map_err(|err| format!("{}", err))
     }
 
     /// Parse an interpolated text as Rib expression. The input is always expected to be wrapped with `${..}`

--- a/golem-rib/src/parser/boolean.rs
+++ b/golem-rib/src/parser/boolean.rs
@@ -15,15 +15,17 @@
 use crate::expr::Expr;
 use combine::parser::char::spaces;
 use combine::parser::char::string;
-use combine::{choice, easy, Parser};
+use combine::{attempt, Parser};
 
-pub fn boolean_literal<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-    choice((
-        string("true").map(|_| Expr::boolean(true)),
-        string("false").map(|_| Expr::boolean(false)),
-    ))
-    .skip(spaces())
-    .message("Unable to parse boolean literal")
+pub fn boolean_literal<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
+    attempt(string("true"))
+        .map(|_| Expr::boolean(true))
+        .or(attempt(string("false")).map(|_| Expr::boolean(false)))
+        .skip(spaces())
+        .message("Unable to parse boolean literal")
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/cond.rs
+++ b/golem-rib/src/parser/cond.rs
@@ -15,20 +15,22 @@
 use crate::expr::Expr;
 use crate::parser::rib_expr::rib_expr;
 use combine::parser::char::{spaces, string};
-use combine::stream::easy;
-use combine::Parser;
+use combine::{attempt, Parser};
 
-pub fn conditional<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-    spaces().with(
+pub fn conditional<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
+    // Use attempt only for the initial "if" to resolve ambiguity with identifiers
+    attempt(string("if").skip(spaces())).with(
         (
-            string("if").skip(spaces()),
             rib_expr().skip(spaces()),
             string("then").skip(spaces()),
             rib_expr().skip(spaces()),
             string("else").skip(spaces()),
             rib_expr().skip(spaces()),
         )
-            .map(|(_, cond, _, then_expr, _, else_expr)| Expr::cond(cond, then_expr, else_expr)),
+            .map(|(cond, _, then_expr, _, else_expr)| Expr::cond(cond, then_expr, else_expr)),
     )
 }
 

--- a/golem-rib/src/parser/errors.rs
+++ b/golem-rib/src/parser/errors.rs
@@ -1,0 +1,423 @@
+// A curated list of most common syntax errors, with the intent
+// not regress user-facing error messages with changing parsing logic
+#[cfg(test)]
+mod error_tests {
+
+    use crate::Expr;
+
+    #[test]
+    fn test_pattern_match_error_missing_opening_curly_brace() {
+        let input = r#"match foo
+            ok(x) => x,
+            err(x) => x,
+            _ => bar,
+          }"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 2, column: 13",
+            "Unexpected `o`",
+            "Expected whitespace or `{`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_pattern_match_error_missing_closing_curly_brace() {
+        let input = r#"match foo {
+            ok(x) => x,
+            err(x) => x,
+            _ => bar
+          "#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 11",
+            "Unexpected end of input",
+            "Expected whitespace or `}`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    // TODO; Missing comma since we have multiple arms is a better error message
+    // This requires change in parsing logic to avoid using sep_by1
+    #[test]
+    fn test_pattern_match_error_missing_comma_between_arms() {
+        let input = r#"match foo {
+            ok(x) => x
+            err(x) => x,
+            _ => bar,
+          }"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 3, column: 13",
+            "Unexpected `e`",
+            "Expected whitespace or `}`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_pattern_match_error_missing_arrow() {
+        let input = r#"match foo {
+            ok(x) x,
+            err(x) => x,
+            _ => bar,
+          }"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 2, column: 19",
+            "Unexpected `x`",
+            "Expected whitespace or =>",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_let_binding_error_missing_variable() {
+        let input = r#"let = 1;"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 5",
+            "Unexpected `=`",
+            "Expected whitespace, letter, digit or `_`",
+            "Unable to parse binding variable",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_let_binding_error_missing_assignment() {
+        let input = r#"let x 1;"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 7",
+            "Unexpected `1`",
+            "Expected whitespace, `:`, whitespaces, bool, s8, u8, s16, u16, s32, u32, s64, u64, f32, f64, chr, str, list, tuple, option or `=`",
+            ""
+        ].join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+    #[test]
+    fn test_conditional_no_then() {
+        let input = r#"if x 1 else 2"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 6",
+            "Unexpected `1`",
+            "Expected whitespace or then",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_result_ok_missing_braces() {
+        let input = r#"ok(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 5",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_result_err_missing_braces() {
+        let input = r#"err(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 6",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_option_some_missing_braces() {
+        let input = r#"some(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 7",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Option type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_option_none_redundant_braces() {
+        let input = r#"none()"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 5",
+            "Unexpected `(`",
+            "Expected `;`, whitespaces or end of input",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_missing_semi_column() {
+        let input = r#"
+          let x = 1;
+          let y = 2
+          y"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 4, column: 11",
+            "Unexpected `y`",
+            "Expected `;`, whitespaces or end of input",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_let_statement() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 14",
+            "Unexpected end of input",
+            "Expected whitespace, letter, digit or `_`",
+            "Unable to parse binding variable",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_if_cond() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = { if x > y 1 else 0 };
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 35",
+            "Unexpected `1`",
+            "Expected whitespace or then",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_pattern_match() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = match x {
+            ok(x) => x
+            err(x) => x,
+          };
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 7, column: 13",
+            "Unexpected `e`",
+            "Expected whitespace or `}`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_err() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = err1(x);
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 27",
+            "Unexpected `1`",
+            "Expected `(`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_ok() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = ok1(x);
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 26",
+            "Unexpected `1`",
+            "Expected `(`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_option_some() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = some1(x);
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 28",
+            "Unexpected `1`",
+            "Expected `(`",
+            "Invalid syntax for Option type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_invalid_tuple() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = (x, y, z;
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 32",
+            "Unexpected `;`",
+            "Expected `,`, whitespaces or `)`",
+            "Invalid syntax for tuple type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_invalid_sequence() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = [x, y, z;
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 32",
+            "Unexpected `;`",
+            "Expected `,`, whitespaces or `]`",
+            "Invalid syntax for sequence type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_invalid_flag() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = {x, y, z;
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 26",
+            "Unexpected `,`",
+            "Expected whitespace or `}`",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn test_syntax_error_in_rib_program_invalid_record() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = {a : b, c : d;
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 27",
+            "Unexpected `:`",
+            "Expected whitespace or `}`",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+}

--- a/golem-rib/src/parser/flag.rs
+++ b/golem-rib/src/parser/flag.rs
@@ -21,21 +21,24 @@ use combine::{
 
 use crate::expr::Expr;
 use combine::sep_by;
-use combine::stream::easy;
 
-pub fn flag<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
+pub fn flag<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
     let flag_name = many1(letter().or(char_('_')).or(digit()).or(char_('-')))
         .map(|s: Vec<char>| s.into_iter().collect());
 
-    spaces().with(
-        between(
-            char_('{').skip(spaces()),
-            char_('}').skip(spaces()),
-            sep_by(flag_name.skip(spaces()), char_(',').skip(spaces())),
+    spaces()
+        .with(
+            between(
+                char_('{').skip(spaces()),
+                char_('}').skip(spaces()),
+                sep_by(flag_name.skip(spaces()), char_(',').skip(spaces())),
+            )
+            .map(Expr::flags),
         )
-        .map(Expr::flags)
-        .message("Unable to parse flag"),
-    )
+        .message("Invalid syntax for flag type")
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/literal.rs
+++ b/golem-rib/src/parser/literal.rs
@@ -15,12 +15,12 @@
 use crate::expr::Expr;
 
 use crate::parser::literal::internal::literal_;
-use combine::{easy, parser, Stream};
+use combine::{parser, Stream};
 
 parser! {
-    pub fn literal['t]()(easy::Stream<&'t str>) -> Expr
+    pub fn literal[Input]()(Input) -> Expr
     where [
-        easy::Stream<&'t str>: Stream<Token = char>,
+        Input: Stream<Token = char>
     ]
     {
         literal_()
@@ -29,35 +29,42 @@ parser! {
 
 mod internal {
     use crate::expr::Expr;
-    use crate::parser::rib_expr::rib_program;
-    use combine::parser::char::{char as char_, letter, space};
+    use crate::parser::rib_expr::rib_expr;
+    use combine::parser::char::{char as char_, char, letter, space};
     use combine::parser::char::{digit, spaces};
     use combine::parser::repeat::many;
-    use combine::stream::easy;
-    use combine::{attempt, between, choice, many1, Parser};
+
+    use combine::{between, choice, many1, sep_by, Parser};
 
     // Literal can handle string interpolation
-    pub fn literal_<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-        spaces().with(
-            between(
-                char_('\"'),
-                char_('\"'),
-                many(choice((attempt(interpolation()), static_part()))),
+    pub fn literal_<Input>() -> impl Parser<Input, Output = Expr>
+    where
+        Input: combine::Stream<Token = char>,
+    {
+        spaces()
+            .with(
+                between(
+                    char_('\"'),
+                    char_('\"'),
+                    many(choice((interpolation(), static_part()))),
+                )
+                .map(|parts: Vec<Expr>| {
+                    if parts.is_empty() {
+                        Expr::literal("")
+                    } else if parts.len() == 1 {
+                        parts.first().unwrap().clone()
+                    } else {
+                        Expr::concat(parts)
+                    }
+                }),
             )
-            .map(|parts: Vec<Expr>| {
-                if parts.is_empty() {
-                    Expr::literal("")
-                } else if parts.len() == 1 {
-                    parts.first().unwrap().clone()
-                } else {
-                    Expr::concat(parts)
-                }
-            })
-            .message("Unable to parse literal"),
-        )
+            .message("Invalid literal")
     }
 
-    fn static_part<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
+    fn static_part<Input>() -> impl Parser<Input, Output = Expr>
+    where
+        Input: combine::Stream<Token = char>,
+    {
         many1(
             letter().or(space()).or(digit()).or(char_('_').or(char_('-')
                 .or(char_('.'))
@@ -68,11 +75,31 @@ mod internal {
         .message("Unable to parse static part of literal")
     }
 
-    fn interpolation<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
+    fn interpolation<Input>() -> impl Parser<Input, Output = Expr>
+    where
+        Input: combine::Stream<Token = char>,
+    {
         between(
             char_('$').with(char_('{')).skip(spaces()),
             char_('}'),
-            rib_program(),
+            block(),
+        )
+    }
+
+    pub fn block<Input>() -> impl Parser<Input, Output = Expr>
+    where
+        Input: combine::Stream<Token = char>,
+    {
+        spaces().with(
+            sep_by(rib_expr().skip(spaces()), char(';').skip(spaces())).map(
+                |expressions: Vec<Expr>| {
+                    if expressions.len() == 1 {
+                        expressions.first().unwrap().clone()
+                    } else {
+                        Expr::multiple(expressions)
+                    }
+                },
+            ),
         )
     }
 }
@@ -80,7 +107,8 @@ mod internal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::rib_expr::rib_expr;
+    use crate::parser::rib_expr::{rib_expr, rib_program};
+    use combine::stream::position;
     use combine::EasyParser;
 
     #[test]
@@ -98,19 +126,18 @@ mod tests {
     }
 
     #[test]
-    fn test_literal_with_interpolation() {
+    fn test_literal_with_interpolation11() {
         let input = "\"foo-${bar}-baz\"";
-        let result = rib_expr().easy_parse(input);
+        let result = rib_program()
+            .easy_parse(position::Stream::new(input))
+            .map(|x| x.0);
         assert_eq!(
             result,
-            Ok((
-                Expr::concat(vec![
-                    Expr::literal("foo-"),
-                    Expr::identifier("bar"),
-                    Expr::literal("-baz"),
-                ]),
-                ""
-            ))
+            Ok(Expr::concat(vec![
+                Expr::literal("foo-"),
+                Expr::identifier("bar"),
+                Expr::literal("-baz"),
+            ]))
         );
     }
 

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -16,6 +16,7 @@ mod binary_comparison;
 mod boolean;
 pub(crate) mod call;
 mod cond;
+mod errors;
 mod flag;
 mod identifier;
 mod let_binding;

--- a/golem-rib/src/parser/not.rs
+++ b/golem-rib/src/parser/not.rs
@@ -15,15 +15,19 @@
 use crate::expr::Expr;
 use crate::parser::rib_expr::rib_expr;
 use combine::parser::char::{spaces, string};
-use combine::stream::easy;
 use combine::Parser;
 
-pub fn not<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-    spaces().with(
-        (string("!").skip(spaces()), rib_expr())
-            .map(|(_, expr)| Expr::not(expr))
-            .message("Unable to parse not"),
-    )
+pub fn not<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
+    spaces()
+        .with(
+            (string("!").skip(spaces()), rib_expr())
+                .map(|(_, expr)| Expr::not(expr))
+                .message("Unable to parse not"),
+        )
+        .message("Unable to parse not")
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/optional.rs
+++ b/golem-rib/src/parser/optional.rs
@@ -13,23 +13,24 @@
 // limitations under the License.
 
 use combine::{
-    between, choice,
-    parser::char::{char, spaces, string},
+    attempt, between,
+    parser::char::{char, string},
     Parser,
 };
 
 use crate::expr::Expr;
 
 use super::rib_expr::rib_expr;
-use combine::stream::easy;
 
-pub fn option<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-    choice((
-        spaces().with(
-            between(string("some("), char(')'), rib_expr()).map(|expr| Expr::option(Some(expr))),
-        ),
-        spaces().with(string("none").map(|_| Expr::option(None))),
-    ))
+pub fn option<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
+    attempt(string("some"))
+        .with(between(char('('), char(')'), rib_expr()))
+        .map(|expr| Expr::option(Some(expr)))
+        .or(attempt(string("none")).map(|_| Expr::option(None)))
+        .message("Invalid syntax for Option type")
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/sequence.rs
+++ b/golem-rib/src/parser/sequence.rs
@@ -18,18 +18,21 @@ use combine::sep_by;
 use combine::{between, Parser};
 
 use crate::parser::rib_expr::rib_expr;
-use combine::stream::easy;
 
-pub fn sequence<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Expr> {
-    spaces().with(
-        between(
-            char('['),
-            char(']'),
-            sep_by(rib_expr(), char(',').skip(spaces())),
+pub fn sequence<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+{
+    spaces()
+        .with(
+            between(
+                char('['),
+                char(']'),
+                sep_by(rib_expr(), char(',').skip(spaces())),
+            )
+            .map(Expr::sequence),
         )
-        .map(Expr::sequence)
-        .message("Unable to parse sequece"),
-    )
+        .message("Invalid syntax for sequence type")
 }
 
 #[cfg(test)]

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -18,7 +18,7 @@ use combine::parser;
 use combine::parser::char;
 use combine::parser::char::{char, spaces, string};
 use combine::parser::choice::choice;
-use combine::{attempt, between, easy, sep_by, Parser, Stream};
+use combine::{attempt, between, sep_by, Parser};
 use golem_api_grpc::proto::golem::rib::type_name::Kind as InnerTypeName;
 use golem_api_grpc::proto::golem::rib::{
     BasicTypeName, ListType, OptionType, TupleType, TypeName as ProtoTypeName,
@@ -188,7 +188,10 @@ impl From<TypeName> for InferredType {
     }
 }
 
-pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+pub fn parse_basic_type<Input>() -> impl Parser<Input, Output = TypeName>
+where
+    Input: combine::Stream<Token = char>,
+{
     choice((
         attempt(string("bool").map(|_| TypeName::Bool)),
         attempt(string("s8").map(|_| TypeName::S8)),
@@ -207,7 +210,10 @@ pub fn parse_basic_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Typ
     .skip(spaces())
 }
 
-pub fn parse_list_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+pub fn parse_list_type<Input>() -> impl Parser<Input, Output = TypeName>
+where
+    Input: combine::Stream<Token = char>,
+{
     string("list")
         .skip(spaces())
         .with(between(
@@ -218,7 +224,10 @@ pub fn parse_list_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Type
         .map(|inner_type| TypeName::List(Box::new(inner_type)))
 }
 
-pub fn parse_option_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+pub fn parse_option_type<Input>() -> impl Parser<Input, Output = TypeName>
+where
+    Input: combine::Stream<Token = char>,
+{
     string("option")
         .skip(spaces())
         .with(between(
@@ -229,7 +238,10 @@ pub fn parse_option_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Ty
         .map(|inner_type| TypeName::Option(Box::new(inner_type)))
 }
 
-pub fn parse_tuple_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+pub fn parse_tuple_type<Input>() -> impl Parser<Input, Output = TypeName>
+where
+    Input: combine::Stream<Token = char>,
+{
     string("tuple")
         .skip(spaces())
         .with(between(
@@ -240,7 +252,10 @@ pub fn parse_tuple_type<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Typ
         .map(TypeName::Tuple)
 }
 
-pub fn parse_type_name_<'t>() -> impl Parser<easy::Stream<&'t str>, Output = TypeName> {
+pub fn parse_type_name_<Input>() -> impl Parser<Input, Output = TypeName>
+where
+    Input: combine::Stream<Token = char>,
+{
     spaces().with(choice((
         attempt(parse_basic_type()),
         attempt(parse_list_type()),
@@ -250,10 +265,8 @@ pub fn parse_type_name_<'t>() -> impl Parser<easy::Stream<&'t str>, Output = Typ
 }
 
 parser! {
-    pub fn parse_type_name['t]()(easy::Stream<&'t str>) -> TypeName
-    where [
-        easy::Stream<&'t str>: Stream<Token = char>,
-    ]
+    pub fn parse_type_name[Input]()(Input) -> TypeName
+     where [Input: combine::Stream<Token = char>]
     {
        parse_type_name_()
     }

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -1617,7 +1617,7 @@ mod tests {
         let noop_executor = DefaultEvaluator::noop();
 
         let expr = rib::from_string(
-            "${let err_n: u64 = 2; match err(\"afsal\") { ok(_) => ok(\"1\"), err(msg) => err(err_n) }}",
+            "${let xyz: u64 = 2; match err(\"afsal\") { ok(_) => ok(\"1\"), err(msg) => err(xyz) }}",
         )
         .unwrap();
 


### PR DESCRIPTION
## Precise error messages 

For an invalid syntax such as the following:

```rust
match foo
  ok(x) => x,
  err(x) => x
}
```

Main branch behaviour:

```scala
Failed to parse: "${match request.id ok(x) => x, err(x) => x }}"
```

## PR branch behaviour


```scala
Parse error at line: 2, column: 1
Unexpected `o`
Expected whitespace or `{`
Invalid syntax for pattern match
```

* Points to the exact line number and column number using Stream Input `position::Stream`
* Better errors (as much as possible). There are corner cases or ambiguous cases such as an invalid expression  `{a` could be  a flag or a record, and it cannot say the exact error but just saying `missing :` or `missing }` in specific location in the code. Also I am stopping it here as this is far better than what we have in main branch.
* Proper use of `eof` instead of partial parsing and fail if there is anything remaining.
* A few minor issues  are raised as part of fixing this issue. Example: https://github.com/golemcloud/golem/issues/943


## Performance improvement (although not the concern of this PR)
While this PR wasn't really concerned with optimization (and therefore no specific benchmark tests), just putting some numbers here to give the reviewers about the importance of the subtle changes done in this PR. Mainly this is an outcome that I had to reduce the backtracking as much as possible to avoid suppression of errors. Avoidance of backtracking involves specific decisions to be made in different parts of the parser.

|Rib Module |Total tests| Time Taken (Main branch) | Time Taken (PR branch) | Remarks |
|--|--|--|--|--|
|text(read+write)|87|~10s|~0.1s| All combinations - Ex: record of sequence, record of record, sequence of record etc. This is why significant difference compared to rest of the modules|
|parser(read)|171|~1s |~0.1s| These are mostly simple Rib expressions compared to roundtrip tests, yet there is difference here
| across-all-modules|400|14s |~0.3s|  Includes more tests for compilation and final execution of Rib.|


 In general, backtracking heavily slowed down Rib parsing before. That said, avoiding backtracking now resulted in subtle/nuance precise `attempts` in only certain parts of the code.  Even if this is all part of pre-compilation, 15s vs 0.1s just for test cases is significant and shouldn't be regressed in future as it is a sign of major issue in the logic. Therefore benchmark tests for Rib (separate task) are required to avoid  performance regression in future.

### TODO
- [x] Support position::Stream
- [x] Reduce backtracking
- [x] All existing test pass
- [x] Precise error tests
- [x] More negative tests
- [x] Some syntax errors in `Record` is showing error as `unable to parse block`. Need to see why.
