### PR TITLE
Parametrize bind address of local Golem server

### DIFF
--- a/golem/src/command.rs
+++ b/golem/src/command.rs
@@ -25,7 +25,7 @@ pub enum SingleExecutableCommand {
     #[clap(name = "start", about = "Start a golem server for local development")]
     Start {
         /// Address to serve the main API on
-        #[clap(long, default_value = "127.0.0.1")]
+        #[clap(long, default_value = "0.0.0.0")]
         router_addr: String,
 
         /// Port to serve the main API on

--- a/golem/src/command.rs
+++ b/golem/src/command.rs
@@ -24,6 +24,10 @@ use std::path::PathBuf;
 pub enum SingleExecutableCommand {
     #[clap(name = "start", about = "Start a golem server for local development")]
     Start {
+        /// Address to serve the main API on
+        #[clap(long, default_value = "127.0.0.1")]
+        router_addr: String,
+
         /// Port to serve the main API on
         #[clap(long, default_value_t = 9881)]
         router_port: u16,
@@ -46,6 +50,7 @@ impl<Ctx> CliCommand<Ctx> for SingleExecutableCommand {
     async fn run(self, _ctx: Ctx) -> Result<GolemResult, GolemError> {
         match self {
             SingleExecutableCommand::Start {
+                router_addr: router_host,
                 router_port,
                 custom_request_port,
                 data_dir,
@@ -63,6 +68,7 @@ impl<Ctx> CliCommand<Ctx> for SingleExecutableCommand {
                 };
 
                 match launch_golem_services(&LaunchArgs {
+                    router_host,
                     router_port,
                     custom_request_port,
                     data_dir,

--- a/golem/src/launch.rs
+++ b/golem/src/launch.rs
@@ -49,6 +49,7 @@ use tracing::Instrument;
 use crate::proxy;
 
 pub struct LaunchArgs {
+    pub router_host: String,
     pub router_port: u16,
     pub custom_request_port: u16,
     pub data_dir: PathBuf,
@@ -110,6 +111,7 @@ pub async fn launch_golem_services(args: &LaunchArgs) -> Result<(), anyhow::Erro
 
     // Don't drop the channel, it will cause the proxy to fail
     let _proxy_command_channel = proxy::start_proxy(
+        &args.router_host,
         args.router_port,
         healthcheck_port,
         &all_run_details,
@@ -188,14 +190,14 @@ fn worker_executor_config(
         blob_storage: blob_storage_config(args),
         component_service: golem_worker_executor_base::services::golem_config::ComponentServiceConfig::Grpc(
             ComponentServiceGrpcConfig {
-                host: "127.0.0.1".to_string(),
+                host: args.router_host.clone(),
                 port: component_service_run_details.grpc_port,
                 ..ComponentServiceGrpcConfig::default()
             }
         ),
         compiled_component_service: CompiledComponentServiceConfig::Disabled(golem_worker_executor_base::services::golem_config::CompiledComponentServiceDisabledConfig {  }),
         shard_manager_service: ShardManagerServiceConfig::Grpc(ShardManagerServiceGrpcConfig {
-            host: "127.0.0.1".to_string(),
+            host: args.router_host.clone(),
             port: shard_manager_run_details.grpc_port,
             ..ShardManagerServiceGrpcConfig::default()
         }),
@@ -236,12 +238,12 @@ fn worker_service_config(
             ),
         blob_storage: blob_storage_config(args),
         component_service: golem_worker_service_base::app_config::ComponentServiceConfig {
-            host: "127.0.0.1".to_string(),
+            host: args.router_host.clone(),
             port: component_service_run_details.grpc_port,
             ..golem_worker_service_base::app_config::ComponentServiceConfig::default()
         },
         routing_table: RoutingTableConfig {
-            host: "127.0.0.1".to_string(),
+            host: args.router_host.clone(),
             port: shard_manager_run_details.grpc_port,
             ..RoutingTableConfig::default()
         },


### PR DESCRIPTION
**Goal:** Allow customization of Golem server address.

**Usage:**
```bash
$ golem start --router-addr 192.168.1.1
```