### PR TITLE
Fixes and tests for oplog enumeration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ futures-core = "0.3.29"
 futures-util = "0.3.29"
 git-version = "0.3.9"
 golem-wasm-ast = "1.0.1"
-golem-wasm-rpc = { version = "1.0.5", default-features = false, features = [
+golem-wasm-rpc = { version = "1.0.6", default-features = false, features = [
     "host",
 ] }
 

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -43,7 +43,7 @@ futures-util = { workspace = true }
 golem-examples = "1.0.6"
 golem-wasm-ast = { workspace = true }
 golem-wasm-rpc = { workspace = true }
-golem-wasm-rpc-stubgen = { version = "1.0.5", optional = true }
+golem-wasm-rpc-stubgen = { version = "1.0.6", optional = true }
 h2 = "0.3.24"
 http = { workspace = true }
 humansize = { workspace = true }

--- a/golem-common/src/model/exports.rs
+++ b/golem-common/src/model/exports.rs
@@ -108,7 +108,10 @@ pub fn find_resource_site(
                 resource: resource_name.to_string(),
             },
         );
-        if functions.iter().any(|f| f.name == constructor.to_string()) {
+        if functions
+            .iter()
+            .any(|f| f.name == constructor.function().function_name())
+        {
             Some(site)
         } else {
             None

--- a/golem-worker-executor-base/src/model/public_oplog/mod.rs
+++ b/golem-worker-executor-base/src/model/public_oplog/mod.rs
@@ -807,10 +807,7 @@ fn encode_host_function_request_as_value(
             Ok(payload.into_value_and_type())
         }
         "golem::rpc::wasm-rpc::generate_unique_local_worker_id" => no_payload(),
-        "cli::preopens::get_directories" => {
-            let payload: Result<Vec<String>, SerializableError> = try_deserialize(bytes)?;
-            Ok(payload.into_value_and_type())
-        }
+        "cli::preopens::get_directories" => no_payload(),
         "filesystem::types::descriptor::stat" => {
             let payload: String = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())

--- a/golem-worker-executor-base/tests/api.rs
+++ b/golem-worker-executor-base/tests/api.rs
@@ -2393,6 +2393,8 @@ async fn counter_resource_test_2(
 
     let (metadata2, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
 
+    let _oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(5)]));
@@ -2461,6 +2463,7 @@ async fn counter_resource_test_2(
             )
         })
         .collect::<Vec<_>>();
+
     check!(resources2 == vec![]);
 }
 

--- a/golem-worker-executor-base/tests/observability.rs
+++ b/golem-worker-executor-base/tests/observability.rs
@@ -76,7 +76,9 @@ async fn get_oplog_1(
 
     drop(executor);
 
-    assert_eq!(oplog.len(), 14);
+    // Whether there is an "enqueued invocation" entry or just directly started invocation
+    // depends on timing
+    assert!(oplog.len() >= 12 && oplog.len() <= 14);
     assert!(matches!(oplog[0], PublicOplogEntry::Create(_)));
     assert_eq!(
         oplog

--- a/integration-tests/tests/worker.rs
+++ b/integration-tests/tests/worker.rs
@@ -1205,7 +1205,9 @@ async fn get_oplog_1(deps: &EnvBasedTestDependencies, _tracing: &Tracing) {
 
     let oplog = deps.get_oplog(&worker_id, OplogIndex::INITIAL).await;
 
-    assert_eq!(oplog.len(), 14);
+    // Whether there is an "enqueued invocation" entry or just directly started invocation
+    // depends on oplog
+    assert!(oplog.len() >= 12 && oplog.len() <= 14);
     assert!(matches!(oplog[0], PublicOplogEntry::Create(_)));
     assert_eq!(
         oplog


### PR DESCRIPTION
Resolves https://github.com/golemcloud/golem/issues/1007

- Fixes some issues with the serialization of public oplog entries and the interpretation of the payloads
- Integrates https://github.com/golemcloud/wasm-rpc/pull/94
- Adds oplog query to more integration tests to cover more cases
- Stabilizes the flaky oplog enumeration tests 