### PR TITLE
No error on nonexisting worker

### DIFF
--- a/golem-component-compilation-service/src/grpc.rs
+++ b/golem-component-compilation-service/src/grpc.rs
@@ -174,4 +174,15 @@ impl TraceErrorKind for ComponentCompilationTraceErrorKind<'_> {
             },
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self.0.error {
+            None => false,
+            Some(error) => match error {
+                component_compilation_error::Error::BadRequest(_) => true,
+                component_compilation_error::Error::NotFound(_) => true,
+                component_compilation_error::Error::InternalError(_) => false,
+            },
+        }
+    }
 }

--- a/golem-component-service-base/src/api/common.rs
+++ b/golem-component-service-base/src/api/common.rs
@@ -38,4 +38,18 @@ impl TraceErrorKind for ComponentTraceErrorKind<'_> {
             },
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self.0.error {
+            None => false,
+            Some(error) => match error {
+                component_error::Error::BadRequest(_) => true,
+                component_error::Error::NotFound(_) => true,
+                component_error::Error::AlreadyExists(_) => true,
+                component_error::Error::LimitExceeded(_) => true,
+                component_error::Error::Unauthorized(_) => true,
+                component_error::Error::InternalError(_) => false,
+            },
+        }
+    }
 }

--- a/golem-component-service/src/api/mod.rs
+++ b/golem-component-service/src/api/mod.rs
@@ -93,6 +93,17 @@ impl TraceErrorKind for ComponentError {
             ComponentError::InternalError(_) => "InternalError",
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self {
+            ComponentError::BadRequest(_) => true,
+            ComponentError::NotFound(_) => true,
+            ComponentError::AlreadyExists(_) => true,
+            ComponentError::LimitExceeded(_) => true,
+            ComponentError::Unauthorized(_) => true,
+            ComponentError::InternalError(_) => false,
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, ComponentError>;

--- a/golem-component-service/src/lib.rs
+++ b/golem-component-service/src/lib.rs
@@ -161,9 +161,7 @@ impl ComponentService {
     ) -> Result<u16, anyhow::Error> {
         let prometheus_registry = self.prometheus_registry.clone();
 
-        let app = api::combined_routes(prometheus_registry, &self.services)
-            .with(OpenTelemetryMetrics::new())
-            .with(Tracing);
+        let app = api::combined_routes(prometheus_registry, &self.services);
 
         let poem_listener =
             poem::listener::TcpListener::bind(format!("0.0.0.0:{}", self.config.http_port));

--- a/golem-component-service/src/lib.rs
+++ b/golem-component-service/src/lib.rs
@@ -24,7 +24,6 @@ use include_dir::{include_dir, Dir};
 use poem::endpoint::BoxEndpoint;
 use poem::listener::Acceptor;
 use poem::listener::Listener;
-use poem::middleware::{OpenTelemetryMetrics, Tracing};
 use poem::{EndpointExt, IntoEndpoint};
 use poem_openapi::OpenApiService;
 use prometheus::Registry;

--- a/golem-shard-manager/src/error.rs
+++ b/golem-shard-manager/src/error.rs
@@ -156,4 +156,15 @@ impl TraceErrorKind for ShardManagerTraceErrorKind<'_> {
             },
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self.0.error {
+            None => false,
+            Some(error) => match error {
+                shard_manager_error::Error::InvalidRequest(_) => true,
+                shard_manager_error::Error::Timeout(_) => true,
+                shard_manager_error::Error::Unknown(_) => false,
+            },
+        }
+    }
 }

--- a/golem-worker-executor-base/src/error.rs
+++ b/golem-worker-executor-base/src/error.rs
@@ -360,6 +360,36 @@ impl TraceErrorKind for GolemError {
             GolemError::FileSystemError { .. } => "FileSystemError",
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match self {
+            GolemError::WorkerAlreadyExists { .. }
+            | GolemError::WorkerNotFound { .. }
+            | GolemError::PromiseNotFound { .. }
+            | GolemError::PromiseDropped { .. }
+            | GolemError::PromiseAlreadyCompleted { .. }
+            | GolemError::Interrupted { .. }
+            | GolemError::InvalidShardId { .. } => true,
+            GolemError::InvalidRequest { .. }
+            | GolemError::WorkerCreationFailed { .. }
+            | GolemError::FailedToResumeWorker { .. }
+            | GolemError::ComponentDownloadFailed { .. }
+            | GolemError::ComponentParseFailed { .. }
+            | GolemError::GetLatestVersionOfComponentFailed { .. }
+            | GolemError::InitialComponentFileDownloadFailed { .. }
+            | GolemError::ParamTypeMismatch { .. }
+            | GolemError::NoValueInMessage
+            | GolemError::ValueMismatch { .. }
+            | GolemError::UnexpectedOplogEntry { .. }
+            | GolemError::InvalidAccount
+            | GolemError::Runtime { .. }
+            | GolemError::PreviousInvocationFailed { .. }
+            | GolemError::PreviousInvocationExited
+            | GolemError::Unknown { .. }
+            | GolemError::ShardingNotReady
+            | GolemError::FileSystemError { .. } => false,
+        }
+    }
 }
 
 impl From<InterruptKind> for GolemError {

--- a/golem-worker-service-base/src/api/common.rs
+++ b/golem-worker-service-base/src/api/common.rs
@@ -56,6 +56,17 @@ impl TraceErrorKind for ApiEndpointError {
             ApiEndpointError::InternalError(_) => "InternalError",
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self {
+            ApiEndpointError::BadRequest(_) => true,
+            ApiEndpointError::NotFound(_) => true,
+            ApiEndpointError::AlreadyExists(_) => true,
+            ApiEndpointError::Forbidden(_) => true,
+            ApiEndpointError::Unauthorized(_) => true,
+            ApiEndpointError::InternalError(_) => false,
+        }
+    }
 }
 
 impl ApiEndpointError {
@@ -116,6 +127,20 @@ impl TraceErrorKind for WorkerTraceErrorKind<'_> {
             },
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self.0.error {
+            None => false,
+            Some(error) => match error {
+                worker::v1::worker_error::Error::BadRequest(_) => true,
+                worker::v1::worker_error::Error::Unauthorized(_) => true,
+                worker::v1::worker_error::Error::LimitExceeded(_) => true,
+                worker::v1::worker_error::Error::NotFound(_) => true,
+                worker::v1::worker_error::Error::AlreadyExists(_) => true,
+                worker::v1::worker_error::Error::InternalError(_) => false,
+            },
+        }
+    }
 }
 
 pub struct ApiDefinitionTraceErrorKind<'a>(pub &'a ApiDefinitionError);
@@ -139,6 +164,22 @@ impl TraceErrorKind for ApiDefinitionTraceErrorKind<'_> {
                 api_definition_error::Error::AlreadyExists(_) => "AlreadyExists",
                 api_definition_error::Error::InternalError(_) => "InternalError",
                 api_definition_error::Error::NotDraft(_) => "NotDraft",
+            },
+        }
+    }
+
+    fn is_expected(&self) -> bool {
+        match &self.0.error {
+            None => false,
+            Some(error) => match error {
+                api_definition_error::Error::BadRequest(_) => true,
+                api_definition_error::Error::InvalidRoutes(_) => true,
+                api_definition_error::Error::Unauthorized(_) => true,
+                api_definition_error::Error::LimitExceeded(_) => true,
+                api_definition_error::Error::NotFound(_) => true,
+                api_definition_error::Error::AlreadyExists(_) => true,
+                api_definition_error::Error::InternalError(_) => false,
+                api_definition_error::Error::NotDraft(_) => true,
             },
         }
     }

--- a/golem-worker-service-base/src/api/error.rs
+++ b/golem-worker-service-base/src/api/error.rs
@@ -54,6 +54,17 @@ impl TraceErrorKind for WorkerApiBaseError {
             WorkerApiBaseError::InternalError(_) => "InternalError",
         }
     }
+
+    fn is_expected(&self) -> bool {
+        match &self {
+            WorkerApiBaseError::BadRequest(_) => true,
+            WorkerApiBaseError::NotFound(_) => true,
+            WorkerApiBaseError::AlreadyExists(_) => true,
+            WorkerApiBaseError::Forbidden(_) => true,
+            WorkerApiBaseError::Unauthorized(_) => true,
+            WorkerApiBaseError::InternalError(_) => false,
+        }
+    }
 }
 
 impl From<tonic::transport::Error> for WorkerApiBaseError {

--- a/golem-worker-service-base/src/service/worker/routing_logic.rs
+++ b/golem-worker-service-base/src/service/worker/routing_logic.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinSet;
 use tokio::time::{sleep, Instant};
 use tonic::transport::Channel;
 use tonic::Status;
-use tracing::{debug, error, info, warn, Instrument};
+use tracing::{debug, error, info, trace, warn, Instrument};
 
 use golem_api_grpc::proto::golem::worker::v1::WorkerExecutionError;
 use golem_api_grpc::proto::golem::workerexecutor::v1::worker_executor_client::WorkerExecutorClient;
@@ -316,6 +316,9 @@ pub enum ResponseMapResult {
         shard_ids: HashSet<ShardId>,
     },
     ShardingNotReady,
+    /// Error that is expected, not to be logged/counted as an error
+    Expected(WorkerServiceError),
+    /// Error that is unexpected, to be logged/counted as an error
     Other(WorkerServiceError),
 }
 
@@ -330,6 +333,9 @@ impl From<GolemError> for ResponseMapResult {
                 shard_ids,
             },
             GolemError::ShardingNotReady(_) => ResponseMapResult::ShardingNotReady,
+            GolemError::WorkerNotFound(_) | GolemError::WorkerAlreadyExists(_) => {
+                ResponseMapResult::Expected(error.into())
+            }
             other => ResponseMapResult::Other(other.into()),
         }
     }
@@ -349,7 +355,7 @@ impl From<WorkerExecutionError> for ResponseMapResult {
             })
         });
         let response_map_result = golem_error.clone().into();
-        debug!(
+        trace!(
             error = format!("{:?}", error),
             golem_error = golem_error.to_string(),
             response_map_result = format!("{:?}", response_map_result),
@@ -390,7 +396,7 @@ impl<T: HasRoutingTableService + HasWorkerExecutorClients + Send + Sync> Routing
         G: Fn(Target::ResultOut) -> Result<R, ResponseMapResult> + Send + Sync,
         H: Fn(CallWorkerExecutorError) -> WorkerServiceError + Send + Sync,
     {
-        let mut retry = RetryState::new(self.worker_executor_retry_config());
+        let mut retry = RetryState::new(self.worker_executor_retry_config(), description.as_ref());
         loop {
             let span = retry.start_attempt(Target::tracing_kind(&target));
 
@@ -412,6 +418,9 @@ impl<T: HasRoutingTableService + HasWorkerExecutorClients + Send + Sync> Routing
                             }
                             Err(error @ ResponseMapResult::ShardingNotReady) => {
                                 retry.retry(self, &error, &pod).await
+                            }
+                            Err(ResponseMapResult::Expected(error)) => {
+                                retry.non_retryable_expected_error(error, &pod)
                             }
                             Err(ResponseMapResult::Other(error)) => {
                                 retry.non_retryable_error(error, &pod)
@@ -499,21 +508,29 @@ struct RetryState<'a> {
     attempt: u64,
     retry_attempt: u64,
     retry_config: &'a RetryConfig,
+    op: &'a str,
 }
 
 impl<'a> RetryState<'a> {
-    fn new(retry_config: &'a RetryConfig) -> Self {
+    fn new(retry_config: &'a RetryConfig, op: &'a str) -> Self {
         RetryState {
             started_at: Instant::now(),
             attempt: 0,
             retry_attempt: 0,
             retry_config,
+            op,
         }
     }
 
     fn start_attempt(&mut self, executor_kind: &'static str) -> RetrySpan {
         self.attempt += 1;
         self.retry_attempt += 1;
+        debug!(
+            attempt = self.attempt,
+            executor_kind = executor_kind,
+            op = self.op,
+            "Call on executor - start attempt"
+        );
         RetrySpan::new(executor_kind, self.attempt)
     }
 
@@ -535,6 +552,7 @@ impl<'a> RetryState<'a> {
                     ?error,
                     ?pod,
                     delay_ms = delay.as_millis(),
+                    op = self.op,
                     "Call on executor - retry"
                 );
                 sleep(delay).await;
@@ -548,11 +566,26 @@ impl<'a> RetryState<'a> {
                     error = format!("{error:?}"),
                     pod = format_pod(pod),
                     delay_ms = delay.as_millis(),
+                    op = self.op,
                     "Call on executor - retry - resetting retry attempts"
                 );
                 Ok(None)
             }
         }
+    }
+
+    fn non_retryable_expected_error<T>(
+        &self,
+        error: WorkerServiceError,
+        pod: &Option<Pod>,
+    ) -> Result<Option<T>, WorkerServiceError> {
+        trace!(
+            error = error.to_string(),
+            pod = format_pod(pod),
+            op = self.op,
+            "Call on executor - non retriable expected error"
+        );
+        Err(error)
     }
 
     fn non_retryable_error<T>(
@@ -563,6 +596,7 @@ impl<'a> RetryState<'a> {
         error!(
             error = error.to_string(),
             pod = format_pod(pod),
+            op = self.op,
             "Call on executor - non retriable error"
         );
         Err(error)
@@ -572,6 +606,7 @@ impl<'a> RetryState<'a> {
         info!(
             duration_ms = self.started_at.elapsed().as_millis(),
             pod = format_pod(pod),
+            op = self.op,
             "Call on executor - success"
         );
     }

--- a/golem-worker-service/src/lib.rs
+++ b/golem-worker-service/src/lib.rs
@@ -146,9 +146,7 @@ impl WorkerService {
     ) -> Result<u16, anyhow::Error> {
         let prometheus_registry = self.prometheus_registry.clone();
 
-        let app = api::combined_routes(prometheus_registry, &self.services)
-            .with(OpenTelemetryMetrics::new())
-            .with(Tracing);
+        let app = api::combined_routes(prometheus_registry, &self.services);
 
         let poem_listener =
             poem::listener::TcpListener::bind(format!("0.0.0.0:{}", self.config.port));


### PR DESCRIPTION
Resolves #1354 

- Removes the poem tracing and logging middlewares because they were redundant (we already had our own `recorded_http_api` stuff, and that one contains more information)
- Removes redundant log lines from the worker service
- Introduces the concept of "expected" failures which are not logged as errors (still logged but on info level). An example is "worker not found" 

With these changes completely normal things like a user trying to get a non-existing worker's metadata are not resulting in multiple error lines in the logs.