### PR TITLE
Easy Dev env setup for a contributer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ golem-client/*
 logs
 data
 .DS_Store
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733366051,
+        "narHash": "sha256-Zlas3LFqrW8bVVrZYgkzS4VNkZgtZ/hsbYhO0GtKLys=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ba5ed0362eaae83fe8925a2d5cfcf356ff22f70f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
               pkg-config
               protobuf
             ]
-            + lib.optionals stdenv.buildPlatform.isDarwin [
+            ++ lib.optionals stdenv.buildPlatform.isDarwin [
               libiconv
             ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,13 +25,19 @@
           stdenv,
           protobuf,
           fontconfig,
+          libiconv,
+          lib,
         }:
         mkShell {
-          nativeBuildInputs = [
-            rust-bin.stable.latest.default
-            pkg-config
-            protobuf
-          ];
+          nativeBuildInputs =
+            [
+              rust-bin.stable.latest.default
+              pkg-config
+              protobuf
+            ]
+            + lib.optionals stdenv.buildPlatform.isDarwin [
+              libiconv
+            ];
 
           depsBuildBuild = [ qemu ];
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      rust-overlay,
+      flake-utils,
+      nixpkgs,
+    }:
+    let
+
+      golemDevEnv =
+        rust-bin: target:
+        {
+          mkShell,
+          pkg-config,
+          qemu,
+          openssl,
+          stdenv,
+          protobuf,
+          fontconfig,
+        }:
+        mkShell {
+          nativeBuildInputs = [
+            rust-bin.stable.latest.default
+            pkg-config
+            protobuf
+          ];
+
+          depsBuildBuild = [ qemu ];
+          buildInputs = [
+            openssl
+            fontconfig
+          ];
+
+          env =
+            if target == "aarch64-linux" then
+              {
+                CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "${stdenv.cc.targetPrefix}cc";
+                CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER = "qemu-aarch64";
+                HOST_CC = "${stdenv.cc.nativePrefix}cc";
+                TARGET_CC = "${stdenv.cc.targetPrefix}cc";
+              }
+            else
+              { };
+        };
+    in
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShells.default =
+        let
+          target = system;
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+        in
+        pkgs.callPackage (golemDevEnv pkgs.rust-bin target) { };
+      devShells.cross-arm64 =
+        let
+          target = "aarch64-linux";
+          pkgsCross = nixpkgs.legacyPackages.${system}.pkgsCross.aarch64-multiplatform;
+          rust-bin = rust-overlay.lib.mkRustBin { } pkgsCross.buildPackages;
+        in
+        pkgsCross.callPackage (golemDevEnv rust-bin target) { };
+    });
+}


### PR DESCRIPTION
### Abstract

Inspired by now closed PR https://github.com/golemcloud/golem/pull/1114 which proposed to use [multipass](https://multipass.run/) to spin up a vm, install necessary dependencies and then do the docker image building within the vm and then use some external registry to push the images so one can use them on their mac.

With power of [Declarative Development Environments](https://nixos.wiki/wiki/Development_environment_with_nix-shell) powered by Nix we can just  `cd` to our `golem` directory and we will have everything we need to compile and even cross compile to aarch64.

#### Native to native dev env
```
cd golem
nix develop
``` 

#### Native to  linux aarch64
```
cd golem
nix develop .#cross-arm64
```

#### Extra credit
Use power of  [Nix direnv](https://github.com/nix-community/nix-direnv) we can just `cd golem` and execute `cargo build` without needing to install anything ourselves


#### Requirements
Nix installed and flakes enabled in `~/.config/nix/nix.conf` like so
```
experimental-features = nix-command flakes
``` 

#### Future possibilities
Can also be used to provision CI servers and build docker images that are published for everyone to use