### PR TITLE
Explicit RibParseError, avoid `expect`s in parsers and handle keywords properly

### DIFF
--- a/golem-rib/src/parser/binary_comparison.rs
+++ b/golem-rib/src/parser/binary_comparison.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::expr::Expr;
-use crate::InferredType;
 use combine::parser::char::{spaces, string};
-use combine::{attempt, choice, Parser};
+use combine::{attempt, choice, ParseError, Parser};
+
+use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
+use crate::InferredType;
 
 pub fn binary<Input>(
     left_expr: impl Parser<Input, Output = Expr>,
@@ -23,6 +25,9 @@ pub fn binary<Input>(
 ) -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     spaces().with(
         (
@@ -55,9 +60,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::parser::rib_expr::rib_expr;
     use combine::EasyParser;
+
+    use crate::parser::rib_expr::rib_expr;
+
+    use super::*;
 
     #[test]
     fn test_greater_than() {

--- a/golem-rib/src/parser/boolean.rs
+++ b/golem-rib/src/parser/boolean.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::expr::Expr;
 use combine::parser::char::spaces;
 use combine::parser::char::string;
-use combine::{attempt, Parser};
+use combine::{attempt, ParseError, Parser};
+
+use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
 
 pub fn boolean_literal<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     attempt(string("true"))
         .map(|_| Expr::boolean(true))
@@ -30,9 +35,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::parser::rib_expr::rib_expr;
     use combine::EasyParser;
+
+    use crate::parser::rib_expr::rib_expr;
+
+    use super::*;
 
     #[test]
     fn test_boolean_true() {

--- a/golem-rib/src/parser/errors.rs
+++ b/golem-rib/src/parser/errors.rs
@@ -1,230 +1,49 @@
-// A curated list of most common syntax errors, with the intent
-// not regress user-facing error messages with changing parsing logic
-#[cfg(test)]
-mod error_tests {
+use std::fmt::Display;
 
+use serde::de::StdError;
+
+// Custom error type to hold specific error messages within individual parser
+// which later gets converted to StreamError
+#[derive(Debug, PartialEq, Clone)]
+pub enum RibParseError {
+    Message(String),
+}
+
+impl Display for RibParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RibParseError::Message(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl StdError for RibParseError {
+    fn description(&self) -> &str {
+        match self {
+            RibParseError::Message(msg) => msg,
+        }
+    }
+}
+
+// A curated list of most common syntax errors, with the intent
+// to not regress user-facing error messages with changing parsing logic
+#[cfg(test)]
+mod invalid_syntax_tests {
     use crate::Expr;
 
     #[test]
-    fn test_pattern_match_error_missing_opening_curly_brace() {
-        let input = r#"match foo
-            ok(x) => x,
-            err(x) => x,
-            _ => bar,
-          }"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 2, column: 13",
-            "Unexpected `o`",
-            "Expected whitespace or `{`",
-            "Invalid syntax for pattern match",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_pattern_match_error_missing_closing_curly_brace() {
-        let input = r#"match foo {
-            ok(x) => x,
-            err(x) => x,
-            _ => bar
-          "#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 5, column: 11",
-            "Unexpected end of input",
-            "Expected whitespace or `}`",
-            "Invalid syntax for pattern match",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    // TODO; Missing comma since we have multiple arms is a better error message
-    // This requires change in parsing logic to avoid using sep_by1
-    #[test]
-    fn test_pattern_match_error_missing_comma_between_arms() {
-        let input = r#"match foo {
-            ok(x) => x
-            err(x) => x,
-            _ => bar,
-          }"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 3, column: 13",
-            "Unexpected `e`",
-            "Expected whitespace or `}`",
-            "Invalid syntax for pattern match",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_pattern_match_error_missing_arrow() {
-        let input = r#"match foo {
-            ok(x) x,
-            err(x) => x,
-            _ => bar,
-          }"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 2, column: 19",
-            "Unexpected `x`",
-            "Expected whitespace or =>",
-            "Invalid syntax for pattern match",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_let_binding_error_missing_variable() {
-        let input = r#"let = 1;"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 5",
-            "Unexpected `=`",
-            "Expected whitespace, letter, digit or `_`",
-            "Unable to parse binding variable",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_let_binding_error_missing_assignment() {
-        let input = r#"let x 1;"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 7",
-            "Unexpected `1`",
-            "Expected whitespace, `:`, whitespaces, bool, s8, u8, s16, u16, s32, u32, s64, u64, f32, f64, chr, str, list, tuple, option or `=`",
-            ""
-        ].join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-    #[test]
-    fn test_conditional_no_then() {
-        let input = r#"if x 1 else 2"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 6",
-            "Unexpected `1`",
-            "Expected whitespace or then",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_result_ok_missing_braces() {
-        let input = r#"ok(1"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 5",
-            "Unexpected end of input",
-            "Expected whitespace or `)`",
-            "Invalid syntax for Result type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_result_err_missing_braces() {
-        let input = r#"err(1"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 6",
-            "Unexpected end of input",
-            "Expected whitespace or `)`",
-            "Invalid syntax for Result type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_option_some_missing_braces() {
-        let input = r#"some(1"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 7",
-            "Unexpected end of input",
-            "Expected whitespace or `)`",
-            "Invalid syntax for Option type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_option_none_redundant_braces() {
-        let input = r#"none()"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 1, column: 5",
-            "Unexpected `(`",
-            "Expected `;`, whitespaces or end of input",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_syntax_error_in_rib_program_missing_semi_column() {
-        let input = r#"
-          let x = 1;
-          let y = 2
-          y"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 4, column: 11",
-            "Unexpected `y`",
-            "Expected `;`, whitespaces or end of input",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_syntax_error_in_rib_program_let_statement() {
+    fn dangling_some_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
           let z = 3;
-          let"#;
+          let result = some [x);
+          result"#;
         let result = Expr::from_text(input);
         let expected_error = [
-            "Parse error at line: 5, column: 14",
-            "Unexpected end of input",
-            "Expected whitespace, letter, digit or `_`",
-            "Unable to parse binding variable",
+            "Parse error at line: 5, column: 24",
+            "some is a keyword",
+            "Invalid identifier",
             "",
         ]
         .join("\n");
@@ -233,7 +52,47 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_if_cond() {
+    fn dangling_ok_in_rib_program() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = ok [x);
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 24",
+            "ok is a keyword",
+            "Invalid identifier",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn dangling_err_in_rib_program() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = err [x);
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 24",
+            "err is a keyword",
+            "Invalid identifier",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn invalid_conditional_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
@@ -253,7 +112,27 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_pattern_match() {
+    fn invalid_flag_in_rib_program() {
+        let input = r#"
+          let x = 1;
+          let y = 2;
+          let z = 3;
+          let result = {x, y, z;
+          result"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 26",
+            "Unexpected `,`",
+            "Expected whitespace or `}`",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn invalid_pattern_match_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
@@ -277,19 +156,18 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_err() {
+    fn invalid_record_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
           let z = 3;
-          let result = err1(x);
+          let result = {a : b, c : d;
           result"#;
         let result = Expr::from_text(input);
         let expected_error = [
             "Parse error at line: 5, column: 27",
-            "Unexpected `1`",
-            "Expected `(`",
-            "Invalid syntax for Result type",
+            "Unexpected `:`",
+            "Expected whitespace or `}`",
             "",
         ]
         .join("\n");
@@ -298,70 +176,7 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_ok() {
-        let input = r#"
-          let x = 1;
-          let y = 2;
-          let z = 3;
-          let result = ok1(x);
-          result"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 5, column: 26",
-            "Unexpected `1`",
-            "Expected `(`",
-            "Invalid syntax for Result type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_syntax_error_in_rib_program_option_some() {
-        let input = r#"
-          let x = 1;
-          let y = 2;
-          let z = 3;
-          let result = some1(x);
-          result"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 5, column: 28",
-            "Unexpected `1`",
-            "Expected `(`",
-            "Invalid syntax for Option type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_syntax_error_in_rib_program_invalid_tuple() {
-        let input = r#"
-          let x = 1;
-          let y = 2;
-          let z = 3;
-          let result = (x, y, z;
-          result"#;
-        let result = Expr::from_text(input);
-        let expected_error = [
-            "Parse error at line: 5, column: 32",
-            "Unexpected `;`",
-            "Expected `,`, whitespaces or `)`",
-            "Invalid syntax for tuple type",
-            "",
-        ]
-        .join("\n");
-
-        assert_eq!(result, Err(expected_error));
-    }
-
-    #[test]
-    fn test_syntax_error_in_rib_program_invalid_sequence() {
+    fn invalid_sequence_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
@@ -382,18 +197,19 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_invalid_flag() {
+    fn invalid_tuple_in_rib_program() {
         let input = r#"
           let x = 1;
           let y = 2;
           let z = 3;
-          let result = {x, y, z;
+          let result = (x, y, z;
           result"#;
         let result = Expr::from_text(input);
         let expected_error = [
-            "Parse error at line: 5, column: 26",
-            "Unexpected `,`",
-            "Expected whitespace or `}`",
+            "Parse error at line: 5, column: 32",
+            "Unexpected `;`",
+            "Expected `,`, whitespaces or `)`",
+            "Invalid syntax for tuple type",
             "",
         ]
         .join("\n");
@@ -402,18 +218,174 @@ mod error_tests {
     }
 
     #[test]
-    fn test_syntax_error_in_rib_program_invalid_record() {
-        let input = r#"
-          let x = 1;
-          let y = 2;
-          let z = 3;
-          let result = {a : b, c : d;
-          result"#;
+    fn missing_arrow_in_pattern_match() {
+        let input = r#"match foo {
+            ok(x) x,
+            err(x) => x,
+            _ => bar,
+          }"#;
         let result = Expr::from_text(input);
         let expected_error = [
-            "Parse error at line: 5, column: 27",
-            "Unexpected `:`",
+            "Parse error at line: 2, column: 19",
+            "Unexpected `x`",
+            "Expected whitespace or =>",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_closing_bracket_in_err() {
+        let input = r#"err(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 6",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_closing_bracket_in_ok() {
+        let input = r#"ok(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 5",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Result type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_closing_bracket_in_some() {
+        let input = r#"some(1"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 7",
+            "Unexpected end of input",
+            "Expected whitespace or `)`",
+            "Invalid syntax for Option type",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_closing_braces_in_pattern_match() {
+        let input = r#"match foo {
+            ok(x) => x,
+            err(x) => x,
+            _ => bar
+          "#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 5, column: 11",
+            "Unexpected end of input",
             "Expected whitespace or `}`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_comma_in_pattern_match() {
+        let input = r#"match foo {
+            ok(x) => x
+            err(x) => x,
+            _ => bar,
+          }"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 3, column: 13",
+            "Unexpected `e`",
+            "Expected whitespace or `}`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_opening_braces_in_pattern_match() {
+        let input = r#"match foo
+            ok(x) => x,
+            err(x) => x,
+            _ => bar,
+          }"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 2, column: 13",
+            "Unexpected `o`",
+            "Expected whitespace or `{`",
+            "Invalid syntax for pattern match",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_semi_column() {
+        let input = r#"
+          let x = 1;
+          let y = 2
+          y"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 4, column: 11",
+            "Unexpected `y`",
+            "Expected `;`, whitespaces or end of input",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn missing_then_in_conditional() {
+        let input = r#"if x 1 else 2"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 6",
+            "Unexpected `1`",
+            "Expected whitespace or then",
+            "",
+        ]
+        .join("\n");
+
+        assert_eq!(result, Err(expected_error));
+    }
+
+    #[test]
+    fn redundant_parenthesis_in_none() {
+        let input = r#"none()"#;
+        let result = Expr::from_text(input);
+        let expected_error = [
+            "Parse error at line: 1, column: 5",
+            "Unexpected `(`",
+            "Expected `;`, whitespaces or end of input",
             "",
         ]
         .join("\n");

--- a/golem-rib/src/parser/flag.rs
+++ b/golem-rib/src/parser/flag.rs
@@ -13,18 +13,22 @@
 // limitations under the License.
 
 use combine::parser::char::digit;
+use combine::sep_by;
 use combine::{
     between, many1,
     parser::char::{char as char_, letter, spaces},
-    Parser,
+    ParseError, Parser,
 };
 
 use crate::expr::Expr;
-use combine::sep_by;
+use crate::parser::errors::RibParseError;
 
 pub fn flag<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     let flag_name = many1(letter().or(char_('_')).or(digit()).or(char_('-')))
         .map(|s: Vec<char>| s.into_iter().collect());
@@ -43,10 +47,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use combine::EasyParser;
+
     use crate::parser::rib_expr::rib_expr;
 
     use super::*;
-    use combine::EasyParser;
 
     #[test]
     fn test_empty_flag() {

--- a/golem-rib/src/parser/not.rs
+++ b/golem-rib/src/parser/not.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::expr::Expr;
-use crate::parser::rib_expr::rib_expr;
 use combine::parser::char::{spaces, string};
-use combine::Parser;
+use combine::{ParseError, Parser};
+
+use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
+use crate::parser::rib_expr::rib_expr;
 
 pub fn not<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     spaces()
         .with(
@@ -32,8 +37,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use combine::EasyParser;
+
+    use super::*;
 
     #[test]
     fn test_not_identifier() {

--- a/golem-rib/src/parser/result.rs
+++ b/golem-rib/src/parser/result.rs
@@ -12,36 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use combine::parser::char::spaces;
 use combine::{
     attempt, choice,
     parser::char::{char, string},
-    Parser,
+    ParseError, Parser,
 };
 
-use combine::parser::char::spaces;
-
 use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
 
 use super::rib_expr::rib_expr;
 
 pub fn result<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     choice((
-        attempt(string("ok")).with(
-            (char('('), rib_expr().skip(spaces()), char(')')).map(|(_, expr, _)| Expr::ok(expr)),
-        ),
-        attempt(string("err")).with(
-            (char('('), rib_expr().skip(spaces()), char(')')).map(|(_, expr, _)| Expr::err(expr)),
-        ),
+        attempt(string("ok").skip(char('(')))
+            .with((rib_expr().skip(spaces()), char(')')).map(|(expr, _)| Expr::ok(expr))),
+        attempt(string("err").skip(char('(')))
+            .with((rib_expr().skip(spaces()), char(')')).map(|(expr, _)| Expr::err(expr))),
     ))
     .message("Invalid syntax for Result type")
 }
+
 #[cfg(test)]
 mod tests {
-    use super::*;
     use combine::EasyParser;
+
+    use super::*;
 
     #[test]
     fn test_result() {

--- a/golem-rib/src/parser/sequence.rs
+++ b/golem-rib/src/parser/sequence.rs
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::expr::Expr;
 use combine::parser::char::{char, spaces};
-use combine::sep_by;
 use combine::{between, Parser};
+use combine::{sep_by, ParseError};
 
+use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
 use crate::parser::rib_expr::rib_expr;
 
 pub fn sequence<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     spaces()
         .with(
@@ -37,8 +41,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use combine::EasyParser;
+
+    use super::*;
 
     #[test]
     fn test_empty_sequence() {

--- a/golem-rib/src/parser/tuple.rs
+++ b/golem-rib/src/parser/tuple.rs
@@ -15,16 +15,20 @@
 use combine::{
     between,
     parser::char::{char, spaces},
-    sep_by, Parser,
+    sep_by, ParseError, Parser,
 };
 
 use crate::expr::Expr;
+use crate::parser::errors::RibParseError;
 
 use super::rib_expr::rib_expr;
 
 pub fn tuple<Input>() -> impl Parser<Input, Output = Expr>
 where
     Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
 {
     spaces()
         .with(
@@ -40,9 +44,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use combine::stream::position;
     use combine::EasyParser;
+
+    use super::*;
 
     #[test]
     fn test_empty_tuple() {


### PR DESCRIPTION
Fixes #943 

Given below are some examples showing how this PR improved/fixed Rib behaviour from a user perspective

* `let let = 1;` was allowed before. This is not allowed anymore.

* `{ err : "foo" }` wasn't allowed before. Now we allow it! Field names can be `err`, or `ok` or such keywords. The idea here is names in `record` are more-or-less text itself. The only difference is they are not wrapped in `quotes` following WASM-WAVE syntax.

* `some1((x)` wasn't allowed before.  Likewise `err1`, `none1`, `match1` etall used to fail. Obviously users can write their own variants having such names. 

### Fundamental changes
* Proper Custom Error called `RibParseError` which can be used only if there is constraints that talks about conversion to combine's native StreamError. This is a very nice feature in combine, that we can have our own errors, but still consider everything as combine's `ParseError`. There is more to it, but they are library details

* With above, we remove all `expects`  in parsers. It is to be noted `combine` libraries examples uses `expect` but pretty sure, its not giving the intended behavior.

* An identifier can be alpha numeric allowing `-` and `_` but it shouldn't be any of the keywords such as `if`, `then`, `else`. 

* With the reduced backtracking, parser also got committed early resulting in prioritized parsers to fail without getting into `identifier` parser, such as `some1`.  The PR tries to solve it without bringing back the usage of `attempt`.

* The precise error messages are more precise due to these changes now. `let x = 1; let` result in `Invalid identifier. let is a keyword` rather than `unexpected eof` and so on. 

* Minor cleanups


With Grammar based fuzzing, or property based tests, we will tighten up all these behaviors even better. 