### PR TITLE
Make sure ParsedFunctionName is not accepting partial matches

### DIFF
--- a/golem-rib/src/function_name.rs
+++ b/golem-rib/src/function_name.rs
@@ -1414,6 +1414,100 @@ mod function_name_tests {
     }
 
     #[test]
+    fn parse_function_name_indexed_method() {
+        let parsed = ParsedFunctionName::parse(
+            "ns:name/interface.{resource1(\"hello\", { field-a: some(1) }).something}",
+        )
+        .expect("Parsing failed");
+        assert_eq!(
+            parsed.site().interface_name(),
+            Some("ns:name/interface".to_string())
+        );
+        assert_eq!(
+            parsed.function().function_name(),
+            "[method]resource1.something".to_string()
+        );
+        assert!(parsed.function().is_indexed_resource());
+        assert_eq!(
+            parsed.function().raw_resource_params(),
+            Some(&vec![
+                "\"hello\"".to_string(),
+                "{field-a: some(1)}".to_string(),
+            ])
+        );
+        assert_eq!(
+            parsed.function().resource_method_name(),
+            Some("something".to_string())
+        );
+        assert_eq!(
+            parsed,
+            ParsedFunctionName {
+                site: ParsedFunctionSite::PackagedInterface {
+                    namespace: "ns".to_string(),
+                    package: "name".to_string(),
+                    interface: "interface".to_string(),
+                    version: None,
+                },
+                function: ParsedFunctionReference::IndexedResourceMethod {
+                    resource: "resource1".to_string(),
+                    resource_params: vec![
+                        "\"hello\"".to_string(),
+                        "{field-a: some(1)}".to_string(),
+                    ],
+                    method: "something".to_string(),
+                },
+            },
+        );
+    }
+
+    #[test]
+    fn parse_function_name_indexed_static_method() {
+        let parsed = ParsedFunctionName::parse(
+            "ns:name/interface.{[static]resource1(\"hello\", { field-a: some(1) }).something}",
+        )
+        .expect("Parsing failed");
+        assert_eq!(
+            parsed.site().interface_name(),
+            Some("ns:name/interface".to_string())
+        );
+        assert_eq!(
+            parsed.function().function_name(),
+            "[static]resource1.something".to_string()
+        );
+        assert!(parsed.function().is_indexed_resource());
+        assert_eq!(
+            parsed.function().raw_resource_params(),
+            Some(&vec![
+                "\"hello\"".to_string(),
+                "{field-a: some(1)}".to_string(),
+            ])
+        );
+        assert_eq!(
+            parsed.function().resource_method_name(),
+            Some("something".to_string())
+        );
+        assert_eq!(
+            parsed,
+            ParsedFunctionName {
+                site: ParsedFunctionSite::PackagedInterface {
+                    namespace: "ns".to_string(),
+                    package: "name".to_string(),
+                    interface: "interface".to_string(),
+                    version: None,
+                },
+                function: ParsedFunctionReference::IndexedResourceStaticMethod {
+                    resource: "resource1".to_string(),
+                    resource_params: vec![
+                        "\"hello\"".to_string(),
+                        "{field-a: some(1)}".to_string(),
+                    ],
+                    method: "something".to_string(),
+                },
+            },
+        );
+    }
+
+    #[test]
     fn parse_function_name_method_syntax_sugar() {
         let parsed = ParsedFunctionName::parse("ns:name/interface.{resource1.do-something}")
             .expect("Parsing failed");
@@ -1708,7 +1802,8 @@ mod function_name_tests {
     }
 
     fn round_trip_function_name_parse(input: &str) {
-        let parsed = ParsedFunctionName::parse(input).expect("Input Parsing failed");
+        let parsed =
+            ParsedFunctionName::parse(input).expect(&format!("Input Parsing failed for {input}"));
         let parsed_written =
             ParsedFunctionName::parse(parsed.to_string()).expect("Round-trip parsing failed");
         assert_eq!(parsed, parsed_written);

--- a/golem-rib/src/function_name.rs
+++ b/golem-rib/src/function_name.rs
@@ -1802,8 +1802,8 @@ mod function_name_tests {
     }
 
     fn round_trip_function_name_parse(input: &str) {
-        let parsed =
-            ParsedFunctionName::parse(input).expect(&format!("Input Parsing failed for {input}"));
+        let parsed = ParsedFunctionName::parse(input)
+            .unwrap_or_else(|_| panic!("Input Parsing failed for {input}"));
         let parsed_written =
             ParsedFunctionName::parse(parsed.to_string()).expect("Round-trip parsing failed");
         assert_eq!(parsed, parsed_written);

--- a/golem-rib/src/function_name.rs
+++ b/golem-rib/src/function_name.rs
@@ -15,7 +15,7 @@
 use crate::Expr;
 use bincode::{BorrowDecode, Decode, Encode};
 use combine::stream::position::Stream;
-use combine::{eof, EasyParser};
+use combine::{eof, EasyParser, Parser};
 use golem_wasm_rpc::{parse_value_and_type, ValueAndType};
 use semver::{BuildMetadata, Prerelease};
 use serde::{Deserialize, Serialize};

--- a/golem-rib/src/parser/call.rs
+++ b/golem-rib/src/parser/call.rs
@@ -175,6 +175,19 @@ where
             }
         },
     );
+    let indexed_static_method_syntax = (
+        string("[static]"),
+        indexed_resource_syntax(),
+        token('.'),
+        identifier(),
+    )
+        .map(|(_, (resource, resource_params), _, method)| {
+            DynamicParsedFunctionReference::IndexedResourceStaticMethod {
+                resource,
+                resource_params,
+                method,
+            }
+        });
 
     let raw_constructor_syntax = (identifier(), token('.'), string("new"))
         .map(|(resource, _, _)| DynamicParsedFunctionReference::RawResourceConstructor { resource })
@@ -214,6 +227,7 @@ where
         attempt(indexed_constructor_syntax),
         attempt(indexed_drop_syntax),
         attempt(indexed_method_syntax),
+        attempt(indexed_static_method_syntax),
         attempt(raw_constructor_syntax),
         attempt(raw_drop_syntax),
         attempt(raw_method_syntax),


### PR DESCRIPTION
Fixes `ParsedFunctionName::parse`

- to consume the whole input, not returning false partial matches
- fixed missing support for "static method in indexed resource" syntax

Part of https://github.com/golemcloud/golem-cli/issues/190