### PR TITLE
Defined the DurabilityHost interface and migrated Durability to it

### DIFF
--- a/golem-common/src/model/oplog.rs
+++ b/golem-common/src/model/oplog.rs
@@ -288,7 +288,7 @@ pub enum OplogEntry {
         timestamp: Timestamp,
         function_name: String,
         response: OplogPayload,
-        wrapped_function_type: WrappedFunctionType,
+        wrapped_function_type: DurableFunctionType, // TODO: rename in Golem 2.0
     },
     /// The worker has been invoked
     ExportedFunctionInvoked {
@@ -405,7 +405,7 @@ pub enum OplogEntry {
         function_name: String,
         request: OplogPayload,
         response: OplogPayload,
-        wrapped_function_type: WrappedFunctionType,
+        wrapped_function_type: DurableFunctionType, // TODO: rename in Golem 2.0
     },
     /// The current version of the Create entry (previous is CreateV1)
     Create {
@@ -648,14 +648,14 @@ impl OplogEntry {
                 wrapped_function_type,
                 ..
             } => match wrapped_function_type {
-                WrappedFunctionType::WriteRemoteBatched(Some(begin_index))
+                DurableFunctionType::WriteRemoteBatched(Some(begin_index))
                     if *begin_index == idx =>
                 {
                     true
                 }
-                WrappedFunctionType::ReadLocal => true,
-                WrappedFunctionType::WriteLocal => true,
-                WrappedFunctionType::ReadRemote => true,
+                DurableFunctionType::ReadLocal => true,
+                DurableFunctionType::WriteLocal => true,
+                DurableFunctionType::ReadRemote => true,
                 _ => false,
             },
             OplogEntry::ExportedFunctionCompleted { .. } => false,
@@ -779,7 +779,7 @@ pub enum OplogPayload {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
-pub enum WrappedFunctionType {
+pub enum DurableFunctionType {
     /// The side-effect reads from the worker's local state (for example local file system,
     /// random generator, etc.)
     ReadLocal,

--- a/golem-worker-executor-base/src/durable_host/blobstore/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/blobstore/mod.rs
@@ -17,7 +17,7 @@ pub mod types;
 
 use async_trait::async_trait;
 use futures_util::TryFutureExt;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime::component::Resource;
 use wasmtime_wasi::WasiView;
 
@@ -36,11 +36,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<Resource<Container>, Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, u64, SerializableError>::new(
+        let durability = Durability::<u64, SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "create_container",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -72,11 +72,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<Resource<Container>, Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, Option<u64>, SerializableError>::new(
+        let durability = Durability::<Option<u64>, SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "get_container",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -105,11 +105,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
 
     async fn delete_container(&mut self, name: ContainerName) -> anyhow::Result<Result<(), Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "delete_container",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -134,11 +134,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         name: ContainerName,
     ) -> anyhow::Result<Result<bool, Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, bool, SerializableError>::new(
+        let durability = Durability::<bool, SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "container_exists",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -164,11 +164,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         dest: ObjectId,
     ) -> anyhow::Result<Result<(), Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "copy_object",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -206,11 +206,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         dest: ObjectId,
     ) -> anyhow::Result<Result<(), Error>> {
         let account_id = self.state.owned_worker_id.account_id();
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem blobstore::blobstore",
             "move_object",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
         let result = if durability.is_live() {

--- a/golem-worker-executor-base/src/durable_host/blobstore/types.rs
+++ b/golem-worker-executor-base/src/durable_host/blobstore/types.rs
@@ -22,8 +22,7 @@ use wasmtime_wasi::{
     HostInputStream, HostOutputStream, InputStream, StreamResult, Subscribe, WasiView,
 };
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 
 use crate::preview2::wasi::blobstore::types::{
     Error, Host, HostIncomingValue, HostOutgoingValue, IncomingValue, IncomingValueAsyncBody,
@@ -34,7 +33,7 @@ use crate::workerctx::WorkerCtx;
 #[async_trait]
 impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
     async fn new_outgoing_value(&mut self) -> anyhow::Result<Resource<OutgoingValueEntry>> {
-        record_host_function_call("blobstore::types::outgoing_value", "new_outgoing_value");
+        self.observe_function_call("blobstore::types::outgoing_value", "new_outgoing_value");
         let outgoing_value = self
             .as_wasi_view()
             .table()
@@ -46,7 +45,7 @@ impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<OutgoingValueEntry>,
     ) -> anyhow::Result<Result<Resource<OutgoingValueBodyAsync>, ()>> {
-        record_host_function_call(
+        self.observe_function_call(
             "blobstore::types::outgoing_value",
             "outgoing_value_write_body",
         );
@@ -62,7 +61,7 @@ impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<OutgoingValueEntry>) -> anyhow::Result<()> {
-        record_host_function_call("blobstore::types::outgoing_value", "drop");
+        self.observe_function_call("blobstore::types::outgoing_value", "drop");
         self.as_wasi_view()
             .table()
             .delete::<OutgoingValueEntry>(rep)?;
@@ -76,7 +75,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingValue>,
     ) -> anyhow::Result<Result<IncomingValueSyncBody, Error>> {
-        record_host_function_call(
+        self.observe_function_call(
             "blobstore::types::incoming_value",
             "incoming_value_consume_sync",
         );
@@ -94,7 +93,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingValue>,
     ) -> anyhow::Result<Result<Resource<IncomingValueAsyncBody>, Error>> {
-        record_host_function_call(
+        self.observe_function_call(
             "blobstore::types::incoming_value",
             "incoming_value_consume_async",
         );
@@ -110,7 +109,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
     }
 
     async fn size(&mut self, self_: Resource<IncomingValue>) -> anyhow::Result<u64> {
-        record_host_function_call("blobstore::types::incoming_value", "size");
+        self.observe_function_call("blobstore::types::incoming_value", "size");
         let body = self
             .as_wasi_view()
             .table()
@@ -122,7 +121,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<IncomingValue>) -> anyhow::Result<()> {
-        record_host_function_call("blobstore::types::incoming_value", "drop");
+        self.observe_function_call("blobstore::types::incoming_value", "drop");
         self.as_wasi_view()
             .table()
             .delete::<IncomingValueEntry>(rep)?;

--- a/golem-worker-executor-base/src/durable_host/cli/environment.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/environment.rs
@@ -17,17 +17,17 @@ use async_trait::async_trait;
 use crate::durable_host::serialized::SerializableError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::cli::environment::Host;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_environment(&mut self) -> anyhow::Result<Vec<(String, String)>> {
-        let durability = Durability::<Ctx, Vec<(String, String)>, SerializableError>::new(
+        let durability = Durability::<Vec<(String, String)>, SerializableError>::new(
             self,
             "golem_environment",
             "get_environment",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 
@@ -40,11 +40,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn get_arguments(&mut self) -> anyhow::Result<Vec<String>> {
-        let durability = Durability::<Ctx, Vec<String>, SerializableError>::new(
+        let durability = Durability::<Vec<String>, SerializableError>::new(
             self,
             "golem_environment",
             "get_arguments",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 
@@ -57,11 +57,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn initial_cwd(&mut self) -> anyhow::Result<Option<String>> {
-        let durability = Durability::<Ctx, Option<String>, SerializableError>::new(
+        let durability = Durability::<Option<String>, SerializableError>::new(
             self,
             "golem_environment",
             "get_arguments", // TODO: fix in 2.0 - for backward compatibility with Golem 1.0
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/cli/exit.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/exit.rs
@@ -14,20 +14,19 @@
 
 use async_trait::async_trait;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::exit::Host;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn exit(&mut self, status: Result<(), ()>) -> anyhow::Result<()> {
-        record_host_function_call("cli::exit", "exit");
+        self.observe_function_call("cli::exit", "exit");
         Host::exit(&mut self.as_wasi_view(), status)
     }
 
     fn exit_with_code(&mut self, status_code: u8) -> anyhow::Result<()> {
-        record_host_function_call("cli::exit", "exit_with_code");
+        self.observe_function_call("cli::exit", "exit_with_code");
         Host::exit_with_code(&mut self.as_wasi_view(), status_code)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/stderr.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/stderr.rs
@@ -14,14 +14,13 @@
 
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::stderr::{Host, OutputStream};
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_stderr(&mut self) -> anyhow::Result<Resource<OutputStream>> {
-        record_host_function_call("cli::stderr", "get_stderr");
+        self.observe_function_call("cli::stderr", "get_stderr");
         self.as_wasi_view().get_stderr()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/stdin.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/stdin.rs
@@ -14,14 +14,13 @@
 
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::stdin::{Host, InputStream};
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_stdin(&mut self) -> anyhow::Result<Resource<InputStream>> {
-        record_host_function_call("cli::stdin", "get_stdin");
+        self.observe_function_call("cli::stdin", "get_stdin");
         self.as_wasi_view().get_stdin()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/stdout.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/stdout.rs
@@ -14,14 +14,13 @@
 
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::stdout::{Host, OutputStream};
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_stdout(&mut self) -> anyhow::Result<Resource<OutputStream>> {
-        record_host_function_call("cli::stdout", "get_stdout");
+        self.observe_function_call("cli::stdout", "get_stdout");
         self.as_wasi_view().get_stdout()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/terminal_input.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/terminal_input.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::terminal_input::{Host, HostTerminalInput, TerminalInput};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> HostTerminalInput for DurableWorkerCtx<Ctx> {
     fn drop(&mut self, rep: Resource<TerminalInput>) -> anyhow::Result<()> {
-        record_host_function_call("cli::terminal_input::terminal_input", "drop");
+        self.observe_function_call("cli::terminal_input::terminal_input", "drop");
         HostTerminalInput::drop(&mut self.as_wasi_view(), rep)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/terminal_output.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/terminal_output.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::terminal_output::{Host, HostTerminalOutput, TerminalOutput};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> HostTerminalOutput for DurableWorkerCtx<Ctx> {
     fn drop(&mut self, rep: Resource<TerminalOutput>) -> anyhow::Result<()> {
-        record_host_function_call("cli::terminal_output::terminal_output", "drop");
+        self.observe_function_call("cli::terminal_output::terminal_output", "drop");
         HostTerminalOutput::drop(&mut self.as_wasi_view(), rep)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/terminal_stderr.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/terminal_stderr.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::terminal_stderr::{Host, TerminalOutput};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_terminal_stderr(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
-        record_host_function_call("cli::terminal_stderr", "get_terminal_stderr");
+        self.observe_function_call("cli::terminal_stderr", "get_terminal_stderr");
         self.as_wasi_view().get_terminal_stderr()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/terminal_stdin.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/terminal_stdin.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::terminal_stdin::{Host, TerminalInput};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_terminal_stdin(&mut self) -> anyhow::Result<Option<Resource<TerminalInput>>> {
-        record_host_function_call("cli::terminal_stdin", "get_terminal_stdin");
+        self.observe_function_call("cli::terminal_stdin", "get_terminal_stdin");
         self.as_wasi_view().get_terminal_stdin()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/cli/terminal_stdout.rs
+++ b/golem-worker-executor-base/src/durable_host/cli/terminal_stdout.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::cli::terminal_stdout::{Host, TerminalOutput};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn get_terminal_stdout(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
-        record_host_function_call("cli::terminal_stdout", "get_terminal_stdout");
+        self.observe_function_call("cli::terminal_stdout", "get_terminal_stdout");
         self.as_wasi_view().get_terminal_stdout()
     }
 }

--- a/golem-worker-executor-base/src/durable_host/clocks/wall_clock.rs
+++ b/golem-worker-executor-base/src/durable_host/clocks/wall_clock.rs
@@ -17,17 +17,17 @@ use async_trait::async_trait;
 use crate::durable_host::serialized::{SerializableDateTime, SerializableError};
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::clocks::wall_clock::{Datetime, Host};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn now(&mut self) -> anyhow::Result<Datetime> {
-        let durability = Durability::<Ctx, SerializableDateTime, SerializableError>::new(
+        let durability = Durability::<SerializableDateTime, SerializableError>::new(
             self,
             "wall_clock",
             "now",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 
@@ -40,11 +40,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn resolution(&mut self) -> anyhow::Result<Datetime> {
-        let durability = Durability::<Ctx, SerializableDateTime, SerializableError>::new(
+        let durability = Durability::<SerializableDateTime, SerializableError>::new(
             self,
             "wall_clock",
             "resolution",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/filesystem/preopens.rs
+++ b/golem-worker-executor-base/src/durable_host/filesystem/preopens.rs
@@ -19,17 +19,17 @@ use wasmtime::component::Resource;
 use crate::durable_host::serialized::SerializableError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::filesystem::preopens::{Descriptor, Host};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_directories(&mut self) -> anyhow::Result<Vec<(Resource<Descriptor>, String)>> {
-        let durability = Durability::<Ctx, Vec<String>, SerializableError>::new(
+        let durability = Durability::<Vec<String>, SerializableError>::new(
             self,
             "cli::preopens",
             "get_directories",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/golem/v11.rs
+++ b/golem-worker-executor-base/src/durable_host/golem/v11.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::model::public_oplog::{
     find_component_version_at, get_public_oplog_chunk, search_public_oplog,
 };
@@ -190,7 +189,7 @@ impl<Ctx: WorkerCtx> HostGetOplog for DurableWorkerCtx<Ctx> {
         worker_id: crate::preview2::golem::api1_1_0::oplog::WorkerId,
         start: crate::preview2::golem::api1_1_0::oplog::OplogIndex,
     ) -> anyhow::Result<Resource<GetOplogEntry>> {
-        record_host_function_call("golem::api::get-oplog", "new");
+        self.observe_function_call("golem::api::get-oplog", "new");
 
         let account_id = self.owned_worker_id.account_id();
         let worker_id: golem_common::model::WorkerId = worker_id.into();
@@ -209,7 +208,7 @@ impl<Ctx: WorkerCtx> HostGetOplog for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<GetOplogEntry>,
     ) -> anyhow::Result<Option<Vec<OplogEntry>>> {
-        record_host_function_call("golem::api::get-oplog", "get-next");
+        self.observe_function_call("golem::api::get-oplog", "get-next");
 
         let component_service = self.state.component_service.clone();
         let oplog_service = self.state.oplog_service();
@@ -247,7 +246,7 @@ impl<Ctx: WorkerCtx> HostGetOplog for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<GetOplogEntry>) -> anyhow::Result<()> {
-        record_host_function_call("golem::api::get-oplog", "drop");
+        self.observe_function_call("golem::api::get-oplog", "drop");
         self.as_wasi_view().table().delete(rep)?;
         Ok(())
     }
@@ -293,7 +292,7 @@ impl<Ctx: WorkerCtx> HostSearchOplog for DurableWorkerCtx<Ctx> {
         worker_id: golem::api1_1_0::oplog::WorkerId,
         text: String,
     ) -> anyhow::Result<Resource<SearchOplog>> {
-        record_host_function_call("golem::api::search-oplog", "new");
+        self.observe_function_call("golem::api::search-oplog", "new");
 
         let account_id = self.owned_worker_id.account_id();
         let worker_id: golem_common::model::WorkerId = worker_id.into();
@@ -313,7 +312,7 @@ impl<Ctx: WorkerCtx> HostSearchOplog for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<SearchOplog>,
     ) -> anyhow::Result<Option<Vec<(golem::api1_1_0::oplog::OplogIndex, OplogEntry)>>> {
-        record_host_function_call("golem::api::search-oplog", "get-next");
+        self.observe_function_call("golem::api::search-oplog", "get-next");
 
         let component_service = self.state.component_service.clone();
         let oplog_service = self.state.oplog_service();
@@ -356,7 +355,7 @@ impl<Ctx: WorkerCtx> HostSearchOplog for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<SearchOplog>) -> anyhow::Result<()> {
-        record_host_function_call("golem::api::search-oplog", "drop");
+        self.observe_function_call("golem::api::search-oplog", "drop");
         self.as_wasi_view().table().delete(rep)?;
         Ok(())
     }

--- a/golem-worker-executor-base/src/durable_host/io/error.rs
+++ b/golem-worker-executor-base/src/durable_host/io/error.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use async_trait::async_trait;
 use wasmtime::component::Resource;
@@ -22,12 +21,12 @@ use wasmtime_wasi::bindings::io::error::{Error, Host, HostError};
 #[async_trait]
 impl<Ctx: WorkerCtx> HostError for DurableWorkerCtx<Ctx> {
     fn to_debug_string(&mut self, self_: Resource<Error>) -> anyhow::Result<String> {
-        record_host_function_call("io::error", "to_debug_string");
+        self.observe_function_call("io::error", "to_debug_string");
         HostError::to_debug_string(&mut self.as_wasi_view(), self_)
     }
 
     fn drop(&mut self, rep: Resource<Error>) -> anyhow::Result<()> {
-        record_host_function_call("io::error", "drop");
+        self.observe_function_call("io::error", "drop");
         HostError::drop(&mut self.as_wasi_view(), rep)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/io/streams.rs
+++ b/golem-worker-executor-base/src/durable_host/io/streams.rs
@@ -21,11 +21,10 @@ use crate::durable_host::http::end_http_request;
 use crate::durable_host::http::serialized::SerializableHttpRequest;
 use crate::durable_host::io::{ManagedStdErr, ManagedStdOut};
 use crate::durable_host::serialized::SerializableStreamError;
-use crate::durable_host::{Durability, DurableWorkerCtx, HttpRequestCloseOwner};
+use crate::durable_host::{Durability, DurabilityHost, DurableWorkerCtx, HttpRequestCloseOwner};
 use crate::error::GolemError;
-use crate::metrics::wasm::record_host_function_call;
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::{OplogIndex, WrappedFunctionType};
+use golem_common::model::oplog::{DurableFunctionType, OplogIndex};
 use golem_common::model::WorkerEvent;
 use wasmtime_wasi::bindings::io::streams::{
     Host, HostInputStream, HostOutputStream, InputStream, OutputStream, Pollable,
@@ -43,11 +42,11 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let handle = self_.rep();
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
-            let durability = Durability::<Ctx, Vec<u8>, SerializableStreamError>::new(
+            let durability = Durability::<Vec<u8>, SerializableStreamError>::new(
                 self,
                 "http::types::incoming_body_stream",
                 "read",
-                WrappedFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
             )
             .await?;
 
@@ -62,7 +61,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             end_http_request_if_closed(self, handle, &result).await?;
             result
         } else {
-            record_host_function_call("io::streams::input_stream", "read");
+            self.observe_function_call("io::streams::input_stream", "read");
             HostInputStream::read(&mut self.as_wasi_view(), self_, len).await
         }
     }
@@ -76,11 +75,11 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let handle = self_.rep();
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
-            let durability = Durability::<Ctx, Vec<u8>, SerializableStreamError>::new(
+            let durability = Durability::<Vec<u8>, SerializableStreamError>::new(
                 self,
                 "http::types::incoming_body_stream",
                 "blocking_read",
-                WrappedFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
             )
             .await?;
             let result = if durability.is_live() {
@@ -95,7 +94,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             end_http_request_if_closed(self, handle, &result).await?;
             result
         } else {
-            record_host_function_call("io::streams::input_stream", "blocking_read");
+            self.observe_function_call("io::streams::input_stream", "blocking_read");
             HostInputStream::blocking_read(&mut self.as_wasi_view(), self_, len).await
         }
     }
@@ -105,11 +104,11 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let handle = self_.rep();
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
-            let durability = Durability::<Ctx, u64, SerializableStreamError>::new(
+            let durability = Durability::<u64, SerializableStreamError>::new(
                 self,
                 "http::types::incoming_body_stream",
                 "skip",
-                WrappedFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
             )
             .await?;
             let result = if durability.is_live() {
@@ -123,7 +122,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             end_http_request_if_closed(self, handle, &result).await?;
             result
         } else {
-            record_host_function_call("io::streams::input_stream", "skip");
+            self.observe_function_call("io::streams::input_stream", "skip");
             HostInputStream::skip(&mut self.as_wasi_view(), self_, len).await
         }
     }
@@ -137,11 +136,11 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let handle = self_.rep();
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
-            let durability = Durability::<Ctx, u64, SerializableStreamError>::new(
+            let durability = Durability::<u64, SerializableStreamError>::new(
                 self,
                 "http::types::incoming_body_stream",
                 "blocking_skip",
-                WrappedFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
             )
             .await?;
 
@@ -156,18 +155,18 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             end_http_request_if_closed(self, handle, &result).await?;
             result
         } else {
-            record_host_function_call("io::streams::input_stream", "blocking_skip");
+            self.observe_function_call("io::streams::input_stream", "blocking_skip");
             HostInputStream::blocking_skip(&mut self.as_wasi_view(), self_, len).await
         }
     }
 
     fn subscribe(&mut self, self_: Resource<InputStream>) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("io::streams::input_stream", "subscribe");
+        self.observe_function_call("io::streams::input_stream", "subscribe");
         HostInputStream::subscribe(&mut self.as_wasi_view(), self_)
     }
 
     async fn drop(&mut self, rep: Resource<InputStream>) -> anyhow::Result<()> {
-        record_host_function_call("io::streams::input_stream", "drop");
+        self.observe_function_call("io::streams::input_stream", "drop");
 
         if is_incoming_http_body_stream(self.table(), &rep) {
             let handle = rep.rep();
@@ -185,7 +184,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
 #[async_trait]
 impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
     fn check_write(&mut self, self_: Resource<OutputStream>) -> Result<u64, StreamError> {
-        record_host_function_call("io::streams::output_stream", "check_write");
+        self.observe_function_call("io::streams::output_stream", "check_write");
         HostOutputStream::check_write(&mut self.as_wasi_view(), self_)
     }
 
@@ -194,7 +193,7 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         self_: Resource<OutputStream>,
         contents: Vec<u8>,
     ) -> Result<(), StreamError> {
-        record_host_function_call("io::streams::output_stream", "write");
+        self.observe_function_call("io::streams::output_stream", "write");
 
         let output = self.table().get(&self_)?;
         let event = if output.as_any().downcast_ref::<ManagedStdOut>().is_some() {
@@ -226,17 +225,17 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
     }
 
     async fn flush(&mut self, self_: Resource<OutputStream>) -> Result<(), StreamError> {
-        record_host_function_call("io::streams::output_stream", "flush");
+        self.observe_function_call("io::streams::output_stream", "flush");
         HostOutputStream::flush(&mut self.as_wasi_view(), self_).await
     }
 
     async fn blocking_flush(&mut self, self_: Resource<OutputStream>) -> Result<(), StreamError> {
-        record_host_function_call("io::streams::output_stream", "blocking_flush");
+        self.observe_function_call("io::streams::output_stream", "blocking_flush");
         HostOutputStream::blocking_flush(&mut self.as_wasi_view(), self_).await
     }
 
     fn subscribe(&mut self, self_: Resource<OutputStream>) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("io::streams::output_stream", "subscribe");
+        self.observe_function_call("io::streams::output_stream", "subscribe");
         HostOutputStream::subscribe(&mut self.as_wasi_view(), self_)
     }
 
@@ -245,7 +244,7 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         self_: Resource<OutputStream>,
         len: u64,
     ) -> Result<(), StreamError> {
-        record_host_function_call("io::streams::output_stream", "write_zeroeas");
+        self.observe_function_call("io::streams::output_stream", "write_zeroeas");
         HostOutputStream::write_zeroes(&mut self.as_wasi_view(), self_, len).await
     }
 
@@ -254,7 +253,7 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         self_: Resource<OutputStream>,
         len: u64,
     ) -> Result<(), StreamError> {
-        record_host_function_call(
+        self.observe_function_call(
             "io::streams::output_stream",
             "blocking_write_zeroes_and_flush",
         );
@@ -268,7 +267,7 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         src: Resource<InputStream>,
         len: u64,
     ) -> Result<u64, StreamError> {
-        record_host_function_call("io::streams::output_stream", "splice");
+        self.observe_function_call("io::streams::output_stream", "splice");
         HostOutputStream::splice(&mut self.as_wasi_view(), self_, src, len).await
     }
 
@@ -278,12 +277,12 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         src: Resource<InputStream>,
         len: u64,
     ) -> Result<u64, StreamError> {
-        record_host_function_call("io::streams::output_stream", "blocking_splice");
+        self.observe_function_call("io::streams::output_stream", "blocking_splice");
         HostOutputStream::blocking_splice(&mut self.as_wasi_view(), self_, src, len).await
     }
 
     async fn drop(&mut self, rep: Resource<OutputStream>) -> anyhow::Result<()> {
-        record_host_function_call("io::streams::output_stream", "drop");
+        self.observe_function_call("io::streams::output_stream", "drop");
         HostOutputStream::drop(&mut self.as_wasi_view(), rep).await
     }
 }

--- a/golem-worker-executor-base/src/durable_host/keyvalue/atomic.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/atomic.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::wasi::keyvalue::atomic::{Bucket, Error, Host, Key};
 use crate::workerctx::WorkerCtx;
 
@@ -28,7 +27,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         _key: Key,
         _delta: u64,
     ) -> anyhow::Result<Result<u64, Resource<Error>>> {
-        record_host_function_call("keyvalue::atomic", "increment");
+        self.observe_function_call("keyvalue::atomic", "increment");
         unimplemented!("increment")
     }
 
@@ -39,7 +38,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         _old: u64,
         _new: u64,
     ) -> anyhow::Result<Result<bool, Resource<Error>>> {
-        record_host_function_call("keyvalue::atomic", "compare_and_swap");
+        self.observe_function_call("keyvalue::atomic", "compare_and_swap");
         unimplemented!("compare_and_swap")
     }
 }

--- a/golem-worker-executor-base/src/durable_host/keyvalue/caching.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/caching.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::wasi::keyvalue::cache::{
     Error, FutureExistsResult, FutureGetOrSetResult, FutureGetResult, FutureResult, GetOrSetEntry,
     Host, HostFutureExistsResult, HostFutureGetOrSetResult, HostFutureGetResult, HostFutureResult,
@@ -30,7 +29,7 @@ impl<Ctx: WorkerCtx> HostFutureGetResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureGetResult>,
     ) -> anyhow::Result<Option<Result<Option<Resource<IncomingValue>>, Resource<Error>>>> {
-        record_host_function_call("keyvalue::cache::future_get", "future_get_result_get");
+        self.observe_function_call("keyvalue::cache::future_get", "future_get_result_get");
         unimplemented!("future_get_result_get")
     }
 
@@ -38,12 +37,12 @@ impl<Ctx: WorkerCtx> HostFutureGetResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureGetResult>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("keyvalue::cache::future_get", "listen_to_future_get_result");
+        self.observe_function_call("keyvalue::cache::future_get", "listen_to_future_get_result");
         unimplemented!("listen_to_future_get_result")
     }
 
     async fn drop(&mut self, _rep: Resource<FutureGetResult>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::cache::future_get", "drop");
+        self.observe_function_call("keyvalue::cache::future_get", "drop");
         unimplemented!("drop")
     }
 }
@@ -54,7 +53,7 @@ impl<Ctx: WorkerCtx> HostFutureExistsResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureExistsResult>,
     ) -> anyhow::Result<Option<Result<bool, Resource<Error>>>> {
-        record_host_function_call("keyvalue::cache::future_exists", "future_exists_result_get");
+        self.observe_function_call("keyvalue::cache::future_exists", "future_exists_result_get");
         unimplemented!("future_exists_result_get")
     }
 
@@ -62,7 +61,7 @@ impl<Ctx: WorkerCtx> HostFutureExistsResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureExistsResult>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::cache::future_exists",
             "listen_to_future_exists_result",
         );
@@ -70,7 +69,7 @@ impl<Ctx: WorkerCtx> HostFutureExistsResult for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, _rep: Resource<FutureExistsResult>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::cache::future_exists", "drop");
+        self.observe_function_call("keyvalue::cache::future_exists", "drop");
         unimplemented!("drop")
     }
 }
@@ -81,7 +80,7 @@ impl<Ctx: WorkerCtx> HostFutureResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureResult>,
     ) -> anyhow::Result<Option<Result<(), Resource<Error>>>> {
-        record_host_function_call("keyvalue::cache::future_result", "future_result_get");
+        self.observe_function_call("keyvalue::cache::future_result", "future_result_get");
         unimplemented!("future_result_get")
     }
 
@@ -89,12 +88,12 @@ impl<Ctx: WorkerCtx> HostFutureResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureResult>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("keyvalue::cache::future_result", "listen_to_future_result");
+        self.observe_function_call("keyvalue::cache::future_result", "listen_to_future_result");
         unimplemented!("listen_to_future_result")
     }
 
     async fn drop(&mut self, _rep: Resource<FutureResult>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::cache::future_result", "drop");
+        self.observe_function_call("keyvalue::cache::future_result", "drop");
         unimplemented!("drop")
     }
 }
@@ -105,7 +104,7 @@ impl<Ctx: WorkerCtx> HostFutureGetOrSetResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureGetOrSetResult>,
     ) -> anyhow::Result<Option<Result<GetOrSetEntry, Resource<Error>>>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::cache::future_get_or_set",
             "future_get_or_set_result_get",
         );
@@ -116,7 +115,7 @@ impl<Ctx: WorkerCtx> HostFutureGetOrSetResult for DurableWorkerCtx<Ctx> {
         &mut self,
         _self_: Resource<FutureGetOrSetResult>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::cache::future_get_or_set",
             "listen_to_future_get_or_set_result",
         );
@@ -124,7 +123,7 @@ impl<Ctx: WorkerCtx> HostFutureGetOrSetResult for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, _rep: Resource<FutureGetOrSetResult>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::cache::future_get_or_set", "drop");
+        self.observe_function_call("keyvalue::cache::future_get_or_set", "drop");
         unimplemented!("drop")
     }
 }
@@ -136,12 +135,12 @@ impl<Ctx: WorkerCtx> HostVacancy for DurableWorkerCtx<Ctx> {
         _self_: Resource<Vacancy>,
         _ttl_ms: Option<u32>,
     ) -> anyhow::Result<Resource<OutgoingValue>> {
-        record_host_function_call("keyvalue::cache::vacancy", "vacancy_fill");
+        self.observe_function_call("keyvalue::cache::vacancy", "vacancy_fill");
         unimplemented!("vacancy_fill")
     }
 
     async fn drop(&mut self, _rep: Resource<Vacancy>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::cache::vacancy", "drop");
+        self.observe_function_call("keyvalue::cache::vacancy", "drop");
         unimplemented!("drop")
     }
 }
@@ -149,12 +148,12 @@ impl<Ctx: WorkerCtx> HostVacancy for DurableWorkerCtx<Ctx> {
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get(&mut self, _k: Key) -> anyhow::Result<Resource<FutureGetResult>> {
-        record_host_function_call("keyvalue::cache", "get");
+        self.observe_function_call("keyvalue::cache", "get");
         unimplemented!("get")
     }
 
     async fn exists(&mut self, _k: Key) -> anyhow::Result<Resource<FutureExistsResult>> {
-        record_host_function_call("keyvalue::cache", "exists");
+        self.observe_function_call("keyvalue::cache", "exists");
         unimplemented!("exists")
     }
 
@@ -164,17 +163,17 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         _v: Resource<OutgoingValue>,
         _ttl_ms: Option<u32>,
     ) -> anyhow::Result<Resource<FutureResult>> {
-        record_host_function_call("keyvalue::cache", "set");
+        self.observe_function_call("keyvalue::cache", "set");
         unimplemented!("set")
     }
 
     async fn get_or_set(&mut self, _k: Key) -> anyhow::Result<Resource<FutureGetOrSetResult>> {
-        record_host_function_call("keyvalue::cache", "get_or_set");
+        self.observe_function_call("keyvalue::cache", "get_or_set");
         unimplemented!("get_or_set")
     }
 
     async fn delete(&mut self, _k: Key) -> anyhow::Result<Resource<FutureResult>> {
-        record_host_function_call("keyvalue::cache", "delete");
+        self.observe_function_call("keyvalue::cache", "delete");
         unimplemented!("delete")
     }
 }

--- a/golem-worker-executor-base/src/durable_host/keyvalue/error.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/error.rs
@@ -16,15 +16,14 @@ use async_trait::async_trait;
 use wasmtime::component::Resource;
 use wasmtime_wasi::WasiView;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::wasi::keyvalue::wasi_keyvalue_error::{Error, Host, HostError};
 use crate::workerctx::WorkerCtx;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> HostError for DurableWorkerCtx<Ctx> {
     async fn trace(&mut self, self_: Resource<Error>) -> anyhow::Result<String> {
-        record_host_function_call("keyvalue::wasi_cloud_error", "trace");
+        self.observe_function_call("keyvalue::wasi_cloud_error", "trace");
         let trace = self
             .as_wasi_view()
             .table()
@@ -35,7 +34,7 @@ impl<Ctx: WorkerCtx> HostError for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<Error>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::wasi_cloud_error", "drop_error");
+        self.observe_function_call("keyvalue::wasi_cloud_error", "drop_error");
         self.as_wasi_view().table().delete::<ErrorEntry>(rep)?;
         Ok(())
     }

--- a/golem-worker-executor-base/src/durable_host/keyvalue/eventual.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/eventual.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime::component::Resource;
 use wasmtime_wasi::WasiView;
 
@@ -41,11 +41,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, Option<Vec<u8>>, SerializableError>::new(
+        let durability = Durability::<Option<Vec<u8>>, SerializableError>::new(
             self,
             "golem keyvalue::eventual",
             "get",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
 
@@ -101,11 +101,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .unwrap()
             .clone();
 
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem keyvalue::eventual",
             "set",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
 
@@ -146,11 +146,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem keyvalue::eventual",
             "delete",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
 
@@ -191,11 +191,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, bool, SerializableError>::new(
+        let durability = Durability::<bool, SerializableError>::new(
             self,
             "golem keyvalue::eventual",
             "exists",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/keyvalue/eventual_batch.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/eventual_batch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime::component::Resource;
 use wasmtime_wasi::{ResourceTableError, WasiView};
 
@@ -41,11 +41,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, Vec<Option<Vec<u8>>>, SerializableError>::new(
+        let durability = Durability::<Vec<Option<Vec<u8>>>, SerializableError>::new(
             self,
             "golem keyvalue::eventual_batch",
             "get_many",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
         let result = if durability.is_live() {
@@ -101,11 +101,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, Vec<String>, SerializableError>::new(
+        let durability = Durability::<Vec<String>, SerializableError>::new(
             self,
             "golem keyvalue::eventual_batch",
             "get_keys",
-            WrappedFunctionType::ReadRemote,
+            DurableFunctionType::ReadRemote,
         )
         .await?;
         let keys = if durability.is_live() {
@@ -149,11 +149,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             })
             .collect::<Result<Vec<(String, Vec<u8>)>, ResourceTableError>>()?;
 
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem keyvalue::eventual_batch",
             "set_many",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
 
@@ -200,11 +200,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .name
             .clone();
 
-        let durability = Durability::<Ctx, (), SerializableError>::new(
+        let durability = Durability::<(), SerializableError>::new(
             self,
             "golem keyvalue::eventual_batch",
             "delete_many",
-            WrappedFunctionType::WriteRemote,
+            DurableFunctionType::WriteRemote,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/keyvalue/types.rs
+++ b/golem-worker-executor-base/src/durable_host/keyvalue/types.rs
@@ -15,8 +15,7 @@
 use std::any::Any;
 use std::sync::{Arc, RwLock};
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::wasi::keyvalue::types::{
     Error, Host, HostBucket, HostIncomingValue, HostOutgoingValue, IncomingValue,
     IncomingValueAsyncBody, IncomingValueSyncBody, OutgoingValueBodyAsync, OutgoingValueBodySync,
@@ -35,13 +34,13 @@ impl<Ctx: WorkerCtx> HostBucket for DurableWorkerCtx<Ctx> {
         &mut self,
         name: String,
     ) -> anyhow::Result<Result<Resource<BucketEntry>, Resource<Error>>> {
-        record_host_function_call("keyvalue::types::bucket", "open");
+        self.observe_function_call("keyvalue::types::bucket", "open");
         let bucket = self.as_wasi_view().table().push(BucketEntry::new(name))?;
         Ok(Ok(bucket))
     }
 
     async fn drop(&mut self, rep: Resource<BucketEntry>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::types::bucket", "drop");
+        self.observe_function_call("keyvalue::types::bucket", "drop");
         self.as_wasi_view().table().delete::<BucketEntry>(rep)?;
         Ok(())
     }
@@ -50,7 +49,7 @@ impl<Ctx: WorkerCtx> HostBucket for DurableWorkerCtx<Ctx> {
 #[async_trait]
 impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
     async fn new_outgoing_value(&mut self) -> anyhow::Result<Resource<OutgoingValueEntry>> {
-        record_host_function_call("keyvalue::types::outgoing_value", "new_outgoing_value");
+        self.observe_function_call("keyvalue::types::outgoing_value", "new_outgoing_value");
         let outgoing_value = self
             .as_wasi_view()
             .table()
@@ -62,7 +61,7 @@ impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<OutgoingValueEntry>,
     ) -> anyhow::Result<Result<Resource<OutgoingValueBodyAsync>, Resource<Error>>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::types::outgoing_value",
             "outgoing_value_write_body_async",
         );
@@ -82,7 +81,7 @@ impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
         self_: Resource<OutgoingValueEntry>,
         value: OutgoingValueBodySync,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::types::outgoing_value",
             "outgoing_value_write_body_sync",
         );
@@ -97,7 +96,7 @@ impl<Ctx: WorkerCtx> HostOutgoingValue for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<OutgoingValueEntry>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::types::outgoing_value", "drop");
+        self.observe_function_call("keyvalue::types::outgoing_value", "drop");
         self.as_wasi_view()
             .table()
             .delete::<OutgoingValueEntry>(rep)?;
@@ -111,7 +110,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingValue>,
     ) -> anyhow::Result<Result<IncomingValueSyncBody, Resource<Error>>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::types::incoming_value",
             "incoming_value_consume_sync",
         );
@@ -129,7 +128,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingValue>,
     ) -> anyhow::Result<Result<Resource<IncomingValueAsyncBody>, Resource<Error>>> {
-        record_host_function_call(
+        self.observe_function_call(
             "keyvalue::types::incoming_value",
             "incoming_value_consume_async",
         );
@@ -148,7 +147,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingValue>,
     ) -> anyhow::Result<Result<u64, Resource<Error>>> {
-        record_host_function_call("keyvalue::types::incoming_value", "size");
+        self.observe_function_call("keyvalue::types::incoming_value", "size");
         let body = self
             .as_wasi_view()
             .table()
@@ -160,7 +159,7 @@ impl<Ctx: WorkerCtx> HostIncomingValue for DurableWorkerCtx<Ctx> {
     }
 
     async fn drop(&mut self, rep: Resource<IncomingValue>) -> anyhow::Result<()> {
-        record_host_function_call("keyvalue::types::incoming_value", "drop");
+        self.observe_function_call("keyvalue::types::incoming_value", "drop");
         self.as_wasi_view()
             .table()
             .delete::<IncomingValueEntry>(rep)?;

--- a/golem-worker-executor-base/src/durable_host/logging/logging.rs
+++ b/golem-worker-executor-base/src/durable_host/logging/logging.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::wasi::logging::logging::{Host, Level};
 use crate::workerctx::WorkerCtx;
 use async_trait::async_trait;
@@ -22,7 +21,7 @@ use golem_common::model::{LogLevel, WorkerEvent};
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn log(&mut self, level: Level, context: String, message: String) -> anyhow::Result<()> {
-        record_host_function_call("logging::handler", "log");
+        self.observe_function_call("logging::handler", "log");
 
         let log_level = match level {
             Level::Critical => LogLevel::Critical,

--- a/golem-worker-executor-base/src/durable_host/random/insecure.rs
+++ b/golem-worker-executor-base/src/durable_host/random/insecure.rs
@@ -17,17 +17,17 @@ use async_trait::async_trait;
 use crate::durable_host::serialized::SerializableError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::random::insecure::Host;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        let durability = Durability::<Ctx, Vec<u8>, SerializableError>::new(
+        let durability = Durability::<Vec<u8>, SerializableError>::new(
             self,
             "golem random::insecure",
             "get_insecure_random_bytes",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 
@@ -40,11 +40,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn get_insecure_random_u64(&mut self) -> anyhow::Result<u64> {
-        let durability = Durability::<Ctx, u64, SerializableError>::new(
+        let durability = Durability::<u64, SerializableError>::new(
             self,
             "golem random::insecure",
             "get_insecure_random_u64",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
 

--- a/golem-worker-executor-base/src/durable_host/random/insecure_seed.rs
+++ b/golem-worker-executor-base/src/durable_host/random/insecure_seed.rs
@@ -17,17 +17,17 @@ use async_trait::async_trait;
 use crate::durable_host::serialized::SerializableError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::random::insecure_seed::Host;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
-        let durability = Durability::<Ctx, (u64, u64), SerializableError>::new(
+        let durability = Durability::<(u64, u64), SerializableError>::new(
             self,
             "golem random::insecure_seed",
             "insecure_seed",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
         if durability.is_live() {

--- a/golem-worker-executor-base/src/durable_host/random/random.rs
+++ b/golem-worker-executor-base/src/durable_host/random/random.rs
@@ -17,17 +17,17 @@ use async_trait::async_trait;
 use crate::durable_host::serialized::SerializableError;
 use crate::durable_host::{Durability, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
-use golem_common::model::oplog::WrappedFunctionType;
+use golem_common::model::oplog::DurableFunctionType;
 use wasmtime_wasi::bindings::random::random::Host;
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        let durability = Durability::<Ctx, Vec<u8>, SerializableError>::new(
+        let durability = Durability::<Vec<u8>, SerializableError>::new(
             self,
             "golem random",
             "get_random_bytes",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
         if durability.is_live() {
@@ -39,11 +39,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn get_random_u64(&mut self) -> anyhow::Result<u64> {
-        let durability = Durability::<Ctx, u64, SerializableError>::new(
+        let durability = Durability::<u64, SerializableError>::new(
             self,
             "golem random",
             "get_random_u64",
-            WrappedFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal,
         )
         .await?;
         if durability.is_live() {

--- a/golem-worker-executor-base/src/durable_host/sockets/instance_network.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/instance_network.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::instance_network::{Host, Network};
 
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn instance_network(&mut self) -> anyhow::Result<Resource<Network>> {
-        record_host_function_call("sockets::instance_network", "instance_network");
+        self.observe_function_call("sockets::instance_network", "instance_network");
         Host::instance_network(&mut self.as_wasi_view())
     }
 }

--- a/golem-worker-executor-base/src/durable_host/sockets/network.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/network.rs
@@ -15,15 +15,14 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::network::{Error, ErrorCode, Host, HostNetwork, Network};
 use wasmtime_wasi::SocketError;
 
 impl<Ctx: WorkerCtx> HostNetwork for DurableWorkerCtx<Ctx> {
     fn drop(&mut self, rep: Resource<Network>) -> anyhow::Result<()> {
-        record_host_function_call("sockets::network", "drop_network");
+        self.observe_function_call("sockets::network", "drop_network");
         HostNetwork::drop(&mut self.as_wasi_view(), rep)
     }
 }
@@ -31,12 +30,12 @@ impl<Ctx: WorkerCtx> HostNetwork for DurableWorkerCtx<Ctx> {
 #[async_trait]
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     fn network_error_code(&mut self, err: Resource<Error>) -> anyhow::Result<Option<ErrorCode>> {
-        record_host_function_call("sockets::network", "network_error_code");
+        self.observe_function_call("sockets::network", "network_error_code");
         Host::network_error_code(&mut self.as_wasi_view(), err)
     }
 
     fn convert_error_code(&mut self, err: SocketError) -> anyhow::Result<ErrorCode> {
-        record_host_function_call("sockets::network", "convert_error_code");
+        self.observe_function_call("sockets::network", "convert_error_code");
         Host::convert_error_code(&mut self.as_wasi_view(), err)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/sockets/tcp.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/tcp.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::tcp::{
     Duration, Host, HostTcpSocket, InputStream, IpAddressFamily, IpSocketAddress, Network,
@@ -32,12 +31,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "start_bind");
+        self.observe_function_call("sockets::tcp", "start_bind");
         HostTcpSocket::start_bind(&mut self.as_wasi_view(), self_, network, local_address).await
     }
 
     fn finish_bind(&mut self, self_: Resource<TcpSocket>) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "finish_bind");
+        self.observe_function_call("sockets::tcp", "finish_bind");
         HostTcpSocket::finish_bind(&mut self.as_wasi_view(), self_)
     }
 
@@ -47,7 +46,7 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         network: Resource<Network>,
         remote_address: IpSocketAddress,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "start_connect");
+        self.observe_function_call("sockets::tcp", "start_connect");
         HostTcpSocket::start_connect(&mut self.as_wasi_view(), self_, network, remote_address).await
     }
 
@@ -55,17 +54,17 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<TcpSocket>,
     ) -> Result<(Resource<InputStream>, Resource<OutputStream>), SocketError> {
-        record_host_function_call("sockets::tcp", "finish_connect");
+        self.observe_function_call("sockets::tcp", "finish_connect");
         HostTcpSocket::finish_connect(&mut self.as_wasi_view(), self_)
     }
 
     fn start_listen(&mut self, self_: Resource<TcpSocket>) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "start_listen");
+        self.observe_function_call("sockets::tcp", "start_listen");
         HostTcpSocket::start_listen(&mut self.as_wasi_view(), self_)
     }
 
     fn finish_listen(&mut self, self_: Resource<TcpSocket>) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "finish_listen");
+        self.observe_function_call("sockets::tcp", "finish_listen");
         HostTcpSocket::finish_listen(&mut self.as_wasi_view(), self_)
     }
 
@@ -80,7 +79,7 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         ),
         SocketError,
     > {
-        record_host_function_call("sockets::tcp", "accept");
+        self.observe_function_call("sockets::tcp", "accept");
         HostTcpSocket::accept(&mut self.as_wasi_view(), self_)
     }
 
@@ -88,7 +87,7 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<TcpSocket>,
     ) -> Result<IpSocketAddress, SocketError> {
-        record_host_function_call("sockets::tcp", "local_address");
+        self.observe_function_call("sockets::tcp", "local_address");
         HostTcpSocket::local_address(&mut self.as_wasi_view(), self_)
     }
 
@@ -96,17 +95,17 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<TcpSocket>,
     ) -> Result<IpSocketAddress, SocketError> {
-        record_host_function_call("sockets::tcp", "remote_address");
+        self.observe_function_call("sockets::tcp", "remote_address");
         HostTcpSocket::remote_address(&mut self.as_wasi_view(), self_)
     }
 
     fn is_listening(&mut self, self_: Resource<TcpSocket>) -> anyhow::Result<bool> {
-        record_host_function_call("sockets::tcp", "is_listening");
+        self.observe_function_call("sockets::tcp", "is_listening");
         HostTcpSocket::is_listening(&mut self.as_wasi_view(), self_)
     }
 
     fn address_family(&mut self, self_: Resource<TcpSocket>) -> anyhow::Result<IpAddressFamily> {
-        record_host_function_call("sockets::tcp", "address_family");
+        self.observe_function_call("sockets::tcp", "address_family");
         HostTcpSocket::address_family(&mut self.as_wasi_view(), self_)
     }
 
@@ -115,12 +114,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: u64,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_listen_backlog_size");
+        self.observe_function_call("sockets::tcp", "set_listen_backlog_size");
         HostTcpSocket::set_listen_backlog_size(&mut self.as_wasi_view(), self_, value)
     }
 
     fn keep_alive_enabled(&mut self, self_: Resource<TcpSocket>) -> Result<bool, SocketError> {
-        record_host_function_call("sockets::tcp", "keep_alive_enabled");
+        self.observe_function_call("sockets::tcp", "keep_alive_enabled");
         HostTcpSocket::keep_alive_enabled(&mut self.as_wasi_view(), self_)
     }
 
@@ -129,7 +128,7 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: bool,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_keep_alive_enabled");
+        self.observe_function_call("sockets::tcp", "set_keep_alive_enabled");
         HostTcpSocket::set_keep_alive_enabled(&mut self.as_wasi_view(), self_, value)
     }
 
@@ -137,7 +136,7 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<TcpSocket>,
     ) -> Result<Duration, SocketError> {
-        record_host_function_call("sockets::tcp", "keep_alive_idle_time");
+        self.observe_function_call("sockets::tcp", "keep_alive_idle_time");
         HostTcpSocket::keep_alive_idle_time(&mut self.as_wasi_view(), self_)
     }
 
@@ -146,12 +145,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: Duration,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_keep_alive_idle_time");
+        self.observe_function_call("sockets::tcp", "set_keep_alive_idle_time");
         HostTcpSocket::set_keep_alive_idle_time(&mut self.as_wasi_view(), self_, value)
     }
 
     fn keep_alive_interval(&mut self, self_: Resource<TcpSocket>) -> Result<Duration, SocketError> {
-        record_host_function_call("sockets::tcp", "keep_alive_interval");
+        self.observe_function_call("sockets::tcp", "keep_alive_interval");
         HostTcpSocket::keep_alive_interval(&mut self.as_wasi_view(), self_)
     }
 
@@ -160,12 +159,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: Duration,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_keep_alive_interval");
+        self.observe_function_call("sockets::tcp", "set_keep_alive_interval");
         HostTcpSocket::set_keep_alive_interval(&mut self.as_wasi_view(), self_, value)
     }
 
     fn keep_alive_count(&mut self, self_: Resource<TcpSocket>) -> Result<u32, SocketError> {
-        record_host_function_call("sockets::tcp", "keep_alive_count");
+        self.observe_function_call("sockets::tcp", "keep_alive_count");
         HostTcpSocket::keep_alive_count(&mut self.as_wasi_view(), self_)
     }
 
@@ -174,22 +173,22 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: u32,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_keep_alive_count");
+        self.observe_function_call("sockets::tcp", "set_keep_alive_count");
         HostTcpSocket::set_keep_alive_count(&mut self.as_wasi_view(), self_, value)
     }
 
     fn hop_limit(&mut self, self_: Resource<TcpSocket>) -> Result<u8, SocketError> {
-        record_host_function_call("sockets::tcp", "hop_limit");
+        self.observe_function_call("sockets::tcp", "hop_limit");
         HostTcpSocket::hop_limit(&mut self.as_wasi_view(), self_)
     }
 
     fn set_hop_limit(&mut self, self_: Resource<TcpSocket>, value: u8) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_hop_limit");
+        self.observe_function_call("sockets::tcp", "set_hop_limit");
         HostTcpSocket::set_hop_limit(&mut self.as_wasi_view(), self_, value)
     }
 
     fn receive_buffer_size(&mut self, self_: Resource<TcpSocket>) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::tcp", "receive_buffer_size");
+        self.observe_function_call("sockets::tcp", "receive_buffer_size");
         HostTcpSocket::receive_buffer_size(&mut self.as_wasi_view(), self_)
     }
 
@@ -198,12 +197,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: u64,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_receive_buffer_size");
+        self.observe_function_call("sockets::tcp", "set_receive_buffer_size");
         HostTcpSocket::set_receive_buffer_size(&mut self.as_wasi_view(), self_, value)
     }
 
     fn send_buffer_size(&mut self, self_: Resource<TcpSocket>) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::tcp", "send_buffer_size");
+        self.observe_function_call("sockets::tcp", "send_buffer_size");
         HostTcpSocket::send_buffer_size(&mut self.as_wasi_view(), self_)
     }
 
@@ -212,12 +211,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         value: u64,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "set_send_buffer_size");
+        self.observe_function_call("sockets::tcp", "set_send_buffer_size");
         HostTcpSocket::set_send_buffer_size(&mut self.as_wasi_view(), self_, value)
     }
 
     fn subscribe(&mut self, self_: Resource<TcpSocket>) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("sockets::tcp", "subscribe");
+        self.observe_function_call("sockets::tcp", "subscribe");
         HostTcpSocket::subscribe(&mut self.as_wasi_view(), self_)
     }
 
@@ -226,12 +225,12 @@ impl<Ctx: WorkerCtx> HostTcpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<TcpSocket>,
         shutdown_type: ShutdownType,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::tcp", "shutdown");
+        self.observe_function_call("sockets::tcp", "shutdown");
         HostTcpSocket::shutdown(&mut self.as_wasi_view(), self_, shutdown_type)
     }
 
     fn drop(&mut self, rep: Resource<TcpSocket>) -> anyhow::Result<()> {
-        record_host_function_call("sockets::tcp", "drop");
+        self.observe_function_call("sockets::tcp", "drop");
         HostTcpSocket::drop(&mut self.as_wasi_view(), rep)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/sockets/tcp_create_socket.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/tcp_create_socket.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::tcp_create_socket::{Host, IpAddressFamily, TcpSocket};
 use wasmtime_wasi::SocketError;
@@ -27,7 +26,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> Result<Resource<TcpSocket>, SocketError> {
-        record_host_function_call("sockets::tcp_create_socket", "create_tcp_socket");
+        self.observe_function_call("sockets::tcp_create_socket", "create_tcp_socket");
         Host::create_tcp_socket(&mut self.as_wasi_view(), address_family)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/sockets/udp.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/udp.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::udp::{
     Host, HostIncomingDatagramStream, HostOutgoingDatagramStream, HostUdpSocket, IncomingDatagram,
@@ -33,12 +32,12 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::udp", "start_bind");
+        self.observe_function_call("sockets::udp", "start_bind");
         HostUdpSocket::start_bind(&mut self.as_wasi_view(), self_, network, local_address).await
     }
 
     fn finish_bind(&mut self, self_: Resource<UdpSocket>) -> Result<(), SocketError> {
-        record_host_function_call("sockets::udp", "finish_bind");
+        self.observe_function_call("sockets::udp", "finish_bind");
         HostUdpSocket::finish_bind(&mut self.as_wasi_view(), self_)
     }
 
@@ -53,7 +52,7 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         ),
         SocketError,
     > {
-        record_host_function_call("sockets::udp", "stream");
+        self.observe_function_call("sockets::udp", "stream");
         HostUdpSocket::stream(&mut self.as_wasi_view(), self_, remote_address).await
     }
 
@@ -61,7 +60,7 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<UdpSocket>,
     ) -> Result<IpSocketAddress, SocketError> {
-        record_host_function_call("sockets::udp", "local_address");
+        self.observe_function_call("sockets::udp", "local_address");
         HostUdpSocket::local_address(&mut self.as_wasi_view(), self_)
     }
 
@@ -69,17 +68,17 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<UdpSocket>,
     ) -> Result<IpSocketAddress, SocketError> {
-        record_host_function_call("sockets::udp", "remote_address");
+        self.observe_function_call("sockets::udp", "remote_address");
         HostUdpSocket::remote_address(&mut self.as_wasi_view(), self_)
     }
 
     fn address_family(&mut self, self_: Resource<UdpSocket>) -> anyhow::Result<IpAddressFamily> {
-        record_host_function_call("sockets::udp", "address_family");
+        self.observe_function_call("sockets::udp", "address_family");
         HostUdpSocket::address_family(&mut self.as_wasi_view(), self_)
     }
 
     fn unicast_hop_limit(&mut self, self_: Resource<UdpSocket>) -> Result<u8, SocketError> {
-        record_host_function_call("sockets::udp", "unicast_hop_limit");
+        self.observe_function_call("sockets::udp", "unicast_hop_limit");
         HostUdpSocket::unicast_hop_limit(&mut self.as_wasi_view(), self_)
     }
 
@@ -88,12 +87,12 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<UdpSocket>,
         value: u8,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::udp", "set_unicast_hop_limit");
+        self.observe_function_call("sockets::udp", "set_unicast_hop_limit");
         HostUdpSocket::set_unicast_hop_limit(&mut self.as_wasi_view(), self_, value)
     }
 
     fn receive_buffer_size(&mut self, self_: Resource<UdpSocket>) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::udp", "receive_buffer_size");
+        self.observe_function_call("sockets::udp", "receive_buffer_size");
         HostUdpSocket::receive_buffer_size(&mut self.as_wasi_view(), self_)
     }
 
@@ -102,12 +101,12 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<UdpSocket>,
         value: u64,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::udp", "set_receive_buffer_size");
+        self.observe_function_call("sockets::udp", "set_receive_buffer_size");
         HostUdpSocket::set_receive_buffer_size(&mut self.as_wasi_view(), self_, value)
     }
 
     fn send_buffer_size(&mut self, self_: Resource<UdpSocket>) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::udp", "send_buffer_size");
+        self.observe_function_call("sockets::udp", "send_buffer_size");
         HostUdpSocket::send_buffer_size(&mut self.as_wasi_view(), self_)
     }
 
@@ -116,17 +115,17 @@ impl<Ctx: WorkerCtx> HostUdpSocket for DurableWorkerCtx<Ctx> {
         self_: Resource<UdpSocket>,
         value: u64,
     ) -> Result<(), SocketError> {
-        record_host_function_call("sockets::udp", "set_send_buffer_size");
+        self.observe_function_call("sockets::udp", "set_send_buffer_size");
         HostUdpSocket::set_send_buffer_size(&mut self.as_wasi_view(), self_, value)
     }
 
     fn subscribe(&mut self, self_: Resource<UdpSocket>) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("sockets::udp", "subscribe");
+        self.observe_function_call("sockets::udp", "subscribe");
         HostUdpSocket::subscribe(&mut self.as_wasi_view(), self_)
     }
 
     fn drop(&mut self, rep: Resource<UdpSocket>) -> anyhow::Result<()> {
-        record_host_function_call("sockets::udp", "drop");
+        self.observe_function_call("sockets::udp", "drop");
         HostUdpSocket::drop(&mut self.as_wasi_view(), rep)
     }
 }
@@ -137,7 +136,7 @@ impl<Ctx: WorkerCtx> HostIncomingDatagramStream for DurableWorkerCtx<Ctx> {
         self_: Resource<IncomingDatagramStream>,
         max_results: u64,
     ) -> Result<Vec<IncomingDatagram>, SocketError> {
-        record_host_function_call("sockets::udp", "receive");
+        self.observe_function_call("sockets::udp", "receive");
         HostIncomingDatagramStream::receive(&mut self.as_wasi_view(), self_, max_results)
     }
 
@@ -145,12 +144,12 @@ impl<Ctx: WorkerCtx> HostIncomingDatagramStream for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<IncomingDatagramStream>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("sockets::udp", "subscribe");
+        self.observe_function_call("sockets::udp", "subscribe");
         HostIncomingDatagramStream::subscribe(&mut self.as_wasi_view(), self_)
     }
 
     fn drop(&mut self, rep: Resource<IncomingDatagramStream>) -> anyhow::Result<()> {
-        record_host_function_call("sockets::udp", "drop");
+        self.observe_function_call("sockets::udp", "drop");
         HostIncomingDatagramStream::drop(&mut self.as_wasi_view(), rep)
     }
 }
@@ -158,7 +157,7 @@ impl<Ctx: WorkerCtx> HostIncomingDatagramStream for DurableWorkerCtx<Ctx> {
 #[async_trait]
 impl<Ctx: WorkerCtx> HostOutgoingDatagramStream for DurableWorkerCtx<Ctx> {
     fn check_send(&mut self, self_: Resource<OutgoingDatagramStream>) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::udp", "check_send");
+        self.observe_function_call("sockets::udp", "check_send");
         HostOutgoingDatagramStream::check_send(&mut self.as_wasi_view(), self_)
     }
 
@@ -167,7 +166,7 @@ impl<Ctx: WorkerCtx> HostOutgoingDatagramStream for DurableWorkerCtx<Ctx> {
         self_: Resource<OutgoingDatagramStream>,
         datagrams: Vec<OutgoingDatagram>,
     ) -> Result<u64, SocketError> {
-        record_host_function_call("sockets::udp", "send");
+        self.observe_function_call("sockets::udp", "send");
         HostOutgoingDatagramStream::send(&mut self.as_wasi_view(), self_, datagrams).await
     }
 
@@ -175,12 +174,12 @@ impl<Ctx: WorkerCtx> HostOutgoingDatagramStream for DurableWorkerCtx<Ctx> {
         &mut self,
         self_: Resource<OutgoingDatagramStream>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        record_host_function_call("sockets::udp", "subscribe");
+        self.observe_function_call("sockets::udp", "subscribe");
         HostOutgoingDatagramStream::subscribe(&mut self.as_wasi_view(), self_)
     }
 
     fn drop(&mut self, rep: Resource<OutgoingDatagramStream>) -> anyhow::Result<()> {
-        record_host_function_call("sockets::udp", "drop");
+        self.observe_function_call("sockets::udp", "drop");
         HostOutgoingDatagramStream::drop(&mut self.as_wasi_view(), rep)
     }
 }

--- a/golem-worker-executor-base/src/durable_host/sockets/udp_create_socket.rs
+++ b/golem-worker-executor-base/src/durable_host/sockets/udp_create_socket.rs
@@ -15,8 +15,7 @@
 use async_trait::async_trait;
 use wasmtime::component::Resource;
 
-use crate::durable_host::DurableWorkerCtx;
-use crate::metrics::wasm::record_host_function_call;
+use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
 use wasmtime_wasi::bindings::sockets::udp_create_socket::{Host, IpAddressFamily, UdpSocket};
 use wasmtime_wasi::SocketError;
@@ -27,7 +26,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> Result<Resource<UdpSocket>, SocketError> {
-        record_host_function_call("sockets::udp_create_socket", "create_udp_socket");
+        self.observe_function_call("sockets::udp_create_socket", "create_udp_socket");
         Host::create_udp_socket(&mut self.as_wasi_view(), address_family)
     }
 }

--- a/golem-worker-executor-base/src/model/mod.rs
+++ b/golem-worker-executor-base/src/model/mod.rs
@@ -296,7 +296,7 @@ impl Display for LastError {
     }
 }
 
-#[derive(Clone, Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 pub enum PersistenceLevel {
     PersistNothing,
     PersistRemoteSideEffects,

--- a/golem-worker-executor-base/src/model/public_oplog/wit.rs
+++ b/golem-worker-executor-base/src/model/public_oplog/wit.rs
@@ -22,7 +22,7 @@ use golem_common::model::public_oplog::{
     ExportedFunctionParameters, FailedUpdateParameters, GrowMemoryParameters,
     ImportedFunctionInvokedParameters, JumpParameters, LogParameters, ManualUpdateParameters,
     PendingUpdateParameters, PendingWorkerInvocationParameters, PluginInstallationDescription,
-    PublicRetryConfig, PublicWorkerInvocation, PublicWrappedFunctionType, ResourceParameters,
+    PublicDurableFunctionType, PublicRetryConfig, PublicWorkerInvocation, ResourceParameters,
     SnapshotBasedUpdateParameters, SuccessfulUpdateParameters, TimestampParameter,
     WriteRemoteBatchedParameters,
 };
@@ -253,14 +253,14 @@ impl From<Timestamp> for Datetime {
     }
 }
 
-impl From<PublicWrappedFunctionType> for oplog::WrappedFunctionType {
-    fn from(value: PublicWrappedFunctionType) -> Self {
+impl From<PublicDurableFunctionType> for oplog::WrappedFunctionType {
+    fn from(value: PublicDurableFunctionType) -> Self {
         match value {
-            PublicWrappedFunctionType::WriteLocal(_) => Self::WriteLocal,
-            PublicWrappedFunctionType::ReadLocal(_) => Self::ReadLocal,
-            PublicWrappedFunctionType::WriteRemote(_) => Self::WriteRemote,
-            PublicWrappedFunctionType::ReadRemote(_) => Self::ReadRemote,
-            PublicWrappedFunctionType::WriteRemoteBatched(WriteRemoteBatchedParameters {
+            PublicDurableFunctionType::WriteLocal(_) => Self::WriteLocal,
+            PublicDurableFunctionType::ReadLocal(_) => Self::ReadLocal,
+            PublicDurableFunctionType::WriteRemote(_) => Self::WriteRemote,
+            PublicDurableFunctionType::ReadRemote(_) => Self::ReadRemote,
+            PublicDurableFunctionType::WriteRemoteBatched(WriteRemoteBatchedParameters {
                 index: idx,
             }) => Self::WriteRemoteBatched(idx.map(|idx| idx.into())),
         }

--- a/golem-worker-executor-base/src/services/oplog/tests.rs
+++ b/golem-worker-executor-base/src/services/oplog/tests.rs
@@ -443,7 +443,7 @@ async fn entries_with_small_payload(_tracing: &Tracing) {
                 "f1".to_string(),
                 &"request".to_string(),
                 &"response".to_string(),
-                WrappedFunctionType::ReadRemote,
+                DurableFunctionType::ReadRemote,
             )
             .await
             .unwrap(),
@@ -562,7 +562,7 @@ async fn entries_with_large_payload(_tracing: &Tracing) {
                 "f1".to_string(),
                 &"request".to_string(),
                 &large_payload1,
-                WrappedFunctionType::ReadRemote,
+                DurableFunctionType::ReadRemote,
             )
             .await
             .unwrap(),
@@ -753,7 +753,7 @@ async fn multilayer_transfers_entries_after_limit_reached(
                     "test-function".to_string(),
                     &"request".to_string(),
                     &i,
-                    WrappedFunctionType::ReadLocal,
+                    DurableFunctionType::ReadLocal,
                 )
                 .await
                 .unwrap(),

--- a/golem-worker-executor-base/tests/compatibility/v1.rs
+++ b/golem-worker-executor-base/tests/compatibility/v1.rs
@@ -24,9 +24,8 @@ use test_r::test;
 use bincode::{Decode, Encode};
 use goldenfile::Mint;
 use golem_common::model::oplog::{
-    IndexedResourceKey, LogLevel, OplogEntry, OplogIndex, OplogPayload, PayloadId,
-    TimestampedUpdateDescription, UpdateDescription, WorkerError, WorkerResourceId,
-    WrappedFunctionType,
+    DurableFunctionType, IndexedResourceKey, LogLevel, OplogEntry, OplogIndex, OplogPayload,
+    PayloadId, TimestampedUpdateDescription, UpdateDescription, WorkerError, WorkerResourceId,
 };
 use golem_common::model::regions::{DeletedRegions, OplogRegion};
 use golem_common::model::RetryConfig;
@@ -603,32 +602,32 @@ pub fn wrapped_function_type() {
     backward_compatible(
         "wrapped_function_type_read_local",
         &mut mint,
-        WrappedFunctionType::ReadLocal,
+        DurableFunctionType::ReadLocal,
     );
     backward_compatible(
         "wrapped_function_type_read_remote",
         &mut mint,
-        WrappedFunctionType::ReadRemote,
+        DurableFunctionType::ReadRemote,
     );
     backward_compatible(
         "wrapped_function_type_write_local",
         &mut mint,
-        WrappedFunctionType::WriteLocal,
+        DurableFunctionType::WriteLocal,
     );
     backward_compatible(
         "wrapped_function_type_write_remote",
         &mut mint,
-        WrappedFunctionType::WriteRemote,
+        DurableFunctionType::WriteRemote,
     );
     backward_compatible(
         "wrapped_function_type_write_remote_batched_none",
         &mut mint,
-        WrappedFunctionType::WriteRemoteBatched(None),
+        DurableFunctionType::WriteRemoteBatched(None),
     );
     backward_compatible(
         "wrapped_function_type_write_remote_batched_some",
         &mut mint,
-        WrappedFunctionType::WriteRemoteBatched(Some(OplogIndex::from_u64(100))),
+        DurableFunctionType::WriteRemoteBatched(Some(OplogIndex::from_u64(100))),
     );
 }
 
@@ -713,7 +712,7 @@ pub fn oplog_entry() {
         timestamp: Timestamp::from(1724701938466),
         function_name: "test:pkg/iface.{fn}".to_string(),
         response: OplogPayload::Inline(vec![0, 1, 2, 3, 4]),
-        wrapped_function_type: WrappedFunctionType::ReadLocal,
+        wrapped_function_type: DurableFunctionType::ReadLocal,
     };
 
     let oe3 = OplogEntry::ExportedFunctionInvoked {

--- a/golem-worker-executor-base/tests/compatibility/v1_1.rs
+++ b/golem-worker-executor-base/tests/compatibility/v1_1.rs
@@ -18,7 +18,7 @@ use test_r::test;
 use crate::compatibility::v1::backward_compatible;
 use goldenfile::Mint;
 use golem_common::model::oplog::{
-    IndexedResourceKey, OplogEntry, OplogIndex, OplogPayload, WorkerResourceId, WrappedFunctionType,
+    DurableFunctionType, IndexedResourceKey, OplogEntry, OplogIndex, OplogPayload, WorkerResourceId,
 };
 use golem_common::model::RetryConfig;
 use golem_common::model::{
@@ -52,7 +52,7 @@ pub fn oplog_entry() {
         function_name: "test:pkg/iface.{fn}".to_string(),
         request: OplogPayload::Inline(vec![5, 6, 7, 8, 9]),
         response: OplogPayload::Inline(vec![0, 1, 2, 3, 4]),
-        wrapped_function_type: WrappedFunctionType::ReadLocal,
+        wrapped_function_type: DurableFunctionType::ReadLocal,
     };
     let oe27a = OplogEntry::Create {
         timestamp: Timestamp::from(1724701938466),

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -4729,7 +4729,7 @@ components:
         response:
           $ref: '#/components/schemas/ValueAndType'
         wrapped_function_type:
-          $ref: '#/components/schemas/PublicWrappedFunctionType'
+          $ref: '#/components/schemas/PublicDurableFunctionType'
       required:
       - timestamp
       - function_name
@@ -4955,6 +4955,46 @@ components:
       - Facebook
       - Microsoft
       - Gitlab
+    PublicDurableFunctionType:
+      discriminator:
+        propertyName: type
+        mapping:
+          ReadLocal: '#/components/schemas/PublicDurableFunctionType_Empty'
+          WriteLocal: '#/components/schemas/PublicDurableFunctionType_Empty'
+          ReadRemote: '#/components/schemas/PublicDurableFunctionType_Empty'
+          WriteRemote: '#/components/schemas/PublicDurableFunctionType_Empty'
+          WriteRemoteBatched: '#/components/schemas/PublicDurableFunctionType_WriteRemoteBatchedParameters'
+      type: object
+      oneOf:
+      - $ref: '#/components/schemas/PublicDurableFunctionType_Empty'
+      - $ref: '#/components/schemas/PublicDurableFunctionType_Empty'
+      - $ref: '#/components/schemas/PublicDurableFunctionType_Empty'
+      - $ref: '#/components/schemas/PublicDurableFunctionType_Empty'
+      - $ref: '#/components/schemas/PublicDurableFunctionType_WriteRemoteBatchedParameters'
+    PublicDurableFunctionType_Empty:
+      allOf:
+      - type: object
+        properties:
+          type:
+            example: WriteRemote
+            type: string
+            enum:
+            - WriteRemote
+        required:
+        - type
+      - $ref: '#/components/schemas/Empty'
+    PublicDurableFunctionType_WriteRemoteBatchedParameters:
+      allOf:
+      - type: object
+        properties:
+          type:
+            example: WriteRemoteBatched
+            type: string
+            enum:
+            - WriteRemoteBatched
+        required:
+        - type
+      - $ref: '#/components/schemas/WriteRemoteBatchedParameters'
     PublicOplogEntry:
       description: |-
         A mirror of the core `OplogEntry` type, without the undefined arbitrary payloads.
@@ -5354,46 +5394,6 @@ components:
         required:
         - type
       - $ref: '#/components/schemas/ManualUpdateParameters'
-    PublicWrappedFunctionType:
-      discriminator:
-        propertyName: type
-        mapping:
-          ReadLocal: '#/components/schemas/PublicWrappedFunctionType_Empty'
-          WriteLocal: '#/components/schemas/PublicWrappedFunctionType_Empty'
-          ReadRemote: '#/components/schemas/PublicWrappedFunctionType_Empty'
-          WriteRemote: '#/components/schemas/PublicWrappedFunctionType_Empty'
-          WriteRemoteBatched: '#/components/schemas/PublicWrappedFunctionType_WriteRemoteBatchedParameters'
-      type: object
-      oneOf:
-      - $ref: '#/components/schemas/PublicWrappedFunctionType_Empty'
-      - $ref: '#/components/schemas/PublicWrappedFunctionType_Empty'
-      - $ref: '#/components/schemas/PublicWrappedFunctionType_Empty'
-      - $ref: '#/components/schemas/PublicWrappedFunctionType_Empty'
-      - $ref: '#/components/schemas/PublicWrappedFunctionType_WriteRemoteBatchedParameters'
-    PublicWrappedFunctionType_Empty:
-      allOf:
-      - type: object
-        properties:
-          type:
-            example: WriteRemote
-            type: string
-            enum:
-            - WriteRemote
-        required:
-        - type
-      - $ref: '#/components/schemas/Empty'
-    PublicWrappedFunctionType_WriteRemoteBatchedParameters:
-      allOf:
-      - type: object
-        properties:
-          type:
-            example: WriteRemoteBatched
-            type: string
-            enum:
-            - WriteRemoteBatched
-        required:
-        - type
-      - $ref: '#/components/schemas/WriteRemoteBatchedParameters'
     ResourceMetadata:
       type: object
       properties:


### PR DESCRIPTION
Resolves #1223

The primary change is introducing https://github.com/golemcloud/golem/pull/1236/files#diff-bcdc1292ac93ac52e1b1b02d1320cae842ccfa169d1b62a97b5aba1abdc44a4eR49 which is going to be moved to Golem's WIT definitions in the next step.