### PR TITLE
docker examples - add depends on

### DIFF
--- a/docker-examples/docker-compose-postgres.yaml
+++ b/docker-examples/docker-compose-postgres.yaml
@@ -121,6 +121,14 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
+      golem-worker-executor:
+        condition: service_started
+      golem-component-service:
+        condition: service_started
+      golem-shard-manager:
+        condition: service_started
 
   golem-component-compilation-service:
     image: golemservices/golem-component-compilation-service:latest
@@ -173,7 +181,6 @@ services:
       - GOLEM__PUBLIC_WORKER_API__PORT=${WORKER_SERVICE_GRPC_PORT}
       - GOLEM__PUBLIC_WORKER_API__ACCESS_TOKEN="2A354594-7A63-4091-A46B-CC58D379F677"
       - GOLEM__COMPILED_COMPONENT_SERVICE__TYPE="Enabled"
-
       - GOLEM__SHARD_MANAGER_SERVICE__TYPE="Grpc"
     volumes:
       - worker_executor_store:/worker_executor_store
@@ -181,6 +188,8 @@ services:
       - "${WORKER_EXECUTOR_HTTP_PORT}:${WORKER_EXECUTOR_HTTP_PORT}"
     depends_on:
       - redis
+      - golem-shard-manager
+      - golem-component-service
 
 volumes:
   redis_data:

--- a/docker-examples/docker-compose-sqlite.yaml
+++ b/docker-examples/docker-compose-sqlite.yaml
@@ -91,6 +91,11 @@ services:
       - "${WORKER_SERVICE_GRPC_PORT}:${WORKER_SERVICE_GRPC_PORT}"
     volumes:
       - golem_db:/app/golem_db
+    depends_on:
+      - redis
+      - golem-worker-executor
+      - golem-component-service
+      - golem-shard-manager
 
   golem-component-compilation-service:
     image: golemservices/golem-component-compilation-service:latest
@@ -143,7 +148,6 @@ services:
       - GOLEM__PUBLIC_WORKER_API__PORT=${WORKER_SERVICE_GRPC_PORT}
       - GOLEM__PUBLIC_WORKER_API__ACCESS_TOKEN="2A354594-7A63-4091-A46B-CC58D379F677"
       - GOLEM__COMPILED_COMPONENT_SERVICE__TYPE="Enabled"
-
       - GOLEM__SHARD_MANAGER_SERVICE__TYPE="Grpc"
     volumes:
       - worker_executor_store:/worker_executor_store
@@ -151,6 +155,8 @@ services:
       - "${WORKER_EXECUTOR_HTTP_PORT}:${WORKER_EXECUTOR_HTTP_PORT}"
     depends_on:
       - redis
+      - golem-shard-manager
+      - golem-component-service
 
 volumes:
   redis_data:


### PR DESCRIPTION

added dependency between services to avoid issues like

```
golem-worker-executor-1                | 2025-01-24T10:02:40.658396Z  WARN golem_common::client: gRPC call failed: Status { code: Unavailable, message: "tcp connect error: Connection refused (os error 111)", source: Some(tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))) }, no more retries
golem-worker-executor-1                | 2025-01-24T10:02:40.658556Z  WARN retry{target="shard_manager" op="register" op_id="None" attempt=4}: golem_common::retries: op failure - retrying delay_ms=833 error="Unknown error: Registering with shard manager failed with status: Unavailable, message: \"tcp connect error: Connection refused (os error 111)\", details: [], metadata: MetadataMap { headers: {} }"
golem-worker-executor-1                | 2025-01-24T10:02:41.283919Z  WARN golem_worker_executor_base::services::scheduler: Skipping schedule, shard service is not ready
golem-worker-executor-1                | 2025-01-24T10:02:43.174435Z  WARN golem_common::client: gRPC call failed: Status { code: Unavailable, message: "tcp connect error: Connection refused (os error 111)", source: Some(tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))) }, no more retries
golem-worker-executor-1                | 2025-01-24T10:02:43.174598Z ERROR retry{target="shard_manager" op="register" op_id="None" attempt=5}: golem_common::retries: op failure - no more retries error="Unknown error: Registering with shard manager failed with status: Unavailable, message: \"tcp connect error: Connection refused (os error 111)\", details: [], metadata: MetadataMap { headers: {} }"
golem-shard-manager-1                  | 2025-01-24T10:02:43.175622Z  WARN retry{target="worker_executor_grpc" op="healtcheck" op_id="f16a7ce8f787:9000 (172.21.0.4)" attempt=2}: golem_common::retries: op failure - retrying delay_ms=208 error="gRPC: error status: status: Unknown, message: \"transport error\", details: [], metadata: MetadataMap { headers: {} }"
golem-worker-executor-1                | Error: Unknown error: Registering with shard manager failed with status: Unavailable, message: "tcp connect error: Connection refused (os error 111)", details: [], metadata: MetadataMap { headers: {} }
golem-worker-executor-1                |
golem-worker-executor-1                | Stack backtrace:
golem-worker-executor-1                |    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
golem-worker-executor-1                |    1: golem_worker_executor_base::Bootstrap::run_server::{{closure}}
golem-worker-executor-1                |    2: golem_worker_executor_base::Bootstrap::run::{{closure}}
golem-worker-executor-1                |    3: worker_executor::async_main::{{closure}}
golem-worker-executor-1                |    4: tokio::runtime::runtime::Runtime::block_on
golem-worker-executor-1                |    5: worker_executor::main
golem-worker-executor-1                |    6: std::sys::backtrace::__rust_begin_short_backtrace
golem-worker-executor-1                |    7: std::rt::lang_start::{{closure}}
golem-worker-executor-1                |    8: std::rt::lang_start_internal
golem-worker-executor-1                |    9: main
golem-worker-executor-1                |   10: <unknown>
golem-worker-executor-1                |   11: __libc_start_main
golem-worker-executor-1                |   12: _start
golem-worker-executor-1 exited with code 1
golem-shard-manager-1                  | 2025-01-24T10:02:45.388727Z  WARN retry{target="worker_executor_grpc" op="healtcheck" op_id="f16a7ce8f787:9000 (172.21.0.4)" attempt=3}: golem_common::retries: op failure - retrying delay_ms=421 error="gRPC: connect timeout"
golem-shard-manager-1                  | 2025-01-24T10:02:47.817623Z  WARN retry{target="worker_executor_grpc" op="healtcheck" op_id="f16a7ce8f787:9000 (172.21.0.4)" attempt=4}: golem_common::retries: op failure - retrying delay_ms=882 error="gRPC: connect timeout"
golem-shard-manager-1                  | 2025-01-24T10:02:50.704612Z ERROR retry{target="worker_executor_grpc" op="healtcheck" op_id="f16a7ce8f787:9000 (172.21.0.4)" attempt=5}: golem_common::retries: op failure - no more retries error="gRPC: connect timeout"
golem-shard-manager-1                  | 2025-01-24T10:02:50.704708Z  INFO golem_shard_manager::shard_management: Initial healthcheck finished

```