### PR TITLE
Fix how invalid parameters are handled in worker executor

### DIFF
--- a/golem-test-framework/src/dsl/mod.rs
+++ b/golem-test-framework/src/dsl/mod.rs
@@ -1352,11 +1352,11 @@ impl<T: TestDependencies + Send + Sync> TestDsl for T {
     }
 
     async fn check_oplog_is_queryable(&self, worker_id: &WorkerId) -> crate::Result<()> {
-        let oplog = TestDsl::get_oplog(self, worker_id, OplogIndex::INITIAL).await?;
+        let _oplog = TestDsl::get_oplog(self, worker_id, OplogIndex::INITIAL).await?;
 
-        for (idx, entry) in oplog.iter().enumerate() {
-            debug!("#{}: {entry:#?}", idx + 1);
-        }
+        // for (idx, entry) in oplog.iter().enumerate() {
+        //     debug!("#{}: {entry:#?}", idx + 1);
+        // }
 
         Ok(())
     }

--- a/golem-worker-executor-base/src/model/mod.rs
+++ b/golem-worker-executor-base/src/model/mod.rs
@@ -256,6 +256,12 @@ impl TrapType {
                             Some(GolemError::InvalidRequest { details }) => {
                                 TrapType::Error(WorkerError::InvalidRequest(details.clone()))
                             }
+                            Some(GolemError::ParamTypeMismatch { details }) => {
+                                TrapType::Error(WorkerError::InvalidRequest(details.clone()))
+                            }
+                            Some(GolemError::ValueMismatch { details }) => {
+                                TrapType::Error(WorkerError::InvalidRequest(details.clone()))
+                            }
                             _ => TrapType::Error(WorkerError::Unknown(format!("{:#}", error))),
                         },
                     },


### PR DESCRIPTION
This makes it behaving the same as invalid function names - the worker remains usable after, and nothing is written to the oplog.

This also explains and fixes the revert related linked issue.

Resolves #1498 