### PR TITLE
allow string concatenation with any type

### DIFF
--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -1938,7 +1938,7 @@ mod tests {
 
         assert_eq!(
             result.get_val().unwrap().value,
-            Value::String("foo-bar-{foo: baz}-42".to_string())
+            Value::String("foo-bar-{foo: \"baz\"}-42".to_string())
         );
     }
 

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -1400,16 +1400,23 @@ mod internal {
         interpreter_stack: &mut InterpreterStack,
         arg_size: usize,
     ) -> Result<(), String> {
-        let literals = interpreter_stack.try_pop_n_literals(arg_size)?;
+        let value_and_types = interpreter_stack.try_pop_n_val(arg_size)?;
 
-        let str = literals
-            .into_iter()
-            .fold(String::new(), |mut acc, literal| {
-                acc.push_str(&literal.as_string());
-                acc
-            });
+        let mut result = String::new();
 
-        interpreter_stack.push_val(str.into_value_and_type());
+        for val in value_and_types {
+            match &val.value {
+                Value::String(s) => {
+                    // Avoid extra quotes when concatenating strings
+                    result.push_str(s);
+                }
+                _ => {
+                    result.push_str(&val.to_string());
+                }
+            }
+        }
+
+        interpreter_stack.push_val(result.into_value_and_type());
 
         Ok(())
     }
@@ -1910,6 +1917,29 @@ mod tests {
             .value;
 
         assert_eq!(result, Value::String("21-foo".to_string()))
+    }
+
+    #[test]
+    async fn test_interpreter_concatenation() {
+        let mut interpreter = test_utils::interpreter_dynamic_response(None);
+
+        let rib_expr = r#"
+            let x = "foo";
+            let y = "bar";
+            let z = {foo: "baz"};
+            let n: u32 = 42;
+            let result = "${x}-${y}-${z}-${n}";
+            result
+        "#;
+
+        let expr = Expr::from_text(rib_expr).unwrap();
+        let compiled = compiler::compile(expr, &vec![]).unwrap();
+        let result = interpreter.run(compiled.byte_code).await.unwrap();
+
+        assert_eq!(
+            result.get_val().unwrap().value,
+            Value::String("foo-bar-{foo: baz}-42".to_string())
+        );
     }
 
     #[test]

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -1410,6 +1410,10 @@ mod internal {
                     // Avoid extra quotes when concatenating strings
                     result.push_str(s);
                 }
+                Value::Char(char) => {
+                    // Avoid extra single quotes when concatenating chars
+                    result.push(*char);
+                }
                 _ => {
                     result.push_str(&val.to_string());
                 }

--- a/golem-rib/src/interpreter/stack.rs
+++ b/golem-rib/src/interpreter/stack.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::interpreter::interpreter_stack_value::RibInterpreterStackValue;
-use crate::{GetLiteralValue, LiteralValue};
+use crate::GetLiteralValue;
 use golem_wasm_ast::analysis::analysed_type::{list, option, record, str, tuple, variant};
 use golem_wasm_ast::analysis::{
     AnalysedType, NameOptionTypePair, NameTypePair, TypeEnum, TypeRecord, TypeResult,
@@ -91,19 +91,6 @@ impl InterpreterStack {
                 ))
             })
             .collect::<Result<Vec<ValueAndType>, String>>()
-    }
-
-    pub fn try_pop_n_literals(&mut self, n: usize) -> Result<Vec<LiteralValue>, String> {
-        let values = self.try_pop_n_val(n)?;
-        values
-            .iter()
-            .map(|type_value| {
-                type_value.get_literal().ok_or(format!(
-                    "internal error: failed to convert last {} in the stack to literals {type_value:?}",
-                    n
-                ))
-            })
-            .collect::<Result<Vec<_>, String>>()
     }
 
     pub fn pop_str(&mut self) -> Option<String> {

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -78,7 +78,6 @@ pub fn type_pull_up(expr: &Expr) -> Result<Expr, RibCompilationError> {
                 let lhs = lhs.to_string();
                 return Err(CustomError {
                     expr: expr.clone(),
-                    parent_expr: None,
                     help_message: vec![],
                     message: format!("invalid method invocation `{}.{}`. make sure `{}` is defined and is a valid instance type (i.e, resource or worker)", lhs, method, lhs),
                 }.into());
@@ -645,7 +644,6 @@ pub fn type_pull_up(expr: &Expr) -> Result<Expr, RibCompilationError> {
     inferred_expr_stack.pop_front().ok_or(
         CustomError {
             expr: expr.clone(),
-            parent_expr: None,
             message: "could not infer type".to_string(),
             help_message: vec![],
         }

--- a/golem-rib/src/type_inference/type_pull_up.rs
+++ b/golem-rib/src/type_inference/type_pull_up.rs
@@ -78,6 +78,7 @@ pub fn type_pull_up(expr: &Expr) -> Result<Expr, RibCompilationError> {
                 let lhs = lhs.to_string();
                 return Err(CustomError {
                     expr: expr.clone(),
+                    parent_expr: None,
                     help_message: vec![],
                     message: format!("invalid method invocation `{}.{}`. make sure `{}` is defined and is a valid instance type (i.e, resource or worker)", lhs, method, lhs),
                 }.into());
@@ -644,6 +645,7 @@ pub fn type_pull_up(expr: &Expr) -> Result<Expr, RibCompilationError> {
     inferred_expr_stack.pop_front().ok_or(
         CustomError {
             expr: expr.clone(),
+            parent_expr: None,
             message: "could not infer type".to_string(),
             help_message: vec![],
         }


### PR DESCRIPTION
Fixes #1047  #1462 

In short, with this PR the following works (previously it will throw run time error if you try to interpolate a record)

```rust
  let x = "foo";
  let y = "bar";
  let z = {foo: "baz"};
  let n: u32 = 42;
  let result = "${x}-${y}-${z}-${n}";
  result
```

will result in the following, where each value is a wasm-wave string.

```
"foo-bar-{foo: baz}-42"
```


The ticket 1462 says to allow only literals, but here _literals_ mainly intend to mean - anything that can be _safely_ interpolated. In that case, `enums`  or primitives (number, string, char) and interestingly developers may want to stringify a no-arg variant term too (whose value can be sometimes available only at runtime disallowing a compile time check as to whether or not a particular variant value is amongst the ones with no-args). In details, this approach is suboptimal, and therefore the above approach which is both intuitive and hence user friendly.
