### PR TITLE
Use latest component version to retrieve files if there is no worker

### DIFF
--- a/golem-worker-service-base/src/gateway_execution/file_server_binding_handler.rs
+++ b/golem-worker-service-base/src/gateway_execution/file_server_binding_handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::empty_worker_metadata;
-use crate::gateway_execution::WorkerDetail;
+use crate::gateway_execution::WorkerDetails;
 use crate::getter::{get_response_headers_or_default, get_status_code};
 use crate::service::component::{ComponentService, ComponentServiceError};
 use crate::service::worker::{WorkerService, WorkerServiceError};
@@ -23,6 +23,7 @@ use futures::Stream;
 use futures_util::TryStreamExt;
 use golem_common::model::{ComponentFilePath, HasAccountId, TargetWorkerId, WorkerId};
 use golem_service_base::auth::EmptyAuthCtx;
+use golem_service_base::model::Component;
 use golem_service_base::service::initial_component_files::InitialComponentFilesService;
 use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::{Value, ValueAndType};
@@ -38,7 +39,7 @@ pub trait FileServerBindingHandler<Namespace> {
     async fn handle_file_server_binding_result(
         &self,
         namespace: &Namespace,
-        worker_detail: &WorkerDetail,
+        worker_detail: &WorkerDetails,
         original_result: RibResult,
     ) -> FileServerBindingResult;
 }
@@ -173,6 +174,49 @@ impl DefaultFileServerBindingHandler {
             worker_service,
         }
     }
+
+    async fn get_component_metadata(
+        &self,
+        worker_detail: &WorkerDetails,
+    ) -> Result<Component, FileServerBindingError> {
+        // Two cases, we either have an existing worker or not (either not configured or not existing).
+        // If there is no worker we need use the lastest component version, if there is none we need to use the exact component version
+        // the worker is using. Not doing that would make the blob_storage optimization for read-only files visible to users.
+
+        let component_version = if let Some(worker_id) = worker_detail.worker_id() {
+            let worker_metadata = self
+                .worker_service
+                .get_metadata(&worker_id, empty_worker_metadata())
+                .await;
+            match worker_metadata {
+                Ok(metadata) => Some(metadata.component_version),
+                Err(WorkerServiceError::WorkerNotFound(_)) => None,
+                Err(other) => Err(FileServerBindingError::InternalError(format!(
+                    "Failed looking up worker metadata: {other}"
+                )))?,
+            }
+        } else {
+            None
+        };
+
+        let component_metadata = if let Some(component_version) = component_version {
+            self.component_service
+                .get_by_version(
+                    &worker_detail.component_id,
+                    component_version,
+                    &EmptyAuthCtx(),
+                )
+                .await
+                .map_err(FileServerBindingError::ComponentServiceError)?
+        } else {
+            self.component_service
+                .get_latest(&worker_detail.component_id, &EmptyAuthCtx())
+                .await
+                .map_err(FileServerBindingError::ComponentServiceError)?
+        };
+
+        Ok(component_metadata)
+    }
 }
 
 #[async_trait]
@@ -182,29 +226,21 @@ impl<Namespace: HasAccountId + Send + Sync + 'static> FileServerBindingHandler<N
     async fn handle_file_server_binding_result(
         &self,
         namespace: &Namespace,
-        worker_detail: &WorkerDetail,
+        worker_detail: &WorkerDetails,
         original_result: RibResult,
     ) -> FileServerBindingResult {
         let binding_details = FileServerBindingDetails::from_rib_result(original_result)
             .map_err(FileServerBindingError::InvalidRibResult)?;
 
-        let component_metadata = self
-            .component_service
-            .get_by_version(
-                &worker_detail.component_id.component_id,
-                worker_detail.component_id.version,
-                &EmptyAuthCtx(),
-            )
-            .await
-            .map_err(FileServerBindingError::ComponentServiceError)?;
+        let component_metadata = self.get_component_metadata(worker_detail).await?;
 
         // if we are serving a read_only file, we can just go straight to the blob storage.
-        let matching_file = component_metadata
+        let matching_ro_file = component_metadata
             .files
             .iter()
             .find(|file| file.path == binding_details.file_path && file.is_read_only());
 
-        if let Some(file) = matching_file {
+        if let Some(file) = matching_ro_file {
             let data = self
                 .initial_component_files_service
                 .get(&namespace.account_id(), &file.key)
@@ -240,7 +276,7 @@ impl<Namespace: HasAccountId + Send + Sync + 'static> FileServerBindingHandler<N
                     FileServerBindingError::InternalError(format!("Invalid worker name: {}", e))
                 })?;
 
-            let component_id = worker_detail.component_id.component_id.clone();
+            let component_id = worker_detail.component_id.clone();
 
             let worker_id = TargetWorkerId {
                 component_id,

--- a/golem-worker-service-base/src/gateway_execution/http_handler_binding_handler.rs
+++ b/golem-worker-service-base/src/gateway_execution/http_handler_binding_handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::{GatewayWorkerRequestExecutor, WorkerRequestExecutorError};
-use crate::gateway_execution::{GatewayResolvedWorkerRequest, WorkerDetail};
+use crate::gateway_execution::{GatewayResolvedWorkerRequest, WorkerDetails};
 use async_trait::async_trait;
 use bytes::Bytes;
 use golem_common::model::HasAccountId;
@@ -32,7 +32,7 @@ pub trait HttpHandlerBindingHandler<Namespace> {
     async fn handle_http_handler_binding(
         &self,
         namespace: &Namespace,
-        worker_detail: &WorkerDetail,
+        worker_detail: &WorkerDetails,
         incoming_http_request: IncomingHttpRequest,
     ) -> HttpHandlerBindingResult;
 }
@@ -70,10 +70,10 @@ impl<Namespace: HasAccountId + Send + Sync + Clone + 'static> HttpHandlerBinding
     async fn handle_http_handler_binding(
         &self,
         namespace: &Namespace,
-        worker_detail: &WorkerDetail,
+        worker_detail: &WorkerDetails,
         incoming_http_request: IncomingHttpRequest,
     ) -> HttpHandlerBindingResult {
-        let component_id = worker_detail.component_id.component_id.clone();
+        let component_id = worker_detail.component_id.clone();
 
         let typ: golem_wasm_ast::analysis::protobuf::Type = (&golem_common::virtual_exports::http_incoming_handler::IncomingHttpRequest::analysed_type()).into();
 

--- a/golem-worker-service-base/src/gateway_execution/mod.rs
+++ b/golem-worker-service-base/src/gateway_execution/mod.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use golem_common::model::{ComponentId, IdempotencyKey};
+use golem_common::model::{ComponentId, IdempotencyKey, WorkerId};
 use golem_common::SafeDisplay;
-use golem_service_base::model::VersionedComponentId;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -49,19 +48,19 @@ pub struct GatewayResolvedWorkerRequest<Namespace> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct WorkerDetail {
-    pub component_id: VersionedComponentId,
+pub struct WorkerDetails {
+    pub component_id: ComponentId,
     pub worker_name: Option<String>,
     pub idempotency_key: Option<IdempotencyKey>,
     pub invocation_context: InvocationContextStack,
 }
 
-impl WorkerDetail {
+impl WorkerDetails {
     fn as_json(&self) -> Value {
         let mut worker_detail_content = HashMap::new();
         worker_detail_content.insert(
             "component_id".to_string(),
-            Value::String(self.component_id.component_id.0.to_string()),
+            Value::String(self.component_id.0.to_string()),
         );
 
         if let Some(worker_name) = &self.worker_name {
@@ -107,6 +106,13 @@ impl WorkerDetail {
             }
             None => Ok(RibInput::default()),
         }
+    }
+
+    fn worker_id(&self) -> Option<WorkerId> {
+        self.worker_name.as_ref().map(|wn| WorkerId {
+            component_id: self.component_id.clone(),
+            worker_name: wn.clone(),
+        })
     }
 }
 

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -1830,7 +1830,7 @@ mod internal {
     use golem_worker_service_base::gateway_execution::http_handler_binding_handler::{
         HttpHandlerBindingHandler, HttpHandlerBindingResult,
     };
-    use golem_worker_service_base::gateway_execution::WorkerDetail;
+    use golem_worker_service_base::gateway_execution::WorkerDetails;
     use golem_worker_service_base::gateway_execution::{
         GatewayResolvedWorkerRequest, GatewayWorkerRequestExecutor, WorkerRequestExecutorError,
         WorkerResponse,
@@ -1934,7 +1934,7 @@ mod internal {
         async fn handle_file_server_binding_result(
             &self,
             _namespace: &Namespace,
-            _worker_detail: &WorkerDetail,
+            _worker_detail: &WorkerDetails,
             _original_result: RibResult,
         ) -> FileServerBindingResult {
             unimplemented!()
@@ -1947,7 +1947,7 @@ mod internal {
         async fn handle_http_handler_binding(
             &self,
             _namespace: &Namespace,
-            _worker_detail: &WorkerDetail,
+            _worker_detail: &WorkerDetails,
             _request_details: IncomingHttpRequest,
         ) -> HttpHandlerBindingResult {
             unimplemented!()


### PR DESCRIPTION
Slightly different than what we discussed, but I believe this way it's fully consistent with other binding types