### PR TITLE
Fix component-service "add component type" sqlite migration

### DIFF
--- a/golem-component-service/db/migration/sqlite/002__add_component_type.sql
+++ b/golem-component-service/db/migration/sqlite/002__add_component_type.sql
@@ -1,2 +1,2 @@
 ALTER TABLE component_versions
-    ADD COLUMN IF NOT EXISTS component_type integer NOT NULL DEFAULT 0;
+    ADD COLUMN component_type integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
Sqlite does not support "IF NOT EXISTS", and we do have a migration table for checks, so let's drop it.