### PR TITLE
Implement list comprehension and list aggregation

### DIFF
--- a/golem-api-grpc/proto/golem/rib/expr.proto
+++ b/golem-api-grpc/proto/golem/rib/expr.proto
@@ -36,6 +36,12 @@ message Expr {
     UnwrapExpr unwrap = 27;
     ThrowExpr throw = 28;
     OrExpr or = 29;
+    ListComprehensionExpr list_comprehension = 30;
+    ListReduceExpr list_reduce = 31;
+    AddExpr add = 32;
+    SubtractExpr subtract = 33;
+    MultiplyExpr multiply = 34;
+    DivideExpr divide = 35;
   }
 }
 
@@ -148,6 +154,26 @@ message EqualToExpr {
 }
 
 message LessThanExpr {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message AddExpr {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message MultiplyExpr {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message SubtractExpr {
+  Expr left = 1;
+  Expr right = 2;
+}
+
+message DivideExpr {
   Expr left = 1;
   Expr right = 2;
 }
@@ -289,4 +315,18 @@ message DynamicIndexedResourceStaticMethodFunctionReference {
 message DynamicIndexedResourceDropFunctionReference {
   string resource = 1;
   repeated golem.rib.Expr resource_params = 2;
+}
+
+message ListComprehensionExpr {
+  string iterated_variable = 1;
+  Expr iterable_expr = 2;
+  Expr yield_expr = 3;
+}
+
+message ListReduceExpr {
+  string reduce_variable = 1;
+  string iterated_variable = 2;
+  Expr iterable_expr = 3;
+  Expr init_value_expr = 4;
+  Expr yield_expr = 5;
 }

--- a/golem-api-grpc/proto/golem/rib/ir.proto
+++ b/golem-api-grpc/proto/golem/rib/ir.proto
@@ -48,8 +48,8 @@ message RibIR {
         AdvanceIterator advance_iterator = 36;
         SinkToList sink_to_list = 37;
         PushToSink push_to_sink = 38;
-        wasm.ast.Type add = 39;
-        wasm.ast.Type subtract = 40;
+        wasm.ast.Type plus = 39;
+        wasm.ast.Type minus = 40;
         wasm.ast.Type multiply = 41;
         wasm.ast.Type divide = 42;
         IsEmpty is_empty = 43;

--- a/golem-api-grpc/proto/golem/rib/ir.proto
+++ b/golem-api-grpc/proto/golem/rib/ir.proto
@@ -43,6 +43,16 @@ message RibIR {
         And and = 31;
         CreateFunctionNameInstruction create_function_name = 32;
         Or or = 33;
+        ListToIterator list_to_iterator = 34;
+        CreateSink create_sink = 35;
+        AdvanceIterator advance_iterator = 36;
+        SinkToList sink_to_list = 37;
+        PushToSink push_to_sink = 38;
+        wasm.ast.Type add = 39;
+        wasm.ast.Type subtract = 40;
+        wasm.ast.Type multiply = 41;
+        wasm.ast.Type divide = 42;
+        IsEmpty is_empty = 43;
     }
 }
 
@@ -116,6 +126,7 @@ message GetTag {}
 message Negate {}
 message And {}
 message Or {}
+message IsEmpty{}
 
 message FunctionReferenceType {
   oneof type {
@@ -174,3 +185,14 @@ message IndexedResourceDrop {
   string resource_name = 1;
   uint32 arg_size = 2;
 }
+
+message SinkToList {}
+
+message PushToSink {}
+
+message AdvanceIterator {}
+
+message CreateSink {
+   wasm.ast.Type list_type = 1;
+}
+message ListToIterator {}

--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -155,14 +155,14 @@ mod internal {
                 let analysed_type = convert_to_analysed_type(expr, inferred_type)?;
                 stack.push(ExprState::from_expr(rhs.deref()));
                 stack.push(ExprState::from_expr(lhs.deref()));
-                instructions.push(RibIR::Add(analysed_type));
+                instructions.push(RibIR::Plus(analysed_type));
             }
             Expr::Minus(lhs, rhs, inferred_type) => {
                 let analysed_type = convert_to_analysed_type(expr, inferred_type)?;
 
                 stack.push(ExprState::from_expr(rhs.deref()));
                 stack.push(ExprState::from_expr(lhs.deref()));
-                instructions.push(RibIR::Subtract(analysed_type));
+                instructions.push(RibIR::Minus(analysed_type));
             }
             Expr::Divide(lhs, rhs, inferred_type) => {
                 let analysed_type = convert_to_analysed_type(expr, inferred_type)?;

--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -619,13 +619,17 @@ mod internal {
         stack.push(ExprState::from_ir(RibIR::ListToIterator));
 
         let loop_start_label = instruction_id.increment_mut();
+
         stack.push(ExprState::from_ir(RibIR::Label(loop_start_label.clone())));
 
         let exit_label = instruction_id.increment_mut();
+
         stack.push(ExprState::from_ir(RibIR::IsEmpty));
+
         stack.push(ExprState::from_ir(RibIR::JumpIfFalse(exit_label.clone())));
 
         stack.push(ExprState::from_ir(RibIR::AdvanceIterator));
+
         stack.push(ExprState::from_ir(RibIR::AssignVar(
             iterated_variable.clone(),
         )));
@@ -639,6 +643,7 @@ mod internal {
         stack.push(ExprState::from_ir(RibIR::Jump(loop_start_label)));
 
         stack.push(ExprState::from_ir(RibIR::Label(exit_label)));
+
         stack.push(ExprState::from_ir(RibIR::LoadVar(reduce_variable.clone())))
     }
 

--- a/golem-rib/src/compiler/desugar.rs
+++ b/golem-rib/src/compiler/desugar.rs
@@ -165,7 +165,7 @@ mod internal {
                     inferred_type.clone(),
                 );
 
-                let block = Expr::multiple(vec![assign_var, resolution.clone()]);
+                let block = Expr::expr_block(vec![assign_var, resolution.clone()]);
 
                 let branch = IfThenBranch {
                     condition: tag.unwrap_or(Expr::boolean(true)),
@@ -258,7 +258,7 @@ mod internal {
                             c
                         }
                     },
-                    body: Expr::multiple(resolution_body),
+                    body: Expr::expr_block(resolution_body),
                 })
             }
 
@@ -440,7 +440,7 @@ mod internal {
                             c
                         }
                     },
-                    body: Expr::multiple(resolution_body),
+                    body: Expr::expr_block(resolution_body),
                 })
             }
 
@@ -488,7 +488,7 @@ mod internal {
                             c
                         }
                     },
-                    body: Expr::multiple(resolution_body),
+                    body: Expr::expr_block(resolution_body),
                 })
             }
 
@@ -515,7 +515,7 @@ mod internal {
             pred_expr.inferred_type(),
         );
 
-        let block = Expr::multiple(vec![binding, resolution.clone()]);
+        let block = Expr::expr_block(vec![binding, resolution.clone()]);
         get_conditions(
             &MatchArm::new(inner_pattern.clone(), block),
             pred_expr,

--- a/golem-rib/src/compiler/ir.rs
+++ b/golem-rib/src/compiler/ir.rs
@@ -61,8 +61,8 @@ pub enum RibIR {
     Throw(String),
     GetTag,
     Concat(usize),
-    Add(AnalysedType),
-    Subtract(AnalysedType),
+    Plus(AnalysedType),
+    Minus(AnalysedType),
     Divide(AnalysedType),
     Multiply(AnalysedType),
     Negate,
@@ -296,8 +296,8 @@ impl TryFrom<ProtoRibIR> for RibIR {
                     |_| "Failed to convert CreateAndPushRecord".to_string(),
                 )?))
             }
-            Instruction::Add(value) => {
-                Ok(RibIR::Add((&value).try_into().map_err(|_| {
+            Instruction::Plus(value) => {
+                Ok(RibIR::Plus((&value).try_into().map_err(|_| {
                     "Failed to convert CreateAndPushRecord".to_string()
                 })?))
             }
@@ -306,8 +306,8 @@ impl TryFrom<ProtoRibIR> for RibIR {
                     "Failed to convert CreateAndPushRecord".to_string()
                 })?))
             }
-            Instruction::Subtract(value) => {
-                Ok(RibIR::Subtract((&value).try_into().map_err(|_| {
+            Instruction::Minus(value) => {
+                Ok(RibIR::Minus((&value).try_into().map_err(|_| {
                     "Failed to convert CreateAndPushRecord".to_string()
                 })?))
             }
@@ -488,8 +488,8 @@ impl From<RibIR> for ProtoRibIR {
             RibIR::AssignVar(value) => Instruction::AssignVar(value.into()),
             RibIR::LoadVar(value) => Instruction::LoadVar(value.into()),
             RibIR::CreateAndPushRecord(value) => Instruction::CreateAndPushRecord((&value).into()),
-            RibIR::Add(value) => Instruction::Add((&value).into()),
-            RibIR::Subtract(value) => Instruction::Subtract((&value).into()),
+            RibIR::Plus(value) => Instruction::Plus((&value).into()),
+            RibIR::Minus(value) => Instruction::Minus((&value).into()),
             RibIR::Multiply(value) => Instruction::Multiply((&value).into()),
             RibIR::Divide(value) => Instruction::Divide((&value).into()),
             RibIR::UpdateRecord(value) => Instruction::UpdateRecord(value),

--- a/golem-rib/src/inferred_type/mod.rs
+++ b/golem-rib/src/inferred_type/mod.rs
@@ -63,6 +63,21 @@ pub enum InferredType {
 }
 
 impl InferredType {
+    pub fn number() -> InferredType {
+        InferredType::OneOf(vec![
+            InferredType::U64,
+            InferredType::U32,
+            InferredType::U8,
+            InferredType::U16,
+            InferredType::S64,
+            InferredType::S32,
+            InferredType::S8,
+            InferredType::S16,
+            InferredType::F64,
+            InferredType::F32,
+        ])
+    }
+
     pub fn un_resolved(&self) -> bool {
         self.is_unknown() || self.is_one_of()
     }

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
-use crate::{RibInterpreterInput, VariableId};
+use crate::{RibInput, VariableId};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -61,7 +61,7 @@ impl InterpreterEnv {
         (self.call_worker_function_async)(function_name, args)
     }
 
-    pub fn from_input(env: &RibInterpreterInput) -> Self {
+    pub fn from_input(env: &RibInput) -> Self {
         let env = env
             .input
             .clone()
@@ -81,7 +81,7 @@ impl InterpreterEnv {
     }
 
     pub fn from(
-        input: &RibInterpreterInput,
+        input: &RibInput,
         call_worker_function_async: &RibFunctionInvoke,
     ) -> Self {
         let mut env = Self::from_input(input);

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::interpreter::result::RibInterpreterResult;
+use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
 use crate::VariableId;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
@@ -22,7 +22,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 pub struct InterpreterEnv {
-    pub env: HashMap<EnvironmentKey, RibInterpreterResult>,
+    pub env: HashMap<EnvironmentKey, RibInterpreterStackValue>,
     pub call_worker_function_async: RibFunctionInvoke,
 }
 
@@ -54,7 +54,7 @@ impl Default for InterpreterEnv {
 
 impl InterpreterEnv {
     pub fn new(
-        env: HashMap<EnvironmentKey, RibInterpreterResult>,
+        env: HashMap<EnvironmentKey, RibInterpreterStackValue>,
         call_worker_function_async: RibFunctionInvoke,
     ) -> Self {
         InterpreterEnv {
@@ -74,7 +74,12 @@ impl InterpreterEnv {
     pub fn from_input(env: HashMap<String, TypeAnnotatedValue>) -> Self {
         let env = env
             .into_iter()
-            .map(|(k, v)| (EnvironmentKey::from_global(k), RibInterpreterResult::Val(v)))
+            .map(|(k, v)| {
+                (
+                    EnvironmentKey::from_global(k),
+                    RibInterpreterStackValue::Val(v),
+                )
+            })
             .collect();
 
         InterpreterEnv {
@@ -92,11 +97,11 @@ impl InterpreterEnv {
         env
     }
 
-    pub fn insert(&mut self, key: EnvironmentKey, value: RibInterpreterResult) {
+    pub fn insert(&mut self, key: EnvironmentKey, value: RibInterpreterStackValue) {
         self.env.insert(key, value);
     }
 
-    pub fn lookup(&self, key: &EnvironmentKey) -> Option<&RibInterpreterResult> {
+    pub fn lookup(&self, key: &EnvironmentKey) -> Option<&RibInterpreterStackValue> {
         self.env.get(key)
     }
 }

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
-use crate::VariableId;
+use crate::{RibInterpreterInput, VariableId};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -53,16 +53,6 @@ impl Default for InterpreterEnv {
 }
 
 impl InterpreterEnv {
-    pub fn new(
-        env: HashMap<EnvironmentKey, RibInterpreterStackValue>,
-        call_worker_function_async: RibFunctionInvoke,
-    ) -> Self {
-        InterpreterEnv {
-            env,
-            call_worker_function_async,
-        }
-    }
-
     pub fn invoke_worker_function_async(
         &self,
         function_name: String,
@@ -71,8 +61,10 @@ impl InterpreterEnv {
         (self.call_worker_function_async)(function_name, args)
     }
 
-    pub fn from_input(env: HashMap<String, TypeAnnotatedValue>) -> Self {
+    pub fn from_input(env: &RibInterpreterInput) -> Self {
         let env = env
+            .input
+            .clone()
             .into_iter()
             .map(|(k, v)| {
                 (
@@ -89,11 +81,11 @@ impl InterpreterEnv {
     }
 
     pub fn from(
-        input: HashMap<String, TypeAnnotatedValue>,
-        call_worker_function_async: RibFunctionInvoke,
+        input: &RibInterpreterInput,
+        call_worker_function_async: &RibFunctionInvoke,
     ) -> Self {
         let mut env = Self::from_input(input);
-        env.call_worker_function_async = call_worker_function_async;
+        env.call_worker_function_async = call_worker_function_async.clone();
         env
     }
 

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -29,7 +29,7 @@ pub struct InterpreterEnv {
 impl Debug for InterpreterEnv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InterpreterEnv")
-            .field("env", &self.env)
+            .field("env", &self.env.iter())
             .finish()
     }
 }
@@ -96,8 +96,8 @@ impl InterpreterEnv {
         self.env.insert(key, value);
     }
 
-    pub fn lookup(&self, key: &EnvironmentKey) -> Option<RibInterpreterResult> {
-        self.env.get(key).cloned()
+    pub fn lookup(&self, key: &EnvironmentKey) -> Option<&RibInterpreterResult> {
+        self.env.get(key)
     }
 }
 

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -80,10 +80,7 @@ impl InterpreterEnv {
         }
     }
 
-    pub fn from(
-        input: &RibInput,
-        call_worker_function_async: &RibFunctionInvoke,
-    ) -> Self {
+    pub fn from(input: &RibInput, call_worker_function_async: &RibFunctionInvoke) -> Self {
         let mut env = Self::from_input(input);
         env.call_worker_function_async = call_worker_function_async.clone();
         env

--- a/golem-rib/src/interpreter/instruction_cursor.rs
+++ b/golem-rib/src/interpreter/instruction_cursor.rs
@@ -1,0 +1,52 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{InstructionId, RibByteCode, RibIR};
+
+pub struct RibByteCodeCursor {
+    byte_code: RibByteCode,
+    position: usize,
+}
+
+impl RibByteCodeCursor {
+    pub fn from_rib_byte_code(byte_code: RibByteCode) -> RibByteCodeCursor {
+        RibByteCodeCursor {
+            byte_code,
+            position: 0,
+        }
+    }
+
+    pub fn get_instruction(&mut self) -> Option<RibIR> {
+        if self.position < self.byte_code.instructions.len() {
+            let ir = self.byte_code.instructions[self.position].clone();
+            self.position += 1;
+            Some(ir)
+        } else {
+            None
+        }
+    }
+
+    pub fn move_to(&mut self, move_to: &InstructionId) -> Option<()> {
+        for (index, current_instruction) in self.byte_code.instructions.iter().enumerate() {
+            if let Some(label_id) = current_instruction.get_instruction_id() {
+                if label_id.index == move_to.index {
+                    self.position = index + 1;
+                    return Some(());
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/golem-rib/src/interpreter/interpreter_input.rs
+++ b/golem-rib/src/interpreter/interpreter_input.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 
@@ -10,7 +24,7 @@ pub struct RibInput {
 impl RibInput {
     pub fn empty() -> RibInput {
         RibInput {
-            input: HashMap::default()
+            input: HashMap::default(),
         }
     }
 

--- a/golem-rib/src/interpreter/interpreter_input.rs
+++ b/golem-rib/src/interpreter/interpreter_input.rs
@@ -22,12 +22,6 @@ pub struct RibInput {
 }
 
 impl RibInput {
-    pub fn empty() -> RibInput {
-        RibInput {
-            input: HashMap::default(),
-        }
-    }
-
     pub fn new(input: HashMap<String, TypeAnnotatedValue>) -> RibInput {
         RibInput { input }
     }

--- a/golem-rib/src/interpreter/interpreter_input.rs
+++ b/golem-rib/src/interpreter/interpreter_input.rs
@@ -1,0 +1,14 @@
+use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
+use std::collections::HashMap;
+
+// Acts as the structure to hold the global input values
+#[derive(Debug, Default)]
+pub struct RibInterpreterInput {
+    pub input: HashMap<String, TypeAnnotatedValue>,
+}
+
+impl RibInterpreterInput {
+    pub fn new(input: HashMap<String, TypeAnnotatedValue>) -> RibInterpreterInput {
+        RibInterpreterInput { input }
+    }
+}

--- a/golem-rib/src/interpreter/interpreter_input.rs
+++ b/golem-rib/src/interpreter/interpreter_input.rs
@@ -2,13 +2,25 @@ use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 
 // Acts as the structure to hold the global input values
-#[derive(Debug, Default)]
-pub struct RibInterpreterInput {
+#[derive(Debug, Default, Clone)]
+pub struct RibInput {
     pub input: HashMap<String, TypeAnnotatedValue>,
 }
 
-impl RibInterpreterInput {
-    pub fn new(input: HashMap<String, TypeAnnotatedValue>) -> RibInterpreterInput {
-        RibInterpreterInput { input }
+impl RibInput {
+    pub fn empty() -> RibInput {
+        RibInput {
+            input: HashMap::default()
+        }
+    }
+
+    pub fn new(input: HashMap<String, TypeAnnotatedValue>) -> RibInput {
+        RibInput { input }
+    }
+
+    pub fn merge(&self, other: RibInput) -> RibInput {
+        let mut cloned = self.clone();
+        cloned.input.extend(other.input);
+        cloned
     }
 }

--- a/golem-rib/src/interpreter/interpreter_result.rs
+++ b/golem-rib/src/interpreter/interpreter_result.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
 use crate::{GetLiteralValue, LiteralValue};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;

--- a/golem-rib/src/interpreter/interpreter_result.rs
+++ b/golem-rib/src/interpreter/interpreter_result.rs
@@ -1,4 +1,5 @@
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
+use crate::{GetLiteralValue, LiteralValue};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 
 pub enum RibResult {
@@ -32,5 +33,9 @@ impl RibResult {
             RibResult::Val(val) => Some(val.clone()),
             RibResult::Unit => None,
         }
+    }
+
+    pub fn get_literal(&self) -> Option<LiteralValue> {
+        self.get_val().and_then(|x| x.get_literal())
     }
 }

--- a/golem-rib/src/interpreter/interpreter_result.rs
+++ b/golem-rib/src/interpreter/interpreter_result.rs
@@ -1,4 +1,4 @@
-use crate::RibInterpreterStackValue;
+use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 
 pub enum RibResult {

--- a/golem-rib/src/interpreter/interpreter_result.rs
+++ b/golem-rib/src/interpreter/interpreter_result.rs
@@ -1,0 +1,36 @@
+use crate::RibInterpreterStackValue;
+use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
+
+pub enum RibResult {
+    Unit,
+    Val(TypeAnnotatedValue),
+}
+
+impl RibResult {
+    pub fn from_rib_interpreter_stack_value(
+        stack_value: &RibInterpreterStackValue,
+    ) -> Option<RibResult> {
+        match stack_value {
+            RibInterpreterStackValue::Unit => Some(RibResult::Unit),
+            RibInterpreterStackValue::Val(type_annotated_value) => {
+                Some(RibResult::Val(type_annotated_value.clone()))
+            }
+            RibInterpreterStackValue::Iterator(_) => None,
+            RibInterpreterStackValue::Sink(_, _) => None,
+        }
+    }
+
+    pub fn get_bool(&self) -> Option<bool> {
+        match self {
+            RibResult::Val(TypeAnnotatedValue::Bool(bool)) => Some(*bool),
+            RibResult::Val(_) => None,
+            RibResult::Unit => None,
+        }
+    }
+    pub fn get_val(&self) -> Option<TypeAnnotatedValue> {
+        match self {
+            RibResult::Val(val) => Some(val.clone()),
+            RibResult::Unit => None,
+        }
+    }
+}

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -18,6 +18,8 @@ use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_wasm_rpc::protobuf::typed_result::ResultValue;
 use std::fmt;
+use golem_wasm_rpc::json::TypeAnnotatedValueJsonExtensions;
+use poem_openapi::types::ToJSON;
 
 // A result of a function can be unit, which is not representable using type_annotated_value
 // A result can be a type_annotated_value
@@ -54,10 +56,10 @@ impl RibInterpreterStackValue {
                 ) {
                     Ok(op(left_lit, right_lit))
                 } else {
-                    Err("Failed to perform math operation".to_string())
+                    Err(format!("Unable to complete the math operation on {}, {}", left.to_json_string(), right.to_json_string()))
                 }
             }
-            _ => Err("Unable to perform math op as the values are not numbers".to_string()),
+            _ => Err("Failed to obtain values to complete the math operation".to_string()),
         }
     }
 

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -26,7 +26,7 @@ use std::fmt;
 pub enum RibInterpreterStackValue {
     Unit,
     Val(TypeAnnotatedValue),
-    Iterator(Box<dyn Iterator<Item = TypeAnnotatedValue>>),
+    Iterator(Box<dyn Iterator<Item = TypeAnnotatedValue> + Send>),
     Sink(Vec<TypeAnnotatedValue>, AnalysedType),
 }
 

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -18,7 +18,6 @@ use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_wasm_rpc::protobuf::typed_result::ResultValue;
 use std::fmt;
-use golem_wasm_rpc::json::TypeAnnotatedValueJsonExtensions;
 use poem_openapi::types::ToJSON;
 
 // A result of a function can be unit, which is not representable using type_annotated_value

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -17,8 +17,8 @@ use crate::CoercedNumericValue;
 use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_wasm_rpc::protobuf::typed_result::ResultValue;
-use std::fmt;
 use poem_openapi::types::ToJSON;
+use std::fmt;
 
 // A result of a function can be unit, which is not representable using type_annotated_value
 // A result can be a type_annotated_value
@@ -55,7 +55,11 @@ impl RibInterpreterStackValue {
                 ) {
                     Ok(op(left_lit, right_lit))
                 } else {
-                    Err(format!("Unable to complete the math operation on {}, {}", left.to_json_string(), right.to_json_string()))
+                    Err(format!(
+                        "Unable to complete the math operation on {}, {}",
+                        left.to_json_string(),
+                        right.to_json_string()
+                    ))
                 }
             }
             _ => Err("Failed to obtain values to complete the math operation".to_string()),

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -23,7 +23,7 @@ use std::fmt;
 // A result of a function can be unit, which is not representable using type_annotated_value
 // A result can be a type_annotated_value
 // A result can be a sink where it collects only the required elements from a possible iterable
-// A result can also be stored as an iterator, that in the future, we rely on the same mechanism to support streams without change of code.
+// A result can also be stored as an iterator, that its easy to stream through any iterables, given a sink is following it.
 pub enum RibInterpreterStackValue {
     Unit,
     Val(TypeAnnotatedValue),

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -42,10 +42,7 @@ pub async fn interpret(
 // This function can be used for those the Rib Scripts
 // where there are no side effecting function calls.
 // It is recommended to use `interpret` over `interpret_pure` if you are unsure.
-pub async fn interpret_pure(
-    rib: &RibByteCode,
-    rib_input: &RibInput,
-) -> Result<RibResult, String> {
+pub async fn interpret_pure(rib: &RibByteCode, rib_input: &RibInput) -> Result<RibResult, String> {
     let mut interpreter = Interpreter::pure(rib_input);
     interpreter.run(rib.clone()).await
 }

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 pub use env::RibFunctionInvoke;
+pub use interpreter_result::*;
+pub use interpreter_stack_value::*;
 pub use literal::*;
-pub use result::*;
 pub use rib_interpreter::*;
 
 use crate::RibByteCode;
@@ -22,8 +23,9 @@ use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 mod env;
 mod instruction_cursor;
+mod interpreter_result;
+mod interpreter_stack_value;
 mod literal;
-mod result;
 mod rib_interpreter;
 mod stack;
 mod tests;
@@ -32,7 +34,7 @@ pub async fn interpret(
     rib: &RibByteCode,
     rib_input: HashMap<String, TypeAnnotatedValue>,
     function_invoke: RibFunctionInvoke,
-) -> Result<RibInterpreterResult, String> {
+) -> Result<RibResult, String> {
     let mut interpreter = Interpreter::new(rib_input, function_invoke);
     interpreter.run(rib.clone()).await
 }
@@ -43,7 +45,7 @@ pub async fn interpret(
 pub async fn interpret_pure(
     rib: &RibByteCode,
     rib_input: &HashMap<String, TypeAnnotatedValue>,
-) -> Result<RibInterpreterResult, String> {
+) -> Result<RibResult, String> {
     let mut interpreter = Interpreter::pure(rib_input.clone());
     interpreter.run(rib.clone()).await
 }

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -14,7 +14,6 @@
 
 pub use env::RibFunctionInvoke;
 pub use interpreter_result::*;
-pub use interpreter_stack_value::*;
 pub use literal::*;
 pub use rib_interpreter::*;
 

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -13,15 +13,18 @@
 // limitations under the License.
 
 pub use env::RibFunctionInvoke;
+pub use interpreter_input::*;
 pub use interpreter_result::*;
 pub use literal::*;
-pub use rib_interpreter::*;
 
+use crate::interpreter::rib_interpreter::Interpreter;
 use crate::RibByteCode;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
+
 mod env;
 mod instruction_cursor;
+mod interpreter_input;
 mod interpreter_result;
 mod interpreter_stack_value;
 mod literal;
@@ -31,7 +34,7 @@ mod tests;
 
 pub async fn interpret(
     rib: &RibByteCode,
-    rib_input: HashMap<String, TypeAnnotatedValue>,
+    rib_input: RibInterpreterInput,
     function_invoke: RibFunctionInvoke,
 ) -> Result<RibResult, String> {
     let mut interpreter = Interpreter::new(rib_input, function_invoke);

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -19,8 +19,6 @@ pub use literal::*;
 
 use crate::interpreter::rib_interpreter::Interpreter;
 use crate::RibByteCode;
-use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
-use std::collections::HashMap;
 
 mod env;
 mod instruction_cursor;
@@ -34,7 +32,7 @@ mod tests;
 
 pub async fn interpret(
     rib: &RibByteCode,
-    rib_input: RibInterpreterInput,
+    rib_input: &RibInput,
     function_invoke: RibFunctionInvoke,
 ) -> Result<RibResult, String> {
     let mut interpreter = Interpreter::new(rib_input, function_invoke);
@@ -46,8 +44,8 @@ pub async fn interpret(
 // It is recommended to use `interpret` over `interpret_pure` if you are unsure.
 pub async fn interpret_pure(
     rib: &RibByteCode,
-    rib_input: &HashMap<String, TypeAnnotatedValue>,
+    rib_input: &RibInput,
 ) -> Result<RibResult, String> {
-    let mut interpreter = Interpreter::pure(rib_input.clone());
+    let mut interpreter = Interpreter::pure(rib_input);
     interpreter.run(rib.clone()).await
 }

--- a/golem-rib/src/interpreter/mod.rs
+++ b/golem-rib/src/interpreter/mod.rs
@@ -21,6 +21,7 @@ use crate::RibByteCode;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 mod env;
+mod instruction_cursor;
 mod literal;
 mod result;
 mod rib_interpreter;

--- a/golem-rib/src/interpreter/result.rs
+++ b/golem-rib/src/interpreter/result.rs
@@ -13,16 +13,65 @@
 // limitations under the License.
 
 use crate::interpreter::literal::{GetLiteralValue, LiteralValue};
+use crate::CoercedNumericValue;
+use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_wasm_rpc::protobuf::typed_result::ResultValue;
+use std::fmt;
 
-#[derive(Debug, Clone, PartialEq)]
+// A result of a function can be unit, which is not representable using type_annotated_value
+// A result can be a type_annotated_value
+// A result can be a sink where it collects only the required elements from a possible iterable
+// A result can also be stored as an iterator, that in the future, we rely on the same mechanism to support streams without change of code.
 pub enum RibInterpreterResult {
     Unit,
     Val(TypeAnnotatedValue),
+    Iterator(Box<dyn Iterator<Item = TypeAnnotatedValue>>),
+    Sink(Vec<TypeAnnotatedValue>, AnalysedType),
+}
+
+impl fmt::Debug for RibInterpreterResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RibInterpreterResult::Unit => write!(f, "Unit"),
+            RibInterpreterResult::Val(value) => write!(f, "val:{:?}", value),
+            RibInterpreterResult::Iterator(_) => write!(f, "Iterator:(...)"),
+            RibInterpreterResult::Sink(value, _) => write!(f, "sink:{}", value.len()),
+        }
+    }
 }
 
 impl RibInterpreterResult {
+    pub fn is_sink(&self) -> bool {
+        matches!(self, RibInterpreterResult::Sink(_, _))
+    }
+    pub fn is_iterator(&self) -> bool {
+        matches!(self, RibInterpreterResult::Iterator(_))
+    }
+
+    pub fn evaluate_math_op<F>(
+        &self,
+        right: &RibInterpreterResult,
+        op: F,
+    ) -> Result<CoercedNumericValue, String>
+    where
+        F: Fn(CoercedNumericValue, CoercedNumericValue) -> CoercedNumericValue,
+    {
+        match (self.get_val(), right.get_val()) {
+            (Some(left), Some(right)) => {
+                if let (Some(left_lit), Some(right_lit)) = (
+                    left.get_literal().and_then(|x| x.get_number()),
+                    right.get_literal().and_then(|x| x.get_number()),
+                ) {
+                    Ok(op(left_lit, right_lit))
+                } else {
+                    Err("Failed to perform math operation".to_string())
+                }
+            }
+            _ => Err("Unable to perform math op as the values are not numbers".to_string()),
+        }
+    }
+
     pub fn compare<F>(
         &self,
         right: &RibInterpreterResult,
@@ -49,12 +98,16 @@ impl RibInterpreterResult {
             RibInterpreterResult::Val(TypeAnnotatedValue::Bool(bool)) => Some(*bool),
             RibInterpreterResult::Val(_) => None,
             RibInterpreterResult::Unit => None,
+            RibInterpreterResult::Iterator(_) => None,
+            RibInterpreterResult::Sink(_, _) => None,
         }
     }
     pub fn get_val(&self) -> Option<TypeAnnotatedValue> {
         match self {
             RibInterpreterResult::Val(val) => Some(val.clone()),
             RibInterpreterResult::Unit => None,
+            RibInterpreterResult::Iterator(_) => None,
+            RibInterpreterResult::Sink(_, _) => None,
         }
     }
 
@@ -62,6 +115,8 @@ impl RibInterpreterResult {
         match self {
             RibInterpreterResult::Val(val) => val.get_literal(),
             RibInterpreterResult::Unit => None,
+            RibInterpreterResult::Iterator(_) => None,
+            RibInterpreterResult::Sink(_, _) => None,
         }
     }
 
@@ -73,7 +128,7 @@ impl RibInterpreterResult {
         RibInterpreterResult::Val(val)
     }
 
-    pub fn unwrap(self) -> Option<TypeAnnotatedValue> {
+    pub fn unwrap(&self) -> Option<TypeAnnotatedValue> {
         match self {
             RibInterpreterResult::Val(val) => match val {
                 TypeAnnotatedValue::Option(option) => option
@@ -81,9 +136,9 @@ impl RibInterpreterResult {
                     .as_deref()
                     .and_then(|x| x.type_annotated_value.clone()),
                 TypeAnnotatedValue::Result(result) => {
-                    let result = match result.result_value {
-                        Some(ResultValue::OkValue(ok)) => Some(*ok),
-                        Some(ResultValue::ErrorValue(err)) => Some(*err),
+                    let result = match &result.result_value {
+                        Some(ResultValue::OkValue(ok)) => Some(ok.clone()),
+                        Some(ResultValue::ErrorValue(err)) => Some(err.clone()),
                         None => None,
                     };
 
@@ -98,6 +153,8 @@ impl RibInterpreterResult {
                 _ => None,
             },
             RibInterpreterResult::Unit => None,
+            RibInterpreterResult::Iterator(_) => None,
+            RibInterpreterResult::Sink(_, _) => None,
         }
     }
 }
@@ -183,9 +240,9 @@ mod internal {
 
         match (left, right) {
             (Ok(left), Ok(right)) => {
-                format!("Unsupported type to compare {:?}, {:?}", left, right)
+                format!("Unsupported op {:?}, {:?}", left, right)
             }
-            _ => "Unsupported type to compare. Un-identified types".to_string(),
+            _ => "Unsupported types. Un-identified types".to_string(),
         }
     }
 }

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -33,7 +33,10 @@ impl Default for Interpreter {
 
 impl Interpreter {
     pub fn new(input: &RibInput, invoke: RibFunctionInvoke) -> Self {
-        Interpreter { input: input.clone(), invoke }
+        Interpreter {
+            input: input.clone(),
+            invoke,
+        }
     }
 
     // Interpreter that's not expected to call a side-effecting function call.

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -1139,11 +1139,12 @@ mod internal {
     ) -> Result<(), String> {
         let literals = interpreter_stack.try_pop_n_literals(arg_size)?;
 
-        let mut str = String::new();
-
-        for literal in literals {
-            str.push_str(&literal.as_string());
-        }
+        let str = literals
+            .into_iter()
+            .fold(String::new(), |mut acc, literal| {
+                acc.push_str(&literal.as_string());
+                acc
+            });
 
         interpreter_stack.push_val(TypeAnnotatedValue::Str(str));
 

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -94,14 +94,14 @@ impl Interpreter {
                 RibIR::LessThanOrEqualTo => {
                     internal::run_compare_instruction(&mut stack, |left, right| left <= right)?;
                 }
-                RibIR::Add(analysed_type) => {
+                RibIR::Plus(analysed_type) => {
                     internal::run_math_instruction(
                         &mut stack,
                         |left, right| left + right,
                         &analysed_type,
                     )?;
                 }
-                RibIR::Subtract(analysed_type) => {
+                RibIR::Minus(analysed_type) => {
                     internal::run_math_instruction(
                         &mut stack,
                         |left, right| left - right,

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -346,16 +346,10 @@ mod internal {
         instruction_stack: &mut RibByteCodeCursor,
         interpreter_stack: &mut InterpreterStack,
     ) -> Result<(), String> {
-        let rib_result = interpreter_stack.pop().ok_or(
-            "Internal Error: Failed to get a value from the stack to do the comparison operation"
-                .to_string(),
-        )?;
+        let predicate = interpreter_stack.try_pop_bool()?;
 
-        let predicate_bool = rib_result
-            .get_bool()
-            .ok_or("Internal Error: Expecting a value that can be converted to bool".to_string())?;
-
-        if !predicate_bool {
+        // Jump if predicate is false
+        if !predicate {
             instruction_stack.move_to(&instruction_id).ok_or(format!(
                 "Internal Error: Failed to move to the instruction at {}",
                 instruction_id.index

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -15,34 +15,32 @@
 use crate::interpreter::env::{InterpreterEnv, RibFunctionInvoke};
 use crate::interpreter::instruction_cursor::RibByteCodeCursor;
 use crate::interpreter::stack::InterpreterStack;
-use crate::{RibByteCode, RibIR, RibInterpreterInput, RibResult};
-use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
-use std::collections::HashMap;
+use crate::{RibByteCode, RibIR, RibInput, RibResult};
 
 pub struct Interpreter {
-    pub input: RibInterpreterInput,
+    pub input: RibInput,
     pub invoke: RibFunctionInvoke,
 }
 
 impl Default for Interpreter {
     fn default() -> Self {
         Interpreter {
-            input: RibInterpreterInput::default(),
+            input: RibInput::default(),
             invoke: internal::default_worker_invoke_async(),
         }
     }
 }
 
 impl Interpreter {
-    pub fn new(input: RibInterpreterInput, invoke: RibFunctionInvoke) -> Self {
-        Interpreter { input, invoke }
+    pub fn new(input: &RibInput, invoke: RibFunctionInvoke) -> Self {
+        Interpreter { input: input.clone(), invoke }
     }
 
     // Interpreter that's not expected to call a side-effecting function call.
     // All it needs is environment with the required variables to evaluate the Rib script
-    pub fn pure(env: HashMap<String, TypeAnnotatedValue>) -> Self {
+    pub fn pure(input: &RibInput) -> Self {
         Interpreter {
-            input: RibInterpreterInput::new(env),
+            input: input.clone(),
             invoke: internal::default_worker_invoke_async(),
         }
     }
@@ -2152,7 +2150,7 @@ mod interpreter_tests {
 
     mod internal {
         use crate::interpreter::rib_interpreter::Interpreter;
-        use crate::{RibFunctionInvoke, RibInterpreterInput};
+        use crate::{RibFunctionInvoke, RibInput};
         use golem_wasm_ast::analysis::analysed_type::{
             case, f32, field, handle, list, r#enum, record, result, str, tuple, u32, u64,
             unit_case, variant,
@@ -2392,7 +2390,7 @@ mod interpreter_tests {
             result_value: &TypeAnnotatedValue,
         ) -> Interpreter {
             Interpreter {
-                input: RibInterpreterInput::default(),
+                input: RibInput::default(),
                 invoke: static_worker_invoke(result_type, result_value),
             }
         }

--- a/golem-rib/src/interpreter/stack.rs
+++ b/golem-rib/src/interpreter/stack.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
-use golem_wasm_ast::analysis::protobuf::{NameTypePair, Type};
+use golem_wasm_ast::analysis::protobuf::NameTypePair;
 use golem_wasm_ast::analysis::{AnalysedType, NameOptionTypePair};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_wasm_rpc::protobuf::{
@@ -44,22 +44,8 @@ impl InterpreterStack {
         }));
     }
 
-    pub fn create_list(&mut self, analysed_type: AnalysedType) {
-        self.push_val(TypeAnnotatedValue::List(TypedList {
-            values: vec![],
-            typ: Some(Type::from(&analysed_type)),
-        }));
-    }
-
     pub fn pop(&mut self) -> Option<RibInterpreterStackValue> {
         self.stack.pop()
-    }
-
-    pub fn pop_iterator(&mut self) -> Option<Box<dyn Iterator<Item = TypeAnnotatedValue>>> {
-        match self.pop() {
-            Some(RibInterpreterStackValue::Iterator(iter)) => Some(iter),
-            _ => None,
-        }
     }
 
     pub fn pop_sink(&mut self) -> Option<Vec<TypeAnnotatedValue>> {

--- a/golem-rib/src/interpreter/tests/mod.rs
+++ b/golem-rib/src/interpreter/tests/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(test)]
 mod comprehensive_test {
     use test_r::test;

--- a/golem-rib/src/interpreter/tests/mod.rs
+++ b/golem-rib/src/interpreter/tests/mod.rs
@@ -2273,7 +2273,7 @@ mod comprehensive_test {
             interpreter_env_input: HashMap<String, TypeAnnotatedValue>,
         ) -> Interpreter {
             Interpreter::new(
-                RibInput::new(interpreter_env_input),
+                &RibInput::new(interpreter_env_input),
                 dynamic_worker_invoke(functions_and_result),
             )
         }

--- a/golem-rib/src/interpreter/tests/mod.rs
+++ b/golem-rib/src/interpreter/tests/mod.rs
@@ -2076,10 +2076,9 @@ mod comprehensive_test {
     }
 
     mod mock_interpreter {
-        use crate::interpreter::env::InterpreterEnv;
-        use crate::interpreter::stack::InterpreterStack;
+        use crate::interpreter::rib_interpreter::Interpreter;
         use crate::interpreter::tests::comprehensive_test::{mock_data, test_utils};
-        use crate::{Interpreter, RibFunctionInvoke};
+        use crate::{RibFunctionInvoke, RibInterpreterInput};
         use golem_wasm_ast::analysis::{AnalysedType, TypeStr};
         use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
         use golem_wasm_rpc::protobuf::TypedTuple;
@@ -2273,13 +2272,10 @@ mod comprehensive_test {
             functions_and_result: HashMap<FunctionName, Option<TypeAnnotatedValue>>,
             interpreter_env_input: HashMap<String, TypeAnnotatedValue>,
         ) -> Interpreter {
-            Interpreter {
-                stack: InterpreterStack::default(),
-                env: InterpreterEnv::from(
-                    interpreter_env_input,
-                    dynamic_worker_invoke(functions_and_result),
-                ),
-            }
+            Interpreter::new(
+                RibInterpreterInput::new(interpreter_env_input),
+                dynamic_worker_invoke(functions_and_result),
+            )
         }
 
         fn dynamic_worker_invoke(

--- a/golem-rib/src/interpreter/tests/mod.rs
+++ b/golem-rib/src/interpreter/tests/mod.rs
@@ -2078,7 +2078,7 @@ mod comprehensive_test {
     mod mock_interpreter {
         use crate::interpreter::rib_interpreter::Interpreter;
         use crate::interpreter::tests::comprehensive_test::{mock_data, test_utils};
-        use crate::{RibFunctionInvoke, RibInterpreterInput};
+        use crate::{RibFunctionInvoke, RibInput};
         use golem_wasm_ast::analysis::{AnalysedType, TypeStr};
         use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
         use golem_wasm_rpc::protobuf::TypedTuple;
@@ -2273,7 +2273,7 @@ mod comprehensive_test {
             interpreter_env_input: HashMap<String, TypeAnnotatedValue>,
         ) -> Interpreter {
             Interpreter::new(
-                RibInterpreterInput::new(interpreter_env_input),
+                RibInput::new(interpreter_env_input),
                 dynamic_worker_invoke(functions_and_result),
             )
         }

--- a/golem-rib/src/parser/binary_op.rs
+++ b/golem-rib/src/parser/binary_op.rs
@@ -24,26 +24,18 @@ where
     >,
 {
     choice((
-        attempt(string(">=")),
-        attempt(string("<=")),
-        attempt(string("==")),
-        string("<"),
-        string(">"),
-        string("&&"),
-        string("||"),
+        attempt(string(">=")).map(|_| BinaryOp::GreaterThanOrEqualTo),
+        attempt(string("<=")).map(|_| BinaryOp::LessThanOrEqualTo),
+        attempt(string("==")).map(|_| BinaryOp::EqualTo),
+        string("<").map(|_| BinaryOp::LessThan),
+        string(">").map(|_| BinaryOp::GreaterThan),
+        string("&&").map(|_| BinaryOp::And),
+        string("||").map(|_| BinaryOp::Or),
+        string("+").map(|_| BinaryOp::Add),
+        string("-").map(|_| BinaryOp::Subtract),
+        string("*").map(|_| BinaryOp::Multiply),
+        string("/").map(|_| BinaryOp::Divide),
     ))
-    .and_then(|str| match str {
-        ">" => Ok(BinaryOp::GreaterThan),
-        "<" => Ok(BinaryOp::LessThan),
-        "==" => Ok(BinaryOp::EqualTo),
-        ">=" => Ok(BinaryOp::GreaterThanOrEqualTo),
-        "<=" => Ok(BinaryOp::LessThanOrEqualTo),
-        "&&" => Ok(BinaryOp::And),
-        "||" => Ok(BinaryOp::Or),
-        _ => Err(RibParseError::Message(
-            "Invalid binary operator".to_string(),
-        )),
-    })
 }
 
 pub enum BinaryOp {
@@ -54,6 +46,10 @@ pub enum BinaryOp {
     EqualTo,
     And,
     Or,
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
 }
 
 #[cfg(test)]
@@ -172,8 +168,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::record(vec![("foo".to_string(), Expr::number(1f64))]),
-                    Expr::record(vec![("foo".to_string(), Expr::number(2f64))]),
+                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(1f64))]),
+                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(2f64))]),
                 ),
                 ""
             ))
@@ -188,8 +184,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::sequence(vec![Expr::number(1f64), Expr::number(2f64)]),
-                    Expr::sequence(vec![Expr::number(3f64), Expr::number(4f64)]),
+                    Expr::sequence(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
+                    Expr::sequence(vec![Expr::untyped_number(3f64), Expr::untyped_number(4f64)]),
                 ),
                 ""
             ))
@@ -204,8 +200,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::tuple(vec![Expr::number(1f64), Expr::number(2f64)]),
-                    Expr::tuple(vec![Expr::number(3f64), Expr::number(4f64)]),
+                    Expr::tuple(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
+                    Expr::tuple(vec![Expr::untyped_number(3f64), Expr::untyped_number(4f64)]),
                 ),
                 ""
             ))

--- a/golem-rib/src/parser/call.rs
+++ b/golem-rib/src/parser/call.rs
@@ -760,7 +760,7 @@ mod function_call_tests {
                         resource: "resource1".to_string(),
                         resource_params: vec![
                             Expr::literal("hello"),
-                            Expr::number(1f64),
+                            Expr::untyped_number(1f64),
                             Expr::boolean(true),
                         ],
                     },
@@ -792,7 +792,7 @@ mod function_call_tests {
                             Expr::literal("hello"),
                             Expr::record(vec![(
                                 "field-a".to_string(),
-                                Expr::option(Some(Expr::number(1f64))),
+                                Expr::option(Some(Expr::untyped_number(1f64))),
                             )]),
                         ],
                     },
@@ -968,7 +968,7 @@ mod function_call_tests {
                         resource: "resource1".to_string(),
                         resource_params: vec![
                             Expr::literal("hello"),
-                            Expr::number(1f64),
+                            Expr::untyped_number(1f64),
                             Expr::boolean(true),
                         ],
                     },
@@ -1000,7 +1000,7 @@ mod function_call_tests {
                             Expr::literal("hello"),
                             Expr::record(vec![(
                                 "field-a".to_string(),
-                                Expr::option(Some(Expr::number(1f64))),
+                                Expr::option(Some(Expr::untyped_number(1f64))),
                             )]),
                         ],
                     },

--- a/golem-rib/src/parser/identifier.rs
+++ b/golem-rib/src/parser/identifier.rs
@@ -20,7 +20,7 @@ use crate::expr::Expr;
 use crate::parser::errors::RibParseError;
 
 const RESERVED_KEYWORDS: &[&str] = &[
-    "if", "then", "else", "match", "ok", "some", "err", "none", "let",
+    "if", "then", "else", "match", "ok", "some", "err", "none", "let", "for", "yield", "reduce",
 ];
 
 pub fn identifier<Input>() -> impl Parser<Input, Output = Expr>

--- a/golem-rib/src/parser/list_aggregation.rs
+++ b/golem-rib/src/parser/list_aggregation.rs
@@ -1,0 +1,151 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::parser::errors::RibParseError;
+use crate::parser::identifier::identifier_text;
+use crate::parser::partial_block_expr::partial_block;
+use crate::parser::rib_expr::rib_expr as expr;
+use crate::{Expr, VariableId};
+use combine::parser::char::{alpha_num, char, spaces, string};
+use combine::{attempt, not_followed_by, optional, ParseError, Parser, Stream};
+
+pub fn list_aggregation<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
+{
+    (
+        attempt(
+            string("reduce").skip(
+                not_followed_by(alpha_num().or(char('-')).or(char('_')))
+                    .skip(spaces())
+                    .skip(spaces()),
+            ),
+        ),
+        identifier_text()
+            .skip(spaces())
+            .map(VariableId::list_reduce_identifier)
+            .skip(spaces()),
+        char(',').skip(spaces()),
+        identifier_text()
+            .skip(spaces())
+            .map(VariableId::list_comprehension_identifier)
+            .skip(spaces()),
+        string("in").skip(spaces()),
+        expr().skip(spaces()),
+        string("from").skip(spaces()),
+        expr().skip(spaces()),
+        char('{').skip(spaces()),
+        optional(partial_block().skip(spaces())),
+        string("yield").skip(spaces()),
+        expr().skip(spaces()),
+        char(';').skip(spaces()),
+        char('}'),
+    )
+        .map(
+            |(
+                _,
+                reduced_variable,
+                _,
+                reduce_variable,
+                _,
+                iterable_expr,
+                _,
+                init_value_expr,
+                _,
+                optional_block,
+                _,
+                yield_expr,
+                _,
+                _,
+            )| {
+                let expr = if let Some(mut block) = optional_block {
+                    block.push(yield_expr);
+                    Expr::expr_block(block)
+                } else {
+                    yield_expr
+                };
+                Expr::list_reduce(
+                    reduced_variable,
+                    reduce_variable,
+                    iterable_expr,
+                    init_value_expr,
+                    expr,
+                )
+            },
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::VariableId;
+    use crate::{Expr, TypeName};
+    use test_r::test;
+
+    #[test]
+    fn test_list_aggregation() {
+        let input = "reduce z, p in [1, 2] from 0 { yield z + p; }";
+        let result = Expr::from_text(input).unwrap();
+        assert_eq!(
+            result,
+            Expr::list_reduce(
+                VariableId::list_reduce_identifier("z"),
+                VariableId::list_comprehension_identifier("p"),
+                Expr::sequence(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
+                Expr::untyped_number(0f64),
+                Expr::expr_block(vec![Expr::plus(
+                    Expr::identifier("z"),
+                    Expr::identifier("p")
+                )]),
+            )
+        );
+    }
+
+    #[test]
+    fn test_list_aggregation2() {
+        let input = r#"
+           let ages: list<u16> = [1, 2, 3];
+           reduce z, a in ages from 0 {
+              yield z + a;
+           }
+        "#;
+        let result = Expr::from_text(input).unwrap();
+        assert_eq!(
+            result,
+            Expr::expr_block(vec![
+                Expr::let_binding_with_type(
+                    "ages",
+                    TypeName::List(Box::new(TypeName::U16)),
+                    Expr::sequence(vec![
+                        Expr::untyped_number(1f64),
+                        Expr::untyped_number(2f64),
+                        Expr::untyped_number(3f64)
+                    ])
+                ),
+                Expr::list_reduce(
+                    VariableId::list_reduce_identifier("z"),
+                    VariableId::list_comprehension_identifier("a"),
+                    Expr::identifier("ages"),
+                    Expr::untyped_number(0f64),
+                    Expr::expr_block(vec![Expr::plus(
+                        Expr::identifier("z"),
+                        Expr::identifier("a")
+                    )]),
+                )
+            ])
+        );
+    }
+}

--- a/golem-rib/src/parser/list_comprehension.rs
+++ b/golem-rib/src/parser/list_comprehension.rs
@@ -1,0 +1,103 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::parser::errors::RibParseError;
+use crate::parser::identifier::identifier_text;
+use crate::parser::partial_block_expr::partial_block;
+use crate::parser::rib_expr::rib_expr as expr;
+use crate::{Expr, VariableId};
+use combine::parser::char::{alpha_num, char, spaces, string};
+use combine::{attempt, not_followed_by, optional, ParseError, Parser, Stream};
+
+pub fn list_comprehension<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
+{
+    (
+        attempt(
+            string("for")
+                .skip(not_followed_by(alpha_num().or(char('-')).or(char('_'))).skip(spaces())),
+        ),
+        identifier_text()
+            .skip(spaces())
+            .map(VariableId::list_comprehension_identifier),
+        string("in").skip(spaces()),
+        expr().skip(spaces()),
+        char('{').skip(spaces()),
+        optional(partial_block().skip(spaces())),
+        string("yield").skip(spaces()),
+        expr().skip(spaces()),
+        char(';').skip(spaces()),
+        char('}'),
+    )
+        .map(|(_, var, _, iterable, _, opt_block, _, yield_expr, _, _)| {
+            let expr = opt_block
+                .map(|mut block| {
+                    block.push(yield_expr.clone());
+                    Expr::expr_block(block)
+                })
+                .unwrap_or(yield_expr);
+            Expr::list_comprehension(var, iterable, expr)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Expr;
+    use crate::VariableId;
+    use test_r::test;
+
+    #[test]
+    fn test_list_comprehension1() {
+        let input = "for x in [\"foo\", \"bar\"] { yield x; }";
+        let result = Expr::from_text(input).unwrap();
+        assert_eq!(
+            result,
+            Expr::list_comprehension(
+                VariableId::list_comprehension_identifier("x"),
+                Expr::sequence(vec![Expr::literal("foo"), Expr::literal("bar")]),
+                Expr::expr_block(vec![Expr::identifier("x")]),
+            )
+        );
+    }
+
+    #[test]
+    fn test_list_comprehension2() {
+        let input = r#"
+           let x = ["foo", "bar"];
+
+           for p in x {
+              yield p;
+           }
+        "#;
+        let result = Expr::from_text(input).unwrap();
+        assert_eq!(
+            result,
+            Expr::expr_block(vec![
+                Expr::let_binding(
+                    "x",
+                    Expr::sequence(vec![Expr::literal("foo"), Expr::literal("bar")])
+                ),
+                Expr::list_comprehension(
+                    VariableId::list_comprehension_identifier("p"),
+                    Expr::identifier("x"),
+                    Expr::expr_block(vec![Expr::identifier("p")]),
+                )
+            ])
+        );
+    }
+}

--- a/golem-rib/src/parser/literal.rs
+++ b/golem-rib/src/parser/literal.rs
@@ -119,7 +119,7 @@ mod internal {
                     if expressions.len() == 1 {
                         expressions.first().unwrap().clone()
                     } else {
-                        Expr::multiple(expressions)
+                        Expr::expr_block(expressions)
                     }
                 },
             ),
@@ -194,7 +194,7 @@ mod tests {
                         Expr::identifier("foo"),
                         Expr::concat(vec![Expr::literal("bar-"), Expr::identifier("worker_id")])
                     ),
-                    Expr::number(1f64),
+                    Expr::untyped_number(1f64),
                     Expr::literal("baz"),
                 ),
                 ""

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod binary_comparison;
+mod binary_op;
 mod boolean;
 pub(crate) mod call;
 mod cond;
@@ -20,11 +20,14 @@ mod errors;
 mod flag;
 mod identifier;
 mod let_binding;
+mod list_aggregation;
+mod list_comprehension;
 pub(crate) mod literal;
 mod multi_line_code_block;
 mod not;
 mod number;
 mod optional;
+mod partial_block_expr;
 mod pattern_match;
 mod record;
 mod result;

--- a/golem-rib/src/parser/multi_line_code_block.rs
+++ b/golem-rib/src/parser/multi_line_code_block.rs
@@ -57,7 +57,7 @@ mod internal {
                     if expressions.len() == 1 {
                         expressions.first().unwrap().clone()
                     } else {
-                        Expr::multiple(expressions)
+                        Expr::expr_block(expressions)
                     }
                 },
             ),
@@ -85,9 +85,9 @@ mod tests {
 
         let expr = Expr::from_text(rib_expr).unwrap();
 
-        let expected = Expr::multiple(vec![
-            Expr::let_binding("x", Expr::number(1f64)),
-            Expr::let_binding("y", Expr::number(2f64)),
+        let expected = Expr::expr_block(vec![
+            Expr::let_binding("x", Expr::untyped_number(1f64)),
+            Expr::let_binding("y", Expr::untyped_number(2f64)),
             Expr::call(
                 DynamicParsedFunctionName::parse("foo").unwrap(),
                 vec![Expr::identifier("x")],
@@ -116,9 +116,9 @@ mod tests {
 
         let expected = Expr::cond(
             Expr::boolean(true),
-            Expr::multiple(vec![
-                Expr::let_binding("x", Expr::number(1f64)),
-                Expr::let_binding("y", Expr::number(2f64)),
+            Expr::expr_block(vec![
+                Expr::let_binding("x", Expr::untyped_number(1f64)),
+                Expr::let_binding("y", Expr::untyped_number(2f64)),
                 Expr::call(
                     DynamicParsedFunctionName::parse("foo").unwrap(),
                     vec![Expr::identifier("x")],
@@ -128,7 +128,7 @@ mod tests {
                     vec![Expr::identifier("y")],
                 ),
             ]),
-            Expr::number(1f64),
+            Expr::untyped_number(1f64),
         );
 
         assert_eq!(expr, expected);
@@ -156,9 +156,9 @@ mod tests {
                     "some".to_string(),
                     vec![ArmPattern::Literal(Box::new(Expr::identifier("x")))],
                 ),
-                Expr::multiple(vec![
-                    Expr::let_binding("x", Expr::number(1f64)),
-                    Expr::let_binding("y", Expr::number(2f64)),
+                Expr::expr_block(vec![
+                    Expr::let_binding("x", Expr::untyped_number(1f64)),
+                    Expr::let_binding("y", Expr::untyped_number(2f64)),
                     Expr::call(
                         DynamicParsedFunctionName::parse("foo").unwrap(),
                         vec![Expr::identifier("x")],
@@ -190,8 +190,8 @@ mod tests {
 
         let expr = Expr::from_text(rib_expr).unwrap();
 
-        let expected = Expr::multiple(vec![
-            Expr::let_binding("foo", Expr::option(Some(Expr::number(1f64)))),
+        let expected = Expr::expr_block(vec![
+            Expr::let_binding("foo", Expr::option(Some(Expr::untyped_number(1f64)))),
             Expr::pattern_match(
                 Expr::identifier("foo"),
                 vec![MatchArm::new(
@@ -199,9 +199,9 @@ mod tests {
                         "some".to_string(),
                         vec![ArmPattern::Literal(Box::new(Expr::identifier("x")))],
                     ),
-                    Expr::multiple(vec![
-                        Expr::let_binding("x", Expr::number(1f64)),
-                        Expr::let_binding("y", Expr::number(2f64)),
+                    Expr::expr_block(vec![
+                        Expr::let_binding("x", Expr::untyped_number(1f64)),
+                        Expr::let_binding("y", Expr::untyped_number(2f64)),
                         Expr::call(
                             DynamicParsedFunctionName::parse("foo").unwrap(),
                             vec![Expr::identifier("x")],

--- a/golem-rib/src/parser/number.rs
+++ b/golem-rib/src/parser/number.rs
@@ -39,9 +39,12 @@ where
                     match primitive {
                         Ok(primitive) => {
                             if let Some(typ_name) = typ_name {
-                                Ok(Expr::number_with_type_name(primitive, typ_name.clone()))
+                                Ok(Expr::untyped_number_with_type_name(
+                                    primitive,
+                                    typ_name.clone(),
+                                ))
                             } else {
-                                Ok(Expr::number(primitive))
+                                Ok(Expr::untyped_number(primitive))
                             }
                         }
                         Err(_) => {
@@ -65,28 +68,28 @@ mod tests {
     fn test_number() {
         let input = "123";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::number(123f64), "")));
+        assert_eq!(result, Ok((Expr::untyped_number(123f64), "")));
     }
 
     #[test]
     fn test_negative_number() {
         let input = "-123";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::number(-123f64), "")));
+        assert_eq!(result, Ok((Expr::untyped_number(-123f64), "")));
     }
 
     #[test]
     fn test_float_number() {
         let input = "123.456";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::number(123.456f64), "")));
+        assert_eq!(result, Ok((Expr::untyped_number(123.456f64), "")));
     }
 
     #[test]
     fn test_number_with_binding_positive() {
         let input = "123u32";
         let result = number().easy_parse(input);
-        let expected = Expr::number_with_type_name(123f64, TypeName::U32);
+        let expected = Expr::untyped_number_with_type_name(123f64, TypeName::U32);
         assert_eq!(result, Ok((expected, "")));
     }
 
@@ -94,7 +97,7 @@ mod tests {
     fn test_number_with_binding_negative() {
         let input = "-123s64";
         let result = number().easy_parse(input);
-        let expected = Expr::number_with_type_name(-123f64, TypeName::S64);
+        let expected = Expr::untyped_number_with_type_name(-123f64, TypeName::S64);
         assert_eq!(result, Ok((expected, "")));
     }
 
@@ -102,7 +105,7 @@ mod tests {
     fn test_number_with_binding_float() {
         let input = "-123.0f64";
         let result = number().easy_parse(input);
-        let expected = Expr::number_with_type_name(-123f64, TypeName::F64);
+        let expected = Expr::untyped_number_with_type_name(-123f64, TypeName::F64);
         assert_eq!(result, Ok((expected, "")));
     }
 }

--- a/golem-rib/src/parser/partial_block_expr.rs
+++ b/golem-rib/src/parser/partial_block_expr.rs
@@ -1,0 +1,35 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::parser::errors::RibParseError;
+use crate::parser::rib_expr::rib_expr;
+use crate::Expr;
+use combine::parser::char::{char, spaces};
+use combine::{attempt, sep_end_by, ParseError, Parser};
+
+// A block expr without the return type
+pub fn partial_block<Input>() -> impl Parser<Input, Output = Vec<Expr>>
+where
+    Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
+{
+    spaces()
+        .with(sep_end_by(
+            attempt(rib_expr().skip(spaces())),
+            char(';').skip(spaces()),
+        ))
+        .map(|block: Vec<Expr>| block)
+}

--- a/golem-rib/src/parser/rib_expr.rs
+++ b/golem-rib/src/parser/rib_expr.rs
@@ -20,7 +20,7 @@ use combine::{parser, sep_by};
 use crate::expr::Expr;
 use crate::parser::errors::RibParseError;
 
-use super::binary_comparison::BinaryOp;
+use super::binary_op::BinaryOp;
 
 // Parse a full Rib Program, and we expect the parser to fully consume the stream
 // unlike rib block expression
@@ -37,7 +37,7 @@ where
                 if expressions.len() == 1 {
                     expressions.first().unwrap().clone()
                 } else {
-                    Expr::multiple(expressions)
+                    Expr::expr_block(expressions)
                 }
             })
             .skip(eof()),
@@ -72,6 +72,10 @@ where
                     BinaryOp::EqualTo => Expr::equal_to(acc, next),
                     BinaryOp::And => Expr::and(acc, next),
                     BinaryOp::Or => Expr::or(acc, next),
+                    BinaryOp::Add => Expr::plus(acc, next),
+                    BinaryOp::Subtract => Expr::minus(acc, next),
+                    BinaryOp::Multiply => Expr::multiply(acc, next),
+                    BinaryOp::Divide => Expr::divide(acc, next),
                 })
             }),
         )
@@ -79,7 +83,7 @@ where
 }
 
 mod internal {
-    use crate::parser::binary_comparison::{binary_op, BinaryOp};
+    use crate::parser::binary_op::{binary_op, BinaryOp};
     use crate::parser::boolean::boolean_literal;
     use crate::parser::call::call;
     use crate::parser::cond::conditional;
@@ -96,6 +100,8 @@ mod internal {
     use crate::parser::record::record;
     use crate::parser::result::result;
 
+    use crate::parser::list_aggregation::list_aggregation;
+    use crate::parser::list_comprehension::list_comprehension;
     use crate::parser::select_field::select_field;
     use crate::parser::select_index::select_index;
     use crate::parser::sequence::sequence;
@@ -114,6 +120,8 @@ mod internal {
     {
         spaces()
             .with(choice((
+                list_comprehension(),
+                list_aggregation(),
                 pattern_match(),
                 let_binding(),
                 conditional(),

--- a/golem-rib/src/parser/select_field.rs
+++ b/golem-rib/src/parser/select_field.rs
@@ -224,7 +224,7 @@ mod tests {
             Ok((
                 Expr::greater_than(
                     Expr::select_field(Expr::identifier("foo"), "bar"),
-                    Expr::number(1f64)
+                    Expr::untyped_number(1f64)
                 ),
                 ""
             ))
@@ -241,7 +241,7 @@ mod tests {
                 Expr::cond(
                     Expr::greater_than(
                         Expr::select_field(Expr::identifier("foo"), "bar"),
-                        Expr::number(1f64)
+                        Expr::untyped_number(1f64)
                     ),
                     Expr::select_field(Expr::identifier("foo"), "bar"),
                     Expr::select_field(Expr::identifier("foo"), "baz")

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -114,8 +114,8 @@ mod record_tests {
     #[test]
     fn test_round_trip_read_write_record_of_number() {
         let input_expr = Expr::record(vec![
-            ("field".to_string(), Expr::number(1f64)),
-            ("field".to_string(), Expr::number(2f64)),
+            ("field".to_string(), Expr::untyped_number(1f64)),
+            ("field".to_string(), Expr::untyped_number(2f64)),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "{field: 1, field: 2}".to_string();
@@ -293,11 +293,11 @@ mod record_tests {
         let input_expr = Expr::record(vec![
             (
                 "a".to_string(),
-                Expr::greater_than(Expr::number(1f64), Expr::number(2f64)),
+                Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
             ),
             (
                 "b".to_string(),
-                Expr::less_than(Expr::number(1f64), Expr::number(2f64)),
+                Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
             ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
@@ -599,8 +599,8 @@ mod sequence_tests {
     #[test]
     fn test_round_trip_read_write_sequence_of_math_op() {
         let input_expr = Expr::sequence(vec![
-            Expr::greater_than(Expr::number(1f64), Expr::number(2f64)),
-            Expr::less_than(Expr::number(1f64), Expr::number(2f64)),
+            Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+            Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "[1 > 2, 1 < 2]".to_string();
@@ -855,8 +855,8 @@ mod tuple_tests {
     #[test]
     fn test_round_trip_read_write_tuple_of_math_op() {
         let input_expr = Expr::tuple(vec![
-            Expr::greater_than(Expr::number(1f64), Expr::number(2f64)),
-            Expr::less_than(Expr::number(1f64), Expr::number(2f64)),
+            Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+            Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "(1 > 2, 1 < 2)".to_string();
@@ -904,7 +904,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_float() {
-        let input_expr = Expr::number(1.1);
+        let input_expr = Expr::untyped_number(1.1);
         let expr_str = to_string(&input_expr).unwrap();
         let output_expr = from_string(expr_str.as_str()).unwrap();
         assert_eq!(input_expr, output_expr);
@@ -912,7 +912,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_u64() {
-        let input_expr = Expr::number(1f64);
+        let input_expr = Expr::untyped_number(1f64);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "1".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
@@ -921,7 +921,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_i64() {
-        let input_expr = Expr::number(-1f64);
+        let input_expr = Expr::untyped_number(-1f64);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "-1".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
@@ -967,7 +967,7 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::let_binding("x", Expr::literal("hello")),
             Expr::let_binding("y", Expr::literal("bar")),
         ]);
@@ -979,7 +979,7 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_str() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::Str),
@@ -1001,17 +1001,17 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_u8() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U8),
-                Box::new(Expr::number(1f64)),
+                Box::new(Expr::untyped_number(1f64)),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U8),
-                Box::new(Expr::number(2f64)),
+                Box::new(Expr::untyped_number(2f64)),
                 InferredType::Unknown,
             ),
         ]);
@@ -1023,17 +1023,17 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_u16() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U16),
-                Box::new(Expr::number(1f64)),
+                Box::new(Expr::untyped_number(1f64)),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U16),
-                Box::new(Expr::number(2f64)),
+                Box::new(Expr::untyped_number(2f64)),
                 InferredType::Unknown,
             ),
         ]);
@@ -1045,17 +1045,17 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_u32() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U32),
-                Box::new(Expr::number(1f64)),
+                Box::new(Expr::untyped_number(1f64)),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U32),
-                Box::new(Expr::number(2f64)),
+                Box::new(Expr::untyped_number(2f64)),
                 InferredType::Unknown,
             ),
         ]);
@@ -1067,7 +1067,7 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_option() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::Option(Box::new(TypeName::Str))),
@@ -1096,7 +1096,7 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_list() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::List(Box::new(TypeName::Str))),
@@ -1125,7 +1125,7 @@ mod let_tests {
 
     #[test]
     fn test_round_trip_read_write_let_with_type_binding_tuple() {
-        let input_expr = Expr::multiple(vec![
+        let input_expr = Expr::expr_block(vec![
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::Tuple(vec![TypeName::Str])),
@@ -1411,14 +1411,14 @@ mod match_tests {
                         "ok",
                         vec![ArmPattern::literal(Expr::identifier("foo"))],
                     ),
-                    Expr::greater_than(Expr::number(1.0), Expr::number(2.0)),
+                    Expr::greater_than(Expr::untyped_number(1.0), Expr::untyped_number(2.0)),
                 ),
                 MatchArm::new(
                     ArmPattern::constructor(
                         "err",
                         vec![ArmPattern::literal(Expr::identifier("msg"))],
                     ),
-                    Expr::less_than(Expr::number(1.0), Expr::number(2.0)),
+                    Expr::less_than(Expr::untyped_number(1.0), Expr::untyped_number(2.0)),
                 ),
             ],
         );
@@ -1776,7 +1776,7 @@ mod if_cond_tests {
         let input_expr = Expr::cond(
             Expr::equal_to(
                 Expr::select_field(Expr::identifier("worker"), "response"),
-                Expr::number(1f64),
+                Expr::untyped_number(1f64),
             ),
             Expr::flags(vec!["flag1".to_string(), "flag2".to_string()]),
             Expr::literal("failed"),

--- a/golem-rib/src/type_inference/call_arguments_inference.rs
+++ b/golem-rib/src/type_inference/call_arguments_inference.rs
@@ -518,7 +518,7 @@ mod function_parameters_inference_tests {
         expr.infer_call_arguments_type(&function_type_registry)
             .unwrap();
 
-        let let_binding = Expr::let_binding("x", Expr::number(1f64));
+        let let_binding = Expr::let_binding("x", Expr::untyped_number(1f64));
 
         let call_expr = Expr::Call(
             CallType::Function(DynamicParsedFunctionName {

--- a/golem-rib/src/type_inference/expr_visitor.rs
+++ b/golem-rib/src/type_inference/expr_visitor.rs
@@ -31,6 +31,22 @@ pub fn visit_children_bottom_up_mut<'a>(expr: &'a mut Expr, queue: &mut VecDeque
             queue.push_back(&mut *lhs);
             queue.push_back(&mut *rhs);
         }
+        Expr::Plus(lhs, rhs, _) => {
+            queue.push_back(&mut *lhs);
+            queue.push_back(&mut *rhs);
+        }
+        Expr::Minus(lhs, rhs, _) => {
+            queue.push_back(&mut *lhs);
+            queue.push_back(&mut *rhs);
+        }
+        Expr::Divide(lhs, rhs, _) => {
+            queue.push_back(&mut *lhs);
+            queue.push_back(&mut *rhs);
+        }
+        Expr::Multiply(lhs, rhs, _) => {
+            queue.push_back(&mut *lhs);
+            queue.push_back(&mut *rhs);
+        }
         Expr::LessThan(lhs, rhs, _) => {
             queue.push_back(&mut *lhs);
             queue.push_back(&mut *rhs);
@@ -67,6 +83,26 @@ pub fn visit_children_bottom_up_mut<'a>(expr: &'a mut Expr, queue: &mut VecDeque
         Expr::Or(expr1, expr2, _) => {
             queue.push_back(&mut *expr1);
             queue.push_back(&mut *expr2)
+        }
+
+        Expr::ListComprehension {
+            iterable_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_back(&mut *iterable_expr);
+            queue.push_back(&mut *yield_expr);
+        }
+
+        Expr::ListReduce {
+            iterable_expr,
+            init_value_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_back(iterable_expr);
+            queue.push_back(init_value_expr);
+            queue.push_back(yield_expr);
         }
 
         Expr::GetTag(exr, _) => {
@@ -110,6 +146,22 @@ pub fn visit_children_bottom_up<'a>(expr: &'a Expr, queue: &mut VecDeque<&'a Exp
             queue.push_back(lhs);
             queue.push_back(rhs);
         }
+        Expr::Plus(lhs, rhs, _) => {
+            queue.push_back(lhs);
+            queue.push_back(rhs);
+        }
+        Expr::Minus(lhs, rhs, _) => {
+            queue.push_back(lhs);
+            queue.push_back(rhs);
+        }
+        Expr::Divide(lhs, rhs, _) => {
+            queue.push_back(lhs);
+            queue.push_back(rhs);
+        }
+        Expr::Multiply(lhs, rhs, _) => {
+            queue.push_back(lhs);
+            queue.push_back(rhs);
+        }
         Expr::LessThan(lhs, rhs, _) => {
             queue.push_back(lhs);
             queue.push_back(rhs);
@@ -146,6 +198,24 @@ pub fn visit_children_bottom_up<'a>(expr: &'a Expr, queue: &mut VecDeque<&'a Exp
         Expr::Or(expr1, expr2, _) => {
             queue.push_back(expr1);
             queue.push_back(expr2);
+        }
+        Expr::ListComprehension {
+            iterable_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_back(iterable_expr);
+            queue.push_back(yield_expr)
+        }
+        Expr::ListReduce {
+            iterable_expr,
+            init_value_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_back(iterable_expr);
+            queue.push_back(init_value_expr);
+            queue.push_back(yield_expr);
         }
         Expr::GetTag(expr, _) => {
             queue.push_back(expr);
@@ -209,6 +279,22 @@ pub fn visit_children_mut_top_down<'a>(expr: &'a mut Expr, queue: &mut VecDeque<
             queue.push_front(&mut *lhs);
             queue.push_front(&mut *rhs);
         }
+        Expr::Plus(lhs, rhs, _) => {
+            queue.push_front(&mut *lhs);
+            queue.push_front(&mut *rhs);
+        }
+        Expr::Minus(lhs, rhs, _) => {
+            queue.push_front(&mut *lhs);
+            queue.push_front(&mut *rhs);
+        }
+        Expr::Divide(lhs, rhs, _) => {
+            queue.push_front(&mut *lhs);
+            queue.push_front(&mut *rhs);
+        }
+        Expr::Multiply(lhs, rhs, _) => {
+            queue.push_front(&mut *lhs);
+            queue.push_front(&mut *rhs);
+        }
         Expr::LessThan(lhs, rhs, _) => {
             queue.push_front(&mut *lhs);
             queue.push_front(&mut *rhs);
@@ -250,6 +336,24 @@ pub fn visit_children_mut_top_down<'a>(expr: &'a mut Expr, queue: &mut VecDeque<
         }
         Expr::GetTag(expr, _) => {
             queue.push_front(&mut *expr);
+        }
+        Expr::ListComprehension {
+            iterable_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_front(iterable_expr);
+            queue.push_front(yield_expr)
+        }
+        Expr::ListReduce {
+            iterable_expr,
+            init_value_expr,
+            yield_expr,
+            ..
+        } => {
+            queue.push_front(iterable_expr);
+            queue.push_front(init_value_expr);
+            queue.push_front(yield_expr);
         }
 
         Expr::Unwrap(expr, _) => queue.push_front(&mut *expr),

--- a/golem-rib/src/type_inference/type_binding.rs
+++ b/golem-rib/src/type_inference/type_binding.rs
@@ -63,6 +63,10 @@ mod internal {
             | Expr::LessThanOrEqualTo(_, _, inferred_type)
             | Expr::EqualTo(_, _, inferred_type)
             | Expr::LessThan(_, _, inferred_type)
+            | Expr::Plus(_, _, inferred_type)
+            | Expr::Minus(_, _, inferred_type)
+            | Expr::Divide(_, _, inferred_type)
+            | Expr::Multiply(_, _, inferred_type)
             | Expr::Cond(_, _, _, inferred_type)
             | Expr::PatternMatch(_, _, inferred_type)
             | Expr::Option(_, inferred_type)
@@ -72,6 +76,8 @@ mod internal {
             | Expr::GetTag(_, inferred_type)
             | Expr::And(_, _, inferred_type)
             | Expr::Or(_, _, inferred_type)
+            | Expr::ListComprehension { inferred_type, .. }
+            | Expr::ListReduce { inferred_type, .. }
             | Expr::Call(_, _, inferred_type) => {
                 *inferred_type = new_type;
             }

--- a/golem-rib/src/type_inference/type_unification.rs
+++ b/golem-rib/src/type_inference/type_unification.rs
@@ -150,6 +150,56 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 }
             }
 
+            Expr::ListComprehension {
+                iterable_expr,
+                yield_expr,
+                inferred_type,
+                ..
+            } => {
+                queue.push(iterable_expr);
+                queue.push(yield_expr);
+
+                let unified_inferred_type = inferred_type.unify();
+
+                match unified_inferred_type {
+                    Ok(unified_type) => *inferred_type = unified_type,
+                    Err(e) => {
+                        errors.push(format!(
+                            "Unable to resolve the type of list comprehension {}",
+                            expr_str
+                        ));
+
+                        errors.push(e)
+                    }
+                }
+            }
+
+            Expr::ListReduce {
+                iterable_expr,
+                init_value_expr,
+                yield_expr,
+                inferred_type,
+                ..
+            } => {
+                queue.push(iterable_expr);
+                queue.push(init_value_expr);
+                queue.push(yield_expr);
+
+                let unified_inferred_type = inferred_type.unify();
+
+                match unified_inferred_type {
+                    Ok(unified_type) => *inferred_type = unified_type,
+                    Err(e) => {
+                        errors.push(format!(
+                            "Unable to resolve the type of list aggregation {}",
+                            expr_str
+                        ));
+
+                        errors.push(e)
+                    }
+                }
+            }
+
             Expr::PatternMatch(expr, arms, inferred_type) => {
                 queue.push(expr);
                 for arm in arms.iter_mut().rev() {
@@ -272,6 +322,7 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                     }
                 }
             }
+
             Expr::Not(expr, inferred_type) => {
                 queue.push(expr);
                 let unified_inferred_type = inferred_type.unify();
@@ -326,6 +377,42 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
                 queue.push(right);
             }
 
+            Expr::Plus(left, right, inferred_type) => internal::handle_math_op(
+                &mut queue,
+                left,
+                right,
+                inferred_type,
+                &mut errors,
+                expr_str,
+            ),
+
+            Expr::Minus(left, right, inferred_type) => internal::handle_math_op(
+                &mut queue,
+                left,
+                right,
+                inferred_type,
+                &mut errors,
+                expr_str,
+            ),
+
+            Expr::Divide(left, right, inferred_type) => internal::handle_math_op(
+                &mut queue,
+                left,
+                right,
+                inferred_type,
+                &mut errors,
+                expr_str,
+            ),
+
+            Expr::Multiply(left, right, inferred_type) => internal::handle_math_op(
+                &mut queue,
+                left,
+                right,
+                inferred_type,
+                &mut errors,
+                expr_str,
+            ),
+
             Expr::And(left, right, _) => {
                 queue.push(left);
                 queue.push(right);
@@ -362,7 +449,28 @@ pub fn unify_types(expr: &mut Expr) -> Result<(), Vec<String>> {
 }
 
 mod internal {
-    use crate::{ArmPattern, Expr};
+    use crate::{ArmPattern, Expr, InferredType};
+
+    pub(crate) fn handle_math_op<'a>(
+        queue: &mut Vec<&'a mut Expr>,
+        left: &'a mut Expr,
+        right: &'a mut Expr,
+        inferred_type: &mut InferredType,
+        errors: &mut Vec<String>,
+        expr_str: &str,
+    ) {
+        queue.push(left);
+        queue.push(right);
+        let unified_inferred_type = inferred_type.unify();
+
+        match unified_inferred_type {
+            Ok(unified_type) => *inferred_type = unified_type,
+            Err(e) => {
+                errors.push(format!("Unable to resolve the type of {}", expr_str));
+                errors.push(e);
+            }
+        }
+    }
 
     // Push any existence of expr in arm patterns to queue
     pub(crate) fn push_arm_pattern_expr<'a>(

--- a/golem-rib/src/type_inference/variable_binding_let_assignment.rs
+++ b/golem-rib/src/type_inference/variable_binding_let_assignment.rs
@@ -15,7 +15,7 @@
 use crate::Expr;
 use std::collections::VecDeque;
 
-pub fn name_binding_local_variables(expr: &mut Expr) {
+pub fn bind_variables_of_let_assignment(expr: &mut Expr) {
     let mut identifier_id_state = internal::IdentifierVariableIdState::new();
     let mut queue = VecDeque::new();
     queue.push_front(expr);
@@ -89,12 +89,12 @@ mod name_binding_tests {
         let mut expr = Expr::from_text(rib_expr).unwrap();
 
         // Bind x in let with the x in foo
-        expr.name_binding_local_variables();
+        expr.bind_variables_of_let_assignment();
 
         let let_binding = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::number(1f64)),
+            Box::new(Expr::untyped_number(1f64)),
             InferredType::Unknown,
         );
 
@@ -112,7 +112,7 @@ mod name_binding_tests {
             InferredType::Unknown,
         );
 
-        let expected = Expr::multiple(vec![let_binding, call_expr]);
+        let expected = Expr::expr_block(vec![let_binding, call_expr]);
 
         assert_eq!(expr, expected);
     }
@@ -129,19 +129,19 @@ mod name_binding_tests {
         let mut expr = Expr::from_text(rib_expr).unwrap();
 
         // Bind x in let with the x in foo
-        expr.name_binding_local_variables();
+        expr.bind_variables_of_let_assignment();
 
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::number(1f64)),
+            Box::new(Expr::untyped_number(1f64)),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("y", 0),
             None,
-            Box::new(Expr::number(2f64)),
+            Box::new(Expr::untyped_number(2f64)),
             InferredType::Unknown,
         );
 
@@ -173,7 +173,7 @@ mod name_binding_tests {
             InferredType::Unknown,
         );
 
-        let expected = Expr::multiple(vec![let_binding1, let_binding2, call_expr1, call_expr2]);
+        let expected = Expr::expr_block(vec![let_binding1, let_binding2, call_expr1, call_expr2]);
 
         assert_eq!(expr, expected);
     }
@@ -190,19 +190,19 @@ mod name_binding_tests {
         let mut expr = Expr::from_text(rib_expr).unwrap();
 
         // Bind x in let with the x in foo
-        expr.name_binding_local_variables();
+        expr.bind_variables_of_let_assignment();
 
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::number(1f64)),
+            Box::new(Expr::untyped_number(1f64)),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("x", 1),
             None,
-            Box::new(Expr::number(2f64)),
+            Box::new(Expr::untyped_number(2f64)),
             InferredType::Unknown,
         );
 
@@ -234,7 +234,7 @@ mod name_binding_tests {
             InferredType::Unknown,
         );
 
-        let expected = Expr::multiple(vec![let_binding1, call_expr1, let_binding2, call_expr2]);
+        let expected = Expr::expr_block(vec![let_binding1, call_expr1, let_binding2, call_expr2]);
 
         assert_eq!(expr, expected);
     }

--- a/golem-rib/src/type_inference/variable_binding_list_comprehension.rs
+++ b/golem-rib/src/type_inference/variable_binding_list_comprehension.rs
@@ -1,0 +1,64 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Expr, VariableId};
+use std::collections::VecDeque;
+
+pub fn bind_variables_of_list_comprehension(expr: &mut Expr) {
+    let mut queue = VecDeque::new();
+    queue.push_front(expr);
+
+    // Start from the end
+    while let Some(expr) = queue.pop_front() {
+        match expr {
+            Expr::ListComprehension {
+                iterated_variable,
+                iterable_expr,
+                yield_expr,
+                ..
+            } => {
+                queue.push_front(iterable_expr);
+                *iterated_variable =
+                    VariableId::list_comprehension_identifier(iterated_variable.name());
+
+                internal::process_yield_expr(iterated_variable, yield_expr)
+            }
+            _ => {
+                expr.visit_children_mut_top_down(&mut queue);
+            }
+        }
+    }
+}
+
+mod internal {
+    use crate::{Expr, VariableId};
+    use std::collections::VecDeque;
+
+    pub(crate) fn process_yield_expr(variable_id: &mut VariableId, yield_expr: &mut Expr) {
+        let mut queue = VecDeque::new();
+
+        queue.push_front(yield_expr);
+
+        while let Some(expr) = queue.pop_front() {
+            match expr {
+                Expr::Identifier(variable_in_yield, _) => {
+                    if variable_id.name() == variable_in_yield.name() {
+                        *variable_in_yield = variable_id.clone();
+                    }
+                }
+                _ => expr.visit_children_mut_top_down(&mut queue),
+            }
+        }
+    }
+}

--- a/golem-rib/src/type_inference/variable_binding_list_reduce.rs
+++ b/golem-rib/src/type_inference/variable_binding_list_reduce.rs
@@ -1,0 +1,77 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Expr, VariableId};
+use std::collections::VecDeque;
+pub fn bind_variables_of_list_reduce(expr: &mut Expr) {
+    let mut queue = VecDeque::new();
+    queue.push_front(expr);
+
+    // Start from the end
+    while let Some(expr) = queue.pop_front() {
+        match expr {
+            Expr::ListReduce {
+                reduce_variable,
+                iterated_variable,
+                iterable_expr,
+                init_value_expr,
+                yield_expr,
+                ..
+            } => {
+                queue.push_front(iterable_expr);
+                queue.push_front(init_value_expr);
+
+                // While parser may update this directly, type inference phase
+                // still ensures that these variables are tagged to its appropriately
+                *iterated_variable =
+                    VariableId::list_comprehension_identifier(iterated_variable.name());
+
+                *reduce_variable = VariableId::list_reduce_identifier(reduce_variable.name());
+
+                internal::process_yield_expr(reduce_variable, iterated_variable, yield_expr)
+            }
+            _ => {
+                expr.visit_children_mut_top_down(&mut queue);
+            }
+        }
+    }
+}
+
+mod internal {
+    use crate::{Expr, VariableId};
+    use std::collections::VecDeque;
+
+    pub(crate) fn process_yield_expr(
+        reduce_variable: &mut VariableId,
+        iterated_variable_id: &mut VariableId,
+        yield_expr: &mut Expr,
+    ) {
+        let mut queue = VecDeque::new();
+
+        queue.push_front(yield_expr);
+
+        while let Some(expr) = queue.pop_front() {
+            match expr {
+                Expr::Identifier(variable_in_yield, _) => {
+                    if iterated_variable_id.name() == variable_in_yield.name() {
+                        *variable_in_yield = iterated_variable_id.clone();
+                    } else if reduce_variable.name() == variable_in_yield.name() {
+                        *variable_in_yield = reduce_variable.clone()
+                    }
+                }
+                _ => expr.visit_children_mut_top_down(&mut queue),
+            }
+        }
+    }
+}

--- a/golem-rib/src/type_inference/variable_binding_pattern_match.rs
+++ b/golem-rib/src/type_inference/variable_binding_pattern_match.rs
@@ -19,15 +19,15 @@ use crate::Expr;
 // we make sure to replace global variable or local variable identifiers with match-arm identifiers (VariableId enum)
 // to prevent conflicts with other local let bindings
 // or global variables, thereby maintaining clear variable scoping and avoiding unintended clashes.
-pub fn name_binding_pattern_matches(expr: &mut Expr) {
-    internal::pattern_match_name_binding(expr, 0, &mut []);
+pub fn bind_variables_of_pattern_match(expr: &mut Expr) {
+    internal::bind_variables(expr, 0, &mut []);
 }
 
 mod internal {
     use crate::{ArmPattern, Expr, MatchArm, MatchIdentifier, VariableId};
     use std::collections::VecDeque;
 
-    pub(crate) fn pattern_match_name_binding(
+    pub(crate) fn bind_variables(
         expr: &mut Expr,
         previous_index: usize,
         match_identifiers: &mut [MatchIdentifier],
@@ -131,7 +131,7 @@ mod internal {
 
         // Continue with original pattern_match_name_binding for resoution expressions
         // to target nested pattern matching.
-        pattern_match_name_binding(
+        bind_variables(
             resolution_expression,
             global_arm_index,
             &mut match_identifiers,
@@ -186,7 +186,7 @@ mod pattern_match_bindings {
 
         let mut expr = Expr::from_text(expr_string).unwrap();
 
-        expr.name_binding_pattern_match_variables();
+        expr.bind_variables_of_pattern_match();
 
         assert_eq!(expr, expected_match(1));
     }
@@ -206,7 +206,7 @@ mod pattern_match_bindings {
 
         let mut expr = Expr::from_text(expr_string).unwrap();
 
-        expr.name_binding_pattern_match_variables();
+        expr.bind_variables_of_pattern_match();
 
         assert_eq!(expr, expected_match_with_let_binding(1));
     }
@@ -228,7 +228,7 @@ mod pattern_match_bindings {
 
         let mut expr = Expr::from_text(expr_string).unwrap();
 
-        expr.name_binding_pattern_match_variables();
+        expr.bind_variables_of_pattern_match();
 
         let first_expr = expected_match(1);
         let second_expr = expected_match(3); // 3 because first block has 2 arms
@@ -252,7 +252,7 @@ mod pattern_match_bindings {
 
         let mut expr = Expr::from_text(expr_string).unwrap();
 
-        expr.name_binding_pattern_match_variables();
+        expr.bind_variables_of_pattern_match();
 
         assert_eq!(expr, expected_nested_match());
     }
@@ -291,7 +291,7 @@ mod pattern_match_bindings {
                     },
                     MatchArm {
                         arm_pattern: ArmPattern::constructor("none", vec![]),
-                        arm_resolution_expr: Box::new(Expr::number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
                     },
                 ],
                 InferredType::Unknown,
@@ -299,7 +299,7 @@ mod pattern_match_bindings {
         }
 
         pub(crate) fn expected_match_with_let_binding(index: usize) -> Expr {
-            let let_binding = Expr::let_binding("x", Expr::number(1f64));
+            let let_binding = Expr::let_binding("x", Expr::untyped_number(1f64));
             let identifier_expr =
                 Expr::Identifier(VariableId::Global("x".to_string()), InferredType::Unknown);
             let block = Expr::ExprBlock(vec![let_binding, identifier_expr], InferredType::Unknown);
@@ -322,7 +322,7 @@ mod pattern_match_bindings {
                     },
                     MatchArm {
                         arm_pattern: ArmPattern::constructor("none", vec![]),
-                        arm_resolution_expr: Box::new(Expr::number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
                     },
                 ],
                 InferredType::Unknown,
@@ -388,7 +388,7 @@ mod pattern_match_bindings {
                                 },
                                 MatchArm {
                                     arm_pattern: ArmPattern::constructor("none", vec![]),
-                                    arm_resolution_expr: Box::new(Expr::number(0f64)),
+                                    arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
                                 },
                             ],
                             InferredType::Unknown,
@@ -405,7 +405,7 @@ mod pattern_match_bindings {
                                 InferredType::Unknown,
                             ))],
                         ),
-                        arm_resolution_expr: Box::new(Expr::number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
                     },
                 ],
                 InferredType::Unknown,

--- a/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
+++ b/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
@@ -275,7 +275,7 @@ mod tests {
                 path: path_pattern,
                 method: MethodPattern::Get,
                 binding: GolemWorkerBinding {
-                    worker_name: Expr::multiple(vec![
+                    worker_name: Expr::expr_block(vec![
                         Expr::let_binding_with_type(
                             "x",
                             rib::TypeName::Str,
@@ -304,7 +304,7 @@ mod tests {
                                 "body".to_string(),
                                 Expr::select_field(Expr::identifier("worker"), "response",),
                             ),
-                            ("status".to_string(), Expr::number(200f64)),
+                            ("status".to_string(), Expr::untyped_number(200f64)),
                         ]
                         .into_iter()
                         .collect()

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -133,7 +133,7 @@ mod tests {
     use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
     use golem_wasm_rpc::protobuf::{NameTypePair, NameValuePair, Type, TypedRecord, TypedTuple};
     use http::{HeaderMap, HeaderValue, Method};
-    use rib::{GetLiteralValue, RibInterpreterStackValue};
+    use rib::{GetLiteralValue, RibResult};
     use serde_json::Value;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -275,7 +275,7 @@ mod tests {
         }
     }
 
-    impl ToResponse<TestResponse> for RibInterpreterStackValue {
+    impl ToResponse<TestResponse> for RibResult {
         fn to_response(&self, _request_details: &RequestDetails) -> TestResponse {
             let function_name = self
                 .get_val()

--- a/golem-worker-service-base/src/http/http_request.rs
+++ b/golem-worker-service-base/src/http/http_request.rs
@@ -133,7 +133,7 @@ mod tests {
     use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
     use golem_wasm_rpc::protobuf::{NameTypePair, NameValuePair, Type, TypedRecord, TypedTuple};
     use http::{HeaderMap, HeaderValue, Method};
-    use rib::{GetLiteralValue, RibInterpreterResult};
+    use rib::{GetLiteralValue, RibInterpreterStackValue};
     use serde_json::Value;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -275,7 +275,7 @@ mod tests {
         }
     }
 
-    impl ToResponse<TestResponse> for RibInterpreterResult {
+    impl ToResponse<TestResponse> for RibInterpreterStackValue {
         fn to_response(&self, _request_details: &RequestDetails) -> TestResponse {
             let function_name = self
                 .get_val()

--- a/golem-worker-service-base/src/worker_binding/rib_input_value_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/rib_input_value_resolver.rs
@@ -1,7 +1,7 @@
 use crate::worker_binding::{RequestDetails, WorkerDetail};
 use golem_wasm_rpc::json::TypeAnnotatedValueJsonExtensions;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
-use rib::RibInputTypeInfo;
+use rib::{RibInput, RibInputTypeInfo};
 use std::collections::HashMap;
 use std::fmt::Display;
 
@@ -13,7 +13,7 @@ pub trait RibInputValueResolver {
     fn resolve_rib_input_value(
         &self,
         required_type: &RibInputTypeInfo,
-    ) -> Result<RibInputValue, RibInputTypeMismatch>;
+    ) -> Result<RibInput, RibInputTypeMismatch>;
 }
 
 #[derive(Debug)]
@@ -25,30 +25,11 @@ impl Display for RibInputTypeMismatch {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct RibInputValue {
-    pub value: HashMap<String, TypeAnnotatedValue>,
-}
-
-impl RibInputValue {
-    pub fn empty() -> Self {
-        RibInputValue {
-            value: HashMap::new(),
-        }
-    }
-
-    pub fn merge(&self, other: RibInputValue) -> RibInputValue {
-        let mut cloned = self.clone();
-        cloned.value.extend(other.value);
-        cloned
-    }
-}
-
 impl RibInputValueResolver for RequestDetails {
     fn resolve_rib_input_value(
         &self,
         required_types: &RibInputTypeInfo,
-    ) -> Result<RibInputValue, RibInputTypeMismatch> {
+    ) -> Result<RibInput, RibInputTypeMismatch> {
         let request_type_info = required_types.types.get("request");
 
         let rib_input_with_request_content = &self.as_json();
@@ -60,11 +41,11 @@ impl RibInputValueResolver for RequestDetails {
 
                 let mut rib_input_map = HashMap::new();
                 rib_input_map.insert("request".to_string(), input);
-                Ok(RibInputValue {
-                    value: rib_input_map,
+                Ok(RibInput {
+                    input: rib_input_map,
                 })
             }
-            None => Ok(RibInputValue::empty()),
+            None => Ok(RibInput::empty()),
         }
     }
 }
@@ -73,7 +54,7 @@ impl RibInputValueResolver for WorkerDetail {
     fn resolve_rib_input_value(
         &self,
         required_types: &RibInputTypeInfo,
-    ) -> Result<RibInputValue, RibInputTypeMismatch> {
+    ) -> Result<RibInput, RibInputTypeMismatch> {
         let request_type_info = required_types.types.get("worker");
 
         match request_type_info {
@@ -85,11 +66,11 @@ impl RibInputValueResolver for WorkerDetail {
 
                 let mut rib_input_map = HashMap::new();
                 rib_input_map.insert("worker".to_string(), request_value);
-                Ok(RibInputValue {
-                    value: rib_input_map,
+                Ok(RibInput {
+                    input: rib_input_map,
                 })
             }
-            None => Ok(RibInputValue::empty()),
+            None => Ok(RibInput::empty()),
         }
     }
 }

--- a/golem-worker-service-base/src/worker_binding/rib_input_value_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/rib_input_value_resolver.rs
@@ -45,7 +45,7 @@ impl RibInputValueResolver for RequestDetails {
                     input: rib_input_map,
                 })
             }
-            None => Ok(RibInput::empty()),
+            None => Ok(RibInput::default()),
         }
     }
 }
@@ -70,7 +70,7 @@ impl RibInputValueResolver for WorkerDetail {
                     input: rib_input_map,
                 })
             }
-            None => Ok(RibInput::empty()),
+            None => Ok(RibInput::default()),
         }
     }
 }

--- a/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
@@ -7,7 +7,7 @@ use crate::worker_service_rib_interpreter::WorkerServiceRibInterpreter;
 use async_trait::async_trait;
 use golem_common::model::IdempotencyKey;
 use golem_service_base::model::VersionedComponentId;
-use rib::RibInterpreterStackValue;
+use rib::RibResult;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -84,7 +84,7 @@ impl ResolvedWorkerBindingFromRequest {
         evaluator: &Arc<dyn WorkerServiceRibInterpreter + Sync + Send>,
     ) -> R
     where
-        RibInterpreterStackValue: ToResponse<R>,
+        RibResult: ToResponse<R>,
         EvaluationError: ToResponse<R>,
         RibInputTypeMismatch: ToResponse<R>,
     {

--- a/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
@@ -7,7 +7,7 @@ use crate::worker_service_rib_interpreter::WorkerServiceRibInterpreter;
 use async_trait::async_trait;
 use golem_common::model::IdempotencyKey;
 use golem_service_base::model::VersionedComponentId;
-use rib::RibInterpreterResult;
+use rib::RibInterpreterStackValue;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -84,7 +84,7 @@ impl ResolvedWorkerBindingFromRequest {
         evaluator: &Arc<dyn WorkerServiceRibInterpreter + Sync + Send>,
     ) -> R
     where
-        RibInterpreterResult: ToResponse<R>,
+        RibInterpreterStackValue: ToResponse<R>,
         EvaluationError: ToResponse<R>,
         RibInputTypeMismatch: ToResponse<R>,
     {

--- a/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
+++ b/golem-worker-service-base/src/worker_binding/worker_binding_resolver.rs
@@ -174,7 +174,7 @@ impl RequestToWorkerBindingResolver<CompiledHttpApiDefinition> for InputHttpRequ
         // To evaluate worker-name, most probably
         let worker_name: String = rib::interpret_pure(
             &binding.worker_name_compiled.compiled_worker_name,
-            &resolve_rib_input.value,
+            &resolve_rib_input,
         )
         .await
         .map_err(|err| format!("Failed to evaluate worker name rib expression. {}", err))?
@@ -188,7 +188,7 @@ impl RequestToWorkerBindingResolver<CompiledHttpApiDefinition> for InputHttpRequ
             if let Some(idempotency_key_compiled) = &binding.idempotency_key_compiled {
                 let idempotency_key_value = rib::interpret_pure(
                     &idempotency_key_compiled.compiled_idempotency_key,
-                    &resolve_rib_input.value,
+                    &resolve_rib_input,
                 )
                 .await
                 .map_err(|err| err.to_string())?;

--- a/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
+++ b/golem-worker-service-base/src/worker_bridge_execution/to_response.rs
@@ -3,13 +3,13 @@ use crate::worker_service_rib_interpreter::EvaluationError;
 
 use http::StatusCode;
 use poem::Body;
-use rib::RibInterpreterStackValue;
+use rib::RibResult;
 
 pub trait ToResponse<A> {
     fn to_response(&self, request_details: &RequestDetails) -> A;
 }
 
-impl ToResponse<poem::Response> for RibInterpreterStackValue {
+impl ToResponse<poem::Response> for RibResult {
     fn to_response(&self, request_details: &RequestDetails) -> poem::Response {
         match internal::IntermediateHttpResponse::from(self) {
             Ok(intermediate_response) => intermediate_response.to_http_response(request_details),
@@ -63,7 +63,7 @@ mod internal {
     use golem_wasm_rpc::protobuf::TypedRecord;
     use poem::web::headers::ContentType;
     use poem::{Body, IntoResponse, ResponseParts};
-    use rib::{GetLiteralValue, LiteralValue, RibInterpreterStackValue};
+    use rib::{GetLiteralValue, LiteralValue, RibResult};
     use std::collections::HashMap;
 
     pub(crate) struct IntermediateHttpResponse {
@@ -74,10 +74,10 @@ mod internal {
 
     impl IntermediateHttpResponse {
         pub(crate) fn from(
-            evaluation_result: &RibInterpreterStackValue,
+            evaluation_result: &RibResult,
         ) -> Result<IntermediateHttpResponse, EvaluationError> {
             match evaluation_result {
-                RibInterpreterStackValue::Val(typed_value) => {
+                RibResult::Val(typed_value) => {
                     let status = match typed_value.get_optional(&Path::from_key("status")) {
                         Some(typed_value) => get_status_code(&typed_value),
                         None => Ok(StatusCode::OK),
@@ -98,7 +98,7 @@ mod internal {
                         headers,
                     })
                 }
-                RibInterpreterStackValue::Unit => Ok(IntermediateHttpResponse {
+                RibResult::Unit => Ok(IntermediateHttpResponse {
                     body: None,
                     status: StatusCode::default(),
                     headers: ResolvedResponseHeaders::default(),
@@ -256,7 +256,7 @@ mod test {
     use crate::worker_bridge_execution::to_response::ToResponse;
     use http::header::CONTENT_TYPE;
     use http::StatusCode;
-    use rib::RibInterpreterStackValue;
+    use rib::RibResult;
     use std::collections::HashMap;
 
     fn create_record(values: Vec<(String, TypeAnnotatedValue)>) -> TypeAnnotatedValue {
@@ -301,7 +301,7 @@ mod test {
             ),
         ]);
 
-        let evaluation_result: RibInterpreterStackValue = RibInterpreterStackValue::Val(record);
+        let evaluation_result: RibResult = RibResult::Val(record);
 
         let http_response: poem::Response =
             evaluation_result.to_response(&RequestDetails::Http(HttpRequestDetails::empty()));
@@ -326,8 +326,8 @@ mod test {
 
     #[test]
     async fn test_evaluation_result_to_response_with_no_http_specifics() {
-        let evaluation_result: RibInterpreterStackValue =
-            RibInterpreterStackValue::Val(TypeAnnotatedValue::Str("Healthy".to_string()));
+        let evaluation_result: RibResult =
+            RibResult::Val(TypeAnnotatedValue::Str("Healthy".to_string()));
 
         let http_response: poem::Response =
             evaluation_result.to_response(&RequestDetails::Http(HttpRequestDetails::empty()));

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -8,7 +8,7 @@ use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_common::model::{ComponentId, IdempotencyKey};
 
 use crate::worker_binding::RibInputValue;
-use rib::{RibByteCode, RibFunctionInvoke, RibResult};
+use rib::{RibByteCode, RibFunctionInvoke, RibInterpreterInput, RibResult};
 
 use crate::worker_bridge_execution::{WorkerRequest, WorkerRequestExecutor};
 
@@ -99,8 +99,12 @@ impl WorkerServiceRibInterpreter for DefaultRibInterpreter {
                 .boxed() // This ensures the future is boxed with the correct type
             },
         );
-        rib::interpret(expr, rib_input.value.clone(), worker_invoke_function)
-            .await
-            .map_err(EvaluationError)
+        rib::interpret(
+            expr,
+            RibInterpreterInput::new(rib_input.value.clone()),
+            worker_invoke_function,
+        )
+        .await
+        .map_err(EvaluationError)
     }
 }

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -8,7 +8,7 @@ use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_common::model::{ComponentId, IdempotencyKey};
 
 use crate::worker_binding::RibInputValue;
-use rib::{RibByteCode, RibFunctionInvoke, RibInterpreterResult};
+use rib::{RibByteCode, RibFunctionInvoke, RibInterpreterStackValue};
 
 use crate::worker_bridge_execution::{WorkerRequest, WorkerRequestExecutor};
 
@@ -25,7 +25,7 @@ pub trait WorkerServiceRibInterpreter {
         idempotency_key: &Option<IdempotencyKey>,
         rib_byte_code: &RibByteCode,
         rib_input: &RibInputValue,
-    ) -> Result<RibInterpreterResult, EvaluationError>;
+    ) -> Result<RibInterpreterStackValue, EvaluationError>;
 }
 
 #[derive(Debug, PartialEq)]
@@ -66,7 +66,7 @@ impl WorkerServiceRibInterpreter for DefaultRibInterpreter {
         idempotency_key: &Option<IdempotencyKey>,
         expr: &RibByteCode,
         rib_input: &RibInputValue,
-    ) -> Result<RibInterpreterResult, EvaluationError> {
+    ) -> Result<RibInterpreterStackValue, EvaluationError> {
         let executor = self.worker_request_executor.clone();
 
         let worker_name = worker_name.to_string();

--- a/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/worker_service_rib_interpreter/mod.rs
@@ -8,7 +8,7 @@ use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use golem_common::model::{ComponentId, IdempotencyKey};
 
 use crate::worker_binding::RibInputValue;
-use rib::{RibByteCode, RibFunctionInvoke, RibInterpreterStackValue};
+use rib::{RibByteCode, RibFunctionInvoke, RibResult};
 
 use crate::worker_bridge_execution::{WorkerRequest, WorkerRequestExecutor};
 
@@ -25,7 +25,7 @@ pub trait WorkerServiceRibInterpreter {
         idempotency_key: &Option<IdempotencyKey>,
         rib_byte_code: &RibByteCode,
         rib_input: &RibInputValue,
-    ) -> Result<RibInterpreterStackValue, EvaluationError>;
+    ) -> Result<RibResult, EvaluationError>;
 }
 
 #[derive(Debug, PartialEq)]
@@ -66,7 +66,7 @@ impl WorkerServiceRibInterpreter for DefaultRibInterpreter {
         idempotency_key: &Option<IdempotencyKey>,
         expr: &RibByteCode,
         rib_input: &RibInputValue,
-    ) -> Result<RibInterpreterStackValue, EvaluationError> {
+    ) -> Result<RibResult, EvaluationError> {
         let executor = self.worker_request_executor.clone();
 
         let worker_name = worker_name.to_string();


### PR DESCRIPTION
Fixes #910  and #909 

- [x]  List Aggregation Support

```scala
let average = 
  reduce z, a in ages from 0 {
    yield z + a;
  };

 ```

- [x]  List Comprehension Support

```scala
let ages = 
  for p in people {
    yield p.age;
  };
```

- [x]  `RibByteCodeCursor` for Jump loops
- [x] Math operations 

- [x] Type inference parts of all of the above. As reviewers may see, it's consistent with the existing approach for rest of the expressions which validates the approach.  

- [x]  Remove `Clone` from interpreter stack values (a derived outcome, yet a good outcome)
- [x]  Remove duplicate types between golem-rib and golem-worker-service-base (Ex: `RibInputValue`). Now we have only 1 single type which is `RibInput` across the project which acts as the global inputs to a rib script
- [x]  Make `rib_interpreter`  module , `stack values` etc private to golem_rib, and only expose `RibInput` (which is just a wrapper over HashMap of global inputs) to other modules. i.e, golem-worker-service has lesser visibility to golem-rib details with this PR.
- [x] Other needed clean ups


A ticket for this week based on my own review:  https://github.com/golemcloud/golem/issues/1035