### PR TITLE
Test oplog query in all worker executor tests, and one fix

### DIFF
--- a/golem-test-framework/src/dsl/mod.rs
+++ b/golem-test-framework/src/dsl/mod.rs
@@ -1352,7 +1352,12 @@ impl<T: TestDependencies + Send + Sync> TestDsl for T {
     }
 
     async fn check_oplog_is_queryable(&self, worker_id: &WorkerId) -> crate::Result<()> {
-        TestDsl::get_oplog(self, worker_id, OplogIndex::INITIAL).await?;
+        let oplog = TestDsl::get_oplog(self, worker_id, OplogIndex::INITIAL).await?;
+
+        for (idx, entry) in oplog.iter().enumerate() {
+            debug!("#{}: {entry:#?}", idx + 1);
+        }
+
         Ok(())
     }
 

--- a/golem-worker-executor-base/src/model/public_oplog/mod.rs
+++ b/golem-worker-executor-base/src/model/public_oplog/mod.rs
@@ -1132,7 +1132,8 @@ fn encode_host_function_request_as_value(
             let payload: SerializableInvokeRequest = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
-        "golem::rpc::wasm-rpc::invoke-and-await" => {
+        "golem::rpc::wasm-rpc::invoke-and-await"
+        | "golem::rpc::wasm-rpc::invoke-and-await result" => {
             let payload: SerializableInvokeRequest = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
@@ -1459,7 +1460,8 @@ fn encode_host_function_response_as_value(
             let payload: Result<(), SerializableError> = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
-        "golem::rpc::wasm-rpc::invoke-and-await" => {
+        "golem::rpc::wasm-rpc::invoke-and-await"
+        | "golem::rpc::wasm-rpc::invoke-and-await result" => {
             let payload: Result<Result<TypeAnnotatedValue, SerializableError>, String> =
                 try_deserialize(bytes);
 

--- a/golem-worker-executor-base/tests/blobstore.rs
+++ b/golem-worker-executor-base/tests/blobstore.rs
@@ -56,6 +56,8 @@ async fn blobstore_exists_return_true_if_the_container_was_created(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::Bool(true)]);
@@ -83,6 +85,8 @@ async fn blobstore_exists_return_false_if_the_container_was_not_created(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/guest_languages1.rs
+++ b/golem-worker-executor-base/tests/guest_languages1.rs
@@ -67,6 +67,8 @@ async fn zig_example_3(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     assert_eq!(result, vec![Value::U64(21)])
@@ -112,6 +114,8 @@ async fn tinygo_example(
             break;
         }
     }
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -204,6 +208,8 @@ async fn tinygo_http_client(
 
     let captured_body = captured_body.lock().unwrap().clone().unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -244,6 +250,8 @@ async fn grain_example_1(
     tokio::time::sleep(Duration::from_secs(5)).await;
     let mut events = vec![];
     rx.recv_many(&mut events, 100).await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -298,6 +306,8 @@ async fn java_example_1(
             break;
         }
     }
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -390,6 +400,8 @@ async fn java_shopping_cart(
         .invoke_and_await(&worker_id, "checkout", vec![])
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     assert_eq!(
@@ -447,6 +459,8 @@ async fn c_example_1(
         }
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     let first_line = log_event_to_string(&events[1]);
@@ -485,6 +499,8 @@ async fn c_example_2(
         }
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     let first_line = log_event_to_string(&events[1]);
@@ -517,6 +533,8 @@ async fn c_example_3(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::U64(536870912)]);
@@ -544,6 +562,8 @@ async fn c_example_4(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/guest_languages2.rs
+++ b/golem-worker-executor-base/tests/guest_languages2.rs
@@ -49,6 +49,8 @@ async fn javascript_example_3(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     let_assert!(Some(Value::String(result_body)) = result_fetch_get.into_iter().next());
@@ -73,6 +75,8 @@ async fn javascript_example_4(
         .invoke_and_await(&worker_id, "golem:it/api.{create-promise}", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -115,6 +119,8 @@ async fn python_example_1(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::U64(11)]);
@@ -147,6 +153,8 @@ async fn swift_example_1(
     while lines.len() < 2 && start.elapsed() < Duration::from_secs(5) {
         lines.extend(events_to_lines(&mut rx).await);
     }
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/guest_languages3.rs
+++ b/golem-worker-executor-base/tests/guest_languages3.rs
@@ -65,6 +65,8 @@ async fn javascript_example_1(
         }
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     let_assert!(Some(Value::Record(record_values)) = result.into_iter().next());
@@ -132,6 +134,8 @@ async fn javascript_example_2(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::U64(11)]);
@@ -168,6 +172,8 @@ async fn csharp_example_1(
     while lines.len() < 4 && start.elapsed() < Duration::from_secs(5) {
         lines.extend(events_to_lines(&mut rx).await);
     }
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/hot_update.rs
+++ b/golem-worker-executor-base/tests/hot_update.rs
@@ -198,6 +198,8 @@ async fn auto_update_on_running(
         .unwrap(); // awaiting a result from f3 to make sure the metadata already contains the updates
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -242,6 +244,8 @@ async fn auto_update_on_idle(
 
     info!("result: {:?}", result);
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     // Expectation: the worker has no history so the update succeeds and then calling f2 returns
     // the current state which is 0
@@ -299,6 +303,8 @@ async fn failing_auto_update_on_idle(
 
     info!("result: {:?}", result);
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -358,6 +364,8 @@ async fn auto_update_on_idle_with_non_diverging_history(
 
     info!("result: {:?}", result);
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     // Expectation: the f3 function is not changing between the versions, so we can safely
     // update the component and call f4 which only exists in the new version.
@@ -438,6 +446,8 @@ async fn failing_auto_update_on_running(
         .unwrap(); // awaiting a result from f3 to make sure the metadata already contains the updates
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -502,6 +512,8 @@ async fn manual_update_on_idle(
 
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     // Explanation: we can call 'get' on the updated component that does not exist in previous
     // versions, and it returns the previous global state which has been transferred to it
     // using the v2 component's 'save' function through the v3 component's load function.
@@ -565,6 +577,8 @@ async fn manual_update_on_idle_without_save_snapshot(
         .unwrap();
 
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -658,6 +672,8 @@ async fn auto_update_on_running_followed_by_manual(
 
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -722,6 +738,8 @@ async fn manual_update_on_idle_with_failing_load(
         .unwrap();
 
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -793,6 +811,8 @@ async fn manual_update_on_idle_using_v11(
         .unwrap();
 
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     // Explanation: we can call 'get' on the updated component that does not exist in previous
     // versions, and it returns the previous global state which has been transferred to it

--- a/golem-worker-executor-base/tests/keyvalue.rs
+++ b/golem-worker-executor-base/tests/keyvalue.rs
@@ -63,6 +63,8 @@ async fn readwrite_get_returns_the_value_that_was_set(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(
@@ -100,6 +102,8 @@ async fn readwrite_get_fails_if_the_value_was_not_set(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -157,6 +161,8 @@ async fn readwrite_set_replaces_the_value_if_it_was_already_set(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -221,6 +227,8 @@ async fn readwrite_delete_removes_the_value_if_it_was_already_set(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::Option(None)]);
@@ -265,6 +273,8 @@ async fn readwrite_exists_returns_true_if_the_value_was_set(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result == vec![Value::Bool(true)]);
@@ -295,6 +305,8 @@ async fn readwrite_exists_returns_false_if_the_value_was_not_set(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -343,6 +355,9 @@ async fn readwrite_buckets_can_be_shared_between_workers(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id_1).await;
+    executor.check_oplog_is_queryable(&worker_id_2).await;
 
     drop(executor);
 
@@ -421,6 +436,8 @@ async fn batch_get_many_gets_multiple_values(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(
@@ -484,6 +501,8 @@ async fn batch_get_many_fails_if_any_value_was_not_set(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -556,6 +575,8 @@ async fn batch_set_many_sets_multiple_values(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -686,6 +707,8 @@ async fn batch_delete_many_deletes_multiple_values(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result1 == vec![Value::Option(None)]);
@@ -754,6 +777,8 @@ async fn batch_get_keys_returns_multiple_keys(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/observability.rs
+++ b/golem-worker-executor-base/tests/observability.rs
@@ -85,7 +85,6 @@ async fn get_oplog_1(
         .unwrap();
 
     let oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await;
-
     drop(executor);
 
     // Whether there is an "enqueued invocation" entry or just directly started invocation
@@ -374,6 +373,8 @@ async fn invocation_context_test(
 
     let dump: Vec<_> = contexts.lock().unwrap().drain(..).collect();
     info!("{:#?}", dump);
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     http_server.abort();
     drop(executor);

--- a/golem-worker-executor-base/tests/revert.rs
+++ b/golem-worker-executor-base/tests/revert.rs
@@ -112,6 +112,8 @@ async fn revert_successful_invocations(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     assert_eq!(result1, vec![5u64.into_value()]);
@@ -168,6 +170,8 @@ async fn revert_failed_worker(
         .invoke_and_await(&worker_id, "golem:component/api.{get}", vec![])
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result1.is_ok());
@@ -222,6 +226,8 @@ async fn revert_auto_update(
 
     info!("result: {:?}", result1);
     let (metadata, _) = executor.get_worker_metadata(&worker_id).await.unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     // Expectation: the worker has no history so the update succeeds and then calling f2 returns
     // the current state which is 0. After the revert, calling f2 again returns a random number.

--- a/golem-worker-executor-base/tests/rust_rpc.rs
+++ b/golem-worker-executor-base/tests/rust_rpc.rs
@@ -80,6 +80,8 @@ async fn auction_example_1(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     info!("result: {:?}", create_auction_result);
@@ -152,6 +154,8 @@ async fn auction_example_2(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     info!("result: {:?}", create_auction_result);
@@ -202,6 +206,8 @@ async fn counter_resource_test_1(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -251,6 +257,8 @@ async fn counter_resource_test_2(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -298,6 +306,8 @@ async fn counter_resource_test_2_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -340,6 +350,8 @@ async fn counter_resource_test_3(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -388,6 +400,8 @@ async fn counter_resource_test_3_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -429,6 +443,8 @@ async fn context_inheritance(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -516,6 +532,8 @@ async fn counter_resource_test_5(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -573,6 +591,8 @@ async fn counter_resource_test_5_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -629,6 +649,8 @@ async fn wasm_rpc_bug_32_test(
             }],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -689,6 +711,8 @@ async fn error_message_non_existing_target_component(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     check!(worker_error_message(&create_auction_result.err().unwrap())
@@ -725,6 +749,8 @@ async fn ephemeral_worker_invocation_via_rpc1(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/rust_rpc_stubless.rs
+++ b/golem-worker-executor-base/tests/rust_rpc_stubless.rs
@@ -107,6 +107,8 @@ async fn auction_example_1(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     info!("result: {:?}", create_auction_result);
@@ -202,6 +204,8 @@ async fn auction_example_2(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     info!("result: {:?}", create_auction_result);
@@ -293,6 +297,8 @@ async fn counter_resource_test_1(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -383,6 +389,8 @@ async fn counter_resource_test_2(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -471,6 +479,8 @@ async fn counter_resource_test_2_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -554,6 +564,8 @@ async fn counter_resource_test_3(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -643,6 +655,8 @@ async fn counter_resource_test_3_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -725,6 +739,8 @@ async fn context_inheritance(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -853,6 +869,8 @@ async fn counter_resource_test_5(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -952,6 +970,8 @@ async fn counter_resource_test_5_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -1050,6 +1070,8 @@ async fn wasm_rpc_bug_32_test(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(
@@ -1132,6 +1154,8 @@ async fn error_message_non_existing_target_component(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&registry_worker_id).await;
+
     drop(executor);
 
     check!(worker_error_message(&create_auction_result.err().unwrap())
@@ -1209,6 +1233,8 @@ async fn ephemeral_worker_invocation_via_rpc1(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 
@@ -1321,6 +1347,8 @@ async fn golem_bug_1265_test(
             vec!["test".into_value_and_type()],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/transactions.rs
+++ b/golem-worker-executor-base/tests/transactions.rs
@@ -160,6 +160,8 @@ async fn jump(
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -216,6 +218,8 @@ async fn explicit_oplog_commit(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     check!(result.is_ok());
 }
@@ -255,6 +259,8 @@ async fn set_retry_policy(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(elapsed < Duration::from_secs(3)); // 2 retry attempts, 1s delay
@@ -290,6 +296,8 @@ async fn atomic_region(
         .invoke_and_await(&worker_id, "golem:it/api.{atomic-region}", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -331,6 +339,8 @@ async fn idempotence_on(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -370,6 +380,8 @@ async fn idempotence_off(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -406,6 +418,8 @@ async fn persist_nothing(
     let result = executor
         .invoke_and_await(&worker_id, "golem:it/api.{persist-nothing}", vec![])
         .await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -447,6 +461,8 @@ async fn golem_rust_explicit_oplog_commit(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     check!(result.is_ok());
 }
@@ -486,6 +502,8 @@ async fn golem_rust_set_retry_policy(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(elapsed < Duration::from_secs(3)); // 2 retry attempts, 1s delay
@@ -521,6 +539,8 @@ async fn golem_rust_atomic_region(
         .invoke_and_await(&worker_id, "golem:it/api.{atomic-region}", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -567,6 +587,8 @@ async fn golem_rust_idempotence_on(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -611,6 +633,8 @@ async fn golem_rust_idempotence_off(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -652,6 +676,8 @@ async fn golem_rust_persist_nothing(
     let result = executor
         .invoke_and_await(&worker_id, "golem:it/api.{persist-nothing}", vec![])
         .await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -708,6 +734,8 @@ async fn golem_rust_fallible_transaction(
         .await;
 
     let events = http_server.get_events();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();
@@ -770,6 +798,8 @@ async fn golem_rust_infallible_transaction(
         .await;
 
     let events = http_server.get_events();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     http_server.abort();

--- a/golem-worker-executor-base/tests/ts_rpc1_stubless.rs
+++ b/golem-worker-executor-base/tests/ts_rpc1_stubless.rs
@@ -94,6 +94,8 @@ async fn counter_resource_test_1(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -167,6 +169,8 @@ async fn counter_resource_test_1_with_restart(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -234,6 +238,8 @@ async fn context_inheritance(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/ts_rpc2_stubless.rs
+++ b/golem-worker-executor-base/tests/ts_rpc2_stubless.rs
@@ -94,6 +94,8 @@ async fn counter_resource_test_2(
         )
         .await;
 
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
+
     drop(executor);
 
     check!(result1 == Ok(vec![Value::U64(1)]));
@@ -166,6 +168,8 @@ async fn counter_resource_test_2_with_restart(
             vec![],
         )
         .await;
+
+    executor.check_oplog_is_queryable(&caller_worker_id).await;
 
     drop(executor);
 

--- a/golem-worker-executor-base/tests/wasi.rs
+++ b/golem-worker-executor-base/tests/wasi.rs
@@ -73,6 +73,8 @@ async fn write_stdout(
         }
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(stdout_events(events.into_iter()) == vec!["Sample text written to the output\n"]);
@@ -105,6 +107,8 @@ async fn write_stderr(
         }
     }
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(stderr_events(events.into_iter()) == vec!["Sample text written to the error output\n"]);
@@ -124,6 +128,8 @@ async fn read_stdin(
     let worker_id = executor.start_worker(&component_id, "read-stdin-1").await;
 
     let result = executor.invoke_and_await(&worker_id, "run", vec![]).await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -147,6 +153,8 @@ async fn clocks(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -201,6 +209,8 @@ async fn file_write_read_delete(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -260,6 +270,8 @@ async fn initial_file_read_write(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -333,6 +345,8 @@ async fn initial_file_listing_through_api(
         .collect::<Vec<_>>();
 
     result.sort_by_key(|e| e.name.clone());
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -418,6 +432,8 @@ async fn initial_file_reading_through_api(
     let result2 = executor.get_file_contents(&worker_id, "/bar/baz.txt").await;
     let result2 = std::str::from_utf8(&result2).unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result1 == "foo\n");
@@ -441,6 +457,8 @@ async fn directories(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -499,6 +517,8 @@ async fn directories_replay(
         .invoke_and_await(&worker_id, "run", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
@@ -574,6 +594,8 @@ async fn file_write_read(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
 
@@ -636,6 +658,8 @@ async fn http_client(
     let result = executor
         .invoke_and_await(&worker_id, "golem:it/api.{run}", vec![])
         .await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     drop(rx);
@@ -704,6 +728,8 @@ async fn http_client_using_reqwest(
         .unwrap();
     let captured_body = captured_body.lock().unwrap().clone().unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     http_server.abort();
 
@@ -742,6 +768,8 @@ async fn environment_service(
         .invoke_and_await(&worker_id, "golem:it/api.{get-environment}", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -822,6 +850,8 @@ async fn http_client_response_persisted_between_invocations(
         .invoke_and_await(&worker_id, "golem:it/api.{send-request}", vec![])
         .await
         .expect("first send-request failed");
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     drop(rx);
@@ -930,6 +960,8 @@ async fn http_client_interrupting_response_stream(
         .invoke_and_await_with_key(&worker_id, &key, "golem:it/api.{slow-body-stream}", vec![])
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     http_server.abort();
@@ -960,6 +992,8 @@ async fn sleep(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
@@ -1010,6 +1044,8 @@ async fn resuming_sleep(
     );
 
     tokio::time::sleep(Duration::from_secs(5)).await;
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let _ = fiber.await;
@@ -1070,6 +1106,8 @@ async fn failing_worker(
         .invoke_and_await(&worker_id, "golem:component/api.{get}", vec![])
         .await;
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
 
     check!(result1.is_ok());
@@ -1106,6 +1144,8 @@ async fn file_service_write_direct(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
@@ -1160,6 +1200,8 @@ async fn filesystem_write_replay_restores_file_times(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
 
@@ -1204,6 +1246,8 @@ async fn filesystem_create_dir_replay_restores_file_times(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
@@ -1343,6 +1387,8 @@ async fn filesystem_link_replay_restores_file_times(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
 
@@ -1412,6 +1458,8 @@ async fn filesystem_remove_dir_replay_restores_file_times(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
     let executor = start(deps, &context).await.unwrap();
@@ -1517,6 +1565,10 @@ async fn filesystem_symlink_replay_restores_file_times(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
+
+    drop(executor);
 
     check!(times_dir_1 == times_dir_2);
     check!(times_file_1 == times_file_2);
@@ -1627,6 +1679,9 @@ async fn filesystem_rename_replay_restores_file_times(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+    drop(executor);
+
     check!(times_srcdir_1 == times_srcdir_2);
     check!(times_destdir_1 == times_destdir_2);
     check!(times_file_1 == times_file_2);
@@ -1695,6 +1750,9 @@ async fn filesystem_remove_file_replay_restores_file_times(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+    drop(executor);
+
     check!(times1 == times2);
 }
 
@@ -1742,6 +1800,10 @@ async fn filesystem_write_via_stream_replay_restores_file_times(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
+
+    drop(executor);
 
     check!(times1 == times2);
 }
@@ -1791,6 +1853,10 @@ async fn filesystem_metadata_hash(
         .await
         .unwrap();
 
+    executor.check_oplog_is_queryable(&worker_id).await;
+
+    drop(executor);
+
     check!(hash1 == hash2);
 }
 
@@ -1823,6 +1889,10 @@ async fn ip_address_resolve(
         .invoke_and_await(&worker_id, "golem:it/api.{get}", vec![])
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
+
+    drop(executor);
 
     // Result 2 is a fresh resolution which is not guaranteed to return the same addresses (or the same order) but we can expect
     // that it could resolve golem.cloud to at least one address.
@@ -1874,6 +1944,8 @@ async fn wasi_incoming_request_handler(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -1963,6 +2035,8 @@ async fn wasi_incoming_request_handler_echo(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 
@@ -2155,6 +2229,8 @@ async fn wasi_incoming_request_handler_state(
         )
         .await
         .unwrap();
+
+    executor.check_oplog_is_queryable(&worker_id).await;
 
     drop(executor);
 


### PR DESCRIPTION
As I could not reproduce #1493 I added more tests for oplog query (into each worker executor test) and found an issue with RPC invocation encoding which is fixed in this PR (and kept backward compatible with older oplog entries too)