### PR TITLE
Make sure request body can be used in multiple rib scripts (if any) within one request

### DIFF
--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -621,12 +621,12 @@ async fn resolve_rib_input(
 
                 match field_name {
                     "body" => {
-                        let body = rich_request
-                            .request_body_value()
+                       rich_request
+                            .take_request_body()
                             .await
                             .map_err(GatewayHttpError::BadRequest)?;
 
-                        let body_value = TypeAnnotatedValue::parse_with_type(&body.0, &record.typ)
+                        let body_value = TypeAnnotatedValue::parse_with_type(&rich_request.cached_request_body, &record.typ)
                             .map_err(|err| {
                                 GatewayHttpError::BadRequest(format!(
                                     "invalid http request body\n{}\nexpected request body: {}",

--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -621,24 +621,23 @@ async fn resolve_rib_input(
 
                 match field_name {
                     "body" => {
-                        rich_request
-                            .take_request_body()
-                            .await
-                            .map_err(GatewayHttpError::BadRequest)?;
-
-                        let body_value = TypeAnnotatedValue::parse_with_type(
-                            &rich_request.cached_request_body(),
-                            &record.typ,
-                        )
-                        .map_err(|err| {
+                        let body = rich_request.request_body().await.map_err(|err| {
                             GatewayHttpError::BadRequest(format!(
-                                "invalid http request body\n{}\nexpected request body: {}",
-                                err.join("\n"),
-                                TypeName::try_from(record.typ.clone())
-                                    .map(|x| x.to_string())
-                                    .unwrap_or_else(|_| format!("{:?}", &record.typ))
+                                "invalid http request body. {}",
+                                err.to_string()
                             ))
                         })?;
+
+                        let body_value = TypeAnnotatedValue::parse_with_type(body, &record.typ)
+                            .map_err(|err| {
+                                GatewayHttpError::BadRequest(format!(
+                                    "invalid http request body\n{}\nexpected request body: {}",
+                                    err.join("\n"),
+                                    TypeName::try_from(record.typ.clone())
+                                        .map(|x| x.to_string())
+                                        .unwrap_or_else(|_| format!("{:?}", &record.typ))
+                                ))
+                            })?;
 
                         let converted_value =
                             ValueAndType::try_from(body_value).map_err(|err| {

--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -624,7 +624,7 @@ async fn resolve_rib_input(
                         let body = rich_request.request_body().await.map_err(|err| {
                             GatewayHttpError::BadRequest(format!(
                                 "invalid http request body. {}",
-                                err.to_string()
+                                err
                             ))
                         })?;
 

--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -621,21 +621,24 @@ async fn resolve_rib_input(
 
                 match field_name {
                     "body" => {
-                       rich_request
+                        rich_request
                             .take_request_body()
                             .await
                             .map_err(GatewayHttpError::BadRequest)?;
 
-                        let body_value = TypeAnnotatedValue::parse_with_type(&rich_request.cached_request_body, &record.typ)
-                            .map_err(|err| {
-                                GatewayHttpError::BadRequest(format!(
-                                    "invalid http request body\n{}\nexpected request body: {}",
-                                    err.join("\n"),
-                                    TypeName::try_from(record.typ.clone())
-                                        .map(|x| x.to_string())
-                                        .unwrap_or_else(|_| format!("{:?}", &record.typ))
-                                ))
-                            })?;
+                        let body_value = TypeAnnotatedValue::parse_with_type(
+                            &rich_request.cached_request_body(),
+                            &record.typ,
+                        )
+                        .map_err(|err| {
+                            GatewayHttpError::BadRequest(format!(
+                                "invalid http request body\n{}\nexpected request body: {}",
+                                err.join("\n"),
+                                TypeName::try_from(record.typ.clone())
+                                    .map(|x| x.to_string())
+                                    .unwrap_or_else(|_| format!("{:?}", &record.typ))
+                            ))
+                        })?;
 
                         let converted_value =
                             ValueAndType::try_from(body_value).map_err(|err| {

--- a/golem-worker-service-base/src/gateway_execution/request.rs
+++ b/golem-worker-service-base/src/gateway_execution/request.rs
@@ -191,8 +191,7 @@ impl RichRequest {
     /// and for that rib-script, there will be no extra logic to read the request body in the hot path.
     /// At the same, if by any chance, multiple rib scripts exist (within a request) that require to lookup the request body, `take_request_body`
     /// is idempotent, that it doesn't affect correctness.
-    /// We intentionally don't consume the body if its not required in any Rib script. This is explained
-    /// in the construction of `RichRequest`
+    /// We intentionally don't consume the body if its not required in any Rib script.
     async fn take_request_body(&mut self) -> Result<(), String> {
         let body = self.underlying.take_body();
 

--- a/golem-worker-service-base/src/gateway_execution/to_response.rs
+++ b/golem-worker-service-base/src/gateway_execution/to_response.rs
@@ -434,14 +434,7 @@ mod test {
     }
 
     fn test_request() -> RichRequest {
-        RichRequest {
-            underlying: poem::Request::default(),
-            path_segments: vec![],
-            path_param_extractors: vec![],
-            query_info: vec![],
-            auth_data: None,
-            cached_request_body: serde_json::Value:: Null
-        }
+        RichRequest::new(poem::Request::default())
     }
 
     #[test]

--- a/golem-worker-service-base/src/gateway_execution/to_response.rs
+++ b/golem-worker-service-base/src/gateway_execution/to_response.rs
@@ -440,6 +440,7 @@ mod test {
             path_param_extractors: vec![],
             query_info: vec![],
             auth_data: None,
+            cached_request_body: serde_json::Value:: Null
         }
     }
 


### PR DESCRIPTION
* The code still ensures that we don't consume request body if unused in any rib script. So this is _NOT_ early consumption and reuse across
* If API definition has multiple rib scripts exists that needs to look up request body (ending up resulting in consuming request body from poem::Request), it should still behave lazy (i.e, only if its used) and yet reuse, avoiding potentially "empty" body errors.