### PR TITLE
Update for composable app manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,27 +1172,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1465,7 +1450,7 @@ dependencies = [
  "bytes 1.9.0",
  "cargo-component-core",
  "cargo-config2",
- "cargo_metadata 0.19.1",
+ "cargo_metadata",
  "clap",
  "futures",
  "heck 0.5.0",
@@ -1543,20 +1528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1865,7 +1836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
  "async-trait",
- "convert_case 0.6.0",
+ "convert_case",
  "json5",
  "nom",
  "pathdiff",
@@ -1960,12 +1931,6 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -2622,19 +2587,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -3172,11 +3124,11 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set 0.5.3",
+ "bit-set",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
@@ -3799,7 +3751,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes 1.9.0",
- "cargo_metadata 0.19.1",
+ "cargo_metadata",
  "futures-core",
  "golem-wasm-ast",
  "golem-wasm-rpc",
@@ -3830,7 +3782,7 @@ dependencies = [
  "clap_complete",
  "cli-table",
  "colored",
- "derive_more 1.0.0",
+ "derive_more",
  "dirs 5.0.1",
  "env_logger 0.11.6",
  "futures-util",
@@ -3925,7 +3877,7 @@ dependencies = [
  "combine",
  "console-subscriber",
  "dashmap",
- "derive_more 1.0.0",
+ "derive_more",
  "figment",
  "fred",
  "git-version",
@@ -4082,20 +4034,22 @@ dependencies = [
 
 [[package]]
 name = "golem-examples"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0bcbbedbbecc9c66f2349150cbeb1b9e9704958611af624fbf11ea7202c4d9"
+checksum = "f0ae4fa06a19377a53f113c47c70724416fd9cf6b9f655749250ded3f81de616"
 dependencies = [
  "Inflector",
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "clap",
  "colored",
  "copy_dir",
- "derive_more 0.99.18",
+ "derive_more",
  "dir-diff",
  "fancy-regex",
  "golem-wit",
  "include_dir",
+ "itertools 0.14.0",
+ "nanoid",
  "once_cell",
  "regex",
  "serde",
@@ -4111,7 +4065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33e98f6cc141902ffcc13d027d0bb9a4d3310e51ff182f67236384e8dfeb3ac"
 dependencies = [
  "clap",
- "convert_case 0.6.0",
+ "convert_case",
  "fmt",
  "indexmap 2.7.0",
  "indoc",
@@ -4311,7 +4265,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "bincode",
- "cargo_metadata 0.19.1",
+ "cargo_metadata",
  "git-version",
  "golem-wasm-ast",
  "poem-openapi",
@@ -4433,7 +4387,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "cap-time-ext",
- "cargo_metadata 0.19.1",
+ "cargo_metadata",
  "chrono",
  "console-subscriber",
  "dashmap",
@@ -4513,7 +4467,7 @@ dependencies = [
  "bincode",
  "bytes 1.9.0",
  "console-subscriber",
- "derive_more 1.0.0",
+ "derive_more",
  "figment",
  "futures",
  "futures-util",
@@ -4568,7 +4522,7 @@ dependencies = [
  "chrono",
  "conditional-trait-gen",
  "criterion",
- "derive_more 1.0.0",
+ "derive_more",
  "fastrand",
  "figment",
  "fred",
@@ -5574,6 +5528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6215,6 +6178,15 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "nanorand"
@@ -7349,7 +7321,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes 1.9.0",
  "chrono",
- "derive_more 1.0.0",
+ "derive_more",
  "futures-util",
  "humantime",
  "indexmap 2.7.0",
@@ -7681,8 +7653,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.7.0",
  "lazy_static 1.5.0",
  "num-traits",

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -45,7 +45,7 @@ derive_more = { workspace = true }
 dirs = "5.0.1"
 futures-util = { workspace = true }
 glob = "0.3.1"
-golem-examples = "1.1.0"
+golem-examples = "1.1.1"
 h2 = "0.4.7"
 http = { workspace = true }
 humansize = { workspace = true }

--- a/golem-cli/src/command.rs
+++ b/golem-cli/src/command.rs
@@ -106,6 +106,8 @@ pub enum StaticSharedCommand {
         #[command(flatten)]
         command: diagnose::cli::Command,
     },
+
+    /// Create a new Golem standalone component example project from built-in examples
     #[command()]
     New {
         #[command(flatten)]
@@ -117,6 +119,17 @@ pub enum StaticSharedCommand {
 
         /// The new component's name
         component_name: ComponentName,
+    },
+
+    /// Add a new Golem component to a project using Golem Application Manifest
+    #[command()]
+    NewAppComponent {
+        /// The component name (and package name) of the generated component (in namespace:name format)
+        component_name: PackageName,
+
+        /// Component language
+        #[arg(short, long, alias = "lang")]
+        language: GuestLanguage,
     },
 
     /// Lists the built-in examples available for creating new components
@@ -140,22 +153,24 @@ impl<Ctx> CliCommand<Ctx> for StaticSharedCommand {
                 Ok(GolemResult::Empty)
             }
             StaticSharedCommand::ListExamples { min_tier, language } => {
-                examples::process_list_examples(min_tier, language)
+                examples::list_standalone_examples(min_tier, language)
             }
             StaticSharedCommand::New {
                 name_or_language,
                 package_name,
                 component_name,
-            } => examples::process_new(
+            } => examples::new(
                 name_or_language.example_name(),
                 component_name,
                 package_name,
             ),
+            StaticSharedCommand::NewAppComponent {
+                component_name,
+                language,
+            } => examples::new_app_component(component_name, language),
         }
     }
 }
-
-
 
 /// Commands that are supported by both the OSS and Cloud version
 #[derive(Subcommand, Debug)]

--- a/golem-cli/src/diagnose.rs
+++ b/golem-cli/src/diagnose.rs
@@ -716,7 +716,7 @@ impl DetectedTool {
 
 pub fn diagnose(command: cli::Command) {
     let selected_language = match &command.language {
-        Some(language) => SelectedLanguage::from_flag(language.clone()),
+        Some(language) => SelectedLanguage::from_flag(*language),
         None => SelectedLanguage::from_env(),
     };
 

--- a/golem-cli/src/examples.rs
+++ b/golem-cli/src/examples.rs
@@ -16,12 +16,13 @@ use std::env;
 
 use crate::model::{ExampleDescription, GolemError, GolemResult};
 use golem_examples::model::{
-    ComponentName, ExampleName, ExampleParameters, GuestLanguage, GuestLanguageTier, PackageName,
-    TargetExistsResolveMode,
+    ComponentName, ComposableAppGroupName, ExampleName, ExampleParameters, GuestLanguage,
+    GuestLanguageTier, PackageName, TargetExistsResolveMode,
 };
 use golem_examples::*;
+use itertools::Itertools;
 
-pub fn process_new(
+pub fn new(
     example_name: ExampleName,
     component_name: ComponentName,
     package_name: Option<PackageName>,
@@ -39,7 +40,7 @@ pub fn process_new(
                         .unwrap_or(PackageName::from_string("golem:component").unwrap()),
                     target_path: cwd,
                 },
-                TargetExistsResolveMode::Fail
+                TargetExistsResolveMode::Fail,
             ) {
                 Ok(instructions) => Ok(GolemResult::Str(instructions.to_string())),
                 Err(err) => GolemResult::err(format!("Failed to instantiate component: {err}")),
@@ -51,7 +52,7 @@ pub fn process_new(
     }
 }
 
-pub fn process_list_examples(
+pub fn list_standalone_examples(
     min_tier: Option<GuestLanguageTier>,
     language: Option<GuestLanguage>,
 ) -> Result<GolemResult, GolemError> {
@@ -69,4 +70,44 @@ pub fn process_list_examples(
         .collect::<Vec<ExampleDescription>>();
 
     Ok(GolemResult::Ok(Box::new(examples)))
+}
+
+pub fn new_app_component(
+    component_name: PackageName,
+    language: GuestLanguage,
+) -> Result<GolemResult, GolemError> {
+    let all_examples = all_composable_app_examples();
+
+    let Some(language_examples) = all_examples.get(&language) else {
+        return Err(GolemError(format!(
+            "No template found for {}, currently supported languages: {}",
+            language,
+            all_examples.keys().join(", ")
+        )));
+    };
+
+    let default_examples = language_examples
+        .get(&ComposableAppGroupName::default())
+        .expect("No default template found for the selected language");
+
+    assert_eq!(
+        default_examples.components.len(),
+        1,
+        "Expected exactly one default component template"
+    );
+
+    let default_component_example = &default_examples.components[0];
+
+    match add_component_by_example(
+        default_examples.common.as_ref(),
+        default_component_example,
+        &env::current_dir().expect("Failed to get current working directory"),
+        &component_name,
+    ) {
+        Ok(_) => Ok(GolemResult::Str(format!(
+            "Added new app component {}",
+            component_name.to_string_with_colon()
+        ))),
+        Err(err) => Err(GolemError(format!("Failed to add component: {err}"))),
+    }
 }

--- a/golem-cli/src/model.rs
+++ b/golem-cli/src/model.rs
@@ -596,7 +596,7 @@ impl ExampleDescription {
     pub fn from_example(example: &Example) -> Self {
         Self {
             name: example.name.clone(),
-            language: example.language.clone(),
+            language: example.language,
             description: example.description.clone(),
             tier: example.language.tier(),
         }

--- a/golem-cli/src/model/text.rs
+++ b/golem-cli/src/model/text.rs
@@ -695,7 +695,7 @@ pub mod example {
         fn from(value: &ExampleDescription) -> Self {
             Self {
                 name: value.name.clone(),
-                language: value.language.clone(),
+                language: value.language,
                 tier: value.tier.clone(),
                 description: textwrap::wrap(&value.description, 30).join("\n"),
             }

--- a/test-components/auction-example/auction-registry/golem.yaml
+++ b/test-components/auction-example/auction-registry/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   auction-registry:

--- a/test-components/auction-example/auction/golem.yaml
+++ b/test-components/auction-example/auction/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   auction:

--- a/test-components/auction-example/golem.yaml
+++ b/test-components/auction-example/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 tempDir: target/golem-temp
 templates:

--- a/test-components/rpc/caller/golem.yaml
+++ b/test-components/rpc/caller/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   caller:

--- a/test-components/rpc/counters/golem.yaml
+++ b/test-components/rpc/counters/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   counters:

--- a/test-components/rpc/ephemeral/golem.yaml
+++ b/test-components/rpc/ephemeral/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   ephemeral:

--- a/test-components/rpc/golem.yaml
+++ b/test-components/rpc/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 tempDir: target/golem-temp
 templates:

--- a/test-components/rust-service/rpc/child-component/golem.yaml
+++ b/test-components/rust-service/rpc/child-component/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   child-component:

--- a/test-components/rust-service/rpc/golem.yaml
+++ b/test-components/rust-service/rpc/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 tempDir: target/golem-temp
 templates:

--- a/test-components/rust-service/rpc/parent-component/golem.yaml
+++ b/test-components/rust-service/rpc/parent-component/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   parent-component:

--- a/test-components/ts-rpc/caller/golem.yaml
+++ b/test-components/ts-rpc/caller/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   caller:

--- a/test-components/ts-rpc/counter/golem.yaml
+++ b/test-components/ts-rpc/counter/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 components:
   counter:

--- a/test-components/ts-rpc/golem.yaml
+++ b/test-components/ts-rpc/golem.yaml
@@ -1,7 +1,7 @@
 # Schema for IDEA:
-# $schema: https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# $schema: https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 # Schema for vscode-yaml
-# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.0/golem.schema.json
+# yaml-language-server: $schema=https://schema.golem.cloud/app/golem/1.1.1/golem.schema.json
 
 tempDir: dist/golem-temp
 witDeps:

--- a/wasm-rpc-stubgen/src/log.rs
+++ b/wasm-rpc-stubgen/src/log.rs
@@ -253,6 +253,10 @@ pub trait LogColorize {
         self.as_str().bold()
     }
 
+    fn log_color_help_group(&self) -> ColoredString {
+        self.as_str().bold().underline()
+    }
+
     fn log_color_error_highlight(&self) -> ColoredString {
         self.as_str().bold().red().underline()
     }


### PR DESCRIPTION
- update app manifest schema refs
- update golem-examples
- add `new-app-component` (for now added a root command, during the Cli Manifest Refactor we will move this to a better place, but that will involve more refactors around how commands are nested)
- extended the dynamic help for `golem-cli app` to include component info

`golem-cli app` in project root folder |  `golem-cli app` in ts folder with release profle
:-------------------------:|:-------------------------:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/71646739-c11e-4b2c-b0db-3e991bf43c7e" />  |  <img width="898" alt="image" src="https://github.com/user-attachments/assets/45861af2-c3a0-42e9-a00d-799ba2c050a7" />

