### PR TITLE
Rename type_annotated_value to value_and_type

### DIFF
--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -120,18 +120,18 @@ mod internal {
                 instructions.push(RibIR::LoadVar(variable_id.clone()));
             }
             Expr::Literal(str, _) => {
-                let type_annotated_value = str.clone().into_value_and_type();
-                instructions.push(RibIR::PushLit(type_annotated_value));
+                let value_and_type = str.clone().into_value_and_type();
+                instructions.push(RibIR::PushLit(value_and_type));
             }
             Expr::Number(num, _, inferred_type) => {
                 let analysed_type = convert_to_analysed_type(expr, inferred_type)?;
 
-                let type_annotated_value = num.to_val(&analysed_type).ok_or(format!(
+                let value_and_type = num.to_val(&analysed_type).ok_or(format!(
                     "Internal error: convert a number to wasm value using {:?}",
                     analysed_type
                 ))?;
 
-                instructions.push(RibIR::PushLit(type_annotated_value));
+                instructions.push(RibIR::PushLit(value_and_type));
             }
             Expr::EqualTo(lhs, rhs, _) => {
                 stack.push(ExprState::from_expr(rhs.deref()));
@@ -791,12 +791,12 @@ mod compiler_tests {
 
         let instructions = RibByteCode::from_expr(&inferred_expr).unwrap();
 
-        let type_annotated_value1 = 1.0f32.into_value_and_type();
-        let type_annotated_value2 = 1u32.into_value_and_type();
+        let value_and_type1 = 1.0f32.into_value_and_type();
+        let value_and_type2 = 1u32.into_value_and_type();
 
         let instruction_set = vec![
-            RibIR::PushLit(type_annotated_value2),
-            RibIR::PushLit(type_annotated_value1),
+            RibIR::PushLit(value_and_type2),
+            RibIR::PushLit(value_and_type1),
             RibIR::EqualTo,
         ];
 
@@ -830,12 +830,12 @@ mod compiler_tests {
 
         let instructions = RibByteCode::from_expr(&inferred_expr).unwrap();
 
-        let type_annotated_value1 = 1.0f32.into_value_and_type();
-        let type_annotated_value2 = 2u32.into_value_and_type();
+        let value_and_type1 = 1.0f32.into_value_and_type();
+        let value_and_type2 = 2u32.into_value_and_type();
 
         let instruction_set = vec![
-            RibIR::PushLit(type_annotated_value2),
-            RibIR::PushLit(type_annotated_value1),
+            RibIR::PushLit(value_and_type2),
+            RibIR::PushLit(value_and_type1),
             RibIR::GreaterThan,
         ];
 
@@ -869,12 +869,12 @@ mod compiler_tests {
 
         let instructions = RibByteCode::from_expr(&inferred_expr).unwrap();
 
-        let type_annotated_value1 = 1.0f32.into_value_and_type();
-        let type_annotated_value2 = 1u32.into_value_and_type();
+        let value_and_type1 = 1.0f32.into_value_and_type();
+        let value_and_type2 = 1u32.into_value_and_type();
 
         let instruction_set = vec![
-            RibIR::PushLit(type_annotated_value2),
-            RibIR::PushLit(type_annotated_value1),
+            RibIR::PushLit(value_and_type2),
+            RibIR::PushLit(value_and_type1),
             RibIR::LessThan,
         ];
 
@@ -908,12 +908,12 @@ mod compiler_tests {
 
         let instructions = RibByteCode::from_expr(&inferred_expr).unwrap();
 
-        let type_annotated_value1 = 1.0f32.into_value_and_type();
-        let type_annotated_value2 = 1u32.into_value_and_type();
+        let value_and_type1 = 1.0f32.into_value_and_type();
+        let value_and_type2 = 1u32.into_value_and_type();
 
         let instruction_set = vec![
-            RibIR::PushLit(type_annotated_value2),
-            RibIR::PushLit(type_annotated_value1),
+            RibIR::PushLit(value_and_type2),
+            RibIR::PushLit(value_and_type1),
             RibIR::GreaterThanOrEqualTo,
         ];
 
@@ -947,12 +947,12 @@ mod compiler_tests {
 
         let instructions = RibByteCode::from_expr(&inferred_expr).unwrap();
 
-        let type_annotated_value1 = 1.0f32.into_value_and_type();
-        let type_annotated_value2 = 1u32.into_value_and_type();
+        let value_and_type1 = 1.0f32.into_value_and_type();
+        let value_and_type2 = 1u32.into_value_and_type();
 
         let instruction_set = vec![
-            RibIR::PushLit(type_annotated_value2),
-            RibIR::PushLit(type_annotated_value1),
+            RibIR::PushLit(value_and_type2),
+            RibIR::PushLit(value_and_type1),
             RibIR::LessThanOrEqualTo,
         ];
 

--- a/golem-rib/src/interpreter/interpreter_stack_value.rs
+++ b/golem-rib/src/interpreter/interpreter_stack_value.rs
@@ -19,8 +19,8 @@ use golem_wasm_rpc::{IntoValueAndType, Value, ValueAndType};
 use std::fmt;
 use std::ops::Deref;
 
-// A result of a function can be unit, which is not representable using type_annotated_value
-// A result can be a type_annotated_value
+// A result of a function can be unit, which is not representable using value_and_type
+// A result can be a value_and_type
 // A result can be a sink where it collects only the required elements from a possible iterable
 // A result can also be stored as an iterator, that its easy to stream through any iterables, given a sink is following it.
 pub enum RibInterpreterStackValue {

--- a/golem-rib/src/interpreter/literal.rs
+++ b/golem-rib/src/interpreter/literal.rs
@@ -322,10 +322,8 @@ mod internal {
     use crate::interpreter::literal::CoercedNumericValue;
     use golem_wasm_rpc::{Value, ValueAndType};
 
-    pub(crate) fn get_numeric_value(
-        type_annotated_value: &ValueAndType,
-    ) -> Option<CoercedNumericValue> {
-        match &type_annotated_value.value {
+    pub(crate) fn get_numeric_value(value_and_type: &ValueAndType) -> Option<CoercedNumericValue> {
+        match &value_and_type.value {
             Value::S8(value) => Some(CoercedNumericValue::NegInt(*value as i64)),
             Value::S16(value) => Some(CoercedNumericValue::NegInt(*value as i64)),
             Value::S32(value) => Some(CoercedNumericValue::NegInt(*value as i64)),

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -402,11 +402,10 @@ mod internal {
 
                 match &mut existing_iterator {
                     RibInterpreterStackValue::Iterator(iter) => {
-                        if let Some(type_annotated_value) = iter.next() {
+                        if let Some(value_and_type) = iter.next() {
                             interpreter_stack.push(existing_iterator);
                             interpreter_stack.push(rib_result);
-                            interpreter_stack
-                                .push(RibInterpreterStackValue::Val(type_annotated_value));
+                            interpreter_stack.push(RibInterpreterStackValue::Val(value_and_type));
                             Ok(())
                         } else {
                             Err("Internal Error: Iterator has no more items".to_string())
@@ -421,9 +420,9 @@ mod internal {
             }
 
             RibInterpreterStackValue::Iterator(iter) => {
-                if let Some(type_annotated_value) = iter.next() {
+                if let Some(value_and_type) = iter.next() {
                     interpreter_stack.push(rib_result);
-                    interpreter_stack.push(RibInterpreterStackValue::Val(type_annotated_value));
+                    interpreter_stack.push(RibInterpreterStackValue::Val(value_and_type));
                     Ok(())
                 } else {
                     Err("Internal Error: Iterator has no more items".to_string())
@@ -1716,10 +1715,10 @@ mod interpreter_tests {
                 .unwrap();
 
             let expected = r#"[]"#;
-            let expected_type_annotated_value =
+            let expected_value_and_type =
                 golem_wasm_rpc::parse_value_and_type(&list(str()), expected).unwrap();
 
-            assert_eq!(result, expected_type_annotated_value);
+            assert_eq!(result, expected_value_and_type);
         }
     }
 

--- a/golem-rib/src/interpreter/stack.rs
+++ b/golem-rib/src/interpreter/stack.rs
@@ -161,7 +161,7 @@ impl InterpreterStack {
         self.stack.push(RibInterpreterStackValue::val(element));
     }
 
-    pub fn push_to_sink(&mut self, type_annotated_value: ValueAndType) -> Result<(), String> {
+    pub fn push_to_sink(&mut self, value_and_type: ValueAndType) -> Result<(), String> {
         let sink = self.pop();
         // sink always followed by an iterator
         let possible_iterator = self
@@ -174,7 +174,7 @@ impl InterpreterStack {
 
         match sink {
             Some(RibInterpreterStackValue::Sink(mut list, analysed_type)) => {
-                list.push(type_annotated_value);
+                list.push(value_and_type);
                 self.push(possible_iterator);
                 self.push(RibInterpreterStackValue::Sink(list, analysed_type));
                 Ok(())

--- a/golem-rib/src/interpreter/tests/mod.rs
+++ b/golem-rib/src/interpreter/tests/mod.rs
@@ -494,18 +494,18 @@ mod comprehensive_test {
         let actual_as_text = test_utils::convert_value_and_type_to_str(&result.get_val().unwrap());
 
         let expected_as_text =
-            test_utils::convert_value_and_type_to_str(&expected_type_annotated_value());
+            test_utils::convert_value_and_type_to_str(&expected_value_and_type());
 
         assert_eq!(
             result.get_val().unwrap(),
-            expected_type_annotated_value(),
+            expected_value_and_type(),
             "Assertion failed! \n\n Actual value as string  : {} \n\n Expected value as string: {}\n",
             actual_as_text,
             expected_as_text
         );
     }
 
-    fn expected_type_annotated_value() -> ValueAndType {
+    fn expected_value_and_type() -> ValueAndType {
         let wasm_wave_str = r#"
           {
             a: "foo",


### PR DESCRIPTION
Certain `value_and_type`s were referred as `type_annotated_value`. Fixing them before other upcoming changes