### PR TITLE
Initial file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 **/*.rs.bk
 *.pdb
 .idea/
+.vscode/
 golem-worker-executor/data/
 golem-worker-executor-base/data/
 golem-worker-executor-base/golem-wit/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3822,7 @@ dependencies = [
  "hyper 1.5.0",
  "num-traits 0.2.19",
  "pin-project 1.1.7",
+ "poem",
  "poem-openapi",
  "proptest",
  "prost-types",
@@ -4057,6 +4069,7 @@ dependencies = [
  "console-subscriber",
  "dashmap",
  "evicting_cache_map",
+ "faccess",
  "figment",
  "flume",
  "fred",
@@ -4116,6 +4129,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "walkdir",
  "warp",
  "wasmtime",
  "wasmtime-wasi",
@@ -4165,6 +4179,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tap",
+ "tempfile",
  "test-r",
  "tokio",
  "tokio-stream",
@@ -4224,6 +4239,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tap",
+ "tempfile",
  "test-r",
  "testcontainers",
  "testcontainers-modules",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,7 +3530,9 @@ dependencies = [
  "textwrap 0.16.1",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tokio-tungstenite 0.20.1",
+ "tokio-util",
  "tonic",
  "tonic-health",
  "tower",
@@ -3531,6 +3544,7 @@ dependencies = [
  "version-compare",
  "walkdir",
  "wasm-wave",
+ "zip",
 ]
 
 [[package]]
@@ -3560,10 +3574,12 @@ name = "golem-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert2",
  "async-trait",
  "bincode",
  "bytes 1.8.0",
  "chrono",
+ "colored",
  "combine",
  "console-subscriber",
  "dashmap",
@@ -3572,6 +3588,7 @@ dependencies = [
  "fred",
  "futures-core",
  "git-version",
+ "glob",
  "golem-api-grpc",
  "golem-rib",
  "golem-wasm-ast",
@@ -3591,6 +3608,7 @@ dependencies = [
  "regex",
  "serde 1.0.213",
  "serde_json",
+ "serde_yaml",
  "test-r",
  "thiserror",
  "tokio",
@@ -3663,6 +3681,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tap",
+ "tempfile",
  "test-r",
  "thiserror",
  "tokio",
@@ -3799,6 +3818,7 @@ dependencies = [
  "serde 1.0.213",
  "serde_json",
  "sqlx",
+ "tempfile",
  "test-r",
  "thiserror",
  "tokio",
@@ -4079,6 +4099,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "sysinfo",
+ "system-interface",
  "tempfile",
  "test-r",
  "testcontainers",
@@ -4087,6 +4108,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-health",
  "tonic-reflection",
@@ -4099,6 +4121,7 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-wasi-http",
  "windows-sys 0.52.0",
+ "zip",
  "zstd",
 ]
 
@@ -11338,6 +11361,23 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zip"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.6.0",
+ "memchr",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 tracing-test = "0.2.5"
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
+walkdir = "2.5.0"
 warp = "0.3.6"
 wasm-wave = "=0.6.0"
 wasmtime = { version = "=21.0.1", features = ["component-model"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ tokio = { version = "1.0", features = [
 tokio-postgres = "0.7.10"
 tokio-rustls = { version = "0.26.0" }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-util = "0.7.10"
+tokio-util = { version = "0.7.10", features = ["io-util"] }
 toml = "0.8.14"
 tonic = { version = "0.11.0", features = ["gzip"] }
 tonic-reflection = "0.11.0"
@@ -194,7 +194,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "json",
 ] }
 tracing-test = "0.2.5"
-url = "2.5.0"
+url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
 warp = "0.3.6"
 wasm-wave = "=0.6.0"
@@ -202,6 +202,7 @@ wasmtime = { version = "=21.0.1", features = ["component-model"] }
 wasmtime-wasi = { version = "=21.0.1" }
 wasmtime-wasi-http = { version = "=21.0.1" }
 webpki-roots = { version = "0.26.0" }
+zip = { version = "2.2.0", default-features = false, features = ["deflate-flate2", "time"] }
 
 [patch.crates-io]
 wasmtime = { git = "https://github.com/golemcloud/wasmtime.git", branch = "golem-wasmtime-v21.0.1" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -384,9 +384,9 @@ description = "Publishes packages to crates.io"
 dependencies = [
     "build-release",
     "publish-golem-api-grpc",
-    "publish-golem-rib",
     "publish-golem-common",
     "publish-golem-client",
+    "publish-golem-rib",
     "publish-golem-service-base",
     "publish-golem-test-framework",
     "publish-golem-cli",
@@ -547,6 +547,8 @@ condition = { fail_message = "Requires lnav, nginx and redis on path. Install th
 condition_script = ["nginx -v", "lnav --version", "redis-server --version"]
 
 script = '''
+#!/bin/bash
+
 mkdir -pv data logs
 
 redis-server --port 6380 --save "" --appendonly no &> logs/redis.log &

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,7 @@
 # - `cargo make generate-openapi`: generates openapi spec from the code and saves it to the openapi directory
 # - `cargo make publish`: publishes packages to crates.io
 # - `cargo make run`: runs all services locally, requires redis, lnav and nginx
+# - `cargo make run-fast`: runs all services locally, requires redis, lnav and nginx, builds only necessary bins
 # - `cargo make check-configs`: generates configs from code deafults and checks if it is up-to-date
 # - `cargo make generate-configs`: generates configs from code defaults
 # - `cargo make elastic-up`: starts elastic, kibana, filebeat (in detached mode) and loads logs into elastic
@@ -612,6 +613,16 @@ kill $shard_manager_pid || true
 kill $router_pid || true
 kill $redis_pid || true
 '''
+
+[tasks.build-bins-fast]
+description = "Builds executables (exluding 'integration-tests') in debug mode"
+command = "cargo"
+args = ["build", "--workspace", "--bins", "--exclude", "integration-tests"]
+
+[tasks.run-fast]
+extend = "run"
+description = "Runs all the services locally, builds only necessary bins"
+dependencies = ["build-bins-fast"]
 
 ## ** GENERATE CONFIGS **
 

--- a/golem-api-grpc/build.rs
+++ b/golem-api-grpc/build.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/golem/worker/worker_metadata.proto",
                 "proto/golem/worker/worker_filter.proto",
                 "proto/golem/worker/worker_status.proto",
+                "proto/golem/worker/v1/file_listing.proto",
                 "proto/golem/worker/v1/worker_service.proto",
                 "proto/golem/worker/v1/worker_execution_error.proto",
                 "proto/golem/worker/v1/worker_error.proto",

--- a/golem-api-grpc/proto/golem/component/v1/component_service.proto
+++ b/golem-api-grpc/proto/golem/component/v1/component_service.proto
@@ -14,6 +14,7 @@ service ComponentService {
   rpc GetComponents (GetComponentsRequest) returns (GetComponentsResponse);
   rpc CreateComponent (stream CreateComponentRequest) returns (CreateComponentResponse);
   rpc DownloadComponent (DownloadComponentRequest) returns (stream DownloadComponentResponse);
+  rpc DownloadComponentFiles (DownloadComponentFilesRequest) returns (stream DownloadComponentFilesResponse);
   rpc GetComponentMetadataAllVersions (GetComponentRequest) returns (GetComponentMetadataAllVersionsResponse);
   rpc GetLatestComponentMetadata (GetLatestComponentRequest) returns (GetComponentMetadataResponse);
   rpc UpdateComponent (stream UpdateComponentRequest) returns (UpdateComponentResponse);
@@ -57,6 +58,7 @@ message CreateComponentRequest {
   oneof data {
     CreateComponentRequestHeader header = 1;
     CreateComponentRequestChunk chunk = 2;
+    CreateComponentRequestFilesChunk filesChunk = 3;
   }
 }
 
@@ -68,6 +70,10 @@ message CreateComponentRequestHeader {
 
 message CreateComponentRequestChunk {
   bytes componentChunk = 1;
+}
+
+message CreateComponentRequestFilesChunk {
+  bytes filesChunk = 1;
 }
 
 message CreateComponentResponse {
@@ -83,6 +89,18 @@ message DownloadComponentRequest {
 }
 
 message DownloadComponentResponse {
+  oneof result {
+    bytes successChunk = 1;
+    golem.component.v1.ComponentError error = 2;
+  }
+}
+
+message DownloadComponentFilesRequest {
+  golem.component.ComponentId componentId = 1;
+  optional uint64 version = 2;
+}
+
+message DownloadComponentFilesResponse {
   oneof result {
     bytes successChunk = 1;
     golem.component.v1.ComponentError error = 2;
@@ -128,6 +146,7 @@ message UpdateComponentRequest {
   oneof data {
     UpdateComponentRequestHeader header = 1;
     UpdateComponentRequestChunk chunk = 2;
+    UpdateComponentRequestFilesChunk filesChunk = 3;
   }
 }
 
@@ -138,6 +157,10 @@ message UpdateComponentRequestHeader {
 
 message UpdateComponentRequestChunk {
   bytes componentChunk = 1;
+}
+
+message UpdateComponentRequestFilesChunk {
+  bytes filesChunk = 1;
 }
 
 message UpdateComponentResponse {

--- a/golem-api-grpc/proto/golem/worker/v1/file_listing.proto
+++ b/golem-api-grpc/proto/golem/worker/v1/file_listing.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package golem.worker.v1;
+
+message FileListings {
+  repeated FileListing file_listings = 1;
+}
+
+message FileListing {
+  oneof result {
+    DirectoryInfo directory_info = 1;
+    FileInfo file_info = 2;
+  }
+}
+
+message DirectoryInfo {
+  string path = 1;
+  uint64 last_modified = 2;
+  optional Permissions permissions = 3;
+}
+
+message FileInfo {
+  string path = 1;
+  uint64 last_modified = 2;
+  optional Permissions permissions = 3;
+  uint64 size = 4;
+}
+
+enum Permissions {
+  ALWAYS_READ_ONLY = 0;
+  READ_ONLY = 1;
+  READ_WRITE = 2;
+}

--- a/golem-api-grpc/proto/golem/workerexecutor/v1/worker_executor.proto
+++ b/golem-api-grpc/proto/golem/workerexecutor/v1/worker_executor.proto
@@ -34,6 +34,7 @@ service WorkerExecutor {
   rpc DeleteWorker(DeleteWorkerRequest) returns (DeleteWorkerResponse);
   rpc CompletePromise(CompletePromiseRequest) returns (CompletePromiseResponse);
   rpc InterruptWorker(InterruptWorkerRequest) returns (InterruptWorkerResponse);
+  rpc GetWorkerFiles(GetWorkerFilesRequest) returns (GetWorkerFilesResponse);
   rpc RevokeShards(RevokeShardsRequest) returns (RevokeShardsResponse);
   rpc AssignShards(AssignShardsRequest) returns (AssignShardsResponse);
   rpc GetWorkerMetadata(GetWorkerMetadataRequest) returns (GetWorkerMetadataResponse);
@@ -84,6 +85,13 @@ message CompletePromiseSuccess {
 message InterruptWorkerResponse {
   oneof result {
     golem.common.Empty success = 1;
+    golem.worker.v1.WorkerExecutionError failure = 2;
+  }
+}
+
+message GetWorkerFilesResponse {
+  oneof result {
+    string dir_contents = 3;
     golem.worker.v1.WorkerExecutionError failure = 2;
   }
 }
@@ -159,6 +167,12 @@ message InterruptWorkerRequest {
   golem.worker.WorkerId worker_id = 1;
   bool recover_immediately = 2;
   golem.common.AccountId account_id = 3;
+}
+
+message GetWorkerFilesRequest {
+  golem.worker.WorkerId worker_id = 1;
+  string path = 2;
+  golem.common.AccountId account_id = 5;
 }
 
 message RevokeShardsRequest {

--- a/golem-api-grpc/proto/golem/workerexecutor/v1/worker_executor.proto
+++ b/golem-api-grpc/proto/golem/workerexecutor/v1/worker_executor.proto
@@ -18,6 +18,7 @@ import public "golem/worker/worker_id.proto";
 import public "golem/worker/worker_metadata.proto";
 import public "golem/worker/worker_status.proto";
 import public "golem/worker/worker_filter.proto";
+import public "golem/worker/v1/file_listing.proto";
 import public "golem/worker/v1/worker_execution_error.proto";
 
 import public "wasm/rpc/val.proto";
@@ -34,7 +35,7 @@ service WorkerExecutor {
   rpc DeleteWorker(DeleteWorkerRequest) returns (DeleteWorkerResponse);
   rpc CompletePromise(CompletePromiseRequest) returns (CompletePromiseResponse);
   rpc InterruptWorker(InterruptWorkerRequest) returns (InterruptWorkerResponse);
-  rpc GetWorkerFiles(GetWorkerFilesRequest) returns (GetWorkerFilesResponse);
+  rpc GetWorkerFiles(GetWorkerFilesRequest) returns (stream GetWorkerFilesResponse);
   rpc RevokeShards(RevokeShardsRequest) returns (RevokeShardsResponse);
   rpc AssignShards(AssignShardsRequest) returns (AssignShardsResponse);
   rpc GetWorkerMetadata(GetWorkerMetadataRequest) returns (GetWorkerMetadataResponse);
@@ -91,8 +92,9 @@ message InterruptWorkerResponse {
 
 message GetWorkerFilesResponse {
   oneof result {
-    string dir_contents = 3;
-    golem.worker.v1.WorkerExecutionError failure = 2;
+    golem.worker.v1.FileListings file_listings = 1;
+    bytes file_chunk = 2;
+    golem.worker.v1.WorkerExecutionError failure = 3;
   }
 }
 
@@ -171,8 +173,9 @@ message InterruptWorkerRequest {
 
 message GetWorkerFilesRequest {
   golem.worker.WorkerId worker_id = 1;
-  string path = 2;
-  golem.common.AccountId account_id = 5;
+  optional string path = 2;
+  optional bool recursive = 3;
+  golem.common.AccountId account_id = 4;
 }
 
 message RevokeShardsRequest {

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -78,7 +78,7 @@ tungstenite = "0.20.1"
 url = { workspace = true }
 uuid = { workspace = true }
 version-compare = "=0.0.11"
-walkdir = "2.5.0"
+walkdir = { workspace = true }
 wasm-wave = { workspace = true }
 zip = { workspace = true }
 

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -68,7 +68,9 @@ strum_macros = { workspace = true }
 testcontainers-modules = { workspace = true }
 textwrap = "0.16.1"
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
+tokio-util = { workspace = true }
 tower = "0.4.13"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -78,6 +80,7 @@ uuid = { workspace = true }
 version-compare = "=0.0.11"
 walkdir = "2.5.0"
 wasm-wave = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 golem-test-framework = { path = "../golem-test-framework", version = "0.0.0" }

--- a/golem-cli/src/async_zip_writer.rs
+++ b/golem-cli/src/async_zip_writer.rs
@@ -33,6 +33,8 @@ enum AsyncZipWriterCommand {
     Drop,
 }
 
+// TODO: Replace with the crate `async-zip` once it produces valid archives or with an alternative
+
 #[derive(Clone)]
 pub struct AsyncZipWriter(Arc<Mutex<AsyncZipWriterHandle>>);
 

--- a/golem-cli/src/async_zip_writer.rs
+++ b/golem-cli/src/async_zip_writer.rs
@@ -1,0 +1,148 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, Sender};
+use std::sync::Arc;
+use tokio::fs::File;
+use tokio::sync::{oneshot, Mutex, MutexGuard};
+use tokio::task::{self, JoinHandle};
+use tokio_util::bytes::Bytes;
+use zip::{result::ZipResult, write::FileOptions, ZipWriter};
+
+enum AsyncZipWriterCommand {
+    StartFileFromPath(
+        Arc<PathBuf>,
+        FileOptions<'static, ()>,
+        oneshot::Sender<ZipResult<()>>,
+    ),
+    WriteAll(Bytes, oneshot::Sender<std::io::Result<()>>),
+    Finish(oneshot::Sender<ZipResult<File>>),
+    Drop,
+}
+
+#[derive(Clone)]
+pub struct AsyncZipWriter(Arc<Mutex<AsyncZipWriterHandle>>);
+
+impl AsyncZipWriter {
+    pub async fn new(archive_file: File) -> Self {
+        let (command_sender, command_receiver) = channel();
+        let archive_file = archive_file.into_std().await;
+        let task_handle = task::spawn_blocking(move || {
+            let mut zip_writer = ZipWriter::new(archive_file);
+            while let Ok(command) = command_receiver.recv() {
+                match command {
+                    AsyncZipWriterCommand::StartFileFromPath(path, options, response_sender) => {
+                        response_sender
+                            .send(zip_writer.start_file_from_path(path.as_ref(), options))
+                            .expect("Failed to send `ZipWriter::start_file_from_path` response")
+                    }
+                    AsyncZipWriterCommand::WriteAll(bytes, response_sender) => response_sender
+                        .send(zip_writer.write_all(&bytes))
+                        .expect("Failed to send `ZipWriter::write_all` response"),
+                    AsyncZipWriterCommand::Finish(response_sender) => {
+                        response_sender
+                            .send(zip_writer.finish().map(File::from_std))
+                            .expect("Failed to send `ZipWriter::finish` response");
+                        break;
+                    }
+                    AsyncZipWriterCommand::Drop => break,
+                }
+            }
+        });
+        let handle = AsyncZipWriterHandle {
+            command_sender,
+            task_handle: Some(task_handle),
+            finished: false,
+        };
+        Self(Arc::new(Mutex::new(handle)))
+    }
+
+    pub async fn lock(&self) -> Result<MutexGuard<AsyncZipWriterHandle>, String> {
+        let handle = self.0.lock().await;
+        if handle.finished {
+            Err("Cannot lock finished 'AsyncZipWriter'".to_owned())
+        } else {
+            Ok(handle)
+        }
+    }
+}
+
+pub struct AsyncZipWriterHandle {
+    command_sender: Sender<AsyncZipWriterCommand>,
+    task_handle: Option<JoinHandle<()>>,
+    finished: bool,
+}
+
+impl AsyncZipWriterHandle {
+    pub async fn start_file_from_path(
+        &self,
+        path: Arc<PathBuf>,
+        options: FileOptions<'static, ()>,
+    ) -> ZipResult<()> {
+        let (response_sender, response_receiver) = oneshot::channel();
+
+        self.command_sender
+            .send(AsyncZipWriterCommand::StartFileFromPath(
+                path,
+                options,
+                response_sender,
+            ))
+            .expect("Failed to send 'AsyncZipWriterCommand::StartFileFromPath'");
+
+        response_receiver
+            .await
+            .expect("Failed to receive 'ZipWriter::finish' response")
+    }
+
+    pub async fn write_all(&self, bytes: Bytes) -> std::io::Result<()> {
+        let (response_sender, response_receiver) = oneshot::channel();
+
+        self.command_sender
+            .send(AsyncZipWriterCommand::WriteAll(bytes, response_sender))
+            .expect("Failed to send 'AsyncZipWriterCommand::WriteAll'");
+
+        response_receiver
+            .await
+            .expect("Failed to receive 'ZipWriter::write_all' response")
+    }
+
+    pub async fn finish(&mut self) -> ZipResult<File> {
+        let (response_sender, response_receiver) = oneshot::channel();
+
+        self.command_sender
+            .send(AsyncZipWriterCommand::Finish(response_sender))
+            .expect("Failed to send 'AsyncZipWriterCommand::Finish'");
+
+        self.finished = true;
+
+        let response = response_receiver
+            .await
+            .expect("Failed to receive 'ZipWriter::finish' response");
+
+        if let Some(task_handle) = self.task_handle.take() {
+            task_handle
+                .await
+                .expect("'AsyncZipWriter' task has been canceled or panicked")
+        }
+        response
+    }
+}
+
+impl Drop for AsyncZipWriterHandle {
+    fn drop(&mut self) {
+        let _ = self.command_sender.send(AsyncZipWriterCommand::Drop);
+    }
+}

--- a/golem-cli/src/clients/component.rs
+++ b/golem-cli/src/clients/component.rs
@@ -17,6 +17,7 @@ use crate::model::{ComponentName, GolemError, PathBufOrStdin};
 use async_trait::async_trait;
 use golem_client::model::ComponentType;
 use golem_common::uri::oss::urn::ComponentUrn;
+use std::path::PathBuf;
 
 #[async_trait]
 pub trait ComponentClient {
@@ -42,11 +43,13 @@ pub trait ComponentClient {
         file: PathBufOrStdin,
         project: &Option<Self::ProjectContext>,
         component_type: ComponentType,
+        initial_fs_archive_path: &Option<PathBuf>,
     ) -> Result<Component, GolemError>;
     async fn update(
         &self,
         urn: ComponentUrn,
         file: PathBufOrStdin,
         component_type: Option<ComponentType>,
+        initial_fs_archive_path: &Option<PathBuf>,
     ) -> Result<Component, GolemError>;
 }

--- a/golem-cli/src/command/component.rs
+++ b/golem-cli/src/command/component.rs
@@ -21,6 +21,7 @@ use crate::service::deploy::DeployService;
 use crate::service::project::ProjectResolver;
 use clap::Subcommand;
 use golem_client::model::ComponentType;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 #[derive(Subcommand, Debug)]
@@ -44,6 +45,10 @@ pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
         /// The component type. If none specified, the command creates a Durable component.
         #[command(flatten)]
         component_type: ComponentTypeArg,
+
+        /// List of application manifests, can be defined multiple times
+        #[arg(long, short)]
+        app: Vec<PathBuf>,
 
         /// Do not ask for confirmation for performing an update in case the component already exists
         #[arg(short = 'y', long)]
@@ -72,6 +77,10 @@ pub enum ComponentSubCommand<ProjectRef: clap::Args, ComponentRef: clap::Args> {
         /// Update mode - auto or manual
         #[arg(long, default_value = "auto", requires = "try_update_workers")]
         update_mode: WorkerUpdateMode,
+
+        /// List of application manifests, can be defined multiple times
+        #[arg(long, short)]
+        app: Vec<PathBuf>,
 
         /// Do not ask for confirmation for creating a new component in case it does not exist
         #[arg(short = 'y', long)]
@@ -188,6 +197,7 @@ impl<
                 component_name,
                 component_file,
                 component_type,
+                app,
                 non_interactive,
             } => {
                 let project_id = projects.resolve_id_or_default(project_ref).await?;
@@ -197,6 +207,7 @@ impl<
                         component_file,
                         component_type.component_type(),
                         Some(project_id),
+                        app,
                         non_interactive,
                         format,
                     )
@@ -208,6 +219,7 @@ impl<
                 component_type,
                 try_update_workers,
                 update_mode,
+                app,
                 non_interactive,
             } => {
                 let (component_name_or_uri, project_ref) = component_name_or_uri.split();
@@ -218,6 +230,7 @@ impl<
                         component_file,
                         component_type.optional_component_type(),
                         project_id.clone(),
+                        app,
                         non_interactive,
                         format,
                     )

--- a/golem-cli/src/initial_fs.rs
+++ b/golem-cli/src/initial_fs.rs
@@ -1,0 +1,252 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::async_zip_writer::AsyncZipWriter;
+use crate::model::GolemError;
+use crate::temp_dir::TempDir;
+use golem_common::log::log_action;
+use golem_common::model::application::{
+    InitialFile, InitialFilePermissions, Resource, WasmComponent,
+};
+use reqwest::Client;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::fs::{self, File};
+use tokio::io::AsyncWriteExt;
+use tokio::task::JoinSet;
+use tokio_stream::StreamExt;
+use tokio_util::io::ReaderStream;
+use url::Url;
+use walkdir::WalkDir;
+
+pub async fn create_archive(
+    wasm_component: WasmComponent,
+    temp_dir: &TempDir,
+) -> Result<Option<(File, PathBuf)>, GolemError> {
+    let WasmComponent {
+        name,
+        source,
+        files,
+        ..
+    } = wasm_component;
+    if files.is_empty() {
+        return Ok(None);
+    }
+    log_action(
+        "Downloading and packing",
+        format!("files for component: {name}"),
+    );
+
+    let (downloaded_files_path, zip_writer, archive_path) =
+        create_download_dir_and_zip_writer(temp_dir, &name)
+            .await
+            .map_err(|error| format!("Failed to create empty download dir or archive: {error}"))?;
+
+    let mut file_tasks = files
+        .into_iter()
+        .enumerate()
+        .map({
+            let client = Client::new();
+            let manifest_dir = Arc::new(
+                source
+                    .parent()
+                    .ok_or_else(|| {
+                        format!(
+                            "Failed to get manifest dir. Manifest path: '{}'",
+                            source.display()
+                        )
+                    })?
+                    .to_path_buf(),
+            );
+            let zip_writer = zip_writer.clone();
+            move |(index, initial_file)| {
+                download_and_pack_initial_file(
+                    index,
+                    initial_file,
+                    client.clone(),
+                    zip_writer.clone(),
+                    Arc::clone(&manifest_dir),
+                    Arc::clone(&downloaded_files_path),
+                )
+            }
+        })
+        .collect::<JoinSet<_>>();
+
+    while let Some(result) = file_tasks.join_next().await {
+        result??
+    }
+
+    let finished_archive_file = zip_writer
+        .lock()
+        .await?
+        .finish()
+        .await
+        .map_err(|error| format!("Failed to finish archive: {error}"))?;
+
+    log_action(
+        "Downloaded and packed",
+        format!("files for component: {name}"),
+    );
+    Ok(Some((finished_archive_file, archive_path)))
+}
+
+async fn create_download_dir_and_zip_writer(
+    temp_dir: &TempDir,
+    component_name: &str,
+) -> Result<(Arc<PathBuf>, AsyncZipWriter, PathBuf), GolemError> {
+    let wasm_component_path = {
+        let mut path = PathBuf::new();
+        path.push(temp_dir.path());
+        path.push("wasm_components");
+        path.push(component_name);
+        path
+    };
+    let downloaded_files_path = Arc::new(wasm_component_path.join("downloaded_files"));
+    fs::create_dir_all(downloaded_files_path.as_ref()).await?;
+
+    let archive_path = wasm_component_path.join(format!("{component_name}_initial_fs.zip"));
+    let archive_file = File::create_new(&archive_path).await?;
+    let zip_writer = AsyncZipWriter::new(archive_file).await;
+
+    Ok((downloaded_files_path, zip_writer, archive_path))
+}
+
+async fn download_and_pack_initial_file(
+    index: usize,
+    file: InitialFile,
+    client: Client,
+    zip_writer: AsyncZipWriter,
+    manifest_dir: Arc<PathBuf>,
+    downloaded_files_path: Arc<PathBuf>,
+) -> Result<(), GolemError> {
+    let InitialFile {
+        source_path,
+        target_path,
+        permissions,
+    } = file;
+
+    let resolved_source_path = match &source_path {
+        Resource::Path(path) => {
+            let path = manifest_dir.join(path);
+            path.canonicalize().map_err(|error| {
+                let path = path.display();
+                format!("Failed to resolve path '{path}': {error}")
+            })?
+        }
+        Resource::Url(url) => {
+            let path = downloaded_files_path.join(format!("file_{index}"));
+            download_file(&client, url, &path)
+                .await
+                .map_err(|error| format!("Failed to download file from '{url}': {error}"))?;
+            path
+        }
+    };
+
+    let permissions = permissions.unwrap_or_default();
+    add_files_to_archive(resolved_source_path, target_path, permissions, zip_writer)
+        .await
+        .map_err(|error| format!("Failed to pack file(s): {error}"))?;
+
+    log_action("Packed", {
+        let permissions = match permissions {
+            InitialFilePermissions::ReadOnly => "read-only",
+            InitialFilePermissions::ReadWrite => "read-write",
+        };
+        let source_path = match &source_path {
+            Resource::Path(path) => path.to_string_lossy(),
+            Resource::Url(url) => url.as_str().into(),
+        };
+        format!("{permissions} file(s): {source_path}")
+    });
+    Ok(())
+}
+
+async fn download_file(client: &Client, url: &Url, path: &Path) -> Result<(), GolemError> {
+    let mut file = File::create_new(path).await?;
+
+    let mut bytes_stream = client.get(url.clone()).send().await?.bytes_stream();
+
+    while let Some(chunk) = bytes_stream.next().await {
+        file.write_all(&chunk?).await?;
+    }
+
+    file.flush().await?;
+    log_action("Downloaded", format!("file: {url}"));
+    Ok(())
+}
+
+async fn add_files_to_archive(
+    source_path: PathBuf,
+    target_path: PathBuf,
+    permissions: InitialFilePermissions,
+    zip_writer: AsyncZipWriter,
+) -> Result<(), GolemError> {
+    let target_path = Arc::new(target_path);
+
+    let resolve_path_in_archive = |absolute_path: &Path, depth: usize| {
+        if depth == 0 {
+            Arc::clone(&target_path)
+        } else {
+            let path_difference = absolute_path.strip_prefix(&source_path).unwrap();
+            Arc::new(target_path.join(path_difference))
+        }
+    };
+
+    let mut add_file_to_archive_tasks = JoinSet::new();
+
+    for entry in WalkDir::new(&source_path).follow_links(true) {
+        let entry = entry.map_err(|error| error.to_string())?;
+        if entry
+            .metadata()
+            .map_err(|error| error.to_string())?
+            .is_file()
+        {
+            add_file_to_archive_tasks.spawn(add_file_to_archive(
+                File::open(entry.path()).await?,
+                resolve_path_in_archive(entry.path(), entry.depth()),
+                permissions,
+                zip_writer.clone(),
+            ));
+        }
+    }
+    while let Some(result) = add_file_to_archive_tasks.join_next().await {
+        result??
+    }
+    Ok(())
+}
+
+async fn add_file_to_archive(
+    source_file: File,
+    target_path: Arc<PathBuf>,
+    permissions: InitialFilePermissions,
+    zip_writer: AsyncZipWriter,
+) -> Result<(), GolemError> {
+    let source_file_size = source_file.metadata().await?.len();
+
+    let zip_file_options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .large_file(source_file_size >= u32::MAX as u64)
+        .unix_permissions(permissions.to_unix_file_permissions());
+
+    let zip_writer = zip_writer.lock().await?;
+    zip_writer
+        .start_file_from_path(target_path, zip_file_options)
+        .await?;
+
+    let mut source_file_stream = ReaderStream::new(source_file);
+    while let Some(chunk) = source_file_stream.next().await {
+        zip_writer.write_all(chunk?).await?;
+    }
+    Ok(())
+}

--- a/golem-cli/src/lib.rs
+++ b/golem-cli/src/lib.rs
@@ -29,6 +29,7 @@ use std::process::ExitCode;
 use tracing::{info, warn};
 use tracing_subscriber::FmtSubscriber;
 
+pub mod async_zip_writer;
 pub mod clients;
 pub mod cloud;
 pub mod command;
@@ -39,10 +40,12 @@ pub mod diagnose;
 pub mod examples;
 pub mod factory;
 pub mod init;
+pub mod initial_fs;
 pub mod model;
 pub mod oss;
 pub mod service;
 pub mod stubgen;
+pub mod temp_dir;
 
 #[cfg(test)]
 test_r::enable!();

--- a/golem-cli/src/model.rs
+++ b/golem-cli/src/model.rs
@@ -46,7 +46,7 @@ use strum_macros::EnumIter;
 use uuid::Uuid;
 
 pub enum GolemResult {
-    Ok(Box<dyn PrintRes>),
+    Ok(Box<dyn PrintRes + Send>),
     Json(serde_json::value::Value),
     Str(String),
 }
@@ -137,6 +137,12 @@ where
 #[derive(Clone, PartialEq, Eq)]
 pub struct GolemError(pub String);
 
+impl From<String> for GolemError {
+    fn from(error: String) -> Self {
+        GolemError(error)
+    }
+}
+
 impl From<reqwest::Error> for GolemError {
     fn from(error: reqwest::Error) -> Self {
         GolemError(format!("Unexpected client error: {error}"))
@@ -146,6 +152,24 @@ impl From<reqwest::Error> for GolemError {
 impl From<reqwest::header::InvalidHeaderValue> for GolemError {
     fn from(value: reqwest::header::InvalidHeaderValue) -> Self {
         GolemError(format!("Invalid request header: {value}"))
+    }
+}
+
+impl From<tokio::task::JoinError> for GolemError {
+    fn from(error: tokio::task::JoinError) -> Self {
+        GolemError(format!("Task failed to execute to completion: {error}"))
+    }
+}
+
+impl From<std::io::Error> for GolemError {
+    fn from(error: std::io::Error) -> Self {
+        GolemError(format!("I/O operation failed: {error}"))
+    }
+}
+
+impl From<zip::result::ZipError> for GolemError {
+    fn from(error: zip::result::ZipError) -> Self {
+        GolemError(format!("Zip operation failed: {error}"))
     }
 }
 

--- a/golem-cli/src/temp_dir.rs
+++ b/golem-cli/src/temp_dir.rs
@@ -1,0 +1,58 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+use tokio::{fs, io};
+
+pub struct TempDir {
+    path: PathBuf,
+    removed: bool,
+}
+
+impl TempDir {
+    #[must_use = "call the `remove` method when the dir is no longer needed"]
+    pub async fn create_new() -> io::Result<Self> {
+        let path = PathBuf::from("golem_temp");
+
+        if let Err(error) = fs::remove_dir_all(&path).await {
+            if !matches!(error.kind(), io::ErrorKind::NotFound) {
+                Err(error)?
+            }
+        }
+        fs::create_dir(&path).await?;
+
+        Ok(Self {
+            path,
+            removed: false,
+        })
+    }
+
+    pub async fn remove(mut self) -> io::Result<()> {
+        fs::remove_dir_all(&self.path).await?;
+        self.removed = true;
+        Ok(())
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if !self.removed {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/golem-cli/src/temp_dir.rs
+++ b/golem-cli/src/temp_dir.rs
@@ -15,6 +15,9 @@
 use std::path::{Path, PathBuf};
 use tokio::{fs, io};
 
+// TODO: Replace with the crate `async-tempfile` once it's stable enough
+// and there is an alternative to the method `TempDir::remove`
+
 pub struct TempDir {
     path: PathBuf,
     removed: bool,

--- a/golem-common/Cargo.toml
+++ b/golem-common/Cargo.toml
@@ -17,10 +17,13 @@ golem-wasm-ast = { workspace = true }
 golem-wasm-rpc = { workspace = true }
 golem-rib = { path = "../golem-rib", version = "0.0.0" }
 
+anyhow = { workspace = true }
+assert2 = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
+colored = "2.1.0"
 combine = { workspace = true }
 console-subscriber = { workspace = true }
 dashmap = { workspace = true }
@@ -29,6 +32,7 @@ figment = { workspace = true }
 fred = { workspace = true }
 futures-core = { workspace = true }
 git-version = { workspace = true }
+glob = "0.3.1"
 humantime-serde = { workspace = true }
 http_02 = { workspace = true }
 iso8601-timestamp = { workspace = true }
@@ -44,6 +48,7 @@ range-set-blaze = "0.1.16"
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }

--- a/golem-common/src/app.rs
+++ b/golem-common/src/app.rs
@@ -1,0 +1,234 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::log::{log_action, log_validated_action_result};
+use crate::model::application::{
+    Application, ComponentBuildProperties, DEFAULT_CONFIG_FILE_NAME, OAM_COMPONENT_TYPE_WASM_BUILD,
+};
+use crate::model::oam;
+use crate::model::validation::ValidatedResult;
+
+use anyhow::anyhow;
+use colored::Colorize;
+use glob::glob;
+use itertools::Itertools;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+enum ApplicationResolveMode {
+    Automatic,
+    Explicit(Vec<PathBuf>),
+}
+
+pub fn load(manifests: Vec<PathBuf>) -> anyhow::Result<Application> {
+    let app_resolve_mode = if manifests.is_empty() {
+        ApplicationResolveMode::Automatic
+    } else {
+        ApplicationResolveMode::Explicit(manifests)
+    };
+    to_anyhow(
+        "Failed to load application manifest(s), see problems above".to_string(),
+        load_validated(app_resolve_mode),
+    )
+}
+
+fn to_anyhow<T>(message: String, result: ValidatedResult<T>) -> anyhow::Result<T> {
+    fn print_warns(warns: Vec<String>) {
+        let label = "Warning".yellow();
+        for warn in warns {
+            eprintln!("{}: {}", label, warn);
+        }
+    }
+
+    fn print_errors(errors: Vec<String>) {
+        let label = "Error".red();
+        for error in errors {
+            eprintln!("{}: {}", label, error);
+        }
+    }
+
+    match result {
+        ValidatedResult::Ok(value) => Ok(value),
+        ValidatedResult::OkWithWarns(components, warns) => {
+            print_warns(warns);
+            println!();
+            Ok(components)
+        }
+        ValidatedResult::WarnsAndErrors(warns, errors) => {
+            print_warns(warns);
+            print_errors(errors);
+            println!();
+
+            Err(anyhow!(message))
+        }
+    }
+}
+
+fn load_validated(app_resolve_mode: ApplicationResolveMode) -> ValidatedResult<Application> {
+    let sources = collect_sources(app_resolve_mode);
+    let oam_apps = sources.and_then(|sources| {
+        sources
+            .into_iter()
+            .map(|source| {
+                ValidatedResult::from_result(oam::ApplicationWithSource::from_yaml_file(source))
+                    .and_then(oam::ApplicationWithSource::validate)
+            })
+            .collect::<ValidatedResult<Vec<_>>>()
+    });
+
+    log_action("Collecting", "components");
+
+    let app = oam_apps.and_then(Application::from_oam_apps);
+
+    log_validated_action_result("Found", &app, |app| {
+        if app.wasm_components_by_name.is_empty() {
+            "no components".to_string()
+        } else {
+            format!(
+                "components: {}",
+                app.wasm_components_by_name.keys().join(", ")
+            )
+        }
+    });
+
+    app
+}
+
+fn collect_sources(mode: ApplicationResolveMode) -> ValidatedResult<Vec<PathBuf>> {
+    log_action("Collecting", "sources");
+
+    let sources = match mode {
+        ApplicationResolveMode::Automatic => match find_main_source() {
+            Some(source) => {
+                std::env::set_current_dir(source.parent().expect("Failed ot get config parent"))
+                    .expect("Failed to set current dir for config parent");
+
+                match include_glob_patter_from_yaml_file(source.as_path()) {
+                    Some(pattern) => ValidatedResult::from_result(
+                        glob(pattern.as_str())
+                            .map_err(|err| {
+                                format!(
+                                    "Failed to compile glob pattern: {}, source: {}, error: {}",
+                                    pattern,
+                                    source.to_string_lossy(),
+                                    err
+                                )
+                            })
+                            .and_then(|matches| {
+                                matches.collect::<Result<Vec<_>, _>>().map_err(|err| {
+                                    format!(
+                                        "Failed to resolve glob pattern: {}, source: {}, error: {}",
+                                        pattern,
+                                        source.to_string_lossy(),
+                                        err
+                                    )
+                                })
+                            }),
+                    )
+                    .map(|mut sources| {
+                        sources.insert(0, source);
+                        sources
+                    }),
+                    None => ValidatedResult::Ok(vec![source]),
+                }
+            }
+            None => ValidatedResult::from_error("No config file found!".to_string()),
+        },
+        ApplicationResolveMode::Explicit(sources) => {
+            let non_unique_source_warns: Vec<_> = sources
+                .iter()
+                .counts()
+                .into_iter()
+                .filter(|(_, count)| *count > 1)
+                .map(|(source, count)| {
+                    format!(
+                        "Source added multiple times, source: {}, count: {}",
+                        source.to_string_lossy(),
+                        count
+                    )
+                })
+                .collect();
+
+            ValidatedResult::from_value_and_warns(sources.clone(), non_unique_source_warns)
+        }
+    };
+
+    log_validated_action_result("Found", &sources, |sources| {
+        if sources.is_empty() {
+            "no sources".to_string()
+        } else {
+            format!(
+                "sources: {}",
+                sources
+                    .iter()
+                    .map(|source| source.to_string_lossy())
+                    .join(", ")
+            )
+        }
+    });
+
+    sources
+}
+
+fn find_main_source() -> Option<PathBuf> {
+    let mut current_dir = std::env::current_dir().expect("Failed to get current dir");
+    let mut last_source: Option<PathBuf> = None;
+
+    loop {
+        let file = current_dir.join(DEFAULT_CONFIG_FILE_NAME);
+        if current_dir.join(DEFAULT_CONFIG_FILE_NAME).exists() {
+            last_source = Some(file);
+        }
+        match current_dir.parent() {
+            Some(parent_dir) => current_dir = parent_dir.to_path_buf(),
+            None => {
+                break;
+            }
+        }
+    }
+
+    last_source
+}
+
+// This a lenient non-validating peek for the include build property,
+// as that is used early, during source collection
+fn include_glob_patter_from_yaml_file(source: &Path) -> Option<String> {
+    fs::read_to_string(source)
+        .ok()
+        .and_then(|source| oam::Application::from_yaml_str(source.as_str()).ok())
+        .and_then(|mut oam_app| {
+            let mut includes = oam_app
+                .spec
+                .extract_components_by_type(&BTreeSet::from([OAM_COMPONENT_TYPE_WASM_BUILD]))
+                .remove(OAM_COMPONENT_TYPE_WASM_BUILD)
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|component| {
+                    component
+                        .typed_properties::<ComponentBuildProperties>()
+                        .ok()
+                        .and_then(|properties| properties.include)
+                });
+
+            match includes.next() {
+                Some(include) => {
+                    // Only return it if it's unique (if not it will cause validation errors later)
+                    includes.next().is_none().then_some(include)
+                }
+                None => None,
+            }
+        })
+}

--- a/golem-common/src/lib.rs
+++ b/golem-common/src/lib.rs
@@ -19,8 +19,10 @@ pub mod cache;
 pub mod client;
 pub mod config;
 
+pub mod app;
 pub mod golem_version;
 pub mod grpc;
+pub mod log;
 pub mod metrics;
 pub mod model;
 pub mod newtype;

--- a/golem-common/src/log.rs
+++ b/golem-common/src/log.rs
@@ -1,0 +1,27 @@
+use crate::model::validation::ValidatedResult;
+use colored::Colorize;
+
+pub fn log_action<T: AsRef<str>>(action: &str, subject: T) {
+    println!("{} {}", action.green(), subject.as_ref())
+}
+
+pub fn log_warn_action<T: AsRef<str>>(action: &str, subject: T) {
+    println!("{} {}", action.yellow(), subject.as_ref())
+}
+
+pub fn log_skipping_up_to_date<T: AsRef<str>>(subject: T) {
+    log_warn_action(
+        "Skipping",
+        format!("{}, already up-to-date", subject.as_ref()),
+    );
+}
+
+pub fn log_validated_action_result<T, F>(action: &str, result: &ValidatedResult<T>, to_log: F)
+where
+    F: Fn(&T) -> String,
+{
+    result
+        .as_ok_ref()
+        .iter()
+        .for_each(|value| log_action(action, to_log(value)));
+}

--- a/golem-common/src/model/application.rs
+++ b/golem-common/src/model/application.rs
@@ -1,0 +1,870 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::oam;
+use crate::model::oam::TypedTraitProperties;
+use crate::model::unknown_properties::HasUnknownProperties;
+use crate::model::validation::{ValidatedResult, ValidationBuilder};
+use golem_wasm_rpc::WASM_RPC_VERSION;
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+mod properties;
+pub use properties::*;
+
+pub const DEFAULT_CONFIG_FILE_NAME: &str = "golem.yaml";
+
+pub const OAM_TRAIT_TYPE_WASM_RPC: &str = "wasm-rpc";
+
+pub const OAM_COMPONENT_TYPE_WASM: &str = "wasm";
+pub const OAM_COMPONENT_TYPE_WASM_BUILD: &str = "wasm-build";
+pub const OAM_COMPONENT_TYPE_WASM_RPC_STUB_BUILD: &str = "wasm-rpc-stub-build";
+
+#[derive(Clone, Debug)]
+pub struct WasmBuild {
+    pub source: PathBuf,
+    pub name: String,
+    pub build_dir: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WasmComponent {
+    pub name: String,
+    pub source: PathBuf,
+    pub build_steps: Vec<BuildStep>,
+    pub wit: PathBuf,
+    pub input_wasm: PathBuf,
+    pub output_wasm: PathBuf,
+    pub wasm_rpc_dependencies: Vec<String>,
+    pub files: Vec<InitialFile>,
+}
+
+impl WasmComponent {
+    pub fn source_as_string(&self) -> String {
+        self.source.to_string_lossy().to_string()
+    }
+
+    pub fn source_dir(&self) -> &Path {
+        self.source
+            .parent()
+            .expect("Failed to get parent for source")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WasmRpcStubBuild {
+    pub source: PathBuf,
+    pub name: String,
+    pub component_name: Option<String>,
+    pub build_dir: Option<PathBuf>,
+    pub wasm: Option<PathBuf>,
+    pub wit: Option<PathBuf>,
+    pub world: Option<String>,
+    pub always_inline_types: Option<bool>,
+    pub crate_version: Option<String>,
+    pub wasm_rpc_path: Option<String>,
+    pub wasm_rpc_version: Option<String>,
+}
+
+impl WasmRpcStubBuild {
+    pub fn source_as_string(&self) -> String {
+        self.source.to_string_lossy().to_string()
+    }
+
+    pub fn source_dir(&self) -> &Path {
+        self.source
+            .parent()
+            .expect("Failed to get parent for source")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Application {
+    pub common_wasm_build: Option<WasmBuild>,
+    pub common_wasm_rpc_stub_build: Option<WasmRpcStubBuild>,
+    pub wasm_rpc_stub_builds_by_name: BTreeMap<String, WasmRpcStubBuild>,
+    pub wasm_components_by_name: BTreeMap<String, WasmComponent>,
+}
+
+impl Application {
+    pub fn from_oam_apps(oam_apps: Vec<oam::ApplicationWithSource>) -> ValidatedResult<Self> {
+        let mut validation = ValidationBuilder::new();
+
+        let (all_components, all_wasm_builds, all_wasm_rpc_stub_builds) = {
+            let mut all_components = Vec::<WasmComponent>::new();
+            let mut all_wasm_builds = Vec::<WasmBuild>::new();
+            let mut all_wasm_rpc_stub_builds = Vec::<WasmRpcStubBuild>::new();
+
+            for mut oam_app in oam_apps {
+                let (components, wasm_build, wasm_rpc_stub_build) =
+                    Self::extract_and_convert_oam_components(&mut validation, &mut oam_app);
+                all_components.extend(components);
+                all_wasm_builds.extend(wasm_build);
+                all_wasm_rpc_stub_builds.extend(wasm_rpc_stub_build);
+            }
+
+            (all_components, all_wasm_builds, all_wasm_rpc_stub_builds)
+        };
+
+        let wasm_components_by_name = Self::validate_components(&mut validation, all_components);
+
+        let (common_wasm_rpc_stub_build, wasm_rpc_stub_builds_by_name) =
+            Self::validate_wasm_rpc_stub_builds(
+                &mut validation,
+                &wasm_components_by_name,
+                all_wasm_rpc_stub_builds,
+            );
+
+        let common_wasm_build = Self::validate_wasm_builds(&mut validation, all_wasm_builds);
+
+        validation.build(Self {
+            common_wasm_build,
+            common_wasm_rpc_stub_build,
+            wasm_rpc_stub_builds_by_name,
+            wasm_components_by_name,
+        })
+    }
+
+    fn extract_and_convert_oam_components(
+        validation: &mut ValidationBuilder,
+        oam_app: &mut oam::ApplicationWithSource,
+    ) -> (Vec<WasmComponent>, Vec<WasmBuild>, Vec<WasmRpcStubBuild>) {
+        validation.push_context("source", oam_app.source_as_string());
+
+        let mut components_by_type =
+            oam_app
+                .application
+                .spec
+                .extract_components_by_type(&BTreeSet::from([
+                    OAM_COMPONENT_TYPE_WASM,
+                    OAM_COMPONENT_TYPE_WASM_BUILD,
+                    OAM_COMPONENT_TYPE_WASM_RPC_STUB_BUILD,
+                ]));
+
+        let wasm_components = Self::convert_components(
+            &oam_app.source,
+            validation,
+            &mut components_by_type,
+            OAM_COMPONENT_TYPE_WASM,
+            Self::convert_wasm_component,
+        );
+
+        let wasm_builds = Self::convert_components(
+            &oam_app.source,
+            validation,
+            &mut components_by_type,
+            OAM_COMPONENT_TYPE_WASM_BUILD,
+            Self::convert_wasm_build,
+        );
+
+        let wasm_rpc_stub_builds = Self::convert_components(
+            &oam_app.source,
+            validation,
+            &mut components_by_type,
+            OAM_COMPONENT_TYPE_WASM_RPC_STUB_BUILD,
+            Self::convert_wasm_rpc_stub_build,
+        );
+
+        validation.add_warns(&oam_app.application.spec.components, |component| {
+            Some((
+                vec![
+                    ("component name", component.name.clone()),
+                    ("component type", component.component_type.clone()),
+                ],
+                "Unknown component-type".to_string(),
+            ))
+        });
+
+        validation.pop_context();
+
+        (wasm_components, wasm_builds, wasm_rpc_stub_builds)
+    }
+
+    fn convert_components<F, C>(
+        source: &Path,
+        validation: &mut ValidationBuilder,
+        components_by_type: &mut BTreeMap<&'static str, Vec<oam::Component>>,
+        component_type: &str,
+        convert: F,
+    ) -> Vec<C>
+    where
+        F: Fn(&Path, &mut ValidationBuilder, oam::Component) -> Option<C>,
+    {
+        components_by_type
+            .remove(component_type)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|component| {
+                validation.push_context("component name", component.name.clone());
+                validation.push_context("component type", component.component_type.clone());
+                let result = convert(source, validation, component);
+                validation.pop_context();
+                validation.pop_context();
+                result
+            })
+            .collect()
+    }
+
+    fn convert_wasm_component(
+        source: &Path,
+        validation: &mut ValidationBuilder,
+        mut component: oam::Component,
+    ) -> Option<WasmComponent> {
+        let properties = component.typed_properties::<WasmComponentProperties>();
+
+        if let Some(err) = properties.as_ref().err() {
+            validation.add_error(format!("Failed to get component properties: {}", err))
+        }
+
+        let wasm_rpc_traits = component
+            .extract_traits_by_type(&BTreeSet::from([OAM_TRAIT_TYPE_WASM_RPC]))
+            .remove(OAM_TRAIT_TYPE_WASM_RPC)
+            .unwrap_or_default();
+
+        let mut wasm_rpc_dependencies = Vec::<String>::new();
+        for wasm_rpc in wasm_rpc_traits {
+            validation.push_context("trait type", wasm_rpc.trait_type.clone());
+
+            match WasmRpcTraitProperties::from_generic_trait(wasm_rpc) {
+                Ok(wasm_rpc) => {
+                    wasm_rpc.add_unknown_property_warns(
+                        || vec![("dep component name", wasm_rpc.component_name.clone())],
+                        validation,
+                    );
+                    wasm_rpc_dependencies.push(wasm_rpc.component_name)
+                }
+                Err(err) => validation
+                    .add_error(format!("Failed to get wasm-rpc trait properties: {}", err)),
+            }
+
+            validation.pop_context();
+        }
+
+        let non_unique_wasm_rpc_dependencies = wasm_rpc_dependencies
+            .iter()
+            .counts()
+            .into_iter()
+            .filter(|(_, count)| *count > 1);
+        validation.add_warns(
+            non_unique_wasm_rpc_dependencies,
+            |(dep_component_name, count)| {
+                Some((
+                    vec![],
+                    format!(
+                        "WASM RPC dependency specified multiple times for component: {}, count: {}",
+                        dep_component_name, count
+                    ),
+                ))
+            },
+        );
+
+        validation.add_warns(component.traits, |component_trait| {
+            Some((
+                vec![],
+                format!(
+                    "Unknown trait for wasm component, trait type: {}",
+                    component_trait.trait_type
+                ),
+            ))
+        });
+
+        let wasm_rpc_dependencies = wasm_rpc_dependencies
+            .into_iter()
+            .unique()
+            .sorted()
+            .collect::<Vec<_>>();
+
+        match (properties, validation.has_any_errors()) {
+            (Ok(properties), false) => {
+                properties.add_unknown_property_warns(Vec::new, validation);
+
+                for build_step in &properties.build {
+                    let has_inputs = !build_step.inputs.is_empty();
+                    let has_outputs = !build_step.outputs.is_empty();
+
+                    if (has_inputs && !has_outputs) || (!has_inputs && has_outputs) {
+                        validation.push_context("command", build_step.command.clone());
+                        validation.add_warn(
+                            "Using inputs and outputs only has effect when both defined"
+                                .to_string(),
+                        );
+                        validation.pop_context();
+                    }
+                }
+
+                Some(WasmComponent {
+                    name: component.name,
+                    source: source.to_path_buf(),
+                    build_steps: properties.build,
+                    wit: properties.wit.into(),
+                    input_wasm: properties.input_wasm.into(),
+                    output_wasm: properties.output_wasm.into(),
+                    wasm_rpc_dependencies,
+                    files: properties.files,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn convert_wasm_build(
+        source: &Path,
+        validation: &mut ValidationBuilder,
+        component: oam::Component,
+    ) -> Option<WasmBuild> {
+        let result = match component.typed_properties::<ComponentBuildProperties>() {
+            Ok(properties) => {
+                properties.add_unknown_property_warns(Vec::new, validation);
+
+                let wasm_rpc_stub_build = WasmBuild {
+                    source: source.to_path_buf(),
+                    name: component.name,
+                    build_dir: properties.build_dir.map(|s| s.into()),
+                };
+
+                Some(wasm_rpc_stub_build)
+            }
+            Err(err) => {
+                validation.add_error(format!("Failed to get wasm build properties: {}", err));
+                None
+            }
+        };
+
+        validation.add_warns(component.traits, |component_trait| {
+            Some((
+                vec![],
+                format!(
+                    "Unknown trait for wasm build, trait type: {}",
+                    component_trait.trait_type
+                ),
+            ))
+        });
+
+        result
+    }
+
+    fn convert_wasm_rpc_stub_build(
+        source: &Path,
+        validation: &mut ValidationBuilder,
+        component: oam::Component,
+    ) -> Option<WasmRpcStubBuild> {
+        let result = match component.typed_properties::<ComponentStubBuildProperties>() {
+            Ok(properties) => {
+                properties.add_unknown_property_warns(Vec::new, validation);
+
+                let wasm_rpc_stub_build = WasmRpcStubBuild {
+                    source: source.to_path_buf(),
+                    name: component.name,
+                    component_name: properties.component_name,
+                    build_dir: properties.build_dir.map(|s| s.into()),
+                    wasm: properties.wasm.map(|s| s.into()),
+                    wit: properties.wit.map(|s| s.into()),
+                    world: properties.world,
+                    always_inline_types: properties.always_inline_types,
+                    crate_version: properties.crate_version,
+                    wasm_rpc_path: properties.wasm_rpc_path,
+                    wasm_rpc_version: properties.wasm_rpc_version,
+                };
+
+                if wasm_rpc_stub_build.build_dir.is_some() && wasm_rpc_stub_build.wasm.is_some() {
+                    validation.add_warn(
+                        "Both buildDir and wasm fields are defined, wasm takes precedence"
+                            .to_string(),
+                    );
+                }
+
+                if wasm_rpc_stub_build.build_dir.is_some() && wasm_rpc_stub_build.wit.is_some() {
+                    validation.add_warn(
+                        "Both buildDir and wit fields are defined, wit takes precedence"
+                            .to_string(),
+                    );
+                }
+
+                if wasm_rpc_stub_build.component_name.is_some()
+                    && wasm_rpc_stub_build.wasm.is_some()
+                {
+                    validation.add_warn(
+                        "In common (without component name) wasm rpc stub build the wasm field has no effect".to_string(),
+                    );
+                }
+
+                if wasm_rpc_stub_build.component_name.is_some() && wasm_rpc_stub_build.wit.is_some()
+                {
+                    validation.add_warn(
+                        "In common (without component name) wasm rpc stub build the wit field has no effect".to_string(),
+                    );
+                }
+
+                Some(wasm_rpc_stub_build)
+            }
+            Err(err) => {
+                validation.add_error(format!(
+                    "Failed to get wasm rpc stub build properties: {}",
+                    err
+                ));
+                None
+            }
+        };
+
+        validation.add_warns(component.traits, |component_trait| {
+            Some((
+                vec![],
+                format!(
+                    "Unknown trait for wasm rpc stub build, trait type: {}",
+                    component_trait.trait_type
+                ),
+            ))
+        });
+
+        result
+    }
+
+    pub fn validate_components(
+        validation: &mut ValidationBuilder,
+        components: Vec<WasmComponent>,
+    ) -> BTreeMap<String, WasmComponent> {
+        let (wasm_components_by_name, sources) = {
+            let mut wasm_components_by_name = BTreeMap::<String, WasmComponent>::new();
+            let mut sources = BTreeMap::<String, Vec<String>>::new();
+            for component in components {
+                sources
+                    .entry(component.name.clone())
+                    .and_modify(|sources| sources.push(component.source_as_string()))
+                    .or_insert_with(|| vec![component.source_as_string()]);
+                wasm_components_by_name.insert(component.name.clone(), component);
+            }
+            (wasm_components_by_name, sources)
+        };
+
+        let non_unique_components = sources.into_iter().filter(|(_, sources)| sources.len() > 1);
+        validation.add_errors(non_unique_components, |(component_name, sources)| {
+            Some((
+                vec![("component name", component_name)],
+                format!(
+                    "Component is specified multiple times in sources: {}",
+                    sources.join(", ")
+                ),
+            ))
+        });
+
+        for (component_name, component) in &wasm_components_by_name {
+            validation.push_context("source", component.source_as_string());
+
+            validation.add_errors(&component.wasm_rpc_dependencies, |dep_component_name| {
+                (!wasm_components_by_name.contains_key(dep_component_name)).then(|| {
+                    (
+                        vec![],
+                        format!(
+                            "Component {} references unknown component {} as dependency",
+                            component_name, dep_component_name,
+                        ),
+                    )
+                })
+            });
+
+            validation.pop_context();
+        }
+
+        wasm_components_by_name
+    }
+
+    fn validate_wasm_builds(
+        validation: &mut ValidationBuilder,
+        wasm_builds: Vec<WasmBuild>,
+    ) -> Option<WasmBuild> {
+        if wasm_builds.len() > 1 {
+            validation.add_error(format!(
+                "Component Build is specified multiple times in sources: {}",
+                wasm_builds
+                    .iter()
+                    .map(|c| format!("{} in {}", c.name, c.source.to_string_lossy()))
+                    .join(", ")
+            ));
+        }
+
+        wasm_builds.into_iter().next()
+    }
+
+    fn validate_wasm_rpc_stub_builds(
+        validation: &mut ValidationBuilder,
+        wasm_components_by_name: &BTreeMap<String, WasmComponent>,
+        wasm_rpc_stub_builds: Vec<WasmRpcStubBuild>,
+    ) -> (Option<WasmRpcStubBuild>, BTreeMap<String, WasmRpcStubBuild>) {
+        let (
+            common_wasm_rpc_stub_builds,
+            wasm_rpc_stub_builds_by_component_name,
+            common_sources,
+            sources,
+        ) = {
+            let mut common_wasm_rpc_stub_builds = Vec::<WasmRpcStubBuild>::new();
+            let mut wasm_rpc_stub_builds_by_component_name =
+                BTreeMap::<String, WasmRpcStubBuild>::new();
+
+            let mut common_sources = Vec::<String>::new();
+            let mut by_name_sources = BTreeMap::<String, Vec<String>>::new();
+
+            for wasm_rpc_stub_build in wasm_rpc_stub_builds {
+                match &wasm_rpc_stub_build.component_name {
+                    Some(component_name) => {
+                        by_name_sources
+                            .entry(component_name.clone())
+                            .and_modify(|sources| {
+                                sources.push(wasm_rpc_stub_build.source_as_string())
+                            })
+                            .or_insert_with(|| vec![wasm_rpc_stub_build.source_as_string()]);
+                        wasm_rpc_stub_builds_by_component_name
+                            .insert(component_name.clone(), wasm_rpc_stub_build);
+                    }
+                    None => {
+                        common_sources.push(wasm_rpc_stub_build.source_as_string());
+                        common_wasm_rpc_stub_builds.push(wasm_rpc_stub_build)
+                    }
+                }
+            }
+
+            (
+                common_wasm_rpc_stub_builds,
+                wasm_rpc_stub_builds_by_component_name,
+                common_sources,
+                by_name_sources,
+            )
+        };
+
+        let non_unique_wasm_rpc_stub_builds =
+            sources.into_iter().filter(|(_, sources)| sources.len() > 1);
+
+        validation.add_errors(
+            non_unique_wasm_rpc_stub_builds,
+            |(component_name, sources)| {
+                Some((
+                    vec![("component name", component_name)],
+                    format!(
+                        "Wasm rpc stub build is specified multiple times in sources: {}",
+                        sources.join(", ")
+                    ),
+                ))
+            },
+        );
+
+        if common_sources.len() > 1 {
+            validation.add_error(
+                format!(
+                    "Common (without component name) wasm rpc build is specified multiple times in sources: {}",
+                    common_sources.join(", "),
+                )
+            )
+        }
+
+        validation.add_errors(
+            &wasm_rpc_stub_builds_by_component_name,
+            |(component_name, wasm_rpc_stub_build)| {
+                (!wasm_components_by_name.contains_key(component_name)).then(|| {
+                    (
+                        vec![("source", wasm_rpc_stub_build.source_as_string())],
+                        format!(
+                            "Wasm rpc stub build {} references unknown component {}",
+                            wasm_rpc_stub_build.name, component_name
+                        ),
+                    )
+                })
+            },
+        );
+
+        (
+            common_wasm_rpc_stub_builds.into_iter().next(),
+            wasm_rpc_stub_builds_by_component_name,
+        )
+    }
+
+    pub fn all_wasm_rpc_dependencies(&self) -> BTreeSet<String> {
+        self.wasm_components_by_name
+            .iter()
+            .flat_map(|(_, component)| {
+                component
+                    .wasm_rpc_dependencies
+                    .iter()
+                    .map(|component_name| component_name.to_string())
+            })
+            .collect()
+    }
+
+    pub fn build_dir(&self) -> PathBuf {
+        self.common_wasm_build
+            .as_ref()
+            .and_then(|build| build.build_dir.clone())
+            .unwrap_or_else(|| PathBuf::from("build"))
+    }
+
+    pub fn component(&self, component_name: &str) -> &WasmComponent {
+        self.wasm_components_by_name
+            .get(component_name)
+            .unwrap_or_else(|| panic!("Component not found: {}", component_name))
+    }
+
+    pub fn component_wit(&self, component_name: &str) -> PathBuf {
+        let component = self.component(component_name);
+        component.source_dir().join(component.wit.clone())
+    }
+
+    pub fn component_input_wasm(&self, component_name: &str) -> PathBuf {
+        let component = self.component(component_name);
+        component.source_dir().join(component.input_wasm.clone())
+    }
+
+    pub fn component_output_wasm(&self, component_name: &str) -> PathBuf {
+        let component = self.component(component_name);
+        component.source_dir().join(component.output_wasm.clone())
+    }
+
+    pub fn stub_world(&self, component_name: &str) -> Option<String> {
+        self.stub_gen_property(component_name, |build| build.world.clone())
+            .flatten()
+    }
+
+    pub fn stub_crate_version(&self, component_name: &str) -> String {
+        self.stub_gen_property(component_name, |build| build.crate_version.clone())
+            .flatten()
+            .unwrap_or_else(|| WASM_RPC_VERSION.to_string())
+    }
+
+    pub fn stub_always_inline_types(&self, component_name: &str) -> bool {
+        self.stub_gen_property(component_name, |build| build.always_inline_types)
+            .flatten()
+            .unwrap_or(false)
+    }
+
+    pub fn stub_wasm_rpc_path(&self, component_name: &str) -> Option<String> {
+        self.stub_gen_property(component_name, |build| build.wasm_rpc_path.clone())
+            .flatten()
+    }
+
+    pub fn stub_wasm_rpc_version(&self, component_name: &str) -> Option<String> {
+        self.stub_gen_property(component_name, |build| build.wasm_rpc_version.clone())
+            .flatten()
+    }
+
+    pub fn stub_build_dir(&self, component_name: &str) -> PathBuf {
+        self.stub_gen_property(component_name, |build| {
+            build
+                .build_dir
+                .as_ref()
+                .map(|build_dir| build.source_dir().join(build_dir))
+        })
+        .flatten()
+        .unwrap_or_else(|| self.build_dir())
+        .join("stub")
+    }
+
+    pub fn stub_wasm(&self, component_name: &str) -> PathBuf {
+        self.wasm_rpc_stub_builds_by_name
+            .get(component_name)
+            .and_then(|build| {
+                build
+                    .wasm
+                    .as_ref()
+                    .map(|wasm| build.source_dir().join(wasm))
+            })
+            .unwrap_or_else(|| {
+                self.stub_build_dir(component_name)
+                    .join(component_name)
+                    .join("stub.wasm")
+            })
+    }
+
+    pub fn stub_wit(&self, component_name: &str) -> PathBuf {
+        self.wasm_rpc_stub_builds_by_name
+            .get(component_name)
+            .and_then(|build| build.wit.as_ref().map(|wit| build.source_dir().join(wit)))
+            .unwrap_or_else(|| {
+                self.stub_build_dir(component_name)
+                    .join(component_name)
+                    .join("wit")
+            })
+    }
+
+    fn stub_gen_property<T, F>(&self, component_name: &str, get_property: F) -> Option<T>
+    where
+        F: Fn(&WasmRpcStubBuild) -> T,
+    {
+        self.wasm_rpc_stub_builds_by_name
+            .get(component_name)
+            .map(&get_property)
+            .or_else(|| self.common_wasm_rpc_stub_build.as_ref().map(get_property))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_r::test;
+
+    use crate::model::application::properties::{InitialFilePermissions, Resource};
+    use crate::model::application::Application;
+    use crate::model::oam;
+    use url::Url;
+
+    #[test]
+    fn load_app_with_warns() {
+        let oam_app: oam::ApplicationWithSource = oam_app_one();
+        let (app, warns, errors) = Application::from_oam_apps(vec![oam_app]).into_product();
+
+        assert!(app.is_some());
+        let app = app.unwrap();
+
+        println!("Warns:\n{}", warns.join("\n"));
+        println!("Errors:\n{}", errors.join("\n"));
+
+        assert!(app.wasm_components_by_name.len() == 3);
+        assert!(warns.len() == 3);
+        assert!(errors.is_empty());
+
+        let (component_name, component) = app.wasm_components_by_name.iter().next().unwrap();
+
+        assert!(component_name == "component-one");
+        assert!(component.name == "component-one");
+        assert!(component.wit.to_string_lossy() == "wit");
+        assert!(component.input_wasm.to_string_lossy() == "out/in.wasm");
+        assert!(component.output_wasm.to_string_lossy() == "out/out.wasm");
+        assert!(component.wasm_rpc_dependencies.len() == 2);
+
+        assert!(component.wasm_rpc_dependencies[0] == "component-three");
+        assert!(component.wasm_rpc_dependencies[1] == "component-two");
+
+        assert!(
+            component.files[0].source_path
+                == Resource::Path("../../../default_counter.json".into())
+        );
+        assert!(component.files[0].target_path.to_string_lossy() == "/default_counter.json");
+        assert!(component.files[0].permissions.is_none());
+
+        assert!(
+            component.files[3].source_path
+                == Resource::Url(Url::parse("https://picsum.photos/200/300").unwrap())
+        );
+        assert!(component.files[3].permissions == Some(InitialFilePermissions::ReadOnly));
+    }
+
+    #[test]
+    fn load_app_with_warns_and_errors() {
+        let oam_app: oam::ApplicationWithSource = oam_app_two();
+        let (_app, warns, errors) = Application::from_oam_apps(vec![oam_app]).into_product();
+
+        println!("Warns:\n{}", warns.join("\n"));
+        println!("Errors:\n{}", errors.join("\n"));
+
+        assert!(errors.len() == 2);
+
+        assert!(errors[0].contains("component-one"));
+        assert!(errors[0].contains("component-three"));
+        assert!(errors[0].contains("test-oam-app-two.yaml"));
+
+        assert!(errors[1].contains("component-one"));
+        assert!(errors[1].contains("component-two"));
+        assert!(errors[1].contains("test-oam-app-two.yaml"));
+    }
+
+    fn oam_app_one() -> oam::ApplicationWithSource {
+        oam::ApplicationWithSource::from_yaml_string(
+            "test-oam-app-one.yaml".into(),
+            r#"
+apiVersion: core.oam.dev/v1beta1
+metadata:
+  name: "App name"
+kind: Application
+spec:
+  components:
+    - name: component-one
+      type: wasm
+      properties:
+        wit: wit
+        inputWasm: out/in.wasm
+        outputWasm: out/out.wasm
+        testUnknownProp: test
+        files:
+          - sourcePath: ../../../default_counter.json
+            targetPath: /default_counter.json
+          - sourcePath: last_counter_value.txt
+            targetPath: /last_value.txt
+            permissions: read-write
+          - sourcePath: ./images
+            targetPath: /images
+          - sourcePath: https://picsum.photos/200/300
+            targetPath: /images/random_picture.jpg
+            permissions: read-only
+      traits:
+        - type: wasm-rpc
+          properties:
+            componentName: component-two
+        - type: wasm-rpc
+          properties:
+            componentName: component-three
+            testUnknownProp: test
+        - type: unknown-trait
+          properties:
+            testUnknownProp: test
+    - name: component-two
+      type: wasm
+      properties:
+        wit: wit
+        inputWasm: out/in.wasm
+        outputWasm: out/out.wasm
+    - name: component-three
+      type: wasm
+      properties:
+        wit: wit
+        inputWasm: out/in.wasm
+        outputWasm: out/out.wasm
+"#
+            .to_string(),
+        )
+        .unwrap()
+    }
+
+    fn oam_app_two() -> oam::ApplicationWithSource {
+        oam::ApplicationWithSource::from_yaml_string(
+            "test-oam-app-two.yaml".into(),
+            r#"
+apiVersion: core.oam.dev/v1beta1
+metadata:
+  name: "App name"
+kind: Application
+spec:
+  components:
+    - name: component-one
+      type: wasm
+      properties:
+        wit: wit
+        inputWasm: out/in.wasm
+        outputWasm: out/out.wasm
+        testUnknownProp: test
+      traits:
+        - type: wasm-rpc
+          properties:
+            componentName: component-two
+        - type: wasm-rpc
+          properties:
+            componentName: component-three
+            testUnknownProp: test
+        - type: unknown-trait
+          properties:
+            testUnknownProp: test
+    - name: component-one
+      type: unknown-component-type
+      properties:
+"#
+            .to_string(),
+        )
+        .unwrap()
+    }
+}

--- a/golem-common/src/model/application/properties.rs
+++ b/golem-common/src/model/application/properties.rs
@@ -1,0 +1,182 @@
+// Copyright 2024 Golem Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::application::{
+    OAM_COMPONENT_TYPE_WASM, OAM_COMPONENT_TYPE_WASM_BUILD, OAM_COMPONENT_TYPE_WASM_RPC_STUB_BUILD,
+    OAM_TRAIT_TYPE_WASM_RPC,
+};
+use crate::model::oam::{TypedComponentProperties, TypedTraitProperties};
+use crate::model::unknown_properties::{HasUnknownProperties, UnknownProperties};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use url::Url;
+
+// -- WasmComponentProperties --
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WasmComponentProperties {
+    pub wit: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub build: Vec<BuildStep>,
+    pub input_wasm: String,
+    pub output_wasm: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<InitialFile>,
+    #[serde(flatten)]
+    pub unknown_properties: UnknownProperties,
+}
+
+impl HasUnknownProperties for WasmComponentProperties {
+    fn unknown_properties(&self) -> &UnknownProperties {
+        &self.unknown_properties
+    }
+}
+
+impl TypedComponentProperties for WasmComponentProperties {
+    fn component_type() -> &'static str {
+        OAM_COMPONENT_TYPE_WASM
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BuildStep {
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outputs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitialFile {
+    pub source_path: Resource,
+    pub target_path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<InitialFilePermissions>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Resource {
+    Url(Url),
+    Path(PathBuf),
+}
+
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum InitialFilePermissions {
+    #[default]
+    ReadOnly,
+    ReadWrite,
+}
+
+impl InitialFilePermissions {
+    // https://chmod-calculator.com/
+    const READ_ONLY_NUMERIC: u32 = 0o444; // r--r--r--
+    const READ_WRITE_NUMERIC: u32 = 0o666; // rw-rw-rw-
+
+    pub fn to_unix_file_permissions(&self) -> u32 {
+        match self {
+            Self::ReadOnly => Self::READ_ONLY_NUMERIC,
+            Self::ReadWrite => Self::READ_WRITE_NUMERIC,
+        }
+    }
+
+    pub fn from_unix_file_permissions(permissions: u32) -> Option<Self> {
+        match permissions {
+            Self::READ_ONLY_NUMERIC => Some(Self::ReadOnly),
+            Self::READ_WRITE_NUMERIC => Some(Self::ReadWrite),
+            _ => None,
+        }
+    }
+}
+
+// -- ComponentBuildProperties --
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentBuildProperties {
+    pub include: Option<String>,
+    pub build_dir: Option<String>,
+    #[serde(flatten)]
+    pub unknown_properties: UnknownProperties,
+}
+
+impl TypedComponentProperties for ComponentBuildProperties {
+    fn component_type() -> &'static str {
+        OAM_COMPONENT_TYPE_WASM_BUILD
+    }
+}
+
+impl HasUnknownProperties for ComponentBuildProperties {
+    fn unknown_properties(&self) -> &UnknownProperties {
+        &self.unknown_properties
+    }
+}
+
+// -- ComponentStubBuildProperties --
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentStubBuildProperties {
+    pub component_name: Option<String>,
+    pub build_dir: Option<String>,
+    pub wasm: Option<String>,
+    pub wit: Option<String>,
+    pub world: Option<String>,
+    pub always_inline_types: Option<bool>,
+    pub crate_version: Option<String>,
+    pub wasm_rpc_path: Option<String>,
+    pub wasm_rpc_version: Option<String>,
+    #[serde(flatten)]
+    pub unknown_properties: UnknownProperties,
+}
+
+impl TypedComponentProperties for ComponentStubBuildProperties {
+    fn component_type() -> &'static str {
+        OAM_COMPONENT_TYPE_WASM_RPC_STUB_BUILD
+    }
+}
+
+impl HasUnknownProperties for ComponentStubBuildProperties {
+    fn unknown_properties(&self) -> &UnknownProperties {
+        &self.unknown_properties
+    }
+}
+
+// -- WasmRpcTraitProperties --
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WasmRpcTraitProperties {
+    pub component_name: String,
+    #[serde(flatten)]
+    pub unknown_properties: UnknownProperties,
+}
+
+impl HasUnknownProperties for WasmRpcTraitProperties {
+    fn unknown_properties(&self) -> &UnknownProperties {
+        &self.unknown_properties
+    }
+}
+
+impl TypedTraitProperties for WasmRpcTraitProperties {
+    fn trait_type() -> &'static str {
+        OAM_TRAIT_TYPE_WASM_RPC
+    }
+}

--- a/golem-common/src/model/mod.rs
+++ b/golem-common/src/model/mod.rs
@@ -17,6 +17,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -47,14 +48,18 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use uuid::{uuid, Uuid};
 
+pub mod application;
 pub mod component_constraint;
 pub mod component_metadata;
 pub mod exports;
 pub mod lucene;
+pub mod oam;
 pub mod oplog;
 pub mod public_oplog;
 pub mod regions;
 pub mod trim_date;
+pub mod unknown_properties;
+pub mod validation;
 
 use crate::uri::oss::urn::WorkerUrn;
 use golem_api_grpc::proto::golem::shardmanager::{
@@ -262,6 +267,14 @@ impl WorkerId {
             component_id: self.component_id,
             worker_name: Some(self.worker_name),
         }
+    }
+
+    pub fn to_root_dir_path(&self) -> PathBuf {
+        format!(
+            "data/workers/root_dir__{}__{}",
+            self.component_id.0, self.worker_name
+        )
+        .into()
     }
 }
 

--- a/golem-common/src/model/oam.rs
+++ b/golem-common/src/model/oam.rs
@@ -1,0 +1,296 @@
+use crate::model::validation::{ValidatedResult, ValidationBuilder};
+use anyhow::Context;
+use itertools::Itertools;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+pub const API_VERSION_V1BETA1: &str = "core.oam.dev/v1beta1";
+pub const KIND_APPLICATION: &str = "Application";
+
+#[derive(Clone, Debug)]
+pub struct ApplicationWithSource {
+    pub source: PathBuf,
+    pub application: Application,
+}
+
+impl ApplicationWithSource {
+    pub fn from_yaml_file(file: PathBuf) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(file.as_path())
+            .with_context(|| format!("Failed to load file: {}", file.to_string_lossy()))?;
+
+        Ok(Self::from_yaml_string(file, content)?)
+    }
+
+    pub fn from_yaml_string(source: PathBuf, string: String) -> serde_yaml::Result<Self> {
+        Ok(Self {
+            source,
+            application: Application::from_yaml_str(string.as_str())?,
+        })
+    }
+
+    pub fn source_as_string(&self) -> String {
+        self.source.to_string_lossy().to_string()
+    }
+
+    pub fn validate(self) -> ValidatedResult<Self> {
+        let mut validation = ValidationBuilder::new();
+        validation.push_context("source", self.source_as_string());
+
+        if self.application.api_version != API_VERSION_V1BETA1 {
+            validation.add_warn(format!("Expected apiVersion: {}", API_VERSION_V1BETA1))
+        }
+
+        if self.application.kind != KIND_APPLICATION {
+            validation.add_error(format!("Expected kind: {}", KIND_APPLICATION))
+        }
+
+        self.application
+            .spec
+            .components
+            .iter()
+            .map(|component| &component.name)
+            .counts()
+            .into_iter()
+            .filter(|(_, count)| *count > 1)
+            .for_each(|(component_name, count)| {
+                validation.add_warn(format!(
+                    "Component specified multiple times component: {}, count: {}",
+                    component_name, count
+                ));
+            });
+
+        validation.pop_context();
+        validation.build(self)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Application {
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: Metadata,
+    pub spec: Spec,
+}
+
+impl Application {
+    pub fn new(name: String) -> Self {
+        Self {
+            api_version: API_VERSION_V1BETA1.to_string(),
+            kind: KIND_APPLICATION.to_string(),
+            metadata: Metadata {
+                name,
+                annotations: Default::default(),
+                labels: Default::default(),
+            },
+            spec: Spec { components: vec![] },
+        }
+    }
+
+    pub fn from_yaml_str(yaml: &str) -> serde_yaml::Result<Self> {
+        serde_yaml::from_str(yaml)
+    }
+
+    pub fn to_yaml_string(&self) -> String {
+        serde_yaml::to_string(self).expect("Failed to serialize Application as YAML")
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub annotations: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Spec {
+    pub components: Vec<Component>,
+}
+
+impl Spec {
+    pub fn extract_components_by_type(
+        &mut self,
+        component_types: &BTreeSet<&'static str>,
+    ) -> BTreeMap<&'static str, Vec<Component>> {
+        let mut components = Vec::<Component>::new();
+
+        std::mem::swap(&mut components, &mut self.components);
+
+        let mut matching_components = BTreeMap::<&'static str, Vec<Component>>::new();
+        let mut remaining_components = Vec::<Component>::new();
+
+        for component in components {
+            if let Some(component_type) = component_types.get(component.component_type.as_str()) {
+                matching_components
+                    .entry(component_type)
+                    .or_default()
+                    .push(component)
+            } else {
+                remaining_components.push(component)
+            }
+        }
+
+        std::mem::swap(&mut remaining_components, &mut self.components);
+
+        matching_components
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Component {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub component_type: String,
+    pub properties: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub traits: Vec<Trait>,
+}
+
+pub trait TypedComponentProperties: Serialize + DeserializeOwned {
+    fn component_type() -> &'static str;
+}
+
+impl Component {
+    pub fn typed_properties<T: TypedComponentProperties>(&self) -> Result<T, serde_json::Error> {
+        if self.component_type != T::component_type() {
+            panic!(
+                "Component type mismatch in clone_properties_as, self: {}, requested: {}",
+                self.component_type,
+                T::component_type()
+            );
+        }
+        serde_json::from_value(self.properties.clone())
+    }
+
+    pub fn set_typed_properties<T: TypedComponentProperties>(&mut self, properties: T) {
+        self.component_type = T::component_type().to_string();
+        self.properties = serde_json::to_value(properties).expect("Failed to serialize properties");
+    }
+
+    pub fn extract_traits_by_type(
+        &mut self,
+        trait_types: &BTreeSet<&'static str>,
+    ) -> BTreeMap<&'static str, Vec<Trait>> {
+        let mut component_traits = Vec::<Trait>::new();
+
+        std::mem::swap(&mut component_traits, &mut self.traits);
+
+        let mut matching_traits = BTreeMap::<&'static str, Vec<Trait>>::new();
+        let mut remaining_traits = Vec::<Trait>::new();
+
+        for component_trait in component_traits {
+            if let Some(trait_type) = trait_types.get(component_trait.trait_type.as_str()) {
+                matching_traits
+                    .entry(trait_type)
+                    .or_default()
+                    .push(component_trait);
+            } else {
+                remaining_traits.push(component_trait);
+            }
+        }
+
+        std::mem::swap(&mut remaining_traits, &mut self.traits);
+
+        matching_traits
+    }
+
+    pub fn add_typed_trait<T: TypedTraitProperties>(&mut self, properties: T) {
+        self.traits.push(Trait {
+            trait_type: T::trait_type().to_string(),
+            properties: serde_json::to_value(properties).expect("Failed to serialize typed trait"),
+        });
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Trait {
+    #[serde(rename = "type")]
+    pub trait_type: String,
+    pub properties: serde_json::Value,
+}
+
+pub trait TypedTraitProperties: Serialize + DeserializeOwned {
+    fn trait_type() -> &'static str;
+
+    fn from_generic_trait(value: Trait) -> Result<Self, serde_json::Error> {
+        if value.trait_type != Self::trait_type() {
+            panic!(
+                "Trait type mismatch in TryFrom<Trait>, value: {}, typed: {}",
+                value.trait_type,
+                Self::trait_type()
+            )
+        }
+        serde_json::from_value(value.properties)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_r::test;
+
+    use crate::model::oam::{Application, API_VERSION_V1BETA1, KIND_APPLICATION};
+
+    #[test]
+    fn deserialize_example_application() {
+        let application: Application = serde_yaml::from_str(
+            r#"
+apiVersion: core.oam.dev/v1beta1
+metadata:
+  name: "App name"
+kind: Application
+spec:
+  components:
+    - name: component-one
+      type: test-component-type
+      properties:
+        testComponentProperty: aaa
+      traits:
+        - type: test-trait-type-1
+          properties:
+            testProperty: bbb
+        - type: test-trait-type-2
+          properties:
+            testTraitProperty: ccc
+"#,
+        )
+        .unwrap();
+
+        assert!(application.api_version == API_VERSION_V1BETA1);
+        assert!(application.kind == KIND_APPLICATION);
+        assert!(application.metadata.name == "App name");
+        assert!(application.spec.components.len() == 1);
+
+        let component = &application.spec.components[0];
+
+        assert!(component.name == "component-one");
+        assert!(component.component_type == "test-component-type");
+        assert!(component.properties.is_object());
+
+        let properties = component.properties.as_object().unwrap();
+
+        assert!(
+            properties
+                .get_key_value("testComponentProperty")
+                .unwrap()
+                .1
+                .as_str()
+                == Some("aaa")
+        );
+
+        assert!(component.traits.len() == 2);
+
+        let component_trait = &component.traits[1];
+
+        assert!(component_trait.trait_type == "test-trait-type-2");
+        assert!(component_trait.properties.is_object());
+
+        let properties = component_trait.properties.as_object().unwrap();
+
+        assert!(properties.get_key_value("testTraitProperty").unwrap().1 == "ccc");
+    }
+}

--- a/golem-common/src/model/unknown_properties.rs
+++ b/golem-common/src/model/unknown_properties.rs
@@ -1,0 +1,36 @@
+use crate::model::validation::ValidationBuilder;
+use std::collections::BTreeMap;
+
+pub type UnknownProperties = BTreeMap<String, serde_json::Value>;
+
+pub trait HasUnknownProperties {
+    fn unknown_properties(&self) -> &UnknownProperties;
+
+    fn add_unknown_property_warns<F>(&self, context: F, validation_builder: &mut ValidationBuilder)
+    where
+        F: FnOnce() -> Vec<(&'static str, String)>,
+    {
+        let unknown_properties = self.unknown_properties();
+        if unknown_properties.is_empty() {
+            return;
+        }
+
+        let context = context();
+        let context_count = context.len();
+
+        for context in context {
+            validation_builder.push_context(context.0, context.1);
+        }
+
+        validation_builder.add_warns(self.unknown_properties().keys(), |unknown_property_name| {
+            Some((
+                vec![],
+                format!("Unknown property: {}", unknown_property_name),
+            ))
+        });
+
+        for _ in 0..context_count {
+            validation_builder.pop_context();
+        }
+    }
+}

--- a/golem-common/src/model/validation.rs
+++ b/golem-common/src/model/validation.rs
@@ -1,0 +1,270 @@
+use itertools::Itertools;
+use std::fmt::Display;
+
+pub struct ValidationContext {
+    pub name: &'static str,
+    pub value: String,
+}
+
+pub enum ValidatedResult<T> {
+    Ok(T),
+    OkWithWarns(T, Vec<String>),
+    WarnsAndErrors(Vec<String>, Vec<String>),
+}
+
+impl<T> ValidatedResult<T> {
+    pub fn from_value_and_warns(value: T, warns: Vec<String>) -> Self {
+        if warns.is_empty() {
+            ValidatedResult::Ok(value)
+        } else {
+            ValidatedResult::OkWithWarns(value, warns)
+        }
+    }
+
+    pub fn from_result<E: Display>(result: Result<T, E>) -> Self {
+        ValidatedResult::Ok(result).flatten()
+    }
+
+    pub fn from_error(error: String) -> Self {
+        ValidatedResult::WarnsAndErrors(vec![], vec![error])
+    }
+
+    pub fn as_ok_ref(&self) -> Option<&T> {
+        match self {
+            ValidatedResult::Ok(value) => Some(value),
+            ValidatedResult::OkWithWarns(value, _) => Some(value),
+            ValidatedResult::WarnsAndErrors(_, _) => None,
+        }
+    }
+
+    pub fn into_product(self) -> (Option<T>, Vec<String>, Vec<String>) {
+        match self {
+            ValidatedResult::Ok(result) => (Some(result), vec![], vec![]),
+            ValidatedResult::OkWithWarns(result, warns) => (Some(result), warns, vec![]),
+            ValidatedResult::WarnsAndErrors(warns, errors) => (None, warns, errors),
+        }
+    }
+
+    pub fn combine<U, V, C>(self, u: ValidatedResult<U>, combine: C) -> ValidatedResult<V>
+    where
+        C: Fn(T, U) -> V,
+    {
+        let (t, mut t_warns, mut t_errors) = self.into_product();
+        let (u, u_warns, u_errors) = u.into_product();
+
+        let warns = {
+            t_warns.extend(u_warns);
+            t_warns
+        };
+
+        let errors = {
+            t_errors.extend(u_errors);
+            t_errors
+        };
+
+        match (t, u, warns.is_empty()) {
+            (Some(t), Some(u), true) => ValidatedResult::Ok(combine(t, u)),
+            (Some(t), Some(u), false) => ValidatedResult::OkWithWarns(combine(t, u), warns),
+            _ => ValidatedResult::WarnsAndErrors(warns, errors),
+        }
+    }
+
+    pub fn map<U, F>(self, f: F) -> ValidatedResult<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            ValidatedResult::Ok(value) => ValidatedResult::Ok(f(value)),
+            ValidatedResult::OkWithWarns(value, warns) => {
+                ValidatedResult::OkWithWarns(f(value), warns)
+            }
+            ValidatedResult::WarnsAndErrors(warns, errors) => {
+                ValidatedResult::WarnsAndErrors(warns, errors)
+            }
+        }
+    }
+
+    pub fn and_then<U, F>(self, f: F) -> ValidatedResult<U>
+    where
+        F: FnOnce(T) -> ValidatedResult<U>,
+    {
+        match self {
+            ValidatedResult::Ok(value) => f(value),
+            ValidatedResult::OkWithWarns(value, warns) => {
+                ValidatedResult::from_value_and_warns((), warns).combine(f(value), |_, value| value)
+            }
+            ValidatedResult::WarnsAndErrors(warns, errors) => {
+                ValidatedResult::WarnsAndErrors(warns, errors)
+            }
+        }
+    }
+}
+
+impl<T, E> ValidatedResult<Result<T, E>> {
+    pub fn transpose(self) -> Result<ValidatedResult<T>, E> {
+        match self {
+            ValidatedResult::Ok(result) => match result {
+                Ok(value) => Ok(ValidatedResult::Ok(value)),
+                Err(err) => Err(err),
+            },
+            ValidatedResult::OkWithWarns(result, warns) => match result {
+                Ok(value) => Ok(ValidatedResult::OkWithWarns(value, warns)),
+                Err(err) => Err(err),
+            },
+            ValidatedResult::WarnsAndErrors(warns, errors) => {
+                Ok(ValidatedResult::WarnsAndErrors(warns, errors))
+            }
+        }
+    }
+
+    pub fn flatten(self) -> ValidatedResult<T>
+    where
+        E: Display,
+    {
+        match self {
+            ValidatedResult::Ok(value) => match value {
+                Ok(value) => ValidatedResult::Ok(value),
+                Err(err) => ValidatedResult::WarnsAndErrors(vec![], vec![format!("{}", err)]),
+            },
+            ValidatedResult::OkWithWarns(value, warns) => match value {
+                Ok(value) => ValidatedResult::OkWithWarns(value, warns),
+                Err(err) => ValidatedResult::WarnsAndErrors(warns, vec![format!("{}", err)]),
+            },
+            ValidatedResult::WarnsAndErrors(warns, errors) => {
+                ValidatedResult::WarnsAndErrors(warns, errors)
+            }
+        }
+    }
+}
+
+// NOTE: Only implemented for Vec and as non-short-circuiting on errors for now
+impl<A> FromIterator<ValidatedResult<A>> for ValidatedResult<Vec<A>> {
+    fn from_iter<T: IntoIterator<Item = ValidatedResult<A>>>(iter: T) -> Self {
+        let mut validation = ValidationBuilder::new();
+        let mut elems = Vec::<A>::new();
+
+        for elem in iter {
+            match elem {
+                ValidatedResult::Ok(elem) => {
+                    elems.push(elem);
+                }
+                ValidatedResult::OkWithWarns(elem, warns) => {
+                    elems.push(elem);
+                    warns.into_iter().for_each(|warn| validation.add_warn(warn));
+                }
+                ValidatedResult::WarnsAndErrors(warns, errors) => {
+                    warns.into_iter().for_each(|warn| validation.add_warn(warn));
+                    errors
+                        .into_iter()
+                        .for_each(|error| validation.add_error(error));
+                }
+            }
+        }
+
+        validation.build(elems)
+    }
+}
+
+pub struct ValidationBuilder {
+    context: Vec<ValidationContext>,
+    warns: Vec<String>,
+    errors: Vec<String>,
+}
+
+impl ValidationBuilder {
+    pub fn new() -> Self {
+        Self {
+            context: vec![],
+            warns: vec![],
+            errors: vec![],
+        }
+    }
+
+    pub fn push_context(&mut self, name: &'static str, value: String) {
+        self.context.push(ValidationContext { name, value })
+    }
+
+    pub fn pop_context(&mut self) {
+        _ = self.context.pop();
+    }
+
+    pub fn add_error(&mut self, error: String) {
+        self.errors.push(format!("{}{}", error, self.context(),));
+    }
+
+    pub fn add_warn(&mut self, warn: String) {
+        self.warns.push(format!("{}{}", warn, self.context(),));
+    }
+
+    pub fn add_errors<T, C, F>(&mut self, elems: C, context_and_error: F)
+    where
+        C: IntoIterator<Item = T>,
+        F: Fn(T) -> Option<(Vec<(&'static str, String)>, String)>,
+    {
+        self.add(elems, context_and_error, Self::add_error);
+    }
+
+    pub fn add_warns<T, C, F>(&mut self, elems: C, context_and_error: F)
+    where
+        C: IntoIterator<Item = T>,
+        F: Fn(T) -> Option<(Vec<(&'static str, String)>, String)>,
+    {
+        self.add(elems, context_and_error, Self::add_warn);
+    }
+
+    pub fn add<T, C, CE, A>(&mut self, elems: C, context_and_error: CE, add: A)
+    where
+        C: IntoIterator<Item = T>,
+        CE: Fn(T) -> Option<(Vec<(&'static str, String)>, String)>,
+        A: Fn(&mut Self, String),
+    {
+        for elem in elems {
+            if let Some((context, error)) = context_and_error(elem) {
+                let context_count = context.len();
+                if !context.is_empty() {
+                    context
+                        .into_iter()
+                        .for_each(|(name, value)| self.push_context(name, value))
+                }
+
+                add(self, error);
+
+                for _ in 0..context_count {
+                    self.pop_context()
+                }
+            }
+        }
+    }
+
+    pub fn has_any_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    pub fn build<T>(self, value: T) -> ValidatedResult<T> {
+        if self.errors.is_empty() {
+            ValidatedResult::from_value_and_warns(value, self.warns)
+        } else {
+            ValidatedResult::WarnsAndErrors(self.warns, self.errors)
+        }
+    }
+
+    fn context(&self) -> String {
+        if self.context.is_empty() {
+            "".to_string()
+        } else {
+            format!(
+                ", {}",
+                self.context
+                    .iter()
+                    .map(|c| format!("{}: {}", c.name, c.value))
+                    .join(", ")
+            )
+        }
+    }
+}
+
+impl Default for ValidationBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/golem-component-service-base/tests/services_tests.rs
+++ b/golem-component-service-base/tests/services_tests.rs
@@ -148,6 +148,7 @@ async fn test_component_constraint_incompatible_updates(
             &component_name,
             ComponentType::Durable,
             get_component_data("shopping-cart"),
+            None,
             &DefaultNamespace::default(),
         )
         .await
@@ -178,6 +179,7 @@ async fn test_component_constraint_incompatible_updates(
         .update(
             &component_id,
             get_component_data("shopping-cart"),
+            None,
             None,
             &DefaultNamespace::default(),
         )
@@ -232,6 +234,7 @@ async fn test_services(component_repo: Arc<dyn ComponentRepo + Sync + Send>) {
             &component_name1,
             ComponentType::Durable,
             get_component_data("shopping-cart"),
+            None,
             &DefaultNamespace::default(),
         )
         .await
@@ -243,6 +246,7 @@ async fn test_services(component_repo: Arc<dyn ComponentRepo + Sync + Send>) {
             &component_name2,
             ComponentType::Durable,
             get_component_data("rust-echo"),
+            None,
             &DefaultNamespace::default(),
         )
         .await
@@ -329,6 +333,7 @@ async fn test_services(component_repo: Arc<dyn ComponentRepo + Sync + Send>) {
         .update(
             &component1.versioned_component_id.component_id,
             get_component_data("shopping-cart"),
+            None,
             None,
             &DefaultNamespace::default(),
         )

--- a/golem-component-service/Cargo.toml
+++ b/golem-component-service/Cargo.toml
@@ -48,6 +48,7 @@ sqlx = { workspace = true, features = [
 ] }
 tap = { workspace = true }
 thiserror = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/golem-service-base/Cargo.toml
+++ b/golem-service-base/Cargo.toml
@@ -30,6 +30,7 @@ humantime-serde = { workspace = true }
 hyper = { workspace = true }
 num-traits = { workspace = true }
 pin-project = "1.1.7"
+poem = { workspace = true }
 poem-openapi = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/golem-service-base/Cargo.toml
+++ b/golem-service-base/Cargo.toml
@@ -43,6 +43,7 @@ sqlx = { workspace = true, features = [
     "migrate",
     "chrono",
 ] }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }

--- a/golem-worker-executor-base/Cargo.toml
+++ b/golem-worker-executor-base/Cargo.toml
@@ -40,6 +40,7 @@ cap-time-ext = "3.0.0"                              # keep in sync with wasmtime
 chrono = { workspace = true }
 dashmap = { workspace = true }
 evicting_cache_map = "0.4.0"
+faccess = "0.2.4"
 figment = { workspace = true }
 flume = "0.11.0"
 fred = { workspace = true }
@@ -84,6 +85,7 @@ tonic-reflection = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+walkdir = { workspace = true }
 warp = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/golem-worker-executor-base/Cargo.toml
+++ b/golem-worker-executor-base/Cargo.toml
@@ -70,12 +70,14 @@ ringbuf = "0.4.1"
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sqlx = { workspace = true }
 sysinfo = "0.30.12"
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-health = { workspace = true }
 tonic-reflection = { workspace = true }
@@ -87,8 +89,8 @@ wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 windows-sys = "0.52.0"
+zip = { workspace = true }
 zstd = "0.13"
-sqlx = { workspace = true }
 
 [dev-dependencies]
 golem-test-framework = { path = "../golem-test-framework", version = "0.0.0" }
@@ -102,6 +104,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 redis = { workspace = true }
 serde_json = { workspace = true }
+system-interface = "0.27.2"
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 test-r = { workspace = true }

--- a/golem-worker-executor-base/build.rs
+++ b/golem-worker-executor-base/build.rs
@@ -53,7 +53,7 @@ fn find_package_root(name: &str) -> String {
 fn preview2_mod_gen(golem_wit_path: &str) -> String {
     format!(
         r#"wasmtime::component::bindgen!({{
-        path: "{golem_wit_path}/wit",
+        path: r"{golem_wit_path}/wit",
         interfaces: "
           import golem:api/host@0.2.0;
           import golem:api/host@1.1.0-rc1;

--- a/golem-worker-executor-base/src/lib.rs
+++ b/golem-worker-executor-base/src/lib.rs
@@ -26,6 +26,7 @@ pub mod services;
 pub mod storage;
 pub mod wasi_host;
 pub mod worker;
+pub mod worker_fs;
 pub mod workerctx;
 
 #[cfg(test)]

--- a/golem-worker-executor-base/src/model/mod.rs
+++ b/golem-worker-executor-base/src/model/mod.rs
@@ -16,11 +16,13 @@ pub mod public_oplog;
 
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bincode::{Decode, Encode};
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use serde::{Deserialize, Serialize};
+use tempfile::TempPath;
 use wasmtime::Trap;
 
 use golem_common::model::oplog::WorkerError;
@@ -340,6 +342,20 @@ pub enum LookupResult {
     Pending,
     Interrupted,
     Complete(Result<TypeAnnotatedValue, GolemError>),
+}
+
+pub enum PathHandle {
+    TemporaryPath(TempPath),
+    StandardPath(PathBuf),
+}
+
+impl PathHandle {
+    pub fn as_path(&self) -> &Path {
+        match self {
+            Self::TemporaryPath(path) => path.as_ref(),
+            Self::StandardPath(path) => path.as_ref(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/golem-worker-executor-base/src/services/golem_config.rs
+++ b/golem-worker-executor-base/src/services/golem_config.rs
@@ -71,6 +71,7 @@ pub struct Limits {
 pub struct ComponentCacheConfig {
     pub max_capacity: usize,
     pub max_metadata_capacity: usize,
+    pub max_files_capacity: usize,
     #[serde(with = "humantime_serde")]
     pub time_to_idle: Duration,
 }
@@ -399,6 +400,7 @@ impl Default for ComponentCacheConfig {
         Self {
             max_capacity: 32,
             max_metadata_capacity: 16384,
+            max_files_capacity: 32,
             time_to_idle: Duration::from_secs(12 * 60 * 60),
         }
     }

--- a/golem-worker-executor-base/src/services/worker.rs
+++ b/golem-worker-executor-base/src/services/worker.rs
@@ -20,6 +20,7 @@ use golem_common::model::{
     ComponentType, OwnedWorkerId, ShardId, Timestamp, WorkerId, WorkerMetadata, WorkerStatus,
     WorkerStatusRecord,
 };
+use tokio::fs;
 use tracing::{debug, warn};
 
 use crate::error::GolemError;
@@ -299,6 +300,13 @@ impl WorkerService for DefaultWorkerService {
                     "failed to remove worker from the set of running worker ids per shard in KV storage: {err}"
                 )
             });
+
+        let root_dir_path = owned_worker_id.worker_id.to_root_dir_path();
+        if root_dir_path.is_dir() {
+            fs::remove_dir_all(root_dir_path)
+                .await
+                .unwrap_or_else(|error| panic!("failed to remove worker root dir: {error}"));
+        }
     }
 
     async fn remove_cached_status(&self, owned_worker_id: &OwnedWorkerId) {

--- a/golem-worker-executor-base/src/wasi_host/mod.rs
+++ b/golem-worker-executor-base/src/wasi_host/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Duration;
 
 use crate::durable_host::DurableWorkerCtx;
@@ -87,7 +87,7 @@ where
 pub fn create_context(
     args: &[impl AsRef<str>],
     env: &[(impl AsRef<str>, impl AsRef<str>)],
-    root_dir: PathBuf,
+    root_dir: &Path,
     stdin: impl StdinStream + Sized + 'static,
     stdout: impl StdoutStream + Sized + 'static,
     stderr: impl StdoutStream + Sized + 'static,
@@ -102,7 +102,7 @@ pub fn create_context(
         .stdout(stdout)
         .stderr(stderr)
         .monotonic_clock(helpers::clocks::monotonic_clock())
-        .preopened_dir(root_dir.clone(), "/", DirPerms::all(), FilePerms::all())?
+        .preopened_dir(root_dir, "/", DirPerms::all(), FilePerms::all())?
         .preopened_dir(root_dir, ".", DirPerms::all(), FilePerms::all())?
         .set_suspend(suspend_threshold, suspend_signal)
         .allow_ip_name_lookup(true)

--- a/golem-worker-executor-base/src/worker_fs.rs
+++ b/golem-worker-executor-base/src/worker_fs.rs
@@ -1,0 +1,298 @@
+use anyhow::anyhow;
+use faccess::PathExt;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::UNIX_EPOCH;
+use tokio::{fs, task};
+use walkdir::WalkDir;
+use zip::read::ZipArchive;
+
+use crate::error::GolemError;
+use crate::services::component::{ComponentMetadata, ComponentService};
+use golem_common::model::{
+    ComponentId, DirectoryInfo, FileInfo, FileListing, FileListingPermissions,
+    Path as FileListingPath, WorkerId,
+};
+
+pub const SYSTEM_ROOT: &str = "system";
+
+#[derive(Debug)]
+pub struct PathsToPreopen {
+    pub root_path: PathBuf,
+    pub system_path: PathBuf,
+    pub component_version_path: PathBuf,
+    pub component_current_path: PathBuf,
+}
+
+// Mapping inside Worker + Host directory structure
+//
+// `/`  OR  `.` => `data/worker_files/component/{component_uuid}/worker/{worker_name}/root/`
+//
+// `/system`  =>  `data/worker_files/component/{component_uuid}/worker/{worker_name}/system/`
+//
+// `/system/component/version/{component_version}` => `data/worker_files/component/{component_uuid}/version`
+//
+// `/system/component/current` => `data/worker_files/component/{component_uuid}/version/{component_version}`
+
+pub fn get_worker_host_root_path(worker_id: &WorkerId) -> PathBuf {
+    let component_id = &worker_id.component_id;
+    let component_uuid = component_id.0;
+    let worker_name = &worker_id.worker_name;
+
+    let component_root_path =
+        PathBuf::from(format!("data/worker_files/component/{component_uuid}"));
+    component_root_path.join(format!("worker/{worker_name}"))
+}
+
+pub fn get_preopened_root_path(worker_id: &WorkerId) -> PathBuf {
+    get_worker_host_root_path(worker_id).join("root")
+}
+
+pub async fn prepare_worker_files_and_get_paths(
+    worker_id: &WorkerId,
+    component_service: Arc<dyn ComponentService + Send + Sync>,
+    component_metadata: &ComponentMetadata,
+) -> Result<PathsToPreopen, GolemError> {
+    let component_id = &worker_id.component_id;
+    let component_uuid = component_id.0;
+    let component_version = component_metadata.version;
+    let worker_name = &worker_id.worker_name;
+
+    // TODO: Sync Workers reading and writing files? Access FS through an RwLock(s)?
+
+    let component_root_path =
+        PathBuf::from(format!("data/worker_files/component/{component_uuid}"));
+    let component_version_path = component_root_path.join("version");
+    let files_path = Arc::new(component_version_path.join(format!("{component_version}/files")));
+    let worker_host_root_path = component_root_path.join(format!("worker/{worker_name}"));
+    let root_path = worker_host_root_path.join("root");
+    let system_path = worker_host_root_path.join("system");
+    let component_current_path = component_version_path.join(component_version.to_string());
+
+    if !files_path.is_dir() {
+        fs::create_dir_all(files_path.as_ref()).await?;
+        extract_initial_fs_archive(
+            Arc::clone(&component_service),
+            component_id,
+            component_version,
+            Arc::clone(&files_path),
+        )
+        .await?;
+    }
+
+    if !worker_host_root_path.is_dir() {
+        fs::create_dir_all(&root_path).await?;
+        fs::create_dir_all(&system_path).await?;
+        copy_or_link_files_to_worker_root(&files_path, &root_path).await?;
+    }
+
+    let paths_to_preopen = PathsToPreopen {
+        root_path,
+        system_path,
+        component_version_path,
+        component_current_path,
+    };
+
+    Ok(paths_to_preopen)
+}
+
+async fn copy_or_link_files_to_worker_root(
+    files_path: &Path,
+    worker_root: &Path,
+) -> Result<(), GolemError> {
+    let absolute_worker_root_path = worker_root.canonicalize()?;
+
+    let dir_entries = WalkDir::new(files_path).min_depth(1).follow_links(true);
+
+    for dir_entry in dir_entries {
+        let dir_entry =
+            dir_entry.map_err(|error| anyhow!("Failed to read component dir or file: {error}"))?;
+
+        let dir_entry_metadata = dir_entry
+            .metadata()
+            .map_err(|error| anyhow!("Failed to read component dir or file metadata: {error}"))?;
+
+        if dir_entry_metadata.is_file() {
+            let absolute_path = dir_entry.path();
+
+            let path = dir_entry
+                .path()
+                .strip_prefix(files_path)
+                .map_err(|error| anyhow!("Failed to strip dir or file prefix: {error}"))?
+                .to_path_buf();
+
+            let new_path = absolute_worker_root_path.join(path);
+
+            // TODO: Parallelize?
+            if absolute_path.readable() {
+                let new_path_parent = new_path
+                    .parent()
+                    .ok_or_else(|| anyhow!("Failed to get file parent '{new_path:?}'"))?;
+                fs::create_dir_all(new_path_parent).await.map_err(|error| {
+                    anyhow!("Failed to create parent directories for '{new_path:?}': {error}")
+                })?;
+                if absolute_path.writable() {
+                    fs::copy(&absolute_path, &new_path).await.map_err(|error| {
+                        anyhow!("Failed to copy '{absolute_path:?}' to '{new_path:?}': {error}")
+                    })?;
+                } else {
+                    // TODO: Debug symlinks with Wasmtime engine
+                    // create_file_symlink(&absolute_path, &new_path).await.map_err(|error| {
+                    //     anyhow!("Failed to symlink '{absolute_path:?}' to '{new_path:?}': {error}")
+                    // })?;
+                }
+            } else {
+                Err(anyhow!("File '{absolute_path:?}' is not readable"))?
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn extract_initial_fs_archive(
+    component_service: Arc<dyn ComponentService + Send + Sync>,
+    component_id: &ComponentId,
+    component_version: u64,
+    target_path: Arc<PathBuf>,
+) -> Result<(), GolemError> {
+    let maybe_archive_path = component_service
+        .get_initial_fs_archive(component_id, component_version)
+        .await?;
+
+    if let Some(archive_path) = maybe_archive_path {
+        task::spawn_blocking(move || {
+            let mut archive = ZipArchive::new(File::open(archive_path.as_path())?)?;
+            archive.extract(target_path.as_ref())?;
+            Ok::<(), anyhow::Error>(())
+        })
+        .await
+        .map_err(|error| anyhow::format_err!("Task to extract files failed: {error}"))??;
+    };
+    // TODO: Verify file permissions? Only non-Unix platforms?
+    Ok(())
+}
+
+pub fn file_listings(
+    dir_path: &Path,
+    recursive: Option<bool>,
+) -> Result<Vec<FileListing>, GolemError> {
+    let dir_entries = WalkDir::new(dir_path)
+        .min_depth(1)
+        .follow_links(true)
+        .max_depth(if recursive.unwrap_or_default() {
+            usize::MAX
+        } else {
+            1
+        })
+        .sort_by_file_name();
+
+    let mut listings = Vec::new();
+
+    for dir_entry in dir_entries {
+        let dir_entry =
+            dir_entry.map_err(|error| anyhow!("Failed to read worker dir or file: {error}"))?;
+
+        let dir_entry_metadata = dir_entry
+            .metadata()
+            .map_err(|error| anyhow!("Failed to read worker dir or file metadata: {error}"))?;
+
+        let path = dir_entry
+            .path()
+            .strip_prefix(dir_path)
+            .map_err(|error| anyhow!("Failed to strip dir or file prefix: {error}"))?
+            .to_path_buf();
+
+        let permissions = file_listing_permissions(dir_entry.path(), &path);
+
+        let last_modified = dir_entry_metadata
+            .modified()?
+            .duration_since(UNIX_EPOCH)
+            .expect("Invalid last modified time")
+            .as_secs();
+
+        let path = path
+            .into_os_string()
+            .into_string()
+            .map(FileListingPath)
+            .map_err(|os_string| {
+                anyhow!("Path '{os_string:?}' does not contain only valid Unicode data")
+            })?;
+
+        let file_listing = if dir_entry_metadata.is_dir() {
+            FileListing::Directory(DirectoryInfo {
+                path,
+                last_modified,
+                permissions,
+            })
+        } else {
+            let size = dir_entry_metadata.len();
+            FileListing::File(FileInfo {
+                path,
+                last_modified,
+                permissions,
+                size,
+            })
+        };
+        listings.push(file_listing);
+    }
+    Ok(listings)
+}
+
+fn file_listing_permissions(
+    absolute_path: &Path,
+    path_in_worker: &Path,
+) -> Option<FileListingPermissions> {
+    if !absolute_path.readable() {
+        return None;
+    }
+    if path_in_worker.starts_with(SYSTEM_ROOT) {
+        return Some(FileListingPermissions::AlwaysReadOnly);
+    }
+    if absolute_path.writable() {
+        return Some(FileListingPermissions::ReadWrite);
+    }
+    Some(FileListingPermissions::ReadOnly)
+}
+
+// TODO: Try symlinks again later when the engine is more stable or remove functions below
+
+pub async fn create_dir_symlink(dir: &Path, symlink: &Path) -> Result<(), GolemError> {
+    create_dir_symlink_internal(dir, symlink)
+        .await
+        .map_err(|error| {
+            GolemError::runtime(format!(
+                "Failed to create dir symlink '{dir:?}' to '{symlink:?}': {error}"
+            ))
+        })
+}
+
+#[cfg(unix)]
+async fn create_dir_symlink_internal(dir: &Path, symlink: &Path) -> tokio::io::Result<()> {
+    tokio::fs::symlink(dir, symlink).await
+}
+
+#[cfg(windows)]
+async fn create_dir_symlink_internal(dir: &Path, symlink: &Path) -> tokio::io::Result<()> {
+    tokio::fs::symlink_dir(dir, symlink).await
+}
+
+pub async fn create_file_symlink(file: &Path, symlink: &Path) -> Result<(), GolemError> {
+    create_file_symlink_internal(file, symlink)
+        .await
+        .map_err(|error| {
+            GolemError::runtime(format!(
+                "Failed to create file symlink '{file:?}' to '{symlink:?}': {error}"
+            ))
+        })
+}
+
+#[cfg(unix)]
+async fn create_file_symlink_internal(file: &Path, symlink: &Path) -> tokio::io::Result<()> {
+    tokio::fs::symlink(file, symlink).await
+}
+
+#[cfg(windows)]
+async fn create_file_symlink_internal(file: &Path, symlink: &Path) -> tokio::io::Result<()> {
+    tokio::fs::symlink_file(file, symlink).await
+}

--- a/golem-worker-executor-base/tests/api.rs
+++ b/golem-worker-executor-base/tests/api.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
-use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -46,6 +45,7 @@ use golem_test_framework::dsl::{
     drain_connection, is_worker_execution_error, stdout_event_matching, stdout_events,
     worker_error_message, TestDslUnsafe,
 };
+use system_interface::fs::FileIoExt;
 use tokio::time::sleep;
 use tonic::transport::Body;
 use tracing::{debug, info};

--- a/golem-worker-service-base/Cargo.toml
+++ b/golem-worker-service-base/Cargo.toml
@@ -63,6 +63,7 @@ sqlx = { workspace = true, features = [
     "chrono",
 ] }
 tap = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/golem-worker-service/Cargo.toml
+++ b/golem-worker-service/Cargo.toml
@@ -55,6 +55,7 @@ serde_yaml = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tap = { workspace = true }
+tempfile = { workspace = true } 
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -834,6 +834,90 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/GolemErrorBody'
+  /v1/components/{component_id}/workers/{worker_name}/files:
+    get:
+      tags:
+      - Worker
+      summary: Get files of a worker
+      description: |-
+        `.../{worker_name}/files` retrieves the top-level listing of nodes in the worker’s file system.
+
+        The listing contains information on the type of each node, as well as other metadata:
+        ```json
+        [{"type": "directory", "name": "foo"}, {"type": "file", "name": "bar.txt"}, ...]`
+        ``````
+
+        `.../{worker_name}/files?path=/root_in_worker/my_file.txt` retrieves the file at the specified path or lists the contents of the directory
+        at the specified path, depending on whether or not the path points to a file node or a directory node.
+      operationId: get_worker_files
+      parameters:
+      - in: path
+        name: component_id
+        required: true
+        deprecated: false
+        schema:
+          type: string
+          format: uuid
+        explode: true
+        style: simple
+      - in: path
+        name: worker_name
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      - in: query
+        name: path
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: form
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: string
+        '400':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/GolemErrorBody'
   /v1/components/{component_id}/workers/find:
     post:
       tags:
@@ -1879,6 +1963,9 @@ paths:
                 component:
                   type: string
                   format: binary
+                files:
+                  type: string
+                  format: binary
               required:
               - name
               - component
@@ -1958,6 +2045,91 @@ paths:
             schema:
               type: string
               format: binary
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Component'
+        '400':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      deprecated: true
+  /v1/components/{component_id}/upload_v2:
+    put:
+      tags:
+      - Component
+      summary: Update a component v2
+      operationId: update_component_v2
+      parameters:
+      - in: path
+        name: component_id
+        required: true
+        deprecated: false
+        schema:
+          type: string
+          format: uuid
+        explode: true
+        style: simple
+      - in: query
+        name: component_type
+        description: |-
+          Type of the new version of the component - if not specified, the type of the previous version
+          is used.
+        deprecated: false
+        schema:
+          $ref: '#/components/schemas/ComponentType'
+        explode: true
+        style: form
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                component:
+                  type: string
+                  format: binary
+                files:
+                  type: string
+                  format: binary
+              required:
+              - component
         required: true
       responses:
         '200':

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -840,16 +840,20 @@ paths:
       - Worker
       summary: Get files of a worker
       description: |-
-        `.../{worker_name}/files` retrieves the top-level listing of nodes in the worker’s file system.
+        **Examples:**
+
+        1. `.../{worker_name}/files` retrieves the top-level listing of nodes in the worker’s file system.
+
+        2. `.../{worker_name}/files?recursive=true` retrieves the listing of nodes including sub-directories.
+
+        3. `.../{worker_name}/files?path=a_dir/my_file.txt` retrieves the file at the specified path or lists the contents of the directory
+        at the specified path, depending on whether or not the path points to a file node or a directory node.
 
         The listing contains information on the type of each node, as well as other metadata:
         ```json
-        [{"type": "directory", "name": "foo"}, {"type": "file", "name": "bar.txt"}, ...]`
-        ``````
-
-        `.../{worker_name}/files?path=/root_in_worker/my_file.txt` retrieves the file at the specified path or lists the contents of the directory
-        at the specified path, depending on whether or not the path points to a file node or a directory node.
-      operationId: get_worker_files
+        [{"type": "directory", "path": "foo"}, {"type": "file", "path": "bar.txt"}, ...]
+        ```
+      operationId: get_worker_files_or_listings
       parameters:
       - in: path
         name: component_id
@@ -875,13 +879,29 @@ paths:
           type: string
         explode: true
         style: form
+      - in: query
+        name: recursive
+        deprecated: false
+        schema:
+          type: boolean
+        explode: true
+        style: form
       responses:
+        '200':
+            description: ''
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
         '200':
           description: ''
           content:
             application/json; charset=utf-8:
               schema:
-                type: string
+                type: array
+                items:
+                  $ref: '#/components/schemas/FileListing'
         '400':
           description: ''
           content:
@@ -2894,6 +2914,19 @@ components:
       - id
       - resource_name
       - resource_params
+    DirectoryInfo:
+      type: object
+      properties:
+        path:
+          type: string
+        lastModified:
+          type: integer
+          format: uint64
+        permissions:
+          $ref: '#/components/schemas/FileListingPermissions'
+      required:
+      - path
+      - lastModified
     Empty:
       type: object
     EndRegionParameters:
@@ -3011,6 +3044,63 @@ components:
       required:
       - timestamp
       - target_version
+    FileInfo:
+      type: object
+      properties:
+        path:
+          type: string
+        lastModified:
+          type: integer
+          format: uint64
+        permissions:
+          $ref: '#/components/schemas/FileListingPermissions'
+        size:
+          type: integer
+          format: uint64
+      required:
+      - path
+      - lastModified
+      - size
+    FileListing:
+      discriminator:
+        propertyName: type
+        mapping:
+          Directory: '#/components/schemas/FileListing_DirectoryInfo'
+          File: '#/components/schemas/FileListing_FileInfo'
+      type: object
+      oneOf:
+      - $ref: '#/components/schemas/FileListing_DirectoryInfo'
+      - $ref: '#/components/schemas/FileListing_FileInfo'
+    FileListingPermissions:
+      type: string
+      enum:
+      - AlwaysReadOnly
+      - ReadOnly
+      - ReadWrite
+    FileListing_DirectoryInfo:
+      allOf:
+      - type: object
+        properties:
+          type:
+            example: Directory
+            type: string
+            enum:
+            - Directory
+        required:
+        - type
+      - $ref: '#/components/schemas/DirectoryInfo'
+    FileListing_FileInfo:
+      allOf:
+      - type: object
+        properties:
+          type:
+            example: File
+            type: string
+            enum:
+            - File
+        required:
+        - type
+      - $ref: '#/components/schemas/FileInfo'
     FilterComparator:
       type: string
       enum:


### PR DESCRIPTION
/claim #1004

Closes #1004, Fixes #843 

## Initial file system 

Specification: https://github.com/golemcloud/golem/issues/1004#issuecomment-2412522032

### Currently implemented flow

**_NOTE_**: You can run the described flow by yourself with this testing example: https://github.com/MartinKavik/golem_async 

1. `golem.yaml` files are collected from the project and validated. Then component `files` are downloaded and packed into a zip archive and uploaded to Golem together with the component data from Golem CLI.

![add_component_with_files](https://github.com/user-attachments/assets/29e611e8-0ff9-4b4d-88e4-cc9760790da6)

2. Uploaded `files` are extracted to a new directory inside the worker executor `data` folder. Each durable worker has one such directory representing its root directory.  The code running inside the worker has access to all files in the directory and all files created by the worker are stored there as well.

![call_workers](https://github.com/user-attachments/assets/c1bc68c6-0fe2-44f6-8ce7-0dac825b41bb)

3. Worker root dir contents can be listed through REST API.

![files_api_result](https://github.com/user-attachments/assets/00eb81b3-1e2d-4688-8783-345b78fcacf7)

4. Worker files are deleted from executor together with the worker itself.

### Files compression & transport

Files are compressed with the default / standard method `Deflated` and packed to a Zip archive. Permissions `read-only` or `read-write` are linked to every file as Unix permissions. If the file is larger than 4GB, then Zip readers need ZIP64 support to open the archive.  The attribute `modification time` is automatically set to the current time without a time zone. Comments are not used. Related code:

```rust
let zip_file_options = zip::write::SimpleFileOptions::default()
    .compression_method(zip::CompressionMethod::Deflated)
    .large_file(source_file_size >= u32::MAX as u64)
    .unix_permissions(permissions.to_unix_file_permissions());
// ...
impl InitialFilePermissions {
    // https://chmod-calculator.com/
    const READ_ONLY_NUMERIC: u32 = 0o444; // r--r--r--
    const READ_WRITE_NUMERIC: u32 = 0o666; // rw-rw-rw-

    pub fn to_unix_file_permissions(&self) -> u32 {
        match self {
            Self::ReadOnly => Self::READ_ONLY_NUMERIC,
            Self::ReadWrite => Self::READ_WRITE_NUMERIC,
        }
    }
   // ...
```

I've chosen `Deflated` method and Zip archive because they are the most used ones so we can read or even create such file archives on different platforms and the related tools and libraries should be reliable enough. Zip doesn't support compression across files but it's a tradeoff for potential parallel packing and simple partial extraction that could be useful for more efficient worker files update. 

If needed, we can optimize packing by choosing a better method like `Zstd` because it should be both faster and produce smaller files. Or we can pack files into a compressed Tar archive or into a second inner Zip archive without any compression to achieve compression across files. It would depend on user files - for example compression across files would be suitable for many text files but not too much for already compressed images and videos.

I've decided to include permissions directly in the archive to make the archive work as a self-contained unit. This way:
- It's easier to transport it through different Golem layers.
- It should save some space.
- It's much harder to accidentally desynchronize files with their associated permissions.
- API for reading and writing is included in both Zip standard and needed Rust libraries.
- When the permissions attribute becomes too limiting, we can use the `comment` attribute or custom ZIP fields.
- It'll make files upload possible even without Golem manifests because users would be able to set file permissions by themselves, even recursively with their native OS tools.
- Most permissions are automatically set on extracted files on Unix systems so `read-only` files will have native read-only flag set as well.

I tried to use the crate [async_zip](https://crates.io/crates/async_zip) but created archives were unreadable (as surprisingly described in their [docs](https://docs.rs/async_zip/0.0.17/async_zip/base/write/struct.ZipFileWriter.html#method.write_entry_stream)). Then I tried to use  the sync [zip](https://crates.io/crates/zip) crate directly together with Tokio's `spawn_blocking` but the code became unreliable when an early return has been triggered by an error. So I decided to "isolate" sync Zip calls with channels in `golem-cli/src/async_zip_writer.rs`.

### OpenAPI path parameters

OpenAPI currently (v3) doesn't support optional path parameters. See e.g. [swagger.io/docs/specification/v3_0/describing-parameters/](https://swagger.io/docs/specification/v3_0/describing-parameters/):

> "... Also remember to add required: true, because path parameters are always required. ...

It means that urls like:
```
/v1/components/{component_id}/workers/{worker_name}/files/<path>
```
aren't officially possible to make even though the generator allows it. It should be somehow possible in OpenAPI v4, see https://github.com/OAI/OpenAPI-Specification/issues/93#issuecomment-1908673473.

I've started to implement `.../workers/{worker_name}/files/<path>` endpoint with url `/workers/{worker_name}/files?path=/my_file.txt` as the OAS-compatible alternative. But it has some benefits - you don't need to urlencode it if you are confident that the path doesn't contain chars `=` and `&` (and maybe others?). And in the future we can add array support when a user wants to define more paths to download more files at once. But I don't know the "business reason" for this API / how real users want to download the files so it depends.

### Nested preopened dirs / files, Copy files to workers

Consider this `Golem.yaml` snippet:

```yaml
files:
  - sourcePath: https://picsum.photos/200/300
    targetPath: /images/random_picture.jpg
    permissions: read-write
  - sourcePath: ./images
    targetPath: /images
```

1. It mixes `read-write` and `read-only` files in one directory. Should it be possible? If I'm not mistaken, Wasi / Wasmtime doesn't support it, you can only _preopen_ directories. 
2. Worker wants to delete all its  `read-write` files and folders (to prepare for a big component files update; to remove all user data if the worker represents a user that wants to be [forgotten](https://en.wikipedia.org/wiki/Right_to_be_forgotten); etc.) You cannot just call a function `remove_dir_all` because it would probably fail if there is a nested `read-only` dir entry. As a worker developer I would probably just try to get permissions from dir entry metadata during walking from the root dir and pray that standard file permissions matches the one set by Wasm engine. Then also host file permissions and guest/standard file permissions may become a bit confusing.
3. If I understand it correctly: All `read-write` files should be copied to the new worker. What if I don't want it as a worker developer? Let's say I have a component `User`. It represents all user data and works as a server session as well (see e.g. [turso.tech/multi-tenancy](https://turso.tech/multi-tenancy) or [plane.dev/concepts/session-backends](https://plane.dev/concepts/session-backends)). I want to start with almost empty worker state and then lazily attach/copy initial files and databases when the user/customer sign up to my app. I don't want to do that for every web visitor or bot. One idea would be to introduce special directories in the worker root like `/static`, `/public`, `/shared` and `/private`, where current `read-only` files and dirs will be inside `/static`; current `read-write` files inside `/private`. `/public` could a special folder accessible from outside world. `/shared` could be for passing/sharing big files among workers. Current `permissions` in the manifest would define classic file permissions. Then we can make  `/static` / `read-only` files public cheaply just by creating a _symlink_ inside `/public`.

### Windows support

I've tried to work on Golem on Windows first - I wasn't really successful but I've made it at least compilable by these two lines:
```rust
// golem-worker-executor-base/build.rs
r#"...path: r"{golem_wit_path}/wit",           // notice `r`
// golem-worker-executor-base/tests/api.rs
use system_interface::fs::FileIoExt;    // replacing `use std::os::unix::fs::FileExt`
```
Then `cargo make run` script would need to be rewritten to make it cross-platform. Redis doesn't support Windows but I can imagine Redis + Postgre + Nginx will be replaced / alternative will be introduced in the future to make the entire architecture and development / deployment simpler. I haven't found a reasonable replacement for [lnav](https://lnav.org/) yet. I've tried to compile it with [MSYS2](https://www.msys2.org/) but I've found out there are too much incompatibilities to make it work on Windows in a reasonable time. 

### Next steps

I've opened some topics to discuss in that wall of text above and the PR is not mergeable yet. I can add comments directly to PR code to make the review easier or continue implementation if you want to. 

I would finish that `..{component_id}/workers/{worker_name}/files/` endpoint and then update/fix other parts of code according to feedback. Also I think this PR is already pretty big so I would recommend to split it and create another PR for the `API Definition API` and potential extra work.