### PR TITLE
Yaml support for API definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.213",
  "serde_json",
+ "serde_yaml",
  "test-r",
  "tracing",
  "uuid",
@@ -3591,6 +3592,7 @@ dependencies = [
  "regex",
  "serde 1.0.213",
  "serde_json",
+ "serde_yaml",
  "test-r",
  "thiserror",
  "tokio",
@@ -3736,9 +3738,8 @@ dependencies = [
 
 [[package]]
 name = "golem-openapi-client-generator"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430154af3448f9b904f0fabd64ea2946100d9fea6fc04ef76533b836b6115321"
+version = "0.0.0"
+source = "git+https://github.com/golemcloud/golem-openapi-client-generator.git?branch=support_yaml#be8adf90f16d264f15c6eafd7d35f73dad74479b"
 dependencies = [
  "clap 4.5.20",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,8 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "golem-openapi-client-generator"
-version = "0.0.0"
-source = "git+https://github.com/golemcloud/golem-openapi-client-generator.git?branch=support_yaml#be8adf90f16d264f15c6eafd7d35f73dad74479b"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33e98f6cc141902ffcc13d027d0bb9a4d3310e51ff182f67236384e8dfeb3ac"
 dependencies = [
  "clap 4.5.20",
  "convert_case 0.6.0",

--- a/golem-cli/src/clients/api_definition.rs
+++ b/golem-cli/src/clients/api_definition.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::model::{ApiDefinitionId, ApiDefinitionVersion, GolemError, PathBufOrStdin};
+use crate::model::{
+    ApiDefinitionFileFormat, ApiDefinitionId, ApiDefinitionVersion, GolemError, PathBufOrStdin,
+};
 use async_trait::async_trait;
 use golem_client::model::HttpApiDefinitionWithTypeInfo;
 
@@ -35,16 +37,19 @@ pub trait ApiDefinitionClient {
         &self,
         path: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError>;
     async fn update(
         &self,
         path: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError>;
     async fn import(
         &self,
         path: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError>;
     async fn delete(
         &self,

--- a/golem-cli/src/command/api_definition.rs
+++ b/golem-cli/src/command/api_definition.rs
@@ -48,7 +48,7 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
 
-        /// Api definition id to get all versions. Optional.
+        /// Api Definition format
         #[arg(short, long)]
         def_format: Option<ApiDefinitionFileFormat>,
     },
@@ -66,7 +66,7 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
 
-        /// Api definition id to get all versions. Optional.
+        /// Api Definition format
         #[arg(short, long)]
         def_format: Option<ApiDefinitionFileFormat>,
     },
@@ -84,7 +84,7 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
 
-        /// Api definition id to get all versions. Optional.
+        /// Api Definition format
         #[arg(short, long)]
         def_format: Option<ApiDefinitionFileFormat>,
     },

--- a/golem-cli/src/command/api_definition.rs
+++ b/golem-cli/src/command/api_definition.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::model::{
-    ApiDefinitionId, ApiDefinitionVersion, GolemError, GolemResult, PathBufOrStdin,
+    ApiDefinitionFileFormat, ApiDefinitionId, ApiDefinitionVersion, GolemError, GolemResult,
+    PathBufOrStdin,
 };
 use crate::service::api_definition::ApiDefinitionService;
 use crate::service::project::ProjectResolver;
@@ -46,6 +47,10 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         /// The Golem API definition file
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
+
+        /// Api definition id to get all versions. Optional.
+        #[arg(short, long)]
+        def_format: Option<ApiDefinitionFileFormat>,
     },
 
     /// Updates an api definition
@@ -60,6 +65,10 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         /// The Golem API definition file
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
+
+        /// Api definition id to get all versions. Optional.
+        #[arg(short, long)]
+        def_format: Option<ApiDefinitionFileFormat>,
     },
 
     /// Import OpenAPI file as api definition
@@ -74,6 +83,10 @@ pub enum ApiDefinitionSubcommand<ProjectRef: clap::Args> {
         /// Json format expected unless file name ends up in `.yaml`
         #[arg(value_hint = clap::ValueHint::FilePath)]
         definition: PathBufOrStdin, // TODO: validate exists
+
+        /// Api definition id to get all versions. Optional.
+        #[arg(short, long)]
+        def_format: Option<ApiDefinitionFileFormat>,
     },
 
     /// Retrieves metadata about an existing api definition
@@ -115,6 +128,9 @@ impl<ProjectRef: clap::Args + Send + Sync + 'static> ApiDefinitionSubcommand<Pro
         service: &(dyn ApiDefinitionService<ProjectContext = ProjectContext> + Send + Sync),
         projects: &(dyn ProjectResolver<ProjectRef, ProjectContext> + Send + Sync),
     ) -> Result<GolemResult, GolemError> {
+        let with_default: fn(Option<ApiDefinitionFileFormat>) -> ApiDefinitionFileFormat =
+            |format| format.unwrap_or(ApiDefinitionFileFormat::Json);
+
         match self {
             ApiDefinitionSubcommand::Get {
                 project_ref,
@@ -127,23 +143,32 @@ impl<ProjectRef: clap::Args + Send + Sync + 'static> ApiDefinitionSubcommand<Pro
             ApiDefinitionSubcommand::Add {
                 project_ref,
                 definition,
+                def_format: format,
             } => {
                 let project_id = projects.resolve_id_or_default(project_ref).await?;
-                service.add(definition, &project_id).await
+                service
+                    .add(definition, &project_id, &with_default(format))
+                    .await
             }
             ApiDefinitionSubcommand::Update {
                 project_ref,
                 definition,
+                def_format: format,
             } => {
                 let project_id = projects.resolve_id_or_default(project_ref).await?;
-                service.update(definition, &project_id).await
+                service
+                    .update(definition, &project_id, &with_default(format))
+                    .await
             }
             ApiDefinitionSubcommand::Import {
                 project_ref,
                 definition,
+                def_format: format,
             } => {
                 let project_id = projects.resolve_id_or_default(project_ref).await?;
-                service.import(definition, &project_id).await
+                service
+                    .import(definition, &project_id, &with_default(format))
+                    .await
             }
             ApiDefinitionSubcommand::List { project_ref, id } => {
                 let project_id = projects.resolve_id_or_default(project_ref).await?;

--- a/golem-cli/src/model.rs
+++ b/golem-cli/src/model.rs
@@ -29,7 +29,7 @@ use crate::cloud::AccountId;
 use crate::model::text::fmt::TextFormat;
 use clap::builder::{StringValueParser, TypedValueParser};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
-use clap::{Arg, ArgMatches, Error, FromArgMatches};
+use clap::{Arg, ArgMatches, Error, FromArgMatches, ValueEnum};
 use clap_verbosity_flag::Verbosity;
 use derive_more::{Display, FromStr};
 use golem_client::model::{ApiDefinitionInfo, ApiSite, ScanCursor};
@@ -381,6 +381,22 @@ impl FromStr for ApiDefinitionIdWithVersion {
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, FromStr)]
 pub struct ApiDefinitionId(pub String); // TODO: Validate
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum ApiDefinitionFileFormat {
+    Json,
+    Yaml,
+}
+
+impl Display for ApiDefinitionFileFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Json => "json",
+            Self::Yaml => "yaml",
+        };
+        Display::fmt(&s, f)
+    }
+}
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, FromStr)]
 pub struct ApiDefinitionVersion(pub String); // TODO: Validate

--- a/golem-cli/src/oss/clients/api_definition.rs
+++ b/golem-cli/src/oss/clients/api_definition.rs
@@ -17,7 +17,6 @@ use std::fmt::Display;
 use std::io::Read;
 
 use async_trait::async_trait;
-
 use golem_client::model::HttpApiDefinitionRequest;
 use golem_client::model::HttpApiDefinitionWithTypeInfo;
 
@@ -77,10 +76,10 @@ async fn create_or_update_api_definition<
 
     match action {
         Action::Import => {
-            let value: serde_json::value::Value = serde_json::from_str(definition_str.as_str())
-                .map_err(|e| GolemError(format!("Failed to parse json: {e:?}")))?;
+            let value = serde_json::from_str(definition_str.as_str())
+                .map_err(|e| GolemError(format!("Failed to parse: {e:?}")))?;
 
-            Ok(client.import_open_api(&value).await?)
+            Ok(client.import_open_api_json(&value).await?)
         }
         Action::Create => {
             let value: HttpApiDefinitionRequest = serde_json::from_str(definition_str.as_str())

--- a/golem-cli/src/oss/clients/api_definition.rs
+++ b/golem-cli/src/oss/clients/api_definition.rs
@@ -85,14 +85,14 @@ async fn create_or_update_api_definition<
             let value: HttpApiDefinitionRequest = serde_json::from_str(definition_str.as_str())
                 .map_err(|e| GolemError(format!("Failed to parse HttpApiDefinition: {e:?}")))?;
 
-            Ok(client.create_definition(&value).await?)
+            Ok(client.create_definition_json(&value).await?)
         }
         Action::Update => {
             let value: HttpApiDefinitionRequest = serde_json::from_str(definition_str.as_str())
                 .map_err(|e| GolemError(format!("Failed to parse HttpApiDefinition: {e:?}")))?;
 
             Ok(client
-                .update_definition(&value.id, &value.version, &value)
+                .update_definition_json(&value.id, &value.version, &value)
                 .await?)
         }
     }

--- a/golem-cli/src/oss/clients/api_definition.rs
+++ b/golem-cli/src/oss/clients/api_definition.rs
@@ -19,12 +19,15 @@ use std::io::Read;
 use async_trait::async_trait;
 use golem_client::model::HttpApiDefinitionRequest;
 use golem_client::model::HttpApiDefinitionWithTypeInfo;
+use serde::Deserialize;
 
 use crate::clients::api_definition::ApiDefinitionClient;
 use tokio::fs::read_to_string;
 use tracing::info;
 
-use crate::model::{ApiDefinitionId, ApiDefinitionVersion, GolemError, PathBufOrStdin};
+use crate::model::{
+    ApiDefinitionFileFormat, ApiDefinitionId, ApiDefinitionVersion, GolemError, PathBufOrStdin,
+};
 use crate::oss::model::OssContext;
 
 #[derive(Clone)]
@@ -56,6 +59,7 @@ async fn create_or_update_api_definition<
     action: Action,
     client: &C,
     path: PathBufOrStdin,
+    format: &ApiDefinitionFileFormat,
 ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError> {
     info!("{action} api definition from {path:?}");
 
@@ -74,23 +78,29 @@ async fn create_or_update_api_definition<
         }
     };
 
+    fn get_definition<'de, T: Deserialize<'de>>(
+        input: &'de str,
+        format: &ApiDefinitionFileFormat,
+    ) -> Result<T, GolemError> {
+        match format {
+            ApiDefinitionFileFormat::Json => serde_json::from_str(input)
+                .map_err(|e| GolemError(format!("Failed to parse json api definition: {e:?}"))),
+            ApiDefinitionFileFormat::Yaml => serde_yaml::from_str(input)
+                .map_err(|e| GolemError(format!("Failed to parse yaml api definition: {e:?}"))),
+        }
+    }
+
     match action {
         Action::Import => {
-            let value = serde_json::from_str(definition_str.as_str())
-                .map_err(|e| GolemError(format!("Failed to parse: {e:?}")))?;
-
+            let value = get_definition(definition_str.as_str(), format)?;
             Ok(client.import_open_api_json(&value).await?)
         }
         Action::Create => {
-            let value: HttpApiDefinitionRequest = serde_json::from_str(definition_str.as_str())
-                .map_err(|e| GolemError(format!("Failed to parse HttpApiDefinition: {e:?}")))?;
-
+            let value: HttpApiDefinitionRequest = get_definition(definition_str.as_str(), format)?;
             Ok(client.create_definition_json(&value).await?)
         }
         Action::Update => {
-            let value: HttpApiDefinitionRequest = serde_json::from_str(definition_str.as_str())
-                .map_err(|e| GolemError(format!("Failed to parse HttpApiDefinition: {e:?}")))?;
-
+            let value: HttpApiDefinitionRequest = get_definition(definition_str.as_str(), format)?;
             Ok(client
                 .update_definition_json(&value.id, &value.version, &value)
                 .await?)
@@ -135,24 +145,27 @@ impl<C: golem_client::api::ApiDefinitionClient + Sync + Send> ApiDefinitionClien
         &self,
         path: PathBufOrStdin,
         _project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError> {
-        create_or_update_api_definition(Action::Create, &self.client, path).await
+        create_or_update_api_definition(Action::Create, &self.client, path, format).await
     }
 
     async fn update(
         &self,
         path: PathBufOrStdin,
         _project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError> {
-        create_or_update_api_definition(Action::Update, &self.client, path).await
+        create_or_update_api_definition(Action::Update, &self.client, path, format).await
     }
 
     async fn import(
         &self,
         path: PathBufOrStdin,
         _project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<HttpApiDefinitionWithTypeInfo, GolemError> {
-        create_or_update_api_definition(Action::Import, &self.client, path).await
+        create_or_update_api_definition(Action::Import, &self.client, path, format).await
     }
 
     async fn delete(

--- a/golem-cli/src/service/api_definition.rs
+++ b/golem-cli/src/service/api_definition.rs
@@ -17,7 +17,8 @@ use crate::model::text::api_definition::{
     ApiDefinitionAddView, ApiDefinitionGetView, ApiDefinitionImportView, ApiDefinitionUpdateView,
 };
 use crate::model::{
-    ApiDefinitionId, ApiDefinitionVersion, GolemError, GolemResult, PathBufOrStdin,
+    ApiDefinitionFileFormat, ApiDefinitionId, ApiDefinitionVersion, GolemError, GolemResult,
+    PathBufOrStdin,
 };
 use async_trait::async_trait;
 
@@ -34,16 +35,19 @@ pub trait ApiDefinitionService {
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError>;
     async fn update(
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError>;
     async fn import(
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError>;
     async fn list(
         &self,
@@ -82,8 +86,9 @@ impl<ProjectContext: Send + Sync> ApiDefinitionService
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError> {
-        let definition = self.client.create(definition, project).await?;
+        let definition = self.client.create(definition, project, format).await?;
         Ok(GolemResult::Ok(Box::new(ApiDefinitionAddView(definition))))
     }
 
@@ -91,8 +96,9 @@ impl<ProjectContext: Send + Sync> ApiDefinitionService
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError> {
-        let definition = self.client.update(definition, project).await?;
+        let definition = self.client.update(definition, project, format).await?;
         Ok(GolemResult::Ok(Box::new(ApiDefinitionUpdateView(
             definition,
         ))))
@@ -102,8 +108,9 @@ impl<ProjectContext: Send + Sync> ApiDefinitionService
         &self,
         definition: PathBufOrStdin,
         project: &Self::ProjectContext,
+        format: &ApiDefinitionFileFormat,
     ) -> Result<GolemResult, GolemError> {
-        let definition = self.client.import(definition, project).await?;
+        let definition = self.client.import(definition, project, format).await?;
         Ok(GolemResult::Ok(Box::new(ApiDefinitionImportView(
             definition,
         ))))

--- a/golem-cli/tests/api_definition.rs
+++ b/golem-cli/tests/api_definition.rs
@@ -20,12 +20,14 @@ use crate::Tracing;
 use assert2::assert;
 use chrono::{DateTime, Utc};
 use golem_cli::model::component::ComponentView;
+use golem_cli::model::ApiDefinitionFileFormat;
 use golem_client::model::{
     GolemWorkerBinding, GolemWorkerBindingWithTypeInfo, HttpApiDefinitionRequest,
     HttpApiDefinitionWithTypeInfo, MethodPattern, RibInputTypeInfo, Route, RouteWithTypeInfo,
     VersionedComponentId,
 };
 use golem_test_framework::config::{EnvBasedTestDependencies, TestDependencies};
+use serde::Serialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
@@ -54,7 +56,10 @@ fn make(r: &mut DynamicTestRegistration, suffix: &'static str, name: &'static st
         format!("api_definition_json_import{suffix}"),
         TestType::IntegrationTest,
         move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
-            api_definition_json_import((deps, name.to_string(), cli.with_args(short)))
+            api_definition_import(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Json,
+            )
         }
     );
     add_test!(
@@ -62,23 +67,54 @@ fn make(r: &mut DynamicTestRegistration, suffix: &'static str, name: &'static st
         format!("api_definition_yaml_import{suffix}"),
         TestType::IntegrationTest,
         move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
-            api_definition_yaml_import((deps, name.to_string(), cli.with_args(short)))
+            api_definition_import(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Yaml,
+            )
         }
     );
     add_test!(
         r,
-        format!("api_definition_add{suffix}"),
+        format!("api_definition_yaml_add{suffix}"),
         TestType::IntegrationTest,
         move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
-            api_definition_add((deps, name.to_string(), cli.with_args(short)))
+            api_definition_add(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Yaml,
+            )
         }
     );
     add_test!(
         r,
-        format!("api_definition_update{suffix}"),
+        format!("api_definition_json_add{suffix}"),
         TestType::IntegrationTest,
         move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
-            api_definition_update((deps, name.to_string(), cli.with_args(short)))
+            api_definition_add(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Json,
+            )
+        }
+    );
+    add_test!(
+        r,
+        format!("api_definition_yaml_update{suffix}"),
+        TestType::IntegrationTest,
+        move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
+            api_definition_update(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Yaml,
+            )
+        }
+    );
+    add_test!(
+        r,
+        format!("api_definition_json_update{suffix}"),
+        TestType::IntegrationTest,
+        move |deps: &EnvBasedTestDependencies, cli: &CliLive, _tracing: &Tracing| {
+            api_definition_update(
+                (deps, name.to_string(), cli.with_args(short)),
+                &ApiDefinitionFileFormat::Json,
+            )
         }
     );
     add_test!(
@@ -131,10 +167,20 @@ pub fn make_shopping_cart_component(
     add_component_from_file(deps, component_name, cli, "shopping-cart.wasm")
 }
 
-fn make_file(id: &str, json: &serde_json::value::Value) -> anyhow::Result<PathBuf> {
-    let text = serde_json::to_string_pretty(json)?;
+pub fn make_json_file<T: Serialize>(id: &str, value: &T) -> anyhow::Result<PathBuf> {
+    let text = serde_json::to_string_pretty(value)?;
 
-    let path = PathBuf::from(format!("../target/api-definition-{id}.json"));
+    let path = PathBuf::from(format!("../target/{id}.json"));
+
+    fs::write(&path, text)?;
+
+    Ok(path)
+}
+
+pub fn make_yaml_file<T: Serialize>(id: &str, value: &T) -> anyhow::Result<PathBuf> {
+    let text = serde_yaml::to_string(value)?;
+
+    let path = PathBuf::from(format!("../target/{id}.yaml"));
 
     fs::write(&path, text)?;
 
@@ -166,19 +212,13 @@ fn golem_def_with_response(
     }
 }
 
-pub fn golem_json_def(id: &str, component_id: &str) -> HttpApiDefinitionRequest {
+pub fn native_api_definition_request(id: &str, component_id: &str) -> HttpApiDefinitionRequest {
     golem_def_with_response(
         id,
         component_id,
         "let x = golem:it/api.{checkout}();\nlet status: u64 = 200;\n{headers: {ContentType: \"json\", userid: \"foo\"}, body: \"foo\", status: status}"
             .to_string(),
     )
-}
-
-pub fn make_golem_file(def: &HttpApiDefinitionRequest) -> anyhow::Result<PathBuf> {
-    let golem_json = serde_json::to_value(def)?;
-
-    make_file(&def.id, &golem_json)
 }
 
 pub fn make_open_api_yaml_file(
@@ -193,8 +233,8 @@ openapi: "3.0.0"
 info:
   title: "Sample API"
   version: "1.0.3"
-x-golem-api-definition-id: "{component_id}"
-x-golem-api-definition-version: "0.1.1"
+x-golem-api-definition-id: "{id}"
+x-golem-api-definition-version: "0.1.0"
 paths:
   "/{{user-id}}/get-cart-contents":
     x-golem-worker-bridge:
@@ -226,7 +266,7 @@ paths:
     let open_api_yaml: serde_json::Value = serde_yaml::from_str(&yaml_open_api_str)?;
 
     // Implement your `make_file` logic here to save `open_api_yaml` to a file
-    make_file(id, &open_api_yaml)
+    make_yaml_file(id, &open_api_yaml)
 }
 
 pub fn make_open_api_json_file(
@@ -304,10 +344,10 @@ pub fn make_open_api_json_file(
         }
     );
 
-    make_file(id, &open_api_json)
+    make_json_file(id, &open_api_json)
 }
 
-pub fn to_definition(
+pub fn to_api_definition_with_type_info(
     request: HttpApiDefinitionRequest,
     created_at: Option<DateTime<Utc>>,
 ) -> HttpApiDefinitionWithTypeInfo {
@@ -350,19 +390,32 @@ fn api_definition_import(
         String,
         CliLive,
     ),
-    make_open_api_file: fn(&str, &str, u64) -> anyhow::Result<PathBuf>,
+    api_definition_format: &ApiDefinitionFileFormat,
 ) -> anyhow::Result<()> {
-    let component_name = format!("api_definition_import{name}");
+    let component_name = format!("api_definition_{api_definition_format}_import{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
     let component_version = component.component_version;
-    let path = make_open_api_file(&component_name, &component_id, component_version)?;
 
-    let res: HttpApiDefinitionWithTypeInfo =
-        cli.run(&["api-definition", "import", path.to_str().unwrap()])?;
+    let res: HttpApiDefinitionWithTypeInfo = match api_definition_format {
+        ApiDefinitionFileFormat::Json => {
+            let path = make_open_api_json_file(&component_name, &component_id, component_version)?;
+            cli.run(&["api-definition", "import", path.to_str().unwrap()])?
+        }
+        ApiDefinitionFileFormat::Yaml => {
+            let path = make_open_api_yaml_file(&component_name, &component_id, component_version)?;
+            cli.run(&[
+                "api-definition",
+                "import",
+                "--def-format",
+                "yaml",
+                path.to_str().unwrap(),
+            ])?
+        }
+    };
 
-    let expected = to_definition(
-        golem_json_def(&component_name, &component_id),
+    let expected = to_api_definition_with_type_info(
+        native_api_definition_request(&component_name, &component_id),
         res.created_at,
     );
 
@@ -371,43 +424,38 @@ fn api_definition_import(
     Ok(())
 }
 
-fn api_definition_json_import(
-    (deps, name, cli): (
-        &(impl TestDependencies + Send + Sync + 'static),
-        String,
-        CliLive,
-    ),
-) -> anyhow::Result<()> {
-    api_definition_import((deps, name, cli), make_open_api_json_file)
-}
-
-fn api_definition_yaml_import(
-    (deps, name, cli): (
-        &(impl TestDependencies + Send + Sync + 'static),
-        String,
-        CliLive,
-    ),
-) -> anyhow::Result<()> {
-    api_definition_import((deps, name, cli), make_open_api_yaml_file)
-}
-
 fn api_definition_add(
     (deps, name, cli): (
         &(impl TestDependencies + Send + Sync + 'static),
         String,
         CliLive,
     ),
+    api_definition_format: &ApiDefinitionFileFormat,
 ) -> anyhow::Result<()> {
-    let component_name = format!("api_definition_add{name}");
+    let component_name = format!("api_definition_{api_definition_format}_add{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
 
-    let res: HttpApiDefinitionWithTypeInfo =
-        cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
+    let res: HttpApiDefinitionWithTypeInfo = match api_definition_format {
+        ApiDefinitionFileFormat::Json => {
+            let path = make_json_file(&def.id, &def)?;
+            cli.run(&["api-definition", "add", path.to_str().unwrap()])?
+        }
+        ApiDefinitionFileFormat::Yaml => {
+            let path = make_yaml_file(&def.id, &def)?;
+            cli.run(&[
+                "api-definition",
+                "add",
+                "--def-format",
+                "yaml",
+                path.to_str().unwrap(),
+            ])?
+        }
+    };
 
-    let expected = to_definition(def, res.created_at);
+    let expected = to_api_definition_with_type_info(def, res.created_at);
+
     assert_eq!(res, expected);
 
     Ok(())
@@ -419,13 +467,14 @@ fn api_definition_update(
         String,
         CliLive,
     ),
+    api_definition_format: &ApiDefinitionFileFormat,
 ) -> anyhow::Result<()> {
-    let component_name = format!("api_definition_update{name}");
+    let component_name = format!("api_definition_{api_definition_format}_update{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
 
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
 
@@ -435,11 +484,25 @@ fn api_definition_update(
         "let status: u64 = 200;\n{headers: {ContentType: \"json\", userid: \"bar\"}, body: \"baz\", status: status}"
             .to_string(),
     );
-    let path = make_golem_file(&updated)?;
-    let res: HttpApiDefinitionWithTypeInfo =
-        cli.run(&["api-definition", "update", path.to_str().unwrap()])?;
 
-    let expected = to_definition(updated, res.created_at);
+    let res: HttpApiDefinitionWithTypeInfo = match api_definition_format {
+        ApiDefinitionFileFormat::Json => {
+            let path = make_json_file(&updated.id, &updated)?;
+            cli.run(&["api-definition", "update", path.to_str().unwrap()])?
+        }
+        ApiDefinitionFileFormat::Yaml => {
+            let path = make_yaml_file(&updated.id, &updated)?;
+            cli.run(&[
+                "api-definition",
+                "update",
+                "--def-format",
+                "yaml",
+                path.to_str().unwrap(),
+            ])?
+        }
+    };
+
+    let expected = to_api_definition_with_type_info(updated, res.created_at);
 
     assert_eq!(res, expected);
 
@@ -457,14 +520,14 @@ fn api_definition_update_immutable(
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
 
-    let mut def = golem_json_def(&component_name, &component_id);
+    let mut def = native_api_definition_request(&component_name, &component_id);
     def.draft = false;
-    let path = make_golem_file(&def)?;
+    let path = make_json_file(&def.id, &def)?;
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
 
     let updated = golem_def_with_response(&component_name, &component_id, "${let status: u64 = 200; {headers: {ContentType: \"json\", userid: \"bar\"}, body: worker.response, status: status}}".to_string());
-    let path = make_golem_file(&updated)?;
+    let path = make_json_file(&updated.id, &updated)?;
     let res = cli.run_string(&["api-definition", "update", path.to_str().unwrap()]);
 
     assert!(res.is_err());
@@ -482,8 +545,8 @@ fn api_definition_list(
     let component_name = format!("api_definition_list{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -491,7 +554,7 @@ fn api_definition_list(
     let res: Vec<HttpApiDefinitionWithTypeInfo> = cli.run(&["api-definition", "list"])?;
 
     let found = res.into_iter().find(|d| {
-        let e = to_definition(def.clone(), d.created_at);
+        let e = to_api_definition_with_type_info(def.clone(), d.created_at);
         d == &e
     });
 
@@ -510,8 +573,8 @@ fn api_definition_list_versions(
     let component_name = format!("api_definition_list_versions{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
     let cfg = &cli.config;
 
     let _: HttpApiDefinitionWithTypeInfo =
@@ -527,7 +590,7 @@ fn api_definition_list_versions(
     assert_eq!(res.len(), 1);
 
     let res: HttpApiDefinitionWithTypeInfo = res.first().unwrap().clone();
-    let expected = to_definition(def, res.created_at);
+    let expected = to_api_definition_with_type_info(def, res.created_at);
 
     assert_eq!(res, expected);
 
@@ -544,8 +607,8 @@ fn api_definition_get(
     let component_name = format!("api_definition_get{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -561,7 +624,7 @@ fn api_definition_get(
         "0.1.0",
     ])?;
 
-    let expected = to_definition(def, res.created_at);
+    let expected = to_api_definition_with_type_info(def, res.created_at);
 
     assert_eq!(res, expected);
 
@@ -578,8 +641,8 @@ fn api_definition_delete(
     let component_name = format!("api_definition_delete{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -595,7 +658,7 @@ fn api_definition_delete(
         "0.1.0",
     ])?;
 
-    let expected = to_definition(def, res.created_at);
+    let expected = to_api_definition_with_type_info(def, res.created_at);
 
     assert_eq!(res, expected);
 

--- a/golem-cli/tests/api_deployment.rs
+++ b/golem-cli/tests/api_deployment.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api_definition::{golem_def, make_golem_file, make_shopping_cart_component};
+use crate::api_definition::{golem_json_def, make_golem_file, make_shopping_cart_component};
 use crate::cli::{Cli, CliLive};
 use crate::Tracing;
 use assert2::assert;
@@ -79,7 +79,7 @@ pub fn make_definition(
 ) -> Result<HttpApiDefinitionWithTypeInfo, anyhow::Error> {
     let component = make_shopping_cart_component(deps, component_name, cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(component_name, &component_id);
+    let def = golem_json_def(component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     cli.run(&["api-definition", "add", path.to_str().unwrap()])

--- a/golem-cli/tests/api_deployment.rs
+++ b/golem-cli/tests/api_deployment.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api_definition::{golem_json_def, make_golem_file, make_shopping_cart_component};
+use crate::api_definition::{
+    make_json_file, make_shopping_cart_component, native_api_definition_request,
+};
 use crate::cli::{Cli, CliLive};
 use crate::Tracing;
 use assert2::assert;
@@ -79,8 +81,8 @@ pub fn make_definition(
 ) -> Result<HttpApiDefinitionWithTypeInfo, anyhow::Error> {
     let component = make_shopping_cart_component(deps, component_name, cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     cli.run(&["api-definition", "add", path.to_str().unwrap()])
 }

--- a/golem-cli/tests/get.rs
+++ b/golem-cli/tests/get.rs
@@ -15,7 +15,8 @@
 use test_r::{inherit_test_dep, test, test_dep};
 
 use crate::api_definition::{
-    golem_json_def, make_golem_file, make_shopping_cart_component, to_definition,
+    make_json_file, make_shopping_cart_component, native_api_definition_request,
+    to_api_definition_with_type_info,
 };
 use crate::api_deployment::make_definition;
 use crate::cli::{Cli, CliLive};
@@ -52,8 +53,8 @@ fn top_level_get_api_definition(
     let component_name = "top_level_get_api_definition";
     let component = make_shopping_cart_component(deps, component_name, cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -65,7 +66,7 @@ fn top_level_get_api_definition(
 
     let res: HttpApiDefinitionWithTypeInfo = cli.run(&["get", &url.to_string()])?;
 
-    let expected = to_definition(def.clone(), res.created_at);
+    let expected = to_api_definition_with_type_info(def.clone(), res.created_at);
     assert_eq!(res, expected);
 
     let urn = ApiDefinitionUrn {
@@ -74,7 +75,7 @@ fn top_level_get_api_definition(
     };
 
     let res: HttpApiDefinitionWithTypeInfo = cli.run(&["get", &urn.to_string()])?;
-    let expected = to_definition(def.clone(), res.created_at);
+    let expected = to_api_definition_with_type_info(def.clone(), res.created_at);
     assert_eq!(res, expected);
 
     Ok(())

--- a/golem-cli/tests/get.rs
+++ b/golem-cli/tests/get.rs
@@ -15,7 +15,7 @@
 use test_r::{inherit_test_dep, test, test_dep};
 
 use crate::api_definition::{
-    golem_def, make_golem_file, make_shopping_cart_component, to_definition,
+    golem_json_def, make_golem_file, make_shopping_cart_component, to_definition,
 };
 use crate::api_deployment::make_definition;
 use crate::cli::{Cli, CliLive};
@@ -52,7 +52,7 @@ fn top_level_get_api_definition(
     let component_name = "top_level_get_api_definition";
     let component = make_shopping_cart_component(deps, component_name, cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(component_name, &component_id);
+    let def = golem_json_def(component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =

--- a/golem-cli/tests/text.rs
+++ b/golem-cli/tests/text.rs
@@ -15,7 +15,7 @@
 use test_r::{add_test, inherit_test_dep, test_dep, test_gen};
 
 use crate::api_definition::{
-    golem_def, make_golem_file, make_open_api_file, make_shopping_cart_component,
+    golem_json_def, make_golem_file, make_open_api_json_file, make_shopping_cart_component,
 };
 use crate::cli::{Cli, CliLive};
 use crate::worker::add_environment_service_component;
@@ -542,7 +542,7 @@ fn text_api_definition_import(
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
     let component_version = component.component_version;
-    let path = make_open_api_file(&component_name, &component_id, component_version)?;
+    let path = make_open_api_json_file(&component_name, &component_id, component_version)?;
 
     let res = cli.with_format(Format::Text).run_string(&[
         "api-definition",
@@ -568,7 +568,7 @@ fn text_api_definition_add(
     let component_name = format!("text_api_definition_add{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(&component_name, &component_id);
+    let def = golem_json_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let res = cli.with_format(Format::Text).run_string(&[
@@ -595,7 +595,7 @@ fn text_api_definition_update(
     let component_name = format!("text_api_definition_update{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(&component_name, &component_id);
+    let def = golem_json_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
@@ -624,7 +624,7 @@ fn text_api_definition_list(
     let component_name = format!("text_api_definition_list{name:_>9}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(&component_name, &component_id);
+    let def = golem_json_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
     let cfg = &cli.config;
 
@@ -656,7 +656,7 @@ fn text_api_definition_get(
     let component_name = format!("text_api_definition_get{name:_>9}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_def(&component_name, &component_id);
+    let def = golem_json_def(&component_name, &component_id);
     let path = make_golem_file(&def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =

--- a/golem-cli/tests/text.rs
+++ b/golem-cli/tests/text.rs
@@ -15,7 +15,8 @@
 use test_r::{add_test, inherit_test_dep, test_dep, test_gen};
 
 use crate::api_definition::{
-    golem_json_def, make_golem_file, make_open_api_json_file, make_shopping_cart_component,
+    make_json_file, make_open_api_json_file, make_shopping_cart_component,
+    native_api_definition_request,
 };
 use crate::cli::{Cli, CliLive};
 use crate::worker::add_environment_service_component;
@@ -568,8 +569,8 @@ fn text_api_definition_add(
     let component_name = format!("text_api_definition_add{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let res = cli.with_format(Format::Text).run_string(&[
         "api-definition",
@@ -595,8 +596,8 @@ fn text_api_definition_update(
     let component_name = format!("text_api_definition_update{name}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;
@@ -624,8 +625,8 @@ fn text_api_definition_list(
     let component_name = format!("text_api_definition_list{name:_>9}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
     let cfg = &cli.config;
 
     let _: HttpApiDefinitionWithTypeInfo =
@@ -656,8 +657,8 @@ fn text_api_definition_get(
     let component_name = format!("text_api_definition_get{name:_>9}");
     let component = make_shopping_cart_component(deps, &component_name, &cli)?;
     let component_id = component.component_urn.id.0.to_string();
-    let def = golem_json_def(&component_name, &component_id);
-    let path = make_golem_file(&def)?;
+    let def = native_api_definition_request(&component_name, &component_id);
+    let path = make_json_file(&def.id, &def)?;
 
     let _: HttpApiDefinitionWithTypeInfo =
         cli.run(&["api-definition", "add", path.to_str().unwrap()])?;

--- a/golem-client/Cargo.toml
+++ b/golem-client/Cargo.toml
@@ -25,6 +25,7 @@ http = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
@@ -32,5 +33,5 @@ uuid = { workspace = true }
 test-r = { workspace = true }
 
 [build-dependencies]
-golem-openapi-client-generator = "0.0.10"
+golem-openapi-client-generator = {git = "https://github.com/golemcloud/golem-openapi-client-generator.git", branch = "support_yaml"}
 relative-path = "1.9.2"

--- a/golem-client/Cargo.toml
+++ b/golem-client/Cargo.toml
@@ -33,5 +33,5 @@ uuid = { workspace = true }
 test-r = { workspace = true }
 
 [build-dependencies]
-golem-openapi-client-generator = {git = "https://github.com/golemcloud/golem-openapi-client-generator.git", branch = "support_yaml"}
+golem-openapi-client-generator = "0.0.12"
 relative-path = "1.9.2"

--- a/golem-common/Cargo.toml
+++ b/golem-common/Cargo.toml
@@ -44,6 +44,7 @@ range-set-blaze = "0.1.16"
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = {workspace = true}
 thiserror = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }

--- a/golem-common/src/json_yaml.rs
+++ b/golem-common/src/json_yaml.rs
@@ -103,7 +103,7 @@ impl<T: ParseFromYAML + ParseFromJSON> ParsePayload for JsonOrYaml<T> {
                     reason: err.into_message(),
                 })?;
             Ok(Self(value))
-        } else if content_type.contains("yaml") || content_type.contains("x-yaml") {
+        } else if content_type.contains("yaml") {
             let yaml_data = serde_yaml::from_slice(&bytes).map_err(|e| {
                 poem::Error::from_string(
                     format!("Failed to read YAML data {}", e),

--- a/golem-common/src/json_yaml.rs
+++ b/golem-common/src/json_yaml.rs
@@ -70,7 +70,7 @@ impl<'a, T: ParseFromJSON + ParseFromYAML> ApiExtractor<'a> for JsonOrYaml<T> {
 
 impl<T: ParseFromYAML + ParseFromJSON> ParsePayload for JsonOrYaml<T> {
     const IS_REQUIRED: bool = true;
-    
+
     async fn from_request(request: &Request, body: &mut RequestBody) -> poem::Result<Self> {
         let content_type = request
             .headers()

--- a/golem-common/src/json_yaml.rs
+++ b/golem-common/src/json_yaml.rs
@@ -1,0 +1,126 @@
+use poem::http::StatusCode;
+use poem::{Request, RequestBody};
+use poem_openapi::__private::mime;
+use poem_openapi::error::ParseRequestPayloadError;
+use poem_openapi::payload::{ParsePayload, Payload};
+use poem_openapi::registry::{MetaMediaType, MetaRequest, MetaSchemaRef, Registry};
+use poem_openapi::types::{ParseFromJSON, ParseFromYAML, Type};
+use poem_openapi::{ApiExtractor, ApiExtractorType, ExtractParamOptions};
+
+// A poem type that supports json or yaml with explicit content type
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct JsonOrYaml<T>(pub T);
+
+impl<T: Type> Payload for JsonOrYaml<T> {
+    const CONTENT_TYPE: &'static str = "*/*";
+
+    fn check_content_type(content_type: &str) -> bool {
+        matches!(content_type.parse::<mime::Mime>(), Ok(content_type) if content_type.type_() == "application"
+                && (content_type.subtype() == "yaml" || content_type.subtype() == "json"
+                || content_type
+                    .suffix()
+                    .map_or(false, |v| v == "yaml" || v == "json")))
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        T::schema_ref()
+    }
+
+    #[allow(unused_variables)]
+    fn register(registry: &mut Registry) {
+        T::register(registry);
+    }
+}
+
+// Explicit ApiExtractor than derived to help with multiple content types
+impl<'a, T: ParseFromJSON + ParseFromYAML> ApiExtractor<'a> for JsonOrYaml<T> {
+    const TYPES: &'static [ApiExtractorType] = &[ApiExtractorType::RequestObject];
+    type ParamType = ();
+    type ParamRawType = ();
+
+    fn register(registry: &mut Registry) {
+        <Self as Payload>::register(registry);
+    }
+
+    fn request_meta() -> Option<MetaRequest> {
+        Some(MetaRequest {
+            description: None,
+            content: vec![
+                MetaMediaType {
+                    content_type: "application/json",
+                    schema: <Self as Payload>::schema_ref(),
+                },
+                MetaMediaType {
+                    content_type: "application/x-yaml",
+                    schema: <Self as Payload>::schema_ref(),
+                },
+            ],
+            required: <Self as ParsePayload>::IS_REQUIRED,
+        })
+    }
+
+    async fn from_request(
+        request: &'a Request,
+        body: &mut RequestBody,
+        _param_opts: ExtractParamOptions<Self::ParamType>,
+    ) -> poem::Result<Self> {
+        <Self as ParsePayload>::from_request(request, body).await
+    }
+}
+
+impl<T: ParseFromYAML + ParseFromJSON> ParsePayload for JsonOrYaml<T> {
+    const IS_REQUIRED: bool = true;
+    async fn from_request(request: &Request, body: &mut RequestBody) -> poem::Result<Self> {
+        let content_type = request
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+
+        let body = body.take().map_err(|e| {
+            poem::Error::from_string(
+                format!("Missing request body {}", e),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        let bytes = body.into_bytes().await.map_err(|e| {
+            poem::Error::from_string(
+                format!("Failed to read request body {}", e),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        if content_type.contains("json") {
+            let json_data = serde_json::from_slice(&bytes).map_err(|e| {
+                poem::Error::from_string(
+                    format!("Failed to read JSON data {}", e),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+            let value =
+                T::parse_from_yaml(Some(json_data)).map_err(|err| ParseRequestPayloadError {
+                    reason: err.into_message(),
+                })?;
+            Ok(Self(value))
+        } else if content_type.contains("yaml") || content_type.contains("x-yaml") {
+            let yaml_data = serde_yaml::from_slice(&bytes).map_err(|e| {
+                poem::Error::from_string(
+                    format!("Failed to read YAML data {}", e),
+                    StatusCode::BAD_REQUEST,
+                )
+            })?;
+
+            let value =
+                T::parse_from_yaml(Some(yaml_data)).map_err(|err| ParseRequestPayloadError {
+                    reason: err.into_message(),
+                })?;
+            Ok(Self(value))
+        } else {
+            Err(poem::Error::from_string(
+                "Unsupported content type".to_string(),
+                StatusCode::BAD_REQUEST,
+            ))
+        }
+    }
+}

--- a/golem-common/src/json_yaml.rs
+++ b/golem-common/src/json_yaml.rs
@@ -70,6 +70,7 @@ impl<'a, T: ParseFromJSON + ParseFromYAML> ApiExtractor<'a> for JsonOrYaml<T> {
 
 impl<T: ParseFromYAML + ParseFromJSON> ParsePayload for JsonOrYaml<T> {
     const IS_REQUIRED: bool = true;
+    
     async fn from_request(request: &Request, body: &mut RequestBody) -> poem::Result<Self> {
         let content_type = request
             .headers()

--- a/golem-common/src/lib.rs
+++ b/golem-common/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 
 pub mod golem_version;
 pub mod grpc;
+pub mod json_yaml;
 pub mod metrics;
 pub mod model;
 pub mod newtype;

--- a/golem-worker-service-base/src/api/register_api_definition_api.rs
+++ b/golem-worker-service-base/src/api/register_api_definition_api.rs
@@ -1,16 +1,18 @@
-use golem_api_grpc::proto::golem::apidefinition as grpc_apidefinition;
-use golem_service_base::model::VersionedComponentId;
-use poem_openapi::*;
-use serde::{Deserialize, Serialize};
-use std::result::Result;
-use std::time::SystemTime;
-
 use crate::api_definition::http::{
     AllPathPatterns, CompiledHttpApiDefinition, CompiledRoute, MethodPattern,
 };
 use crate::api_definition::{ApiDefinitionId, ApiSite, ApiVersion};
 use crate::worker_binding::CompiledGolemWorkerBinding;
+use golem_api_grpc::proto::golem::apidefinition as grpc_apidefinition;
+use golem_service_base::model::VersionedComponentId;
+use poem_openapi::payload::{ParsePayload, Payload};
+use poem_openapi::types::{ParseFromJSON, ParseFromYAML, Type};
+use poem_openapi::*;
 use rib::{Expr, RibInputTypeInfo};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::result::Result;
+use std::time::SystemTime;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Object)]
 #[serde(rename_all = "camelCase")]

--- a/golem-worker-service-base/src/api/register_api_definition_api.rs
+++ b/golem-worker-service-base/src/api/register_api_definition_api.rs
@@ -5,12 +5,9 @@ use crate::api_definition::{ApiDefinitionId, ApiSite, ApiVersion};
 use crate::worker_binding::CompiledGolemWorkerBinding;
 use golem_api_grpc::proto::golem::apidefinition as grpc_apidefinition;
 use golem_service_base::model::VersionedComponentId;
-use poem_openapi::payload::{ParsePayload, Payload};
-use poem_openapi::types::{ParseFromJSON, ParseFromYAML, Type};
 use poem_openapi::*;
 use rib::{Expr, RibInputTypeInfo};
 use serde::{Deserialize, Serialize};
-use std::future::Future;
 use std::result::Result;
 use std::time::SystemTime;
 

--- a/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
+++ b/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
@@ -3,9 +3,9 @@ use crate::api_definition::{ApiDefinitionId, ApiVersion};
 use internal::*;
 use openapiv3::OpenAPI;
 use poem_openapi::registry::{MetaSchema, MetaSchemaRef};
-use std::borrow::Cow;
 use poem_openapi::types::{ParseError, ParseFromJSON, ParseFromYAML, ParseResult};
 use serde_json::Value;
+use std::borrow::Cow;
 
 pub fn get_api_definition(openapi: OpenAPI) -> Result<HttpApiDefinitionRequest, String> {
     let api_definition_id = ApiDefinitionId(get_root_extension(
@@ -46,7 +46,6 @@ impl ParseFromJSON for OpenApiDefinitionRequest {
     }
 }
 
-
 impl ParseFromYAML for OpenApiDefinitionRequest {
     fn parse_from_yaml(value: Option<Value>) -> ParseResult<Self> {
         match value {
@@ -79,9 +78,7 @@ impl poem_openapi::types::Type for OpenApiDefinitionRequest {
     fn schema_ref() -> MetaSchemaRef {
         MetaSchemaRef::Inline(Box::new(MetaSchema {
             title: Some("API definition in OpenAPI format".to_string()),
-            description: Some(
-                "API definition in OpenAPI format with required custom extensions",
-            ),
+            description: Some("API definition in OpenAPI format with required custom extensions"),
             ..MetaSchema::new("OpenAPI+WorkerBridgeCustomExtension")
         }))
     }
@@ -96,7 +93,6 @@ impl poem_openapi::types::Type for OpenApiDefinitionRequest {
         Box::new(self.as_raw_value().into_iter())
     }
 }
-
 
 mod internal {
     use crate::api_definition::http::{AllPathPatterns, MethodPattern, Route};

--- a/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
+++ b/golem-worker-service-base/src/api_definition/http/http_oas_api_definition.rs
@@ -1,14 +1,8 @@
 use crate::api_definition::http::HttpApiDefinitionRequest;
 use crate::api_definition::{ApiDefinitionId, ApiVersion};
-use http::StatusCode;
 use internal::*;
 use openapiv3::OpenAPI;
-use poem::web::Yaml;
-use poem::Request;
-use poem_openapi::payload::Json;
-use poem_openapi::registry::{MetaMediaType, MetaRequest, MetaSchema, MetaSchemaRef};
-use poem_openapi::{registry, ApiExtractor, ApiExtractorType, ExtractParamOptions};
-use sqlx::types;
+use poem_openapi::registry::{MetaSchema, MetaSchemaRef};
 use std::borrow::Cow;
 use poem_openapi::types::{ParseError, ParseFromJSON, ParseFromYAML, ParseResult};
 use serde_json::Value;

--- a/golem-worker-service/src/api/api_definition.rs
+++ b/golem-worker-service/src/api/api_definition.rs
@@ -1,23 +1,24 @@
-use std::result::Result;
-use std::sync::Arc;
-
 use golem_common::{recorded_http_api_request, safe};
 use golem_service_base::api_tags::ApiTags;
 use golem_service_base::auth::{DefaultNamespace, EmptyAuthCtx};
-use golem_worker_service_base::api::ApiEndpointError;
 use golem_worker_service_base::api::HttpApiDefinitionRequest;
 use golem_worker_service_base::api::HttpApiDefinitionWithTypeInfo;
-use golem_worker_service_base::api_definition::http::get_api_definition;
+use golem_worker_service_base::api::{ApiEndpointError};
 use golem_worker_service_base::api_definition::http::CompiledHttpApiDefinition;
 use golem_worker_service_base::api_definition::http::HttpApiDefinitionRequest as CoreHttpApiDefinitionRequest;
-use golem_worker_service_base::api_definition::http::JsonOpenApiDefinition;
+use golem_worker_service_base::api_definition::http::{
+    get_api_definition, OpenApiDefinitionRequest,
+};
 use golem_worker_service_base::api_definition::{ApiDefinitionId, ApiVersion};
 use golem_worker_service_base::service::api_definition::ApiDefinitionService;
 use golem_worker_service_base::service::http::http_api_definition_validator::RouteValidationError;
 use poem_openapi::param::{Path, Query};
 use poem_openapi::payload::Json;
 use poem_openapi::*;
+use std::result::Result;
+use std::sync::Arc;
 use tracing::{error, Instrument};
+use golem_common::json_yaml::JsonOrYaml;
 
 pub struct RegisterApiDefinitionApi {
     definition_service: Arc<
@@ -46,12 +47,12 @@ impl RegisterApiDefinitionApi {
     #[oai(path = "/import", method = "put", operation_id = "import_open_api")]
     async fn create_or_update_open_api(
         &self,
-        Json(openapi): Json<JsonOpenApiDefinition>,
+        payload: JsonOrYaml<OpenApiDefinitionRequest>,
     ) -> Result<Json<HttpApiDefinitionWithTypeInfo>, ApiEndpointError> {
         let record = recorded_http_api_request!("import_open_api",);
 
         let response = {
-            let definition = get_api_definition(openapi.0).map_err(|e| {
+            let definition = get_api_definition(payload.0.0).map_err(|e| {
                 error!("Invalid Spec {}", e);
                 ApiEndpointError::bad_request(safe(e))
             })?;
@@ -74,7 +75,7 @@ impl RegisterApiDefinitionApi {
     #[oai(path = "/", method = "post", operation_id = "create_definition")]
     async fn create(
         &self,
-        payload: Json<HttpApiDefinitionRequest>,
+        payload: JsonOrYaml<HttpApiDefinitionRequest>,
     ) -> Result<Json<HttpApiDefinitionWithTypeInfo>, ApiEndpointError> {
         let record = recorded_http_api_request!(
             "create_definition",
@@ -112,7 +113,7 @@ impl RegisterApiDefinitionApi {
         &self,
         id: Path<ApiDefinitionId>,
         version: Path<ApiVersion>,
-        payload: Json<HttpApiDefinitionRequest>,
+        payload: JsonOrYaml<HttpApiDefinitionRequest>,
     ) -> Result<Json<HttpApiDefinitionWithTypeInfo>, ApiEndpointError> {
         let record = recorded_http_api_request!(
             "update_definition",

--- a/golem-worker-service/src/api/api_definition.rs
+++ b/golem-worker-service/src/api/api_definition.rs
@@ -445,6 +445,50 @@ mod test {
     }
 
     #[test]
+    async fn create_api_definition_yaml() {
+        let (api, _db) = make_route().await;
+        let client = TestClient::new(api);
+
+        let definition =
+            golem_worker_service_base::api_definition::http::HttpApiDefinitionRequest {
+                id: ApiDefinitionId("sample".to_string()),
+                version: ApiVersion("42.0".to_string()),
+                routes: vec![],
+                draft: false,
+            };
+
+        let response = client
+            .post("/v1/api/definitions")
+            .body_yaml(&definition)
+            .send()
+            .await;
+
+        response.assert_status(http::StatusCode::OK);
+    }
+
+    #[test]
+    async fn create_api_definition_json() {
+        let (api, _db) = make_route().await;
+        let client = TestClient::new(api);
+
+        let definition =
+            golem_worker_service_base::api_definition::http::HttpApiDefinitionRequest {
+                id: ApiDefinitionId("sample".to_string()),
+                version: ApiVersion("42.0".to_string()),
+                routes: vec![],
+                draft: false,
+            };
+
+        let response = client
+            .post("/v1/api/definitions")
+            .body_json(&definition)
+            .send()
+            .await;
+
+        response.assert_status(http::StatusCode::OK);
+    }
+
+    #[test]
     async fn update_non_existant() {
         let (api, _db) = make_route().await;
         let client = TestClient::new(api);

--- a/golem-worker-service/src/api/api_definition.rs
+++ b/golem-worker-service/src/api/api_definition.rs
@@ -1,9 +1,10 @@
+use golem_common::json_yaml::JsonOrYaml;
 use golem_common::{recorded_http_api_request, safe};
 use golem_service_base::api_tags::ApiTags;
 use golem_service_base::auth::{DefaultNamespace, EmptyAuthCtx};
+use golem_worker_service_base::api::ApiEndpointError;
 use golem_worker_service_base::api::HttpApiDefinitionRequest;
 use golem_worker_service_base::api::HttpApiDefinitionWithTypeInfo;
-use golem_worker_service_base::api::{ApiEndpointError};
 use golem_worker_service_base::api_definition::http::CompiledHttpApiDefinition;
 use golem_worker_service_base::api_definition::http::HttpApiDefinitionRequest as CoreHttpApiDefinitionRequest;
 use golem_worker_service_base::api_definition::http::{
@@ -18,7 +19,6 @@ use poem_openapi::*;
 use std::result::Result;
 use std::sync::Arc;
 use tracing::{error, Instrument};
-use golem_common::json_yaml::JsonOrYaml;
 
 pub struct RegisterApiDefinitionApi {
     definition_service: Arc<
@@ -52,7 +52,7 @@ impl RegisterApiDefinitionApi {
         let record = recorded_http_api_request!("import_open_api",);
 
         let response = {
-            let definition = get_api_definition(payload.0.0).map_err(|e| {
+            let definition = get_api_definition(payload.0 .0).map_err(|e| {
                 error!("Invalid Spec {}", e);
                 ApiEndpointError::bad_request(safe(e))
             })?;

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -1168,8 +1168,16 @@ paths:
       operationId: import_open_api
       requestBody:
         content:
-          application/json; charset=utf-8:
-            schema: {}
+          application/json:
+            schema:
+              title: API definition in OpenAPI format
+              description: API definition in OpenAPI format with required custom extensions
+              type: OpenAPI+WorkerBridgeCustomExtension
+          application/x-yaml:
+            schema:
+              title: API definition in OpenAPI format
+              description: API definition in OpenAPI format with required custom extensions
+              type: OpenAPI+WorkerBridgeCustomExtension
         required: true
       responses:
         '200':
@@ -1286,7 +1294,10 @@ paths:
       operationId: create_definition
       requestBody:
         content:
-          application/json; charset=utf-8:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpApiDefinitionRequest'
+          application/x-yaml:
             schema:
               $ref: '#/components/schemas/HttpApiDefinitionRequest'
         required: true
@@ -1425,7 +1436,10 @@ paths:
         style: simple
       requestBody:
         content:
-          application/json; charset=utf-8:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HttpApiDefinitionRequest'
+          application/x-yaml:
             schema:
               $ref: '#/components/schemas/HttpApiDefinitionRequest'
         required: true


### PR DESCRIPTION
TODO

- [x] Make sure multiline Rib works in yaml (just to validate prioritizing this work)
- [x] REST-API support for  importing open-api-format-api-definition for both `yaml` and `json` using content-type negotiation. yaml content-type in header will support yaml import.
- [x] golem-CLI support for  importing open-api-format-api-definition for both `yaml` and `json`. 
- [x] REST-API Native API definition format, supporting both yaml and json.  Here, make sure to support output  yaml and json formats. Probably output can be a concern of just clients instead of lots of changes required in client generation side to support Accept headers (similar to content type header)
- [x] golem-cli support for Native API definition format in both yaml and json format. Specify `--def-format yaml` if importing yaml spec through golem-cli. `json` is by default to keep backward compatibility.
- [x]  Make sure multiple content type is specified in generated golem-service.yaml spec, and make sure client-generator code works with this.  I had to fix a lot there: See https://github.com/golemcloud/golem-openapi-client-generator/compare/master...support_yaml
- [x] FYI:  CLI tests succeed only if we strongly distinguish yaml and json parsing, instead of trying to magically parse anything that user passes without any hint of what's the format of file (hints being content-type for REST API, and --def-format for CLI), and also error reporting becomes clear.


### OpenAPI in yaml format with multi-line Rib that works

```yaml
openapi: "3.0.0"
info:
  title: "Sample API"
  version: "1.0.3"
x-golem-api-definition-id: "myapi"
x-golem-api-definition-version: "0.1.1"
paths:
  "/{user-id}/get-cart-contents":
    x-golem-worker-bridge:
      worker-name: "\"foo\""
      component-id: "aae6dd36-8caa-4271-8ef3-cf1f88ef9c97"
      component-version: 0
      response: |
        let style = "font-family: Arial, sans-serif; display: flex; align-items: center; 
                     justify-content: center; height: 100vh; background: linear-gradient(135deg, 
                     #1e3c72, #2a5298); color: #ffffff; text-align: center; padding: 20px;";
        let user: u64 = request.path.user-id;
        {
          Content-Type: "text/html",
          status: 200u64,
          body: "<!DOCTYPE html><html><head></head><body style='${style}'>
                 <div><h1>Welcome to Golem Cloud!</h1>
                 <p style='font-size: 1.5em;'>Hello, User ID: ${user}</p>
                 <p style='color: #dcdcdc;'>Explore your cart contents and more on this personalized page.</p>
                 </div></body></html>"
        }
    get:
      summary: "Get Cart Contents"
      description: "Get the contents of a user's cart"
      parameters:
        - name: "user-id"
          in: "path"
          required: true
          schema:
            type: "string"
      responses:
        "200":
          description: "OK"
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/CartItem"
        "404":
          description: "Contents not found"
components:
  schemas:
    CartItem:
      type: "object"
      properties:
        id:
          type: "string"
        name:
          type: "string"
        price:
          type: "number"

```