### PR TITLE
Move to big decimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,6 +4505,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bigdecimal",
  "bincode",
  "bytes 1.8.0",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,7 @@ name = "golem-rib"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "bigdecimal",
  "bincode",
  "combine",
  "golem-api-grpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ reqwest = { version = "0.12.5", features = [
 ] }
 rustls = { version = "0.23.10" }
 rand = "0.8.5"
+semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 serde_yaml = { version = "0.9.33 " }

--- a/golem-api-grpc/proto/golem/rib/expr.proto
+++ b/golem-api-grpc/proto/golem/rib/expr.proto
@@ -87,8 +87,9 @@ message LiteralExpr {
 }
 
 message NumberExpr {
-  double float = 1;
+  optional double float = 1;
   optional TypeName type_name = 2;
+  optional string number = 3;
 }
 
 message FlagsExpr {

--- a/golem-rib/Cargo.toml
+++ b/golem-rib/Cargo.toml
@@ -11,12 +11,13 @@ description = "Parser for Golem's Rib language"
 golem-api-grpc = { path = "../golem-api-grpc", version = "0.0.0" }
 
 async-trait = { workspace = true }
+bigdecimal = {workspace = true }
 bincode = { workspace = true }
 combine = { workspace = true }
 golem-wasm-ast = { workspace = true }
 golem-wasm-rpc = { workspace = true }
 poem-openapi = { workspace = true }
-semver = "1.0.23"
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = {workspace = true}

--- a/golem-rib/src/call_type.rs
+++ b/golem-rib/src/call_type.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 use crate::{DynamicParsedFunctionName, ParsedFunctionName};
-use bincode::{Decode, Encode};
 use std::convert::TryFrom;
 use std::fmt::Display;
 
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CallType {
     Function(DynamicParsedFunctionName),
     VariantConstructor(String),

--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -679,6 +679,7 @@ mod internal {
 
 #[cfg(test)]
 mod compiler_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use super::*;
@@ -755,8 +756,20 @@ mod compiler_tests {
 
     #[test]
     fn test_instructions_equal_to() {
-        let number_f32 = Expr::Number(Number { value: 1f64 }, None, InferredType::F32);
-        let number_u32 = Expr::Number(Number { value: 1f64 }, None, InferredType::U32);
+        let number_f32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::F32,
+        );
+        let number_u32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::U32,
+        );
 
         let expr = Expr::equal_to(number_f32, number_u32);
         let empty_registry = FunctionTypeRegistry::empty();
@@ -782,8 +795,20 @@ mod compiler_tests {
 
     #[test]
     fn test_instructions_greater_than() {
-        let number_f32 = Expr::Number(Number { value: 1f64 }, None, InferredType::F32);
-        let number_u32 = Expr::Number(Number { value: 2f64 }, None, InferredType::U32);
+        let number_f32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::F32,
+        );
+        let number_u32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(2),
+            },
+            None,
+            InferredType::U32,
+        );
 
         let expr = Expr::greater_than(number_f32, number_u32);
         let empty_registry = FunctionTypeRegistry::empty();
@@ -809,8 +834,20 @@ mod compiler_tests {
 
     #[test]
     fn test_instructions_less_than() {
-        let number_f32 = Expr::Number(Number { value: 1f64 }, None, InferredType::F32);
-        let number_u32 = Expr::Number(Number { value: 1f64 }, None, InferredType::U32);
+        let number_f32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::F32,
+        );
+        let number_u32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::U32,
+        );
 
         let expr = Expr::less_than(number_f32, number_u32);
         let empty_registry = FunctionTypeRegistry::empty();
@@ -836,8 +873,20 @@ mod compiler_tests {
 
     #[test]
     fn test_instructions_greater_than_or_equal_to() {
-        let number_f32 = Expr::Number(Number { value: 1f64 }, None, InferredType::F32);
-        let number_u32 = Expr::Number(Number { value: 1f64 }, None, InferredType::U32);
+        let number_f32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::F32,
+        );
+        let number_u32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::U32,
+        );
 
         let expr = Expr::greater_than_or_equal_to(number_f32, number_u32);
         let empty_registry = FunctionTypeRegistry::empty();
@@ -863,8 +912,20 @@ mod compiler_tests {
 
     #[test]
     fn test_instructions_less_than_or_equal_to() {
-        let number_f32 = Expr::Number(Number { value: 1f64 }, None, InferredType::F32);
-        let number_u32 = Expr::Number(Number { value: 1f64 }, None, InferredType::U32);
+        let number_f32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::F32,
+        );
+        let number_u32 = Expr::Number(
+            Number {
+                value: BigDecimal::from(1),
+            },
+            None,
+            InferredType::U32,
+        );
 
         let expr = Expr::less_than_or_equal_to(number_f32, number_u32);
         let empty_registry = FunctionTypeRegistry::empty();

--- a/golem-rib/src/compiler/desugar.rs
+++ b/golem-rib/src/compiler/desugar.rs
@@ -598,6 +598,7 @@ mod desugar_tests {
     }
     mod expectations {
         use crate::{Expr, InferredType, Number, TypeName, VariableId};
+        use bigdecimal::BigDecimal;
         pub(crate) fn expected_condition_with_identifiers() -> Expr {
             Expr::Cond(
                 Box::new(Expr::EqualTo(
@@ -645,7 +646,9 @@ mod desugar_tests {
                         InferredType::Bool,
                     )),
                     Box::new(Expr::Number(
-                        Number { value: 1f64 },
+                        Number {
+                            value: BigDecimal::from(1),
+                        },
                         Some(TypeName::U64),
                         InferredType::U64,
                     )),

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -20,6 +20,7 @@ use crate::{
     from_string, text, type_checker, type_inference, DynamicParsedFunctionName, InferredType,
     ParsedFunctionName, VariableId,
 };
+use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use combine::parser::char::spaces;
 use combine::stream::position;
 use combine::Parser;
@@ -33,7 +34,6 @@ use std::collections::VecDeque;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::str::FromStr;
-use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 
 // https://github.com/golemcloud/golem/issues/1035
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -770,7 +770,11 @@ impl Expr {
         type_name: TypeName,
         inferred_type: InferredType,
     ) -> Expr {
-        Expr::Number(Number { value: big_decimal }, Some(type_name), inferred_type)
+        Expr::Number(
+            Number { value: big_decimal },
+            Some(type_name),
+            inferred_type,
+        )
     }
 
     pub fn untyped_number(big_decimal: BigDecimal) -> Expr {
@@ -785,7 +789,7 @@ impl Expr {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Number {
-    pub value: BigDecimal
+    pub value: BigDecimal,
 }
 
 impl Eq for Number {}
@@ -814,7 +818,7 @@ impl Display for Number {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchArm {
     pub arm_pattern: ArmPattern,
     pub arm_resolution_expr: Box<Expr>,

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -20,7 +20,6 @@ use crate::{
     from_string, text, type_checker, type_inference, DynamicParsedFunctionName, InferredType,
     ParsedFunctionName, VariableId,
 };
-use bincode::{Decode, Encode};
 use combine::parser::char::spaces;
 use combine::stream::position;
 use combine::Parser;
@@ -37,7 +36,7 @@ use std::str::FromStr;
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 
 // https://github.com/golemcloud/golem/issues/1035
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     Let(VariableId, Option<TypeName>, Box<Expr>, InferredType),
     SelectField(Box<Expr>, String, InferredType),
@@ -784,7 +783,7 @@ impl Expr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Number {
     pub value: BigDecimal
 }
@@ -829,7 +828,7 @@ impl MatchArm {
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArmPattern {
     WildCard,
     As(String, Box<ArmPattern>),
@@ -1812,6 +1811,7 @@ impl Serialize for Expr {
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::ParsedFunctionSite::PackagedInterface;

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -1175,12 +1175,10 @@ impl TryFrom<golem_api_grpc::proto::golem::rib::Expr> for Expr {
                 let type_name = number.type_name.map(TypeName::try_from).transpose()?;
                 let big_decimal = if let Some(number) = number.number {
                     BigDecimal::from_str(&number).map_err(|e| e.to_string())?
+                } else if let Some(float) = number.float {
+                    BigDecimal::from_f64(float).ok_or("Invalid float")?
                 } else {
-                    if let Some(float) = number.float {
-                        BigDecimal::from_f64(float).ok_or("Invalid float")?
-                    } else {
-                        return Err("Missing number".to_string());
-                    }
+                    return Err("Missing number".to_string());
                 };
 
                 if let Some(type_name) = type_name {

--- a/golem-rib/src/function_name.rs
+++ b/golem-rib/src/function_name.rs
@@ -268,7 +268,7 @@ pub enum ParsedFunctionReference {
     },
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum DynamicParsedFunctionReference {
     Function {
         function: String,
@@ -903,7 +903,7 @@ pub struct ParsedFunctionName {
 // `Examples`:
 // `DynamicParsedFunctionName` : ns:name/interface.{resource1(identifier1, { field-a: some(identifier2) }).new}
 // `ParsedFunctionName` : ns:name/interface.{resource1("foo", { field-a: some("bar") }).new}
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DynamicParsedFunctionName {
     pub site: ParsedFunctionSite,
     pub function: DynamicParsedFunctionReference,

--- a/golem-rib/src/parser/binary_op.rs
+++ b/golem-rib/src/parser/binary_op.rs
@@ -169,8 +169,14 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(BigDecimal::from(1)))]),
-                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(BigDecimal::from(2)))]),
+                    Expr::record(vec![(
+                        "foo".to_string(),
+                        Expr::untyped_number(BigDecimal::from(1))
+                    )]),
+                    Expr::record(vec![(
+                        "foo".to_string(),
+                        Expr::untyped_number(BigDecimal::from(2))
+                    )]),
                 ),
                 ""
             ))
@@ -185,8 +191,14 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
-                    Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(3)), Expr::untyped_number(BigDecimal::from(4))]),
+                    Expr::sequence(vec![
+                        Expr::untyped_number(BigDecimal::from(1)),
+                        Expr::untyped_number(BigDecimal::from(2))
+                    ]),
+                    Expr::sequence(vec![
+                        Expr::untyped_number(BigDecimal::from(3)),
+                        Expr::untyped_number(BigDecimal::from(4))
+                    ]),
                 ),
                 ""
             ))
@@ -201,8 +213,14 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::tuple(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
-                    Expr::tuple(vec![Expr::untyped_number(BigDecimal::from(3)), Expr::untyped_number(BigDecimal::from(4))]),
+                    Expr::tuple(vec![
+                        Expr::untyped_number(BigDecimal::from(1)),
+                        Expr::untyped_number(BigDecimal::from(2))
+                    ]),
+                    Expr::tuple(vec![
+                        Expr::untyped_number(BigDecimal::from(3)),
+                        Expr::untyped_number(BigDecimal::from(4))
+                    ]),
                 ),
                 ""
             ))

--- a/golem-rib/src/parser/binary_op.rs
+++ b/golem-rib/src/parser/binary_op.rs
@@ -54,6 +54,7 @@ pub enum BinaryOp {
 
 #[cfg(test)]
 mod test {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::parser::rib_expr::rib_expr;
@@ -168,8 +169,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(1f64))]),
-                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(2f64))]),
+                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(BigDecimal::from(1)))]),
+                    Expr::record(vec![("foo".to_string(), Expr::untyped_number(BigDecimal::from(2)))]),
                 ),
                 ""
             ))
@@ -184,8 +185,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::sequence(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
-                    Expr::sequence(vec![Expr::untyped_number(3f64), Expr::untyped_number(4f64)]),
+                    Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
+                    Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(3)), Expr::untyped_number(BigDecimal::from(4))]),
                 ),
                 ""
             ))
@@ -200,8 +201,8 @@ mod test {
             result,
             Ok((
                 Expr::equal_to(
-                    Expr::tuple(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
-                    Expr::tuple(vec![Expr::untyped_number(3f64), Expr::untyped_number(4f64)]),
+                    Expr::tuple(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
+                    Expr::tuple(vec![Expr::untyped_number(BigDecimal::from(3)), Expr::untyped_number(BigDecimal::from(4))]),
                 ),
                 ""
             ))

--- a/golem-rib/src/parser/block.rs
+++ b/golem-rib/src/parser/block.rs
@@ -22,6 +22,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use super::*;
@@ -49,8 +50,8 @@ mod tests {
         let expr = block().easy_parse(input).unwrap().0;
 
         let expected = Expr::expr_block(vec![
-            Expr::let_binding("x", Expr::untyped_number(1f64)),
-            Expr::let_binding("y", Expr::untyped_number(2f64)),
+            Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+            Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
             Expr::plus(Expr::identifier("x"), Expr::identifier("y")),
         ]);
         assert_eq!(expr, expected);

--- a/golem-rib/src/parser/block_without_return.rs
+++ b/golem-rib/src/parser/block_without_return.rs
@@ -39,6 +39,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use super::*;
@@ -54,8 +55,8 @@ mod tests {
         let expr = block_without_return().easy_parse(input).unwrap().0;
 
         let expected = vec![
-            Expr::let_binding("x", Expr::untyped_number(1f64)),
-            Expr::let_binding("y", Expr::untyped_number(2f64)),
+            Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+            Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
             Expr::plus(Expr::identifier("x"), Expr::identifier("y")),
         ];
         assert_eq!(expr, expected);

--- a/golem-rib/src/parser/call.rs
+++ b/golem-rib/src/parser/call.rs
@@ -215,6 +215,7 @@ where
 }
 #[cfg(test)]
 mod function_call_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::{DynamicParsedFunctionName, DynamicParsedFunctionReference};

--- a/golem-rib/src/parser/call.rs
+++ b/golem-rib/src/parser/call.rs
@@ -760,7 +760,7 @@ mod function_call_tests {
                         resource: "resource1".to_string(),
                         resource_params: vec![
                             Expr::literal("hello"),
-                            Expr::untyped_number(1f64),
+                            Expr::untyped_number(BigDecimal::from(1)),
                             Expr::boolean(true),
                         ],
                     },
@@ -792,7 +792,7 @@ mod function_call_tests {
                             Expr::literal("hello"),
                             Expr::record(vec![(
                                 "field-a".to_string(),
-                                Expr::option(Some(Expr::untyped_number(1f64))),
+                                Expr::option(Some(Expr::untyped_number(BigDecimal::from(1)))),
                             )]),
                         ],
                     },
@@ -968,7 +968,7 @@ mod function_call_tests {
                         resource: "resource1".to_string(),
                         resource_params: vec![
                             Expr::literal("hello"),
-                            Expr::untyped_number(1f64),
+                            Expr::untyped_number(BigDecimal::from(1)),
                             Expr::boolean(true),
                         ],
                     },
@@ -1000,7 +1000,7 @@ mod function_call_tests {
                             Expr::literal("hello"),
                             Expr::record(vec![(
                                 "field-a".to_string(),
-                                Expr::option(Some(Expr::untyped_number(1f64))),
+                                Expr::option(Some(Expr::untyped_number(BigDecimal::from(1)))),
                             )]),
                         ],
                     },

--- a/golem-rib/src/parser/list_aggregation.rs
+++ b/golem-rib/src/parser/list_aggregation.rs
@@ -91,6 +91,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use crate::VariableId;
     use crate::{Expr, TypeName};
     use test_r::test;
@@ -104,8 +105,8 @@ mod tests {
             Expr::list_reduce(
                 VariableId::list_reduce_identifier("z"),
                 VariableId::list_comprehension_identifier("p"),
-                Expr::sequence(vec![Expr::untyped_number(1f64), Expr::untyped_number(2f64)]),
-                Expr::untyped_number(0f64),
+                Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
+                Expr::untyped_number(BigDecimal::from(0)),
                 Expr::expr_block(vec![Expr::plus(
                     Expr::identifier("z"),
                     Expr::identifier("p")
@@ -130,16 +131,16 @@ mod tests {
                     "ages",
                     TypeName::List(Box::new(TypeName::U16)),
                     Expr::sequence(vec![
-                        Expr::untyped_number(1f64),
-                        Expr::untyped_number(2f64),
-                        Expr::untyped_number(3f64)
+                        Expr::untyped_number(BigDecimal::from(1)),
+                        Expr::untyped_number(BigDecimal::from(2)),
+                        Expr::untyped_number(BigDecimal::from(3))
                     ])
                 ),
                 Expr::list_reduce(
                     VariableId::list_reduce_identifier("z"),
                     VariableId::list_comprehension_identifier("a"),
                     Expr::identifier("ages"),
-                    Expr::untyped_number(0f64),
+                    Expr::untyped_number(BigDecimal::from(0)),
                     Expr::expr_block(vec![Expr::plus(
                         Expr::identifier("z"),
                         Expr::identifier("a")

--- a/golem-rib/src/parser/list_aggregation.rs
+++ b/golem-rib/src/parser/list_aggregation.rs
@@ -91,9 +91,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bigdecimal::BigDecimal;
     use crate::VariableId;
     use crate::{Expr, TypeName};
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     #[test]
@@ -105,7 +105,10 @@ mod tests {
             Expr::list_reduce(
                 VariableId::list_reduce_identifier("z"),
                 VariableId::list_comprehension_identifier("p"),
-                Expr::sequence(vec![Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))]),
+                Expr::sequence(vec![
+                    Expr::untyped_number(BigDecimal::from(1)),
+                    Expr::untyped_number(BigDecimal::from(2))
+                ]),
                 Expr::untyped_number(BigDecimal::from(0)),
                 Expr::expr_block(vec![Expr::plus(
                     Expr::identifier("z"),

--- a/golem-rib/src/parser/literal.rs
+++ b/golem-rib/src/parser/literal.rs
@@ -116,6 +116,7 @@ mod internal {
 
 #[cfg(test)]
 mod literal_parse_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::parser::rib_expr::rib_expr;
@@ -162,7 +163,7 @@ mod literal_parse_tests {
                     Expr::identifier("foo"),
                     Expr::concat(vec![Expr::literal("bar-"), Expr::identifier("worker_id")])
                 ),
-                Expr::untyped_number(1f64),
+                Expr::untyped_number(BigDecimal::from(1)),
                 Expr::literal("baz"),
             )
         );

--- a/golem-rib/src/parser/multi_line_code_block.rs
+++ b/golem-rib/src/parser/multi_line_code_block.rs
@@ -66,6 +66,7 @@ mod internal {
 }
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::Expr;
@@ -86,8 +87,8 @@ mod tests {
         let expr = Expr::from_text(rib_expr).unwrap();
 
         let expected = Expr::expr_block(vec![
-            Expr::let_binding("x", Expr::untyped_number(1f64)),
-            Expr::let_binding("y", Expr::untyped_number(2f64)),
+            Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+            Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
             Expr::call(
                 DynamicParsedFunctionName::parse("foo").unwrap(),
                 vec![Expr::identifier("x")],
@@ -117,8 +118,8 @@ mod tests {
         let expected = Expr::cond(
             Expr::boolean(true),
             Expr::expr_block(vec![
-                Expr::let_binding("x", Expr::untyped_number(1f64)),
-                Expr::let_binding("y", Expr::untyped_number(2f64)),
+                Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+                Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
                 Expr::call(
                     DynamicParsedFunctionName::parse("foo").unwrap(),
                     vec![Expr::identifier("x")],
@@ -128,7 +129,7 @@ mod tests {
                     vec![Expr::identifier("y")],
                 ),
             ]),
-            Expr::untyped_number(1f64),
+            Expr::untyped_number(BigDecimal::from(1)),
         );
 
         assert_eq!(expr, expected);
@@ -157,8 +158,8 @@ mod tests {
                     vec![ArmPattern::Literal(Box::new(Expr::identifier("x")))],
                 ),
                 Expr::expr_block(vec![
-                    Expr::let_binding("x", Expr::untyped_number(1f64)),
-                    Expr::let_binding("y", Expr::untyped_number(2f64)),
+                    Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+                    Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
                     Expr::call(
                         DynamicParsedFunctionName::parse("foo").unwrap(),
                         vec![Expr::identifier("x")],
@@ -191,7 +192,7 @@ mod tests {
         let expr = Expr::from_text(rib_expr).unwrap();
 
         let expected = Expr::expr_block(vec![
-            Expr::let_binding("foo", Expr::option(Some(Expr::untyped_number(1f64)))),
+            Expr::let_binding("foo", Expr::option(Some(Expr::untyped_number(BigDecimal::from(1))))),
             Expr::pattern_match(
                 Expr::identifier("foo"),
                 vec![MatchArm::new(
@@ -200,8 +201,8 @@ mod tests {
                         vec![ArmPattern::Literal(Box::new(Expr::identifier("x")))],
                     ),
                     Expr::expr_block(vec![
-                        Expr::let_binding("x", Expr::untyped_number(1f64)),
-                        Expr::let_binding("y", Expr::untyped_number(2f64)),
+                        Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1))),
+                        Expr::let_binding("y", Expr::untyped_number(BigDecimal::from(2))),
                         Expr::call(
                             DynamicParsedFunctionName::parse("foo").unwrap(),
                             vec![Expr::identifier("x")],

--- a/golem-rib/src/parser/multi_line_code_block.rs
+++ b/golem-rib/src/parser/multi_line_code_block.rs
@@ -192,7 +192,10 @@ mod tests {
         let expr = Expr::from_text(rib_expr).unwrap();
 
         let expected = Expr::expr_block(vec![
-            Expr::let_binding("foo", Expr::option(Some(Expr::untyped_number(BigDecimal::from(1))))),
+            Expr::let_binding(
+                "foo",
+                Expr::option(Some(Expr::untyped_number(BigDecimal::from(1)))),
+            ),
             Expr::pattern_match(
                 Expr::identifier("foo"),
                 vec![MatchArm::new(

--- a/golem-rib/src/parser/number.rs
+++ b/golem-rib/src/parser/number.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
 use bigdecimal::BigDecimal;
 use combine::parser::char::{char, digit, spaces};
 use combine::{many1, optional, ParseError, Parser};
+use std::str::FromStr;
 
 use crate::expr::Expr;
 use crate::parser::errors::RibParseError;
@@ -71,21 +71,33 @@ mod tests {
     fn test_number() {
         let input = "123";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::untyped_number(BigDecimal::from(123)), "")));
+        assert_eq!(
+            result,
+            Ok((Expr::untyped_number(BigDecimal::from(123)), ""))
+        );
     }
 
     #[test]
     fn test_negative_number() {
         let input = "-123";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::untyped_number(BigDecimal::from(-123)), "")));
+        assert_eq!(
+            result,
+            Ok((Expr::untyped_number(BigDecimal::from(-123)), ""))
+        );
     }
 
     #[test]
     fn test_float_number() {
         let input = "123.456";
         let result = number().easy_parse(input);
-        assert_eq!(result, Ok((Expr::untyped_number(BigDecimal::from_str("123.456f64").unwrap()), "")));
+        assert_eq!(
+            result,
+            Ok((
+                Expr::untyped_number(BigDecimal::from_str("123.456f64").unwrap()),
+                ""
+            ))
+        );
     }
 
     #[test]
@@ -108,7 +120,10 @@ mod tests {
     fn test_number_with_binding_float() {
         let input = "-123.0f64";
         let result = number().easy_parse(input);
-        let expected = Expr::untyped_number_with_type_name(BigDecimal::from_str("-123.0").unwrap(), TypeName::F64);
+        let expected = Expr::untyped_number_with_type_name(
+            BigDecimal::from_str("-123.0").unwrap(),
+            TypeName::F64,
+        );
         assert_eq!(result, Ok((expected, "")));
     }
 }

--- a/golem-rib/src/parser/number.rs
+++ b/golem-rib/src/parser/number.rs
@@ -94,7 +94,7 @@ mod tests {
         assert_eq!(
             result,
             Ok((
-                Expr::untyped_number(BigDecimal::from_str("123.456f64").unwrap()),
+                Expr::untyped_number(BigDecimal::from_str("123.456").unwrap()),
                 ""
             ))
         );

--- a/golem-rib/src/parser/select_field.rs
+++ b/golem-rib/src/parser/select_field.rs
@@ -123,6 +123,7 @@ mod internal {
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use combine::EasyParser;
@@ -224,7 +225,7 @@ mod tests {
             Ok((
                 Expr::greater_than(
                     Expr::select_field(Expr::identifier("foo"), "bar"),
-                    Expr::untyped_number(1f64)
+                    Expr::untyped_number(BigDecimal::from(1))
                 ),
                 ""
             ))
@@ -241,7 +242,7 @@ mod tests {
                 Expr::cond(
                     Expr::greater_than(
                         Expr::select_field(Expr::identifier("foo"), "bar"),
-                        Expr::untyped_number(1f64)
+                        Expr::untyped_number(BigDecimal::from(1))
                     ),
                     Expr::select_field(Expr::identifier("foo"), "bar"),
                     Expr::select_field(Expr::identifier("foo"), "baz")

--- a/golem-rib/src/parser/select_index.rs
+++ b/golem-rib/src/parser/select_index.rs
@@ -48,6 +48,7 @@ where
 }
 
 mod internal {
+    use bigdecimal::BigDecimal;
     use combine::parser::char::char as char_;
 
     use crate::parser::number::number;
@@ -90,10 +91,10 @@ mod internal {
     {
         number().map(|s: Expr| match s {
             Expr::Number(number, _, _) => {
-                if number.value < 0.0 {
+                if number.value < BigDecimal::from(0) {
                     panic!("Cannot use a negative number to index",)
                 } else {
-                    number.value as usize
+                    number.value
                 }
             }
             _ => panic!("Cannot use a float number to index",),

--- a/golem-rib/src/parser/select_index.rs
+++ b/golem-rib/src/parser/select_index.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bigdecimal::ToPrimitive;
 use combine::parser::char::{char as char_, spaces};
 use combine::{attempt, choice, many1, optional, ParseError, Parser};
 
@@ -94,7 +95,7 @@ mod internal {
                 if number.value < BigDecimal::from(0) {
                     panic!("Cannot use a negative number to index",)
                 } else {
-                    number.value
+                    number.value.to_usize().unwrap()
                 }
             }
             _ => panic!("Cannot use a float number to index",),

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -1463,7 +1463,7 @@ mod match_tests {
         );
 
         let expr_str = to_string(&input_expr).unwrap();
-        let expected_str = "match request {  ok(foo) => 1 > 2, err(msg) => 1 < 2 } ".to_string();
+        let expected_str = "match request {  ok(foo) => 1.1 > 2, err(msg) => 1 < 2 } ".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
         assert_eq!((expr_str, input_expr), (expected_str, output_expr));
     }

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -114,8 +114,8 @@ mod record_tests {
     #[test]
     fn test_round_trip_read_write_record_of_number() {
         let input_expr = Expr::record(vec![
-            ("field".to_string(), Expr::untyped_number(1f64)),
-            ("field".to_string(), Expr::untyped_number(2f64)),
+            ("field".to_string(), Expr::untyped_number(BigDecimal::from(1))),
+            ("field".to_string(), Expr::untyped_number(BigDecimal::from(2))),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "{field: 1, field: 2}".to_string();
@@ -293,11 +293,11 @@ mod record_tests {
         let input_expr = Expr::record(vec![
             (
                 "a".to_string(),
-                Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+                Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
             ),
             (
                 "b".to_string(),
-                Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+                Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
             ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
@@ -599,8 +599,8 @@ mod sequence_tests {
     #[test]
     fn test_round_trip_read_write_sequence_of_math_op() {
         let input_expr = Expr::sequence(vec![
-            Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
-            Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+            Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+            Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "[1 > 2, 1 < 2]".to_string();
@@ -855,8 +855,8 @@ mod tuple_tests {
     #[test]
     fn test_round_trip_read_write_tuple_of_math_op() {
         let input_expr = Expr::tuple(vec![
-            Expr::greater_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
-            Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64)),
+            Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+            Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "(1 > 2, 1 < 2)".to_string();
@@ -912,7 +912,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_u64() {
-        let input_expr = Expr::untyped_number(1f64);
+        let input_expr = Expr::untyped_number(BigDecimal::from(1));
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "1".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
@@ -1005,13 +1005,13 @@ mod let_tests {
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U8),
-                Box::new(Expr::untyped_number(1f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(1))),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U8),
-                Box::new(Expr::untyped_number(2f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(2))),
                 InferredType::Unknown,
             ),
         ]);
@@ -1027,13 +1027,13 @@ mod let_tests {
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U16),
-                Box::new(Expr::untyped_number(1f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(1))),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U16),
-                Box::new(Expr::untyped_number(2f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(2))),
                 InferredType::Unknown,
             ),
         ]);
@@ -1049,13 +1049,13 @@ mod let_tests {
             Expr::Let(
                 VariableId::global("x".to_string()),
                 Some(TypeName::U32),
-                Box::new(Expr::untyped_number(1f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(1))),
                 InferredType::Unknown,
             ),
             Expr::Let(
                 VariableId::global("y".to_string()),
                 Some(TypeName::U32),
-                Box::new(Expr::untyped_number(2f64)),
+                Box::new(Expr::untyped_number(BigDecimal::from(2))),
                 InferredType::Unknown,
             ),
         ]);
@@ -1777,7 +1777,7 @@ mod if_cond_tests {
         let input_expr = Expr::cond(
             Expr::equal_to(
                 Expr::select_field(Expr::identifier("worker"), "response"),
-                Expr::untyped_number(1f64),
+                Expr::untyped_number(BigDecimal::from(1)),
             ),
             Expr::flags(vec!["flag1".to_string(), "flag2".to_string()]),
             Expr::literal("failed"),

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -114,8 +114,14 @@ mod record_tests {
     #[test]
     fn test_round_trip_read_write_record_of_number() {
         let input_expr = Expr::record(vec![
-            ("field".to_string(), Expr::untyped_number(BigDecimal::from(1))),
-            ("field".to_string(), Expr::untyped_number(BigDecimal::from(2))),
+            (
+                "field".to_string(),
+                Expr::untyped_number(BigDecimal::from(1)),
+            ),
+            (
+                "field".to_string(),
+                Expr::untyped_number(BigDecimal::from(2)),
+            ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "{field: 1, field: 2}".to_string();
@@ -293,11 +299,17 @@ mod record_tests {
         let input_expr = Expr::record(vec![
             (
                 "a".to_string(),
-                Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+                Expr::greater_than(
+                    Expr::untyped_number(BigDecimal::from(1)),
+                    Expr::untyped_number(BigDecimal::from(2)),
+                ),
             ),
             (
                 "b".to_string(),
-                Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+                Expr::less_than(
+                    Expr::untyped_number(BigDecimal::from(1)),
+                    Expr::untyped_number(BigDecimal::from(2)),
+                ),
             ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
@@ -599,8 +611,14 @@ mod sequence_tests {
     #[test]
     fn test_round_trip_read_write_sequence_of_math_op() {
         let input_expr = Expr::sequence(vec![
-            Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
-            Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+            Expr::greater_than(
+                Expr::untyped_number(BigDecimal::from(1)),
+                Expr::untyped_number(BigDecimal::from(2)),
+            ),
+            Expr::less_than(
+                Expr::untyped_number(BigDecimal::from(1)),
+                Expr::untyped_number(BigDecimal::from(2)),
+            ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "[1 > 2, 1 < 2]".to_string();
@@ -855,8 +873,14 @@ mod tuple_tests {
     #[test]
     fn test_round_trip_read_write_tuple_of_math_op() {
         let input_expr = Expr::tuple(vec![
-            Expr::greater_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
-            Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2))),
+            Expr::greater_than(
+                Expr::untyped_number(BigDecimal::from(1)),
+                Expr::untyped_number(BigDecimal::from(2)),
+            ),
+            Expr::less_than(
+                Expr::untyped_number(BigDecimal::from(1)),
+                Expr::untyped_number(BigDecimal::from(2)),
+            ),
         ]);
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "(1 > 2, 1 < 2)".to_string();

--- a/golem-rib/src/text/mod.rs
+++ b/golem-rib/src/text/mod.rs
@@ -72,6 +72,7 @@ mod interpolation_tests {
 
 #[cfg(test)]
 mod record_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::*;
@@ -457,6 +458,7 @@ mod record_tests {
 
 #[cfg(test)]
 mod sequence_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::Expr;
@@ -734,6 +736,7 @@ mod sequence_tests {
 
 #[cfg(test)]
 mod tuple_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::Expr;
@@ -903,6 +906,8 @@ mod tuple_tests {
 
 #[cfg(test)]
 mod simple_values_test {
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
     use test_r::test;
 
     use crate::expr::Expr;
@@ -928,7 +933,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_float() {
-        let input_expr = Expr::untyped_number(1.1);
+        let input_expr = Expr::untyped_number(BigDecimal::from_str("1.1").unwrap());
         let expr_str = to_string(&input_expr).unwrap();
         let output_expr = from_string(expr_str.as_str()).unwrap();
         assert_eq!(input_expr, output_expr);
@@ -945,7 +950,7 @@ mod simple_values_test {
 
     #[test]
     fn test_round_trip_read_write_number_i64() {
-        let input_expr = Expr::untyped_number(-1f64);
+        let input_expr = Expr::untyped_number(BigDecimal::from(-1));
         let expr_str = to_string(&input_expr).unwrap();
         let expected_str = "-1".to_string();
         let output_expr = from_string(expr_str.as_str()).unwrap();
@@ -982,6 +987,7 @@ mod simple_values_test {
 
 #[cfg(test)]
 mod let_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::Expr;
@@ -1263,6 +1269,8 @@ mod flag_tests {
 
 #[cfg(test)]
 mod match_tests {
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
     use test_r::test;
 
     use crate::expr::ArmPattern;
@@ -1436,14 +1444,20 @@ mod match_tests {
                         "ok",
                         vec![ArmPattern::literal(Expr::identifier("foo"))],
                     ),
-                    Expr::greater_than(Expr::untyped_number(1.0), Expr::untyped_number(2.0)),
+                    Expr::greater_than(
+                        Expr::untyped_number(BigDecimal::from_str("1.1").unwrap()),
+                        Expr::untyped_number(BigDecimal::from(2)),
+                    ),
                 ),
                 MatchArm::new(
                     ArmPattern::constructor(
                         "err",
                         vec![ArmPattern::literal(Expr::identifier("msg"))],
                     ),
-                    Expr::less_than(Expr::untyped_number(1.0), Expr::untyped_number(2.0)),
+                    Expr::less_than(
+                        Expr::untyped_number(BigDecimal::from(1)),
+                        Expr::untyped_number(BigDecimal::from(2)),
+                    ),
                 ),
             ],
         );
@@ -1688,6 +1702,7 @@ mod match_tests {
 
 #[cfg(test)]
 mod if_cond_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::expr::Expr;

--- a/golem-rib/src/text/writer.rs
+++ b/golem-rib/src/text/writer.rs
@@ -140,7 +140,7 @@ impl<W: Write> Writer<W> {
                 self.write_display(")")
             }
             Expr::Number(number, type_name, _) => {
-                self.write_display(number.value)?;
+                self.write_display(number.value.to_string())?;
                 if let Some(type_name) = type_name {
                     self.write_display(type_name)?;
                 }

--- a/golem-rib/src/type_inference/call_arguments_inference.rs
+++ b/golem-rib/src/type_inference/call_arguments_inference.rs
@@ -473,6 +473,7 @@ mod internal {
 
 #[cfg(test)]
 mod function_parameters_inference_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::call_type::CallType;

--- a/golem-rib/src/type_inference/call_arguments_inference.rs
+++ b/golem-rib/src/type_inference/call_arguments_inference.rs
@@ -518,7 +518,7 @@ mod function_parameters_inference_tests {
         expr.infer_call_arguments_type(&function_type_registry)
             .unwrap();
 
-        let let_binding = Expr::let_binding("x", Expr::untyped_number(1f64));
+        let let_binding = Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1)));
 
         let call_expr = Expr::Call(
             CallType::Function(DynamicParsedFunctionName {

--- a/golem-rib/src/type_inference/inference_fix_point.rs
+++ b/golem-rib/src/type_inference/inference_fix_point.rs
@@ -195,6 +195,7 @@ mod internal {
 
 #[cfg(test)]
 mod tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::parser::type_name::TypeName;
@@ -395,7 +396,9 @@ mod tests {
                     VariableId::local("x", 0),
                     Some(TypeName::U64),
                     Box::new(Expr::Number(
-                        Number { value: 1f64 },
+                        Number {
+                            value: BigDecimal::from(1),
+                        },
                         None,
                         InferredType::U64,
                     )),

--- a/golem-rib/src/type_inference/mod.rs
+++ b/golem-rib/src/type_inference/mod.rs
@@ -58,6 +58,7 @@ mod variable_binding_list_reduce;
 mod type_inference_tests {
 
     mod let_binding_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::call_type::CallType;
@@ -82,7 +83,9 @@ mod type_inference_tests {
                 VariableId::local("x", 0),
                 None,
                 Box::new(Expr::Number(
-                    Number { value: 1f64 },
+                    Number {
+                        value: BigDecimal::from(1),
+                    },
                     None,
                     InferredType::U64,
                 )), // The number in let expression is identified to be a U64
@@ -128,7 +131,9 @@ mod type_inference_tests {
                 VariableId::local("x", 0),
                 None,
                 Box::new(Expr::Number(
-                    Number { value: 1f64 },
+                    Number {
+                        value: BigDecimal::from(1),
+                    },
                     None,
                     InferredType::U64,
                 )),
@@ -139,7 +144,9 @@ mod type_inference_tests {
                 VariableId::local("y", 0),
                 None,
                 Box::new(Expr::Number(
-                    Number { value: 2f64 },
+                    Number {
+                        value: BigDecimal::from(2),
+                    },
                     None,
                     InferredType::U32,
                 )),
@@ -183,6 +190,7 @@ mod type_inference_tests {
         }
     }
     mod literal_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -207,7 +215,9 @@ mod type_inference_tests {
                         VariableId::local("x", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -250,6 +260,7 @@ mod type_inference_tests {
         }
     }
     mod comparison_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -278,7 +289,9 @@ mod type_inference_tests {
                         VariableId::local("x", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -288,7 +301,9 @@ mod type_inference_tests {
                         VariableId::local("y", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 2f64 },
+                            Number {
+                                value: BigDecimal::from(2),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -582,6 +597,7 @@ mod type_inference_tests {
         }
     }
     mod cond_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -608,7 +624,9 @@ mod type_inference_tests {
                         VariableId::local("x", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -618,7 +636,9 @@ mod type_inference_tests {
                         VariableId::local("y", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 2f64 },
+                            Number {
+                                value: BigDecimal::from(2),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -666,6 +686,7 @@ mod type_inference_tests {
         }
     }
     mod identifier_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -730,7 +751,9 @@ mod type_inference_tests {
                         VariableId::local("x", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -763,6 +786,7 @@ mod type_inference_tests {
         }
     }
     mod list_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -788,9 +812,27 @@ mod type_inference_tests {
                         Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
-                                Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 2f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 3f64 }, None, InferredType::U64),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(1),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(2),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(3),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
                             ],
                             InferredType::List(Box::new(InferredType::U64)),
                         )),
@@ -808,6 +850,7 @@ mod type_inference_tests {
         }
     }
     mod select_index_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -833,9 +876,27 @@ mod type_inference_tests {
                         Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
-                                Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 2f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 3f64 }, None, InferredType::U64),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(1),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(2),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(3),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
                             ],
                             InferredType::List(Box::new(InferredType::U64)),
                         )),
@@ -857,6 +918,7 @@ mod type_inference_tests {
         }
     }
     mod select_field_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -882,7 +944,9 @@ mod type_inference_tests {
                         VariableId::local("n", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -919,6 +983,7 @@ mod type_inference_tests {
         }
     }
     mod tuple_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -944,7 +1009,13 @@ mod type_inference_tests {
                         Some(TypeName::Tuple(vec![TypeName::U64, TypeName::Str])),
                         Box::new(Expr::Tuple(
                             vec![
-                                Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(1),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
                                 Expr::literal("2"),
                             ],
                             InferredType::Tuple(vec![InferredType::U64, InferredType::Str]),
@@ -963,6 +1034,7 @@ mod type_inference_tests {
         }
     }
     mod variable_conflict_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -992,7 +1064,9 @@ mod type_inference_tests {
                         VariableId::local("y", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -1029,7 +1103,9 @@ mod type_inference_tests {
                             MatchArm::new(
                                 ArmPattern::constructor("none", vec![]),
                                 Expr::Number(
-                                    Number { value: 0f64 },
+                                    Number {
+                                        value: BigDecimal::from(0),
+                                    },
                                     Some(TypeName::U64),
                                     InferredType::U64,
                                 ),
@@ -1045,6 +1121,7 @@ mod type_inference_tests {
         }
     }
     mod pattern_match_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::call_type::CallType;
@@ -1075,7 +1152,9 @@ mod type_inference_tests {
                 VariableId::local("x", 0),
                 None,
                 Box::new(Expr::Number(
-                    Number { value: 1f64 },
+                    Number {
+                        value: BigDecimal::from(1),
+                    },
                     None,
                     InferredType::U64,
                 )),
@@ -1086,7 +1165,9 @@ mod type_inference_tests {
                 VariableId::local("y", 0),
                 None,
                 Box::new(Expr::Number(
-                    Number { value: 2f64 },
+                    Number {
+                        value: BigDecimal::from(2),
+                    },
                     None,
                     InferredType::U32,
                 )),
@@ -1101,7 +1182,9 @@ mod type_inference_tests {
                 vec![
                     MatchArm::new(
                         ArmPattern::Literal(Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         ))),
@@ -1121,7 +1204,9 @@ mod type_inference_tests {
                     ),
                     MatchArm::new(
                         ArmPattern::Literal(Box::new(Expr::Number(
-                            Number { value: 2f64 },
+                            Number {
+                                value: BigDecimal::from(2),
+                            },
                             None,
                             InferredType::U64, // because predicate is u64
                         ))),
@@ -1191,7 +1276,9 @@ mod type_inference_tests {
                         VariableId::local("x", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -1201,7 +1288,9 @@ mod type_inference_tests {
                         VariableId::local("y", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 2f64 },
+                            Number {
+                                value: BigDecimal::from(2),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -1451,9 +1540,27 @@ mod type_inference_tests {
                         Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
-                                Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 2f64 }, None, InferredType::U64),
-                                Expr::Number(Number { value: 3f64 }, None, InferredType::U64),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(1),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(2),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
+                                Expr::Number(
+                                    Number {
+                                        value: BigDecimal::from(3),
+                                    },
+                                    None,
+                                    InferredType::U64,
+                                ),
                             ],
                             InferredType::List(Box::new(InferredType::U64)),
                         )),
@@ -1532,7 +1639,9 @@ mod type_inference_tests {
                             MatchArm::new(
                                 ArmPattern::constructor("none", vec![]),
                                 Expr::Number(
-                                    Number { value: 0f64 },
+                                    Number {
+                                        value: BigDecimal::from(0),
+                                    },
                                     Some(TypeName::U64),
                                     InferredType::U64,
                                 ),
@@ -1548,6 +1657,7 @@ mod type_inference_tests {
         }
     }
     mod option_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -1573,7 +1683,9 @@ mod type_inference_tests {
                         Some(TypeName::Option(Box::new(TypeName::U64))),
                         Box::new(Expr::Option(
                             Some(Box::new(Expr::Number(
-                                Number { value: 1f64 },
+                                Number {
+                                    value: BigDecimal::from(1),
+                                },
                                 None,
                                 InferredType::U64,
                             ))),
@@ -1612,7 +1724,9 @@ mod type_inference_tests {
                         Some(TypeName::Option(Box::new(TypeName::U64))),
                         Box::new(Expr::Option(
                             Some(Box::new(Expr::Number(
-                                Number { value: 1f64 },
+                                Number {
+                                    value: BigDecimal::from(1),
+                                },
                                 None,
                                 InferredType::U64,
                             ))),
@@ -1648,6 +1762,7 @@ mod type_inference_tests {
         }
     }
     mod record_tests {
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         use crate::parser::type_name::TypeName;
@@ -1675,7 +1790,9 @@ mod type_inference_tests {
                         VariableId::local("number", 0),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -1730,12 +1847,16 @@ mod type_inference_tests {
                         Box::new(Expr::Cond(
                             Box::new(Expr::boolean(true)),
                             Box::new(Expr::Number(
-                                Number { value: 1f64 },
+                                Number {
+                                    value: BigDecimal::from(1),
+                                },
                                 Some(TypeName::U64),
                                 InferredType::U64,
                             )),
                             Box::new(Expr::Number(
-                                Number { value: 20f64 },
+                                Number {
+                                    value: BigDecimal::from(20),
+                                },
                                 Some(TypeName::U64),
                                 InferredType::U64,
                             )),
@@ -1837,6 +1958,7 @@ mod type_inference_tests {
 
     mod list_aggregation_tests {
         use crate::{Expr, FunctionTypeRegistry, InferredExpr, InferredType, TypeName, VariableId};
+        use bigdecimal::BigDecimal;
         use test_r::test;
 
         #[test]
@@ -1861,9 +1983,9 @@ mod type_inference_tests {
                         Some(TypeName::List(Box::new(TypeName::U64))),
                         Box::new(Expr::Sequence(
                             vec![
-                                Expr::number(1f64, InferredType::U64),
-                                Expr::number(2f64, InferredType::U64),
-                                Expr::number(3f64, InferredType::U64),
+                                Expr::number(BigDecimal::from(1), InferredType::U64),
+                                Expr::number(BigDecimal::from(2), InferredType::U64),
+                                Expr::number(BigDecimal::from(3), InferredType::U64),
                             ],
                             InferredType::List(Box::new(InferredType::U64)),
                         )),
@@ -1876,7 +1998,11 @@ mod type_inference_tests {
                             VariableId::local("ages", 0),
                             InferredType::List(Box::new(InferredType::U64)),
                         ),
-                        Expr::number_with_type_name(0f64, TypeName::U64, InferredType::U64),
+                        Expr::number_with_type_name(
+                            BigDecimal::from(0),
+                            TypeName::U64,
+                            InferredType::U64,
+                        ),
                         Expr::ExprBlock(
                             vec![
                                 Expr::Let(

--- a/golem-rib/src/type_inference/type_binding.rs
+++ b/golem-rib/src/type_inference/type_binding.rs
@@ -87,6 +87,7 @@ mod internal {
 
 #[cfg(test)]
 mod type_binding_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use super::*;
@@ -107,7 +108,9 @@ mod type_binding_tests {
             VariableId::global("x".to_string()),
             Some(TypeName::U64),
             Box::new(Expr::Number(
-                Number { value: 1f64 },
+                Number {
+                    value: BigDecimal::from(1),
+                },
                 None,
                 InferredType::U64,
             )),
@@ -131,7 +134,9 @@ mod type_binding_tests {
             VariableId::global("x".to_string()),
             Some(TypeName::U64),
             Box::new(Expr::Number(
-                Number { value: 1f64 },
+                Number {
+                    value: BigDecimal::from(1),
+                },
                 Some(TypeName::U64),
                 InferredType::U64,
             )),
@@ -163,7 +168,9 @@ mod type_binding_tests {
                         VariableId::global("y".to_string()),
                         Some(TypeName::U64),
                         Box::new(Expr::Number(
-                            Number { value: 1f64 },
+                            Number {
+                                value: BigDecimal::from(1),
+                            },
                             None,
                             InferredType::U64,
                         )),
@@ -202,7 +209,9 @@ mod type_binding_tests {
                     InferredType::Unknown,
                 ))),
                 arm_resolution_expr: Box::new(Expr::Number(
-                    Number { value: 2f64 },
+                    Number {
+                        value: BigDecimal::from(2),
+                    },
                     Some(TypeName::U64),
                     InferredType::U64,
                 )),
@@ -232,12 +241,16 @@ mod type_binding_tests {
                 InferredType::Unknown,
             )),
             Box::new(Expr::Number(
-                Number { value: 1f64 },
+                Number {
+                    value: BigDecimal::from(1),
+                },
                 Some(TypeName::U64),
                 InferredType::U64,
             )),
             Box::new(Expr::Number(
-                Number { value: 2f64 },
+                Number {
+                    value: BigDecimal::from(2),
+                },
                 Some(TypeName::U64),
                 InferredType::U64,
             )),

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -1213,14 +1213,20 @@ mod type_pull_up_tests {
 
     #[test]
     pub fn test_pull_up_for_equal_to() {
-        let expr = Expr::equal_to(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2)));
+        let expr = Expr::equal_to(
+            Expr::untyped_number(BigDecimal::from(1)),
+            Expr::untyped_number(BigDecimal::from(2)),
+        );
         let new_expr = expr.pull_types_up().unwrap();
         assert_eq!(new_expr.inferred_type(), InferredType::Bool);
     }
 
     #[test]
     pub fn test_pull_up_for_less_than() {
-        let expr = Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2)));
+        let expr = Expr::less_than(
+            Expr::untyped_number(BigDecimal::from(1)),
+            Expr::untyped_number(BigDecimal::from(2)),
+        );
         let new_expr = expr.pull_types_up().unwrap();
         assert_eq!(new_expr.inferred_type(), InferredType::Bool);
     }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -1213,14 +1213,14 @@ mod type_pull_up_tests {
 
     #[test]
     pub fn test_pull_up_for_equal_to() {
-        let expr = Expr::equal_to(Expr::untyped_number(1f64), Expr::untyped_number(2f64));
+        let expr = Expr::equal_to(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2)));
         let new_expr = expr.pull_types_up().unwrap();
         assert_eq!(new_expr.inferred_type(), InferredType::Bool);
     }
 
     #[test]
     pub fn test_pull_up_for_less_than() {
-        let expr = Expr::less_than(Expr::untyped_number(1f64), Expr::untyped_number(2f64));
+        let expr = Expr::less_than(Expr::untyped_number(BigDecimal::from(1)), Expr::untyped_number(BigDecimal::from(2)));
         let new_expr = expr.pull_types_up().unwrap();
         assert_eq!(new_expr.inferred_type(), InferredType::Bool);
     }
@@ -1229,7 +1229,7 @@ mod type_pull_up_tests {
     pub fn test_pull_up_for_call() {
         let expr = Expr::call(
             DynamicParsedFunctionName::parse("global_fn").unwrap(),
-            vec![Expr::untyped_number(1f64)],
+            vec![Expr::untyped_number(BigDecimal::from(1))],
         );
         expr.pull_types_up().unwrap();
         assert_eq!(expr.inferred_type(), InferredType::Unknown);
@@ -1307,7 +1307,7 @@ mod type_pull_up_tests {
 
     #[test]
     pub fn test_pull_up_for_unwrap() {
-        let mut number = Expr::untyped_number(1f64);
+        let mut number = Expr::untyped_number(BigDecimal::from(1));
         number.override_type_type_mut(InferredType::F64);
         let expr = Expr::option(Some(number)).unwrap();
         let expr = expr.pull_types_up().unwrap();
@@ -1319,7 +1319,7 @@ mod type_pull_up_tests {
 
     #[test]
     pub fn test_pull_up_for_tag() {
-        let mut number = Expr::untyped_number(1f64);
+        let mut number = Expr::untyped_number(BigDecimal::from(1));
         number.override_type_type_mut(InferredType::F64);
         let expr = Expr::get_tag(Expr::option(Some(number)));
         let expr = expr.pull_types_up().unwrap();

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -933,6 +933,7 @@ mod internal {
 
 #[cfg(test)]
 mod type_pull_up_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::call_type::CallType;
@@ -978,8 +979,20 @@ mod type_pull_up_tests {
     #[test]
     pub fn test_pull_up_for_sequence() {
         let elems = vec![
-            Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
-            Expr::Number(Number { value: 2f64 }, None, InferredType::U64),
+            Expr::Number(
+                Number {
+                    value: BigDecimal::from(1),
+                },
+                None,
+                InferredType::U64,
+            ),
+            Expr::Number(
+                Number {
+                    value: BigDecimal::from(2),
+                },
+                None,
+                InferredType::U64,
+            ),
         ];
 
         let expr = Expr::Sequence(elems.clone(), InferredType::Unknown);
@@ -995,7 +1008,13 @@ mod type_pull_up_tests {
     pub fn test_pull_up_for_tuple() {
         let expr = Expr::tuple(vec![
             Expr::literal("foo"),
-            Expr::Number(Number { value: 1f64 }, None, InferredType::U64),
+            Expr::Number(
+                Number {
+                    value: BigDecimal::from(1),
+                },
+                None,
+                InferredType::U64,
+            ),
         ]);
         let new_expr = expr.pull_types_up().unwrap();
         assert_eq!(
@@ -1010,7 +1029,9 @@ mod type_pull_up_tests {
             (
                 "foo".to_string(),
                 Box::new(Expr::Number(
-                    Number { value: 1f64 },
+                    Number {
+                        value: BigDecimal::from(1),
+                    },
                     None,
                     InferredType::U64,
                 )),
@@ -1018,7 +1039,9 @@ mod type_pull_up_tests {
             (
                 "bar".to_string(),
                 Box::new(Expr::Number(
-                    Number { value: 2f64 },
+                    Number {
+                        value: BigDecimal::from(2),
+                    },
                     None,
                     InferredType::U32,
                 )),

--- a/golem-rib/src/type_inference/variable_binding_let_assignment.rs
+++ b/golem-rib/src/type_inference/variable_binding_let_assignment.rs
@@ -73,6 +73,7 @@ mod internal {
 
 #[cfg(test)]
 mod name_binding_tests {
+    use bigdecimal::BigDecimal;
     use test_r::test;
 
     use crate::call_type::CallType;

--- a/golem-rib/src/type_inference/variable_binding_let_assignment.rs
+++ b/golem-rib/src/type_inference/variable_binding_let_assignment.rs
@@ -94,7 +94,7 @@ mod name_binding_tests {
         let let_binding = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::untyped_number(1f64)),
+            Box::new(Expr::untyped_number(BigDecimal::from(1))),
             InferredType::Unknown,
         );
 
@@ -134,14 +134,14 @@ mod name_binding_tests {
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::untyped_number(1f64)),
+            Box::new(Expr::untyped_number(BigDecimal::from(1))),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("y", 0),
             None,
-            Box::new(Expr::untyped_number(2f64)),
+            Box::new(Expr::untyped_number(BigDecimal::from(2))),
             InferredType::Unknown,
         );
 
@@ -195,14 +195,14 @@ mod name_binding_tests {
         let let_binding1 = Expr::Let(
             VariableId::local("x", 0),
             None,
-            Box::new(Expr::untyped_number(1f64)),
+            Box::new(Expr::untyped_number(BigDecimal::from(1))),
             InferredType::Unknown,
         );
 
         let let_binding2 = Expr::Let(
             VariableId::local("x", 1),
             None,
-            Box::new(Expr::untyped_number(2f64)),
+            Box::new(Expr::untyped_number(BigDecimal::from(2))),
             InferredType::Unknown,
         );
 

--- a/golem-rib/src/type_inference/variable_binding_pattern_match.rs
+++ b/golem-rib/src/type_inference/variable_binding_pattern_match.rs
@@ -258,6 +258,7 @@ mod pattern_match_bindings {
     }
 
     mod expectations {
+        use bigdecimal::BigDecimal;
         use crate::{ArmPattern, Expr, InferredType, MatchArm, MatchIdentifier, VariableId};
 
         pub(crate) fn expected_match(index: usize) -> Expr {
@@ -291,7 +292,7 @@ mod pattern_match_bindings {
                     },
                     MatchArm {
                         arm_pattern: ArmPattern::constructor("none", vec![]),
-                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(BigDecimal::from(0))),
                     },
                 ],
                 InferredType::Unknown,
@@ -299,7 +300,7 @@ mod pattern_match_bindings {
         }
 
         pub(crate) fn expected_match_with_let_binding(index: usize) -> Expr {
-            let let_binding = Expr::let_binding("x", Expr::untyped_number(1f64));
+            let let_binding = Expr::let_binding("x", Expr::untyped_number(BigDecimal::from(1)));
             let identifier_expr =
                 Expr::Identifier(VariableId::Global("x".to_string()), InferredType::Unknown);
             let block = Expr::ExprBlock(vec![let_binding, identifier_expr], InferredType::Unknown);
@@ -322,7 +323,7 @@ mod pattern_match_bindings {
                     },
                     MatchArm {
                         arm_pattern: ArmPattern::constructor("none", vec![]),
-                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(BigDecimal::from(0))),
                     },
                 ],
                 InferredType::Unknown,
@@ -388,7 +389,7 @@ mod pattern_match_bindings {
                                 },
                                 MatchArm {
                                     arm_pattern: ArmPattern::constructor("none", vec![]),
-                                    arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
+                                    arm_resolution_expr: Box::new(Expr::untyped_number(BigDecimal::from(0))),
                                 },
                             ],
                             InferredType::Unknown,
@@ -405,7 +406,7 @@ mod pattern_match_bindings {
                                 InferredType::Unknown,
                             ))],
                         ),
-                        arm_resolution_expr: Box::new(Expr::untyped_number(0f64)),
+                        arm_resolution_expr: Box::new(Expr::untyped_number(BigDecimal::from(0))),
                     },
                 ],
                 InferredType::Unknown,

--- a/golem-rib/src/type_inference/variable_binding_pattern_match.rs
+++ b/golem-rib/src/type_inference/variable_binding_pattern_match.rs
@@ -258,8 +258,8 @@ mod pattern_match_bindings {
     }
 
     mod expectations {
-        use bigdecimal::BigDecimal;
         use crate::{ArmPattern, Expr, InferredType, MatchArm, MatchIdentifier, VariableId};
+        use bigdecimal::BigDecimal;
 
         pub(crate) fn expected_match(index: usize) -> Expr {
             Expr::PatternMatch(
@@ -389,7 +389,9 @@ mod pattern_match_bindings {
                                 },
                                 MatchArm {
                                     arm_pattern: ArmPattern::constructor("none", vec![]),
-                                    arm_resolution_expr: Box::new(Expr::untyped_number(BigDecimal::from(0))),
+                                    arm_resolution_expr: Box::new(Expr::untyped_number(
+                                        BigDecimal::from(0),
+                                    )),
                                 },
                             ],
                             InferredType::Unknown,

--- a/golem-worker-service-base/Cargo.toml
+++ b/golem-worker-service-base/Cargo.toml
@@ -29,6 +29,7 @@ golem-wasm-rpc = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
+bigdecimal = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 conditional-trait-gen = { workspace = true }

--- a/golem-worker-service-base/src/gateway_binding/worker_binding.rs
+++ b/golem-worker-service-base/src/gateway_binding/worker_binding.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::gateway_binding::WorkerBindingCompiled;
@@ -28,7 +27,7 @@ pub struct WorkerBinding {
 }
 
 // ResponseMapping will consist of actual logic such as invoking worker functions
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResponseMapping(pub Expr);
 
 impl From<WorkerBindingCompiled> for WorkerBinding {

--- a/golem-worker-service-base/src/gateway_binding/worker_binding_compiled.rs
+++ b/golem-worker-service-base/src/gateway_binding/worker_binding_compiled.rs
@@ -14,7 +14,6 @@
 
 use crate::gateway_binding::{ResponseMapping, WorkerBinding};
 use crate::gateway_rib_compiler::{DefaultWorkerServiceRibCompiler, WorkerServiceRibCompiler};
-use bincode::{Decode, Encode};
 use golem_service_base::model::VersionedComponentId;
 use golem_wasm_ast::analysis::AnalysedExport;
 use rib::{Expr, RibByteCode, RibInputTypeInfo, RibOutputTypeInfo, WorkerFunctionsInRib};
@@ -61,7 +60,7 @@ impl WorkerBindingCompiled {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WorkerNameCompiled {
     pub worker_name: Expr,
     pub compiled_worker_name: RibByteCode,
@@ -83,7 +82,7 @@ impl WorkerNameCompiled {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IdempotencyKeyCompiled {
     pub idempotency_key: Expr,
     pub compiled_idempotency_key: RibByteCode,

--- a/golem-worker-service-base/src/gateway_middleware/http/cors.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/cors.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bigdecimal::BigDecimal;
 use http::header::*;
 use poem_openapi::Object;
 use rib::{Expr, GetLiteralValue, RibInput, TypeName};
@@ -285,7 +286,7 @@ impl CorsPreflightExpr {
         if let Some(max_age) = &cors.max_age {
             cors_parameters.push((
                 ACCESS_CONTROL_MAX_AGE.to_string(),
-                Expr::untyped_number_with_type_name(*max_age as f64, TypeName::U64),
+                Expr::untyped_number_with_type_name(BigDecimal::from(*max_age), TypeName::U64),
             ));
         }
 


### PR DESCRIPTION
This change is important to avoid surprises for majority use cases. We see everything as a big decimal before we refine it further.


However, this may not be 100% perfect solution either, mainly because this big decimal is getting converted to less optimal types by the time things gets converted to type annotated value which holds things like f64 which are culprits for precision loss. However this behaviour is less surprising, because in this scenario user is specifically mentioning their number is f64, and its unto them if they loss precision.

