### PR TITLE
Bug fix: uninferred arguments to `instance` in first class worker support

### DIFF
--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -1041,6 +1041,7 @@ impl Expr {
 
     pub fn resolve_method_calls(&mut self) -> Result<(), RibCompilationError> {
         self.bind_instance_types();
+        //dbg!(self.to_string());
         self.infer_worker_function_invokes()
     }
 

--- a/golem-rib/src/inferred_type/mod.rs
+++ b/golem-rib/src/inferred_type/mod.rs
@@ -165,45 +165,32 @@ impl InferredType {
 
                     Ok(())
                 }
-                InferredType::Bool => Err(format!("expected a number type, found {}", "bool")),
-                InferredType::Chr => Err(format!("expected a number type, found {}", "char")),
-                InferredType::Str => Err(format!("expected a number type, found {}", "string")),
-                InferredType::List(_) => Err(format!("expected a number type, found {}", "list")),
-                InferredType::Tuple(_) => Err(format!("expected a number type, found {}", "tuple")),
-                InferredType::Record(_) => {
-                    Err(format!("expected a number type, found {}", "record"))
-                }
-                InferredType::Flags(_) => Err(format!("expected a number type, found {}", "flags")),
-                InferredType::Enum(_) => Err(format!("expected a number type, found {}", "enum")),
-                InferredType::Option(_) => {
-                    Err(format!("expected a number type, found {}", "option"))
-                }
-                InferredType::Result { .. } => {
-                    Err(format!("expected a number type, found {}", "result"))
-                }
-                InferredType::Variant(_) => {
-                    Err(format!("expected a number type, found {}", "variant"))
-                }
+                InferredType::Bool => Err(format!("used as {}", "bool")),
+                InferredType::Chr => Err(format!("used as {}", "char")),
+                InferredType::Str => Err(format!("used as {}", "string")),
+                InferredType::List(_) => Err(format!("used as {}", "list")),
+                InferredType::Tuple(_) => Err(format!("used as {}", "tuple")),
+                InferredType::Record(_) => Err(format!("used as {}", "record")),
+                InferredType::Flags(_) => Err(format!("used as {}", "flags")),
+                InferredType::Enum(_) => Err(format!("used as {}", "enum")),
+                InferredType::Option(_) => Err(format!("used as {}", "option")),
+                InferredType::Result { .. } => Err(format!("used as {}", "result")),
+                InferredType::Variant(_) => Err(format!("used as {}", "variant")),
 
                 InferredType::OneOf(_) => {
                     if found.is_empty() {
-                        Err("Not a number.".to_string())
+                        Err("not a number.".to_string())
                     } else {
                         Ok(())
                     }
                 }
-                InferredType::Unknown => Err("expected a number type, found unknown".to_string()),
+                InferredType::Unknown => Err("found unknown".to_string()),
 
-                InferredType::Sequence(_) => Err(format!(
-                    "expected a number type, found {}",
-                    "function-multi-parameter-return"
-                )),
-                InferredType::Resource { .. } => {
-                    Err(format!("expected a number type, found {}", "resource"))
+                InferredType::Sequence(_) => {
+                    Err(format!("used as {}", "function-multi-parameter-return"))
                 }
-                InferredType::Instance { .. } => {
-                    Err(format!("expected a number type, found {}", "instance"))
-                }
+                InferredType::Resource { .. } => Err(format!("used as {}", "resource")),
+                InferredType::Instance { .. } => Err(format!("used as {}", "instance")),
             }
         }
 

--- a/golem-rib/src/rib_compilation_error.rs
+++ b/golem-rib/src/rib_compilation_error.rs
@@ -7,15 +7,21 @@ use crate::{
     TypeName, UnResolvedTypesError,
 };
 use std::fmt;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RibCompilationError {
     pub cause: String,
     pub expr: Expr,
     pub immediate_parent: Option<Expr>,
     pub additional_error_details: Vec<String>,
     pub help_messages: Vec<String>,
+}
+
+impl Debug for RibCompilationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
 }
 
 impl RibCompilationError {
@@ -239,7 +245,7 @@ impl From<InvalidExpr> for RibCompilationError {
         let expr_inferred_type = value.found.printable();
 
         let cause = format!(
-            "inferred a {} to be `{}` which is invalid",
+            "expected to be of the type `{}`, but inferred as `{}`",
             value.expected_type, expr_inferred_type
         );
 

--- a/golem-rib/src/type_checker/invalid_expr.rs
+++ b/golem-rib/src/type_checker/invalid_expr.rs
@@ -11,12 +11,12 @@ pub fn check_invalid_expr(expr: &Expr) -> Result<(), InvalidExpr> {
         match expr {
             Expr::Number { inferred_type, .. } => match inferred_type.as_number() {
                 Ok(_) => {}
-                Err(msg) => {
+                Err(message) => {
                     return Err(InvalidExpr {
                         expr: expr.clone(),
                         expected_type: TypeKind::Number,
                         found: inferred_type.clone(),
-                        message: msg,
+                        message,
                     });
                 }
             },
@@ -56,8 +56,8 @@ mod tests {
         let expected = r#"
         error in the following rib found at line 2, column 30
         `1`
-        cause: inferred a number to be `list<u32>` which is invalid
-        expected a number type, found list
+        cause: expected to be of the type `number`, but inferred as `list<u32>`
+        used as list
         "#;
 
         assert_eq!(error_message, strip_spaces(expected));

--- a/golem-rib/src/type_checker/mod.rs
+++ b/golem-rib/src/type_checker/mod.rs
@@ -32,9 +32,9 @@ pub fn type_check(
 ) -> Result<(), RibCompilationError> {
     check_type_error_in_function_calls(expr, function_type_registry)?;
     check_unresolved_types(expr)?;
+    check_invalid_worker_name(expr)?;
     check_invalid_expr(expr)?;
     check_invalid_program_return(expr)?;
-    check_invalid_worker_name(expr)?;
     check_invalid_math_expr(expr)?;
     check_exhaustive_pattern_match(expr, function_type_registry)?;
     Ok(())

--- a/golem-rib/src/type_inference/call_arguments_inference.rs
+++ b/golem-rib/src/type_inference/call_arguments_inference.rs
@@ -49,7 +49,7 @@ pub fn infer_function_call_types(
 }
 
 mod internal {
-    use crate::call_type::CallType;
+    use crate::call_type::{CallType, InstanceCreationType};
     use crate::type_inference::kind::GetTypeKind;
     use crate::{
         ActualType, DynamicParsedFunctionName, ExpectedType, Expr, FunctionCallError,
@@ -68,7 +68,17 @@ mod internal {
         let cloned = call_type.clone();
 
         match call_type {
-            CallType::InstanceCreation(_) => Ok(()),
+            CallType::InstanceCreation(instance) => match instance {
+                InstanceCreationType::Worker { .. } => {
+                    for arg in args.iter_mut() {
+                        arg.add_infer_type_mut(InferredType::Str);
+                    }
+
+                    Ok(())
+                }
+
+                _ => Ok(()),
+            },
             CallType::Function { function_name, .. } => {
                 let resource_constructor_registry_key =
                     RegistryKey::resource_constructor_registry_key(function_name);

--- a/golem-rib/src/type_inference/kind.rs
+++ b/golem-rib/src/type_inference/kind.rs
@@ -43,7 +43,7 @@ impl Display for TypeKind {
             TypeKind::Variant => write!(f, "variant"),
             TypeKind::Unknown => write!(f, "unknown"),
             TypeKind::Ambiguous { possibilities } => {
-                write!(f, "ambiguous: ")?;
+                write!(f, "conflicting types: ")?;
                 for (i, kind) in possibilities.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;

--- a/golem-rib/src/type_inference/worker_function_invocation.rs
+++ b/golem-rib/src/type_inference/worker_function_invocation.rs
@@ -169,7 +169,7 @@ pub fn infer_worker_function_invokes(expr: &mut Expr) -> Result<(), RibCompilati
                         function_name: method.to_string(),
                         expr: expr_copied,
                         message: format!(
-                            "Invalid worker function invoke. Expected to be an instance type, found {}",
+                            "invalid worker function invoke. Expected to be an instance type, found {}",
                             TypeName::try_from(inferred_type)
                                 .map(|x| x.to_string())
                                 .unwrap_or("Unknown".to_string())

--- a/golem-worker-service-base/src/lib.rs
+++ b/golem-worker-service-base/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Golem Cloud
+    // Copyright 2024-2025 Golem Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ pub mod gateway_binding;
 pub mod gateway_execution;
 pub mod gateway_middleware;
 pub mod gateway_request;
-mod gateway_rib_compiler;
+pub mod gateway_rib_compiler;
 pub mod gateway_rib_interpreter;
 pub mod gateway_security;
 pub mod getter;

--- a/golem-worker-service-base/src/lib.rs
+++ b/golem-worker-service-base/src/lib.rs
@@ -1,4 +1,4 @@
-    // Copyright 2024-2025 Golem Cloud
+// Copyright 2024-2025 Golem Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/golem-worker-service/src/main.rs
+++ b/golem-worker-service/src/main.rs
@@ -21,35 +21,23 @@ use golem_worker_service_base::metrics;
 use opentelemetry::global;
 use prometheus::Registry;
 use tokio::task::JoinSet;
+use golem_worker_service_base::gateway_rib_compiler::{DefaultWorkerServiceRibCompiler, WorkerServiceRibCompiler};
+use rib::{compile, Expr};
 
 fn main() -> Result<(), anyhow::Error> {
-    if std::env::args().any(|arg| arg == "--dump-openapi-yaml") {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()?
-            .block_on(dump_openapi_yaml())
-    } else if let Some(config) = make_config_loader().load_or_dump_config() {
-        init_tracing_with_default_env_filter(&config.tracing);
+    let expr = r#"
+                let x = request.body.user-id;
+                let worker = instance(x);
+                let cart1 = worker.cart("bar");
+                cart1.add-item("foo");
+                "success"
+            "#;
+    let expr = Expr::from_text(expr).unwrap();
+    let component_metadata = internal::get_metadata_with_resource_with_params();
 
-        let prometheus = metrics::register_all();
+    let compiled = rib::compile(&expr, &component_metadata).unwrap();
 
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(prometheus.clone())
-            .build()?;
-
-        global::set_meter_provider(
-            opentelemetry_sdk::metrics::MeterProviderBuilder::default()
-                .with_reader(exporter)
-                .build(),
-        );
-
-        Ok(tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()?
-            .block_on(async_main(config, prometheus))?)
-    } else {
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn async_main(
@@ -85,4 +73,59 @@ async fn dump_openapi_yaml() -> Result<(), anyhow::Error> {
     let yaml = service.http_service().spec_yaml();
     println!("{yaml}");
     Ok(())
+}
+
+mod internal {
+
+    use async_trait::async_trait;
+    use golem_wasm_ast::analysis::analysed_type::{
+        case, f32, field, handle, list, option, r#enum, record, result, str, tuple, u32, u64,
+        unit_case, variant,
+    };
+    use golem_wasm_ast::analysis::{
+        AnalysedExport, AnalysedFunction, AnalysedFunctionParameter, AnalysedFunctionResult,
+        AnalysedInstance, AnalysedResourceId, AnalysedResourceMode, AnalysedType,
+    };
+    use golem_wasm_rpc::{IntoValueAndType, Value, ValueAndType};
+    use std::sync::Arc;
+    pub(crate) fn get_metadata_with_resource_with_params() -> Vec<AnalysedExport> {
+        get_metadata_with_resource(vec![AnalysedFunctionParameter {
+            name: "user-id".to_string(),
+            typ: str(),
+        }])
+    }
+
+    fn get_metadata_with_resource(
+        resource_constructor_params: Vec<AnalysedFunctionParameter>,
+    ) -> Vec<AnalysedExport> {
+        let instance = AnalysedExport::Instance(AnalysedInstance {
+            name: "golem:it/api".to_string(),
+            functions: vec![
+                AnalysedFunction {
+                    name: "[constructor]cart".to_string(),
+                    parameters: resource_constructor_params,
+                    results: vec![AnalysedFunctionResult {
+                        name: None,
+                        typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Owned),
+                    }],
+                },
+                AnalysedFunction {
+                    name: "[method]cart.add-item".to_string(),
+                    parameters: vec![
+                        AnalysedFunctionParameter {
+                            name: "self".to_string(),
+                            typ: handle(AnalysedResourceId(0), AnalysedResourceMode::Borrowed),
+                        },
+                        AnalysedFunctionParameter {
+                            name: "item".to_string(),
+                            typ: str(),
+                        },
+                    ],
+                    results: vec![],
+                }
+            ],
+        });
+
+        vec![instance]
+    }
 }


### PR DESCRIPTION
* The argument to instance will be always inferred as `string`
* checking invalid worker_name in the type_check phase is now early in the order.