### PR TITLE
Docker fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,7 +3896,7 @@ dependencies = [
  "derive_more",
  "dir-diff",
  "fancy-regex",
- "golem-wit",
+ "golem-wit 1.1.2",
  "include_dir",
  "itertools 0.14.0",
  "nanoid",
@@ -4179,6 +4179,11 @@ dependencies = [
 
 [[package]]
 name = "golem-wit"
+version = "0.0.0"
+source = "git+https://github.com/golemcloud/golem-wit.git?branch=add_fork#ec67df3ec43c921439f254d3d87843f1f0fc8fbe"
+
+[[package]]
+name = "golem-wit"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf53fc25db491f96c480d7f195175f6da5f18dcc6ef548d04b2ae648b7796bbf"
@@ -4258,7 +4263,7 @@ dependencies = [
  "golem-test-framework",
  "golem-wasm-ast",
  "golem-wasm-rpc",
- "golem-wit",
+ "golem-wit 0.0.0",
  "hex",
  "http 1.2.0",
  "http-body 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ futures = "0.3"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 git-version = "0.3.9"
-golem-wit = { version = "=1.1.2" }
+golem-wit = { git = "https://github.com/golemcloud/golem-wit.git", branch = "add_fork" }
 hex = "0.4.3"
 http = "1.2.0" # keep in sync with wasmtime
 humansize = "2.1.3"

--- a/golem-component-compilation-service/docker/Dockerfile
+++ b/golem-component-compilation-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-component-service/docker/Dockerfile
+++ b/golem-component-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-shard-manager/docker/Dockerfile
+++ b/golem-shard-manager/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-worker-executor-base/build.rs
+++ b/golem-worker-executor-base/build.rs
@@ -67,7 +67,7 @@ fn preview2_mod_gen(golem_wit_path: &str) -> String {
               import golem:api/host@1.1.0;
               import golem:api/host@1.2.0;
               import golem:api/oplog@1.1.0;
-              import golem:api/durability@1.2.0;
+              import golem:durability/durability@1.2.0;
 
               import wasi:blobstore/blobstore;
               import wasi:blobstore/container;

--- a/golem-worker-executor-base/build.rs
+++ b/golem-worker-executor-base/build.rs
@@ -65,6 +65,7 @@ fn preview2_mod_gen(golem_wit_path: &str) -> String {
           world golem {{
               import golem:api/host@0.2.0;
               import golem:api/host@1.1.0;
+              import golem:api/host@1.2.0;
               import golem:api/oplog@1.1.0;
               import golem:api/durability@1.2.0;
 

--- a/golem-worker-executor-base/src/durable_host/durability.rs
+++ b/golem-worker-executor-base/src/durable_host/durability.rs
@@ -17,7 +17,7 @@ use crate::error::GolemError;
 use crate::metrics::wasm::record_host_function_call;
 use crate::model::PersistenceLevel;
 use crate::preview2::golem;
-use crate::preview2::golem::api1_2_0;
+use crate::preview2::golem::durability::durability;
 use crate::services::oplog::{CommitLevel, OplogOps};
 use crate::workerctx::WorkerCtx;
 use async_trait::async_trait;
@@ -105,62 +105,62 @@ pub trait DurabilityHost {
     ) -> Result<PersistedDurableFunctionInvocation, GolemError>;
 }
 
-impl From<api1_2_0::durability::DurableFunctionType> for DurableFunctionType {
-    fn from(value: api1_2_0::durability::DurableFunctionType) -> Self {
+impl From<durability::DurableFunctionType> for DurableFunctionType {
+    fn from(value: durability::DurableFunctionType) -> Self {
         match value {
-            api1_2_0::durability::DurableFunctionType::WriteRemote => {
+            durability::DurableFunctionType::WriteRemote => {
                 DurableFunctionType::WriteRemote
             }
-            api1_2_0::durability::DurableFunctionType::WriteLocal => {
+            durability::DurableFunctionType::WriteLocal => {
                 DurableFunctionType::WriteLocal
             }
-            api1_2_0::durability::DurableFunctionType::WriteRemoteBatched(oplog_index) => {
+            durability::DurableFunctionType::WriteRemoteBatched(oplog_index) => {
                 DurableFunctionType::WriteRemoteBatched(oplog_index.map(OplogIndex::from_u64))
             }
-            api1_2_0::durability::DurableFunctionType::ReadRemote => {
+            durability::DurableFunctionType::ReadRemote => {
                 DurableFunctionType::ReadRemote
             }
-            api1_2_0::durability::DurableFunctionType::ReadLocal => DurableFunctionType::ReadLocal,
+            durability::DurableFunctionType::ReadLocal => DurableFunctionType::ReadLocal,
         }
     }
 }
 
-impl From<DurableFunctionType> for api1_2_0::durability::DurableFunctionType {
+impl From<DurableFunctionType> for durability::DurableFunctionType {
     fn from(value: DurableFunctionType) -> Self {
         match value {
             DurableFunctionType::WriteRemote => {
-                api1_2_0::durability::DurableFunctionType::WriteRemote
+                durability::DurableFunctionType::WriteRemote
             }
             DurableFunctionType::WriteLocal => {
-                api1_2_0::durability::DurableFunctionType::WriteLocal
+                durability::DurableFunctionType::WriteLocal
             }
             DurableFunctionType::WriteRemoteBatched(oplog_index) => {
-                api1_2_0::durability::DurableFunctionType::WriteRemoteBatched(
+                durability::DurableFunctionType::WriteRemoteBatched(
                     oplog_index.map(|idx| idx.into()),
                 )
             }
             DurableFunctionType::ReadRemote => {
-                api1_2_0::durability::DurableFunctionType::ReadRemote
+                durability::DurableFunctionType::ReadRemote
             }
-            DurableFunctionType::ReadLocal => api1_2_0::durability::DurableFunctionType::ReadLocal,
+            DurableFunctionType::ReadLocal => durability::DurableFunctionType::ReadLocal,
         }
     }
 }
 
-impl From<OplogEntryVersion> for api1_2_0::durability::OplogEntryVersion {
+impl From<OplogEntryVersion> for durability::OplogEntryVersion {
     fn from(value: OplogEntryVersion) -> Self {
         match value {
-            OplogEntryVersion::V1 => api1_2_0::durability::OplogEntryVersion::V1,
-            OplogEntryVersion::V2 => api1_2_0::durability::OplogEntryVersion::V2,
+            OplogEntryVersion::V1 => durability::OplogEntryVersion::V1,
+            OplogEntryVersion::V2 => durability::OplogEntryVersion::V2,
         }
     }
 }
 
 impl From<PersistedDurableFunctionInvocation>
-    for api1_2_0::durability::PersistedDurableFunctionInvocation
+    for durability::PersistedDurableFunctionInvocation
 {
     fn from(value: PersistedDurableFunctionInvocation) -> Self {
-        api1_2_0::durability::PersistedDurableFunctionInvocation {
+        durability::PersistedDurableFunctionInvocation {
             timestamp: value.timestamp.into(),
             function_name: value.function_name,
             response: value.response,
@@ -171,7 +171,7 @@ impl From<PersistedDurableFunctionInvocation>
 }
 
 #[async_trait]
-impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
+impl<Ctx: WorkerCtx> durability::Host for DurableWorkerCtx<Ctx> {
     async fn observe_function_call(
         &mut self,
         iface: String,
@@ -183,16 +183,16 @@ impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
 
     async fn begin_durable_function(
         &mut self,
-        function_type: api1_2_0::durability::DurableFunctionType,
-    ) -> anyhow::Result<api1_2_0::durability::OplogIndex> {
+        function_type: durability::DurableFunctionType,
+    ) -> anyhow::Result<durability::OplogIndex> {
         let oplog_idx = DurabilityHost::begin_durable_function(self, &function_type.into()).await?;
         Ok(oplog_idx.into())
     }
 
     async fn end_durable_function(
         &mut self,
-        function_type: api1_2_0::durability::DurableFunctionType,
-        begin_index: api1_2_0::durability::OplogIndex,
+        function_type: durability::DurableFunctionType,
+        begin_index: durability::OplogIndex,
     ) -> anyhow::Result<()> {
         DurabilityHost::end_durable_function(
             self,
@@ -205,11 +205,11 @@ impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
 
     async fn current_durable_execution_state(
         &mut self,
-    ) -> anyhow::Result<api1_2_0::durability::DurableExecutionState> {
+    ) -> anyhow::Result<durability::DurableExecutionState> {
         let state = DurabilityHost::durable_execution_state(self);
         let persistence_level: golem::api0_2_0::host::PersistenceLevel =
             state.persistence_level.into();
-        Ok(api1_2_0::durability::DurableExecutionState {
+        Ok(durability::DurableExecutionState {
             is_live: state.is_live,
             persistence_level: persistence_level.into(),
         })
@@ -220,7 +220,7 @@ impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
         function_name: String,
         request: Vec<u8>,
         response: Vec<u8>,
-        function_type: api1_2_0::durability::DurableFunctionType,
+        function_type: durability::DurableFunctionType,
     ) -> anyhow::Result<()> {
         DurabilityHost::persist_durable_function_invocation(
             self,
@@ -236,19 +236,19 @@ impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
     async fn persist_typed_durable_function_invocation(
         &mut self,
         function_name: String,
-        request: api1_2_0::durability::ValueAndType,
-        response: api1_2_0::durability::ValueAndType,
-        function_type: api1_2_0::durability::DurableFunctionType,
+        request: durability::ValueAndType,
+        response: durability::ValueAndType,
+        function_type: durability::DurableFunctionType,
     ) -> anyhow::Result<()> {
         let request = unsafe {
             transmute::<
-                api1_2_0::durability::ValueAndType,
+                durability::ValueAndType,
                 golem_wasm_rpc::golem::rpc::types::ValueAndType,
             >(request)
         };
         let response = unsafe {
             transmute::<
-                api1_2_0::durability::ValueAndType,
+                durability::ValueAndType,
                 golem_wasm_rpc::golem::rpc::types::ValueAndType,
             >(response)
         };
@@ -265,7 +265,7 @@ impl<Ctx: WorkerCtx> api1_2_0::durability::Host for DurableWorkerCtx<Ctx> {
 
     async fn read_persisted_durable_function_invocation(
         &mut self,
-    ) -> anyhow::Result<api1_2_0::durability::PersistedDurableFunctionInvocation> {
+    ) -> anyhow::Result<durability::PersistedDurableFunctionInvocation> {
         let invocation = DurabilityHost::read_persisted_durable_function_invocation(self).await?;
         Ok(invocation.into())
     }

--- a/golem-worker-executor/docker/Dockerfile
+++ b/golem-worker-executor/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-worker-executor/src/lib.rs
+++ b/golem-worker-executor/src/lib.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use golem_common::model::component::ComponentOwner;
 use golem_common::model::plugin::{DefaultPluginOwner, DefaultPluginScope};
 use golem_worker_executor_base::durable_host::DurableWorkerCtx;
-use golem_worker_executor_base::preview2::golem::{api0_2_0, api1_1_0, api1_2_0};
+use golem_worker_executor_base::preview2::golem::{api0_2_0, api1_1_0, durability};
 use golem_worker_executor_base::services::active_workers::ActiveWorkers;
 use golem_worker_executor_base::services::blob_store::BlobStoreService;
 use golem_worker_executor_base::services::component::ComponentService;
@@ -205,7 +205,7 @@ impl Bootstrap<Context> for ServerBootstrap {
         api0_2_0::host::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
         api1_1_0::host::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
         api1_1_0::oplog::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
-        api1_2_0::durability::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
+        durability::durability::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
         golem_wasm_rpc::golem::rpc::types::add_to_linker_get_host(&mut linker, get_durable_ctx)?;
         Ok(linker)
     }

--- a/golem-worker-service/docker/Dockerfile
+++ b/golem-worker-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 


### PR DESCRIPTION
```
(Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres-1                             | 2025-01-21 13:22:53.444 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres-1                             | 2025-01-21 13:22:53.444 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres-1                             | 2025-01-21 13:22:53.460 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres-1                             | 2025-01-21 13:22:53.471 UTC [29] LOG:  database system was shut down at 2025-01-21 13:22:48 UTC
postgres-1                             | 2025-01-21 13:22:53.482 UTC [1] LOG:  database system is ready to accept connections
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-shard-manager)
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-shard-manager)
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-shard-manager)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./worker-executor)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./worker-executor)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./worker-executor)
golem-shard-manager-1 exited with code 1
golem-worker-executor-1 exited with code 1
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-worker-service)
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-worker-service)
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-worker-service)
golem-component-service-1              | ./golem-component-service: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-component-service)
golem-component-service-1              | ./golem-component-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-component-service)
golem-component-service-1              | ./golem-component-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-component-service)
golem-component-service-1 exited with code 1
golem-worker-service-1 exited with code 1
golem-component-compilation-service-1  | ./golem-component-compilation-service: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-component-compilation-service)
golem-component-compilation-service-1  | ./golem-component-compilation-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-component-compilation-service)
golem-component-compilation-service-1  | ./golem-component-compilation-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-component-compilation-service)
golem-component-compilation-service-1 exited with code 1
router-1                               | 2025/01/21 13:23:00 [emerg] 1#1: host not found in upstream "golem-worker-service" in /etc/nginx/nginx.conf:16
router-1                               | nginx: [emerg] host not found in upstream "golem-worker-service" in /etc/nginx/nginx.conf:16

```

I think we can also use specific 24.10 version if needed: https://hub.docker.com/_/ubuntu, and that's 2.40

https://packages.debian.org/bookworm/libc6 (I guess that's 2.36)