### PR TITLE
Fix query params and avoid redundant lookups in hot path

### DIFF
--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -607,7 +607,6 @@ async fn resolve_rib_input(
     let mut values: Vec<golem_wasm_rpc::Value> = vec![];
     let mut types: Vec<NameTypePair> = vec![];
 
-    // API Gateway allows only "request" as input
     let request_analysed_type = required_types.types.get("request");
 
     match request_analysed_type {
@@ -627,8 +626,6 @@ async fn resolve_rib_input(
                             .await
                             .map_err(GatewayHttpError::BadRequest)?;
 
-                        // Ideally there is no need to go from TypeAnnotatedValue and then to ValueAndType
-                        // because these are in hot path, and we should remove as much as possible
                         let body_value = TypeAnnotatedValue::parse_with_type(&body.0, &record.typ)
                             .map_err(|err| {
                                 GatewayHttpError::BadRequest(format!(

--- a/golem-worker-service-base/src/gateway_execution/request.rs
+++ b/golem-worker-service-base/src/gateway_execution/request.rs
@@ -36,6 +36,10 @@ pub struct RichRequest {
 }
 
 impl RichRequest {
+    pub fn auth_data(&self) -> Option<&Value> {
+        self.auth_data.as_ref()
+    }
+
     pub fn headers(&self) -> &HeaderMap {
         self.underlying.headers()
     }

--- a/golem-worker-service-base/src/gateway_execution/request.rs
+++ b/golem-worker-service-base/src/gateway_execution/request.rs
@@ -74,8 +74,7 @@ impl RichRequest {
     pub fn path_params(&self) -> HashMap<String, String> {
         use crate::gateway_request::http_request::router;
 
-        self
-            .path_param_extractors
+        self.path_param_extractors
             .iter()
             .map(|param| match param {
                 router::PathParamExtractor::Single { var_info, index } => (

--- a/golem-worker-service-base/src/gateway_rib_compiler/mod.rs
+++ b/golem-worker-service-base/src/gateway_rib_compiler/mod.rs
@@ -45,6 +45,11 @@ impl WorkerServiceRibCompiler for DefaultWorkerServiceRibCompiler {
                     path: Path::from_elems(vec!["headers"]),
                     inferred_type: InferredType::Str,
                 },
+                GlobalVariableTypeSpec {
+                    variable_id: VariableId::global("request".to_string()),
+                    path: Path::from_elems(vec!["header"]),
+                    inferred_type: InferredType::Str,
+                },
             ],
         )
     }

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -621,7 +621,7 @@ async fn test_api_def_with_request_with_request_body_type_mismatch() {
     let body = response.into_body().into_string().await.unwrap();
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(body, "Invalid http request. Available types in request: record{body: record{bar_key: string, foo_key: u32}, path: record{user-id: string}}");
+    assert_eq!(body, "invalid http request body\ninvalid value for key foo_key: expected number, found string\nexpected request body: record{bar_key: string, foo_key: u32}");
 }
 
 #[test]

--- a/integration-tests/tests/api/api_deployment.rs
+++ b/integration-tests/tests/api/api_deployment.rs
@@ -150,7 +150,10 @@ async fn create_and_get_api_deployment(deps: &EnvBasedTestDependencies) {
         .create_or_update_api_deployment(request.clone())
         .await
         .unwrap();
-    check!(expected_merged.api_definitions == response.api_definitions);
+    check!(expected_merged
+        .api_definitions
+        .iter()
+        .all(|item| response.api_definitions.contains(item)));
     check!(request.site == response.site);
 
     let response = deps
@@ -158,7 +161,10 @@ async fn create_and_get_api_deployment(deps: &EnvBasedTestDependencies) {
         .get_api_deployment("subdomain.localhost")
         .await
         .unwrap();
-    check!(expected_merged.api_definitions == response.api_definitions);
+    check!(expected_merged
+        .api_definitions
+        .iter()
+        .all(|item| response.api_definitions.contains(item)));
     check!(request.site == response.site);
 
     deps.worker_service()

--- a/wasm-rpc/src/json/impl.rs
+++ b/wasm-rpc/src/json/impl.rs
@@ -179,7 +179,7 @@ fn get_bool(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         _ => {
             let type_description = type_description(json);
             Err(vec![format!(
-                "Expected function parameter type is Boolean. But found {}",
+                "expected bool, found {}",
                 type_description
             )])
         }
@@ -276,7 +276,7 @@ fn get_string(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         // If the JSON value is not a string, return an error with type information
         let type_description = type_description(json);
         Err(vec![format!(
-            "Expected function parameter type is String. But found {}",
+            "expected string, found {}",
             type_description
         )])
     }
@@ -296,7 +296,7 @@ fn get_char(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         let type_description = type_description(json);
 
         Err(vec![format!(
-            "Expected function parameter type is Char. But found {}",
+            "expected char, found {}",
             type_description
         )])
     }
@@ -504,7 +504,7 @@ fn get_record(
                 Err(value_errors) => errors.extend(
                     value_errors
                         .iter()
-                        .map(|err| format!("Invalid value for the key {}. Error: {}", name, err))
+                        .map(|err| format!("invalid value for key {}: {}", name, err))
                         .collect::<Vec<_>>(),
                 ),
             }
@@ -518,7 +518,7 @@ fn get_record(
 
                     vals.push((name.clone(), TypeAnnotatedValue::Option(Box::new(option))))
                 }
-                _ => errors.push(format!("Key '{}' not found", name)),
+                _ => errors.push(format!("key '{}' not found", name)),
             }
         }
     }
@@ -694,13 +694,13 @@ fn get_handle(
                 }
             } else {
                 Err(vec![format!(
-                    "Expected function parameter type is Handle, represented by a worker-url/resource-id string. But found {}",
+                    "expected handle, represented by a worker-url/resource-id string, found {}",
                     str
                 )])
             }
         }
         None => Err(vec![format!(
-            "Expected function parameter type is Handle, represented by a worker-url/resource-id string. But found {}",
+            "expected handle, represented by a worker-url/resource-id string, found {}",
             type_description(value)
         )]),
     }
@@ -708,12 +708,12 @@ fn get_handle(
 
 fn type_description(value: &JsonValue) -> &'static str {
     match value {
-        JsonValue::Null => "Null",
-        JsonValue::Bool(_) => "Boolean",
-        JsonValue::Number(_) => "Number",
-        JsonValue::String(_) => "String",
-        JsonValue::Array(_) => "Array",
-        JsonValue::Object(_) => "Object",
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "boolean",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "list",
+        JsonValue::Object(_) => "record",
     }
 }
 
@@ -739,13 +739,13 @@ fn get_big_decimal(value: &JsonValue) -> Result<BigDecimal, Vec<String>> {
             if let Ok(f64) = BigDecimal::from_str(num.to_string().as_str()) {
                 Ok(f64)
             } else {
-                Err(vec![format!("Cannot convert {} to f64", num)])
+                Err(vec![format!("cannot convert {} to f64", num)])
             }
         }
         _ => {
             let type_description = type_description(value);
             Err(vec![format!(
-                "Expected function parameter type is BigDecimal. But found {}",
+                "expected number, found {}",
                 type_description
             )])
         }
@@ -764,7 +764,7 @@ fn get_u64(value: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         _ => {
             let type_description = type_description(value);
             Err(vec![format!(
-                "Expected function parameter type is u64. But found {}",
+                "expected u64, found {}",
                 type_description
             )])
         }

--- a/wasm-rpc/src/json/impl.rs
+++ b/wasm-rpc/src/json/impl.rs
@@ -518,7 +518,7 @@ fn get_record(
 
                     vals.push((name.clone(), TypeAnnotatedValue::Option(Box::new(option))))
                 }
-                _ => errors.push(format!("Key '{}' not found in json_map", name)),
+                _ => errors.push(format!("Key '{}' not found", name)),
             }
         }
     }

--- a/wasm-rpc/src/json/impl.rs
+++ b/wasm-rpc/src/json/impl.rs
@@ -178,10 +178,7 @@ fn get_bool(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         JsonValue::Bool(bool_val) => Ok(TypeAnnotatedValue::Bool(*bool_val)),
         _ => {
             let type_description = type_description(json);
-            Err(vec![format!(
-                "expected bool, found {}",
-                type_description
-            )])
+            Err(vec![format!("expected bool, found {}", type_description)])
         }
     }
 }
@@ -275,10 +272,7 @@ fn get_string(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
     } else {
         // If the JSON value is not a string, return an error with type information
         let type_description = type_description(json);
-        Err(vec![format!(
-            "expected string, found {}",
-            type_description
-        )])
+        Err(vec![format!("expected string, found {}", type_description)])
     }
 }
 
@@ -295,10 +289,7 @@ fn get_char(json: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
     } else {
         let type_description = type_description(json);
 
-        Err(vec![format!(
-            "expected char, found {}",
-            type_description
-        )])
+        Err(vec![format!("expected char, found {}", type_description)])
     }
 }
 
@@ -684,13 +675,14 @@ fn get_handle(
                                 },
                             }),
                             uri,
-                            resource_id
+                            resource_id,
                         };
                         Ok(TypeAnnotatedValue::Handle(handle))
                     }
-                    Err(err) => {
-                        Err(vec![format!("Failed to parse resource-id section of the handle value: {}", err)])
-                    }
+                    Err(err) => Err(vec![format!(
+                        "Failed to parse resource-id section of the handle value: {}",
+                        err
+                    )]),
                 }
             } else {
                 Err(vec![format!(
@@ -744,10 +736,7 @@ fn get_big_decimal(value: &JsonValue) -> Result<BigDecimal, Vec<String>> {
         }
         _ => {
             let type_description = type_description(value);
-            Err(vec![format!(
-                "expected number, found {}",
-                type_description
-            )])
+            Err(vec![format!("expected number, found {}", type_description)])
         }
     }
 }
@@ -763,10 +752,7 @@ fn get_u64(value: &JsonValue) -> Result<TypeAnnotatedValue, Vec<String>> {
         }
         _ => {
             let type_description = type_description(value);
-            Err(vec![format!(
-                "expected u64, found {}",
-                type_description
-            )])
+            Err(vec![format!("expected u64, found {}", type_description)])
         }
     }
 }


### PR DESCRIPTION
The changes are small, but these are some fundamental changes in my view - and very important. 

* Look up query or path or headers only if needed by the Rib script. Not for every http request. Infact, look up from `poem::Request` for specific header keys that are _required_ and transform/parse them specifically, instead of collecting everything together.
* Make sure if a number is passed in path or query, but rib expects a string (which by default expects string for these global paths except body), it should work. I think this might be a regression and the lack of tests in this space need to be fixed
* Better error messages. Such as instead of `invalid request. expected : record { headers: {user-id: string} }`, with this PR, it will be `missing header: user-id`.  Bring back more details into the error message as well  "invalid http request body \n Invalid value for key `foo`: expected number, found string \n expected body: ...". 
* More precise approach rather than blindy using`wasm_rpc::TypeAnnotatedValue::parse_with_type` after collecting all fields into HashMap and then forming a ValueAndType etc in hot path. This in a hot path is not good. I think we only did some compiler driven refactoring in this space of the code after August 2023 where we quickly glued everything together - more of as a POC.  This is gone now, for the most part. We use wasm_rpc mappings only for request body. Here too, I guess I am missing `ValueAndType::parse_with_type` than `TypeAnnotatedValue::parse_with_type` but I haven't gone much deep into it, nor it is a concern of this PR. But I believe any reduction of loops and hoops in the hot path is an advantage. We will see.
* Try to make use of `RichRequest.inner` especially headers, as poem has efficient lookups
* Make sure both `request.header.x` as well as `request.headers.x` work. This has always been confusing to me and I don't want to keep going back to docs to see which one is correct

I have focussed on these fundamental requirements, and hasn't done any extra refactoring as part of this work!