### PR TITLE
Bugfix: Fix variable conflicts when metadata has enums and variants

### DIFF
--- a/golem-rib/src/compiler/byte_code.rs
+++ b/golem-rib/src/compiler/byte_code.rs
@@ -1506,7 +1506,7 @@ mod compiler_tests {
             let compiler_error = compiler::compile(expr, &metadata).unwrap_err().to_string();
             assert_eq!(
                 compiler_error,
-                "error in the following rib found at line 3, column 54\n`\"apple\"`\nfound within:\n`golem:it/api.{cart(user_id).add-item}(\"apple\")`\ncause: type mismatch. expected record{name: string}. found string\ninvalid argument to the function `[method]cart.add-item`\n"
+                "error in the following rib found at line 3, column 54\n`\"apple\"`\nfound within:\n`golem:it/api.{cart(user_id).add-item}(\"apple\")`\ncause: type mismatch. expected record { name: string }. found string\ninvalid argument to the function `[method]cart.add-item`\n"
             );
         }
 
@@ -1522,7 +1522,7 @@ mod compiler_tests {
             let compiler_error = compiler::compile(expr, &metadata).unwrap_err().to_string();
             assert_eq!(
                 compiler_error,
-                "error in the following rib found at line 1, column 1\n`{foo: \"bar\"}`\nfound within:\n`golem:it/api.{cart({foo: \"bar\"}).add-item}(\"apple\")`\ncause: type mismatch. expected string. found record{foo: string}\ninvalid argument to the function `[constructor]cart`\n"
+                "error in the following rib found at line 1, column 1\n`{foo: \"bar\"}`\nfound within:\n`golem:it/api.{cart({foo: \"bar\"}).add-item}(\"apple\")`\ncause: type mismatch. expected string. found record { foo: string }\ninvalid argument to the function `[constructor]cart`\n"
             );
         }
 

--- a/golem-rib/src/expr.rs
+++ b/golem-rib/src/expr.rs
@@ -1117,7 +1117,6 @@ impl Expr {
         self.bind_variables_of_let_assignment();
         self.infer_variants(function_type_registry);
         self.infer_enums(function_type_registry);
-
         Ok(())
     }
 

--- a/golem-rib/src/parser/type_name.rs
+++ b/golem-rib/src/parser/type_name.rs
@@ -108,14 +108,14 @@ impl Display for TypeName {
                 }
             },
             TypeName::Record(fields) => {
-                write!(f, "record{{")?;
+                write!(f, "record {{ ")?;
                 for (i, (field, typ)) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write!(f, "{}: {}", field, typ)?;
                 }
-                write!(f, "}}")
+                write!(f, " }}")
             }
             TypeName::Flags(flags) => {
                 write!(f, "flags<")?;
@@ -128,17 +128,17 @@ impl Display for TypeName {
                 write!(f, ">")
             }
             TypeName::Enum(cases) => {
-                write!(f, "enum<")?;
+                write!(f, "enum {{ ")?;
                 for (i, case) in cases.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write!(f, "{}", case)?;
                 }
-                write!(f, ">")
+                write!(f, " }}")
             }
             TypeName::Variant { cases } => {
-                write!(f, "variant<")?;
+                write!(f, "variant {{")?;
                 for (i, (case, typ)) in cases.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -148,7 +148,7 @@ impl Display for TypeName {
                         write!(f, "({})", typ)?;
                     }
                 }
-                write!(f, ">")
+                write!(f, " }}")
             }
         }
     }

--- a/golem-rib/src/type_inference/enum_resolution.rs
+++ b/golem-rib/src/type_inference/enum_resolution.rs
@@ -42,7 +42,7 @@ mod internal {
                 type_annotation,
             } = expr
             {
-                if enum_cases.cases.contains(&variable_id.name()) {
+                if enum_cases.cases.contains(&variable_id.name()) && !variable_id.is_local() {
                     *expr = Expr::Call {
                         call_type: CallType::EnumConstructor(variable_id.name()),
                         generic_type_parameter: None,
@@ -71,14 +71,17 @@ mod internal {
                     inferred_type,
                     ..
                 } => {
-                    // Retrieve the possible no-arg variant from the registry
-                    let key = RegistryKey::FunctionName(variable_id.name().clone());
-                    if let Some(RegistryValue::Value(AnalysedType::Enum(typed_enum))) =
-                        function_type_registry.types.get(&key)
-                    {
-                        enum_cases.push(variable_id.name());
-                        *inferred_type = inferred_type
-                            .merge(AnalysedType::Enum(typed_enum.clone()).clone().into());
+                    // If variable is local, it takes priority over being a global enum
+                    if !variable_id.is_local() {
+                        // Retrieve the possible no-arg variant from the registry
+                        let key = RegistryKey::FunctionName(variable_id.name().clone());
+                        if let Some(RegistryValue::Value(AnalysedType::Enum(typed_enum))) =
+                            function_type_registry.types.get(&key)
+                        {
+                            enum_cases.push(variable_id.name());
+                            *inferred_type = inferred_type
+                                .merge(AnalysedType::Enum(typed_enum.clone()).clone().into());
+                        }
                     }
                 }
 

--- a/golem-rib/src/type_inference/errors.rs
+++ b/golem-rib/src/type_inference/errors.rs
@@ -178,7 +178,7 @@ impl TypeMismatchError {
 
 pub struct MultipleUnResolvedTypesError(pub Vec<UnResolvedTypesError>);
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UnResolvedTypesError {
     pub unresolved_expr: Expr,
     pub parent_expr: Option<Expr>,
@@ -274,6 +274,7 @@ impl Display for UnResolvedTypesError {
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum FunctionCallError {
     InvalidFunctionCall {
         function_name: String,

--- a/golem-rib/src/type_inference/identifier_inference.rs
+++ b/golem-rib/src/type_inference/identifier_inference.rs
@@ -14,13 +14,12 @@
 
 use crate::Expr;
 
-// let deadline = some("foo")
-// call_x(deadline)
-// let deadline = 2.0;
-// call_y(deadline)
 pub fn infer_all_identifiers(expr: &mut Expr) {
-    internal::infer_all_identifiers_forward(expr);
-    internal::infer_all_identifiers_backward(expr);
+    // We scan top-down and bottom-up to inform the type between the identifiers
+    // It doesn't matter which order we do it in (i.e, which identifier expression has the right type isn't a problem),
+    // as we accumulate all the types in both directions
+    internal::infer_all_identifiers_bottom_up(expr);
+    internal::infer_all_identifiers_top_down(expr);
     internal::infer_match_binding_variables(expr);
 }
 
@@ -29,13 +28,23 @@ mod internal {
     use crate::{ArmPattern, Expr, ExprVisitor, InferredType, MatchArm, VariableId};
     use std::collections::{HashMap, VecDeque};
 
-    pub(crate) fn infer_all_identifiers_backward(expr: &mut Expr) {
+    pub(crate) fn infer_all_identifiers_bottom_up(expr: &mut Expr) {
         let mut identifier_lookup = IdentifierTypeState::new();
 
-        let mut visitor = ExprVisitor::top_down(expr);
+        // Given
+        //   `Expr::Block(Expr::Let(x, Expr::Num(1)), Expr::Call(func, x))`
+        // Expr::Num(1)
+        // Expr::Let(Variable(x), Expr::Num(1))
+        // Expr::Identifier(x)
+        // Expr::Call(func, Expr::Identifier(x))
+        // Expr::Block(Expr::Let(x, Expr::Num(1)), Expr::Call(func, x))
+        let mut visitor = ExprVisitor::bottom_up(expr);
+
+        // Popping it from the back results in `Expr::Identifier(x)` to be processed first
+        // in the above example.
         while let Some(expr) = visitor.pop_back() {
             match expr {
-                // If identifier is inferred (probably because it was part of a function call before),
+                // If identifier is inferred (probably because it was part of a function call befre),
                 // make sure to update the identifier inference lookup table.
                 // If lookup table is already updated, merge the inferred type
                 Expr::Identifier {
@@ -69,7 +78,7 @@ mod internal {
 
     // This is more of an optional stage, as bottom-up type propagation would be enough
     // but helps with reaching early fix point later down the line of compilation phases
-    pub(crate) fn infer_all_identifiers_forward(expr: &mut Expr) {
+    pub(crate) fn infer_all_identifiers_top_down(expr: &mut Expr) {
         let mut identifier_lookup = IdentifierTypeState::new();
         let mut visitor = ExprVisitor::top_down(expr);
         while let Some(expr) = visitor.pop_front() {

--- a/golem-rib/src/type_inference/variant_resolution.rs
+++ b/golem-rib/src/type_inference/variant_resolution.rs
@@ -75,7 +75,7 @@ mod internal {
                     inferred_type,
                     ..
                 } => {
-                    if variants.contains(&variable_id.name()) {
+                    if !variable_id.is_local() && variants.contains(&variable_id.name()) {
                         *expr = Expr::call(
                             CallType::VariantConstructor(variable_id.name()),
                             None,
@@ -105,13 +105,15 @@ mod internal {
                     inferred_type,
                     ..
                 } => {
-                    let key = RegistryKey::FunctionName(variable_id.name().clone());
-                    if let Some(RegistryValue::Value(AnalysedType::Variant(type_variant))) =
-                        function_type_registry.types.get(&key)
-                    {
-                        no_arg_variants.push(variable_id.name());
-                        *inferred_type =
-                            inferred_type.merge(InferredType::from_variant_cases(type_variant));
+                    if !variable_id.is_local() {
+                        let key = RegistryKey::FunctionName(variable_id.name().clone());
+                        if let Some(RegistryValue::Value(AnalysedType::Variant(type_variant))) =
+                            function_type_registry.types.get(&key)
+                        {
+                            no_arg_variants.push(variable_id.name());
+                            *inferred_type =
+                                inferred_type.merge(InferredType::from_variant_cases(type_variant));
+                        }
                     }
                 }
 

--- a/golem-rib/src/variable_id.rs
+++ b/golem-rib/src/variable_id.rs
@@ -66,6 +66,16 @@ impl VariableId {
         }
     }
 
+    pub fn is_local(&self) -> bool {
+        match self {
+            VariableId::Global(_) => false,
+            VariableId::Local(_, _) => true,
+            VariableId::MatchIdentifier(_) => false,
+            VariableId::ListComprehension(_) => false,
+            VariableId::ListReduce(_) => false,
+        }
+    }
+
     pub fn is_match_binding(&self) -> bool {
         match self {
             VariableId::Global(_) => false,


### PR DESCRIPTION
Fix #1491 

Let's say we have a metadata with the following enum and variant

```
enum foo {
  x,
  y,
  z
}

```

then the following should work  (sounds obvious, but it never did)

```rust
let x = 1;
let y = 2;
add(x, y)
```

Given `process` takes the enum `foo`,

```rust
let x = x;
let y = x;
process-enum-fn(x, y)

```

This scoping was handled before. However during enum resolution phase (this is when compiler assigns the type of `enum` to identifier with the same `enum` name),  the  actual `variable-id` was not taken into account - that it only compared names. So this is only a 1 liner fix.  

In the above case the variable-id of the identifier `x` (within the add function) will be a local identifier, and hence during enum resolution, it can be skipped.

This is the same for variants with no arguments too
