### PR TITLE
Attempt to fix a race condition when interrupting workers for update

### DIFF
--- a/golem-worker-executor-base/src/worker/mod.rs
+++ b/golem-worker-executor-base/src/worker/mod.rs
@@ -1510,7 +1510,10 @@ impl RunningWorker {
     }
 
     fn interrupt(&self, kind: InterruptKind) {
-        self.sender.send(WorkerCommand::Interrupt(kind)).unwrap();
+        // In some cases it is possible that the invocation loop is already quitting and the receiver gets
+        // dropped when we get here. In this case the send fails, but we ignore it as the running worker got
+        // interrupted anyway.
+        let _ = self.sender.send(WorkerCommand::Interrupt(kind));
     }
 
     async fn create_instance<Ctx: WorkerCtx>(


### PR DESCRIPTION
This is a simple fix for the issue reported about `unwrap()` panicking when trying to automatically update a worker.

The fix is just to simply ignore this error - because the only way it can fail is if the receiver of this channel is already being dropped, which means the run loop has quit anyway; this is basically the same effect we want from the interruption (stop the running worker so we can update it) so we can safely ignore it.