### PR TITLE
Add a span for outgoing http requests and add trace context headers

### DIFF
--- a/golem-worker-executor-base/src/durable_host/http/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/http/mod.rs
@@ -44,6 +44,13 @@ pub(crate) async fn end_http_request<Ctx: WorkerCtx>(
                 warn!("No matching BeginRemoteWrite index was found when HTTP response arrived. Handle: {}; open functions: {:?}", state.root_handle, ctx.state.open_function_table);
             }
         }
+
+        ctx.state
+            .invocation_context
+            .finish_span(&state.span_id)
+            .map_err(|err| GolemError::Runtime {
+                details: format!("Failed to close outgoing http request span: {err}"),
+            })?;
     } else {
         warn!("No matching HTTP request is associated with resource handle. Handle: {}, open requests: {:?}", current_handle, ctx.state.open_http_requests);
     }

--- a/golem-worker-executor-base/src/durable_host/http/serialized.rs
+++ b/golem-worker-executor-base/src/durable_host/http/serialized.rs
@@ -16,6 +16,7 @@ use bincode::{Decode, Encode};
 use http::{HeaderName, HeaderValue, Version};
 
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use crate::durable_host::serialized::SerializableError;
@@ -417,6 +418,23 @@ impl From<Method> for SerializableHttpMethod {
             Method::Trace => SerializableHttpMethod::Trace,
             Method::Patch => SerializableHttpMethod::Patch,
             Method::Other(method) => SerializableHttpMethod::Other(method),
+        }
+    }
+}
+
+impl Display for SerializableHttpMethod {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SerializableHttpMethod::Get => write!(f, "GET"),
+            SerializableHttpMethod::Post => write!(f, "POST"),
+            SerializableHttpMethod::Put => write!(f, "PUT"),
+            SerializableHttpMethod::Delete => write!(f, "DELETE"),
+            SerializableHttpMethod::Head => write!(f, "HEAD"),
+            SerializableHttpMethod::Connect => write!(f, "CONNECT"),
+            SerializableHttpMethod::Options => write!(f, "OPTIONS"),
+            SerializableHttpMethod::Trace => write!(f, "TRACE"),
+            SerializableHttpMethod::Patch => write!(f, "PATCH"),
+            SerializableHttpMethod::Other(method) => write!(f, "{}", method),
         }
     }
 }

--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -1844,6 +1844,8 @@ struct HttpRequestState {
     pub root_handle: u32,
     /// Information about the request to be included in the oplog
     pub request: SerializableHttpRequest,
+    /// SpanId
+    pub span_id: SpanId,
 }
 
 struct PrivateDurableWorkerState<Ctx: WorkerCtx> {
@@ -1882,6 +1884,7 @@ struct PrivateDurableWorkerState<Ctx: WorkerCtx> {
 
     invocation_context: InvocationContext,
     current_span_id: SpanId,
+    forward_trace_context_headers: bool,
 }
 
 impl<Ctx: WorkerCtx> PrivateDurableWorkerState<Ctx> {
@@ -1947,6 +1950,7 @@ impl<Ctx: WorkerCtx> PrivateDurableWorkerState<Ctx> {
             replay_state,
             invocation_context,
             current_span_id,
+            forward_trace_context_headers: true,
         }
     }
 


### PR DESCRIPTION
Resolves #1333 

- Starts a span with uri/method information for outgoing wasi-http requests
- Finishes the span when the request is dropped
- Adds the trace-context headers to the outgoing request if this option is enabled (way to change the option will come in a follow-up PR when host functions are added)