### PR TITLE
Make string interpolation flexible

### DIFF
--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::call_type::CallType;
-use crate::parser::rib_expr::rib_program;
+use crate::parser::block::block;
 use crate::parser::type_name::TypeName;
 use crate::type_registry::FunctionTypeRegistry;
 use crate::{
@@ -21,8 +21,10 @@ use crate::{
     ParsedFunctionName, VariableId,
 };
 use bincode::{Decode, Encode};
+use combine::parser::char::spaces;
 use combine::stream::position;
-use combine::EasyParser;
+use combine::Parser;
+use combine::{eof, EasyParser};
 use golem_api_grpc::proto::golem::rib::RecordFieldArmPattern;
 use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
@@ -113,7 +115,8 @@ impl Expr {
     /// string interpolation (see error_message above) etc.
     ///
     pub fn from_text(input: &str) -> Result<Expr, String> {
-        rib_program()
+        spaces()
+            .with(block().skip(eof()))
             .easy_parse(position::Stream::new(input))
             .map(|t| t.0)
             .map_err(|err| format!("{}", err))

--- a/golem-rib/src/parser/block.rs
+++ b/golem-rib/src/parser/block.rs
@@ -1,0 +1,58 @@
+use crate::parser::errors::RibParseError;
+use crate::parser::rib_expr::rib_expr;
+use crate::Expr;
+use combine::parser::char::{char, spaces};
+use combine::{sep_by, ParseError, Parser};
+
+pub fn block<Input>() -> impl Parser<Input, Output = Expr>
+where
+    Input: combine::Stream<Token = char>,
+    RibParseError: Into<
+        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
+    >,
+{
+    sep_by(rib_expr().skip(spaces()), char(';').skip(spaces())).map(|expressions: Vec<Expr>| {
+        if expressions.len() == 1 {
+            expressions.first().unwrap().clone()
+        } else {
+            Expr::expr_block(expressions)
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use test_r::test;
+
+    use super::*;
+    use combine::EasyParser;
+
+    #[test]
+    fn test_block() {
+        let input = "\"foo\"; \"bar\"";
+        let result = block().easy_parse(input);
+        assert!(result.is_ok());
+        let (expr, _) = result.unwrap();
+        assert_eq!(
+            expr,
+            Expr::expr_block(vec![Expr::literal("foo"), Expr::literal("bar")])
+        );
+    }
+
+    #[test]
+    fn test_block_multiline() {
+        let input = r#"
+        let x = 1;
+        let y = 2;
+        x + y
+        "#;
+        let expr = block().easy_parse(input).unwrap().0;
+
+        let expected = Expr::expr_block(vec![
+            Expr::let_binding("x", Expr::untyped_number(1f64)),
+            Expr::let_binding("y", Expr::untyped_number(2f64)),
+            Expr::plus(Expr::identifier("x"), Expr::identifier("y")),
+        ]);
+        assert_eq!(expr, expected);
+    }
+}

--- a/golem-rib/src/parser/list_aggregation.rs
+++ b/golem-rib/src/parser/list_aggregation.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::parser::block_without_return::block_without_return;
 use crate::parser::errors::RibParseError;
 use crate::parser::identifier::identifier_text;
-use crate::parser::partial_block_expr::partial_block;
 use crate::parser::rib_expr::rib_expr as expr;
 use crate::{Expr, VariableId};
 use combine::parser::char::{alpha_num, char, spaces, string};
@@ -49,7 +49,7 @@ where
         string("from").skip(spaces()),
         expr().skip(spaces()),
         char('{').skip(spaces()),
-        optional(partial_block().skip(spaces())),
+        optional(block_without_return().skip(spaces())),
         string("yield").skip(spaces()),
         expr().skip(spaces()),
         char(';').skip(spaces()),

--- a/golem-rib/src/parser/list_comprehension.rs
+++ b/golem-rib/src/parser/list_comprehension.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::parser::block_without_return::block_without_return;
 use crate::parser::errors::RibParseError;
 use crate::parser::identifier::identifier_text;
-use crate::parser::partial_block_expr::partial_block;
 use crate::parser::rib_expr::rib_expr as expr;
 use crate::{Expr, VariableId};
 use combine::parser::char::{alpha_num, char, spaces, string};
@@ -38,7 +38,7 @@ where
         string("in").skip(spaces()),
         expr().skip(spaces()),
         char('{').skip(spaces()),
-        optional(partial_block().skip(spaces())),
+        optional(block_without_return().skip(spaces())),
         string("yield").skip(spaces()),
         expr().skip(spaces()),
         char(';').skip(spaces()),

--- a/golem-rib/src/parser/literal.rs
+++ b/golem-rib/src/parser/literal.rs
@@ -170,12 +170,12 @@ mod literal_parse_tests {
 
     #[test]
     fn test_interpolated_strings_with_special_chars() {
-        let input = "\"<>/!@#%&^&*()_+[];',.${bar}-ba!z-${qux}\"";
+        let input = "\"\n\t<>/!@#%&^&*()_+[]; ',.${bar}-ba!z-${qux}\"";
         let result = Expr::from_text(input).unwrap();
         assert_eq!(
             result,
             Expr::concat(vec![
-                Expr::literal("<>/!@#%&^&*()_+[];',."),
+                Expr::literal("\n\t<>/!@#%&^&*()_+[]; ',."),
                 Expr::identifier("bar"),
                 Expr::literal("-ba!z-"),
                 Expr::identifier("qux"),

--- a/golem-rib/src/parser/mod.rs
+++ b/golem-rib/src/parser/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 mod binary_op;
+pub(crate) mod block;
+mod block_without_return;
 mod boolean;
 pub(crate) mod call;
 mod cond;
@@ -27,7 +29,6 @@ mod multi_line_code_block;
 mod not;
 mod number;
 mod optional;
-mod partial_block_expr;
 mod pattern_match;
 mod record;
 mod result;

--- a/golem-rib/src/parser/rib_expr.rs
+++ b/golem-rib/src/parser/rib_expr.rs
@@ -12,37 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use combine::parser;
 use combine::parser::char;
-use combine::parser::char::{char, spaces};
-use combine::{eof, ParseError, Parser};
-use combine::{parser, sep_by};
+use combine::parser::char::spaces;
+use combine::{ParseError, Parser};
 
 use crate::expr::Expr;
 use crate::parser::errors::RibParseError;
 
 use super::binary_op::BinaryOp;
-
-// Parse a full Rib Program, and we expect the parser to fully consume the stream
-// unlike rib block expression
-pub fn rib_program<Input>() -> impl Parser<Input, Output = Expr>
-where
-    Input: combine::Stream<Token = char>,
-    RibParseError: Into<
-        <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError,
-    >,
-{
-    spaces().with(
-        sep_by(rib_expr().skip(spaces()), char(';').skip(spaces()))
-            .map(|expressions: Vec<Expr>| {
-                if expressions.len() == 1 {
-                    expressions.first().unwrap().clone()
-                } else {
-                    Expr::expr_block(expressions)
-                }
-            })
-            .skip(eof()),
-    )
-}
 
 // A rib expression := (simple_expr, rib_expr_rest*)
 parser! {


### PR DESCRIPTION
In response to https://discord.com/channels/1134448700572319785/1134448701260169249/1300769907755061268

**_and tracked as part of https://github.com/golemcloud/golem/issues/1035 which is currently in progress_**

Previously I  tested the html str responded from worker, however, not inlining HTML within Rib. Things failed when inlining within a string interpolation, as indicated by discord user.


#### Rib
```scala
let style = "font-family: Arial, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; background: linear-gradient(135deg, #1e3c72, #2a5298); color: #ffffff; text-align: center; padding: 20px;";

let user: u64 = request.path.user-id;

let body = "
  <!DOCTYPE html>
     <html>
       <head>
      </head>
      <body style='${style}'>
         <div>
           <h1>Welcome to Golem Cloud!</h1>
           <p style='font-size: 1.5em;'>Hello, User ID: ${user}</p>
           <p style='color: #dcdcdc;'>Explore your cart contents and more on this personalized page.</p>
       </div>
    </body>
  </html>"

{Content-Type: "text/html", status: 200u64, body: body}

```

#### Result

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/a8a788a8-9406-47a6-a1ed-4d37a6298102">

NOTE: Having a complex HTML within Rib within API Definition JSON is really hard. Everything has to be 1 line. Or else use golem-cloud console Rib editor.


https://github.com/afsalthaj/golem-worker-gateway-examples/blob/main/html/api-definition.json





