### PR TITLE
Use ubuntu latest in docker

### DIFF
--- a/golem-component-compilation-service/docker/Dockerfile
+++ b/golem-component-compilation-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-component-service/docker/Dockerfile
+++ b/golem-component-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-shard-manager/docker/Dockerfile
+++ b/golem-shard-manager/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-worker-executor/docker/Dockerfile
+++ b/golem-worker-executor/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 

--- a/golem-worker-service/docker/Dockerfile
+++ b/golem-worker-service/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM ubuntu:latest as base
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Fixing


```
(Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres-1                             | 2025-01-21 13:22:53.444 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres-1                             | 2025-01-21 13:22:53.444 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres-1                             | 2025-01-21 13:22:53.460 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres-1                             | 2025-01-21 13:22:53.471 UTC [29] LOG:  database system was shut down at 2025-01-21 13:22:48 UTC
postgres-1                             | 2025-01-21 13:22:53.482 UTC [1] LOG:  database system is ready to accept connections
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-shard-manager)
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-shard-manager)
golem-shard-manager-1                  | ./golem-shard-manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-shard-manager)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./worker-executor)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./worker-executor)
golem-worker-executor-1                | ./worker-executor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./worker-executor)
golem-shard-manager-1 exited with code 1
golem-worker-executor-1 exited with code 1
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-worker-service)
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./golem-worker-service)
golem-worker-service-1                 | ./golem-worker-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./golem-worker-service)
golem-component-service-1              | ./golem-component-service: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./golem-component-service)
golem-component-se
```