### PR TITLE
clean ups in API definition (for CORS and security) - to make DX integration easier

### DIFF
--- a/golem-test-framework/src/components/worker_service/mod.rs
+++ b/golem-test-framework/src/components/worker_service/mod.rs
@@ -1850,8 +1850,8 @@ async fn grpc_api_definition_request_to_http(
                                     .as_ref()
                                     .and_then(|cp| cp.allow_credentials),
                             },
-                            cors: None,     // TODO: map this from route.middleware?
-                            security: None, // TODO: map this from route.middleware?
+                            cors: None,
+                            security: None,
                         }
                     }))
                     .await

--- a/golem-worker-service-base/src/api/api_definition.rs
+++ b/golem-worker-service-base/src/api/api_definition.rs
@@ -230,7 +230,6 @@ pub struct RouteRequestData {
     pub method: MethodPattern,
     pub path: String,
     pub binding: GatewayBindingData,
-    pub cors: Option<HttpCors>,
     pub security: Option<String>,
 }
 
@@ -251,7 +250,6 @@ impl RouteRequestData {
             path,
             binding,
             security,
-            cors: self.cors,
         })
     }
 }
@@ -323,37 +321,21 @@ pub struct ResolvedGatewayBindingComponent {
 pub struct GatewayBindingData {
     #[oai(rename = "bindingType")]
     pub binding_type: Option<GatewayBindingType>, // descriminator to keep backward compatibility
-
-    // WORKER
-    // For binding type - worker
+    // For binding type - worker/default and file-server
     // Optional only to keep backward compatibility
     pub component: Option<GatewayBindingComponent>,
-    // For binding type - worker
+    // worker-name is optional to keep backward compatibility
+    // this is not required anymore with first class worker support in rib
+    // which is embedded in response field
     pub worker_name: Option<String>,
-    // For binding type - worker
+    // For binding type - worker/default
     pub idempotency_key: Option<String>,
-    // For binding type - worker
-    // Optional only to keep backward compatibility
+    // For binding type - worker/default and fileserver, this is required
+    // For binding type cors-preflight, this is optional otherwise default cors-preflight settings
+    // is used
     pub response: Option<String>,
-    // For binding type - worker
+    // For binding type - worker/default
     pub invocation_context: Option<String>,
-
-    // CORS binding type
-    //  For binding type - cors-middleware
-    // Optional only to keep backward compatibility
-    pub allow_origin: Option<String>,
-    //  For binding type - cors-middleware
-    // Optional only to keep backward compatibility
-    pub allow_methods: Option<String>,
-    //  For binding type - cors-middleware
-    // Optional only to keep backward compatibility
-    pub allow_headers: Option<String>,
-    //  For binding type - cors-middleware
-    pub expose_headers: Option<String>,
-    //  For binding type - cors-middleware
-    pub max_age: Option<u64>,
-    //  For binding type - cors-middleware
-    pub allow_credentials: Option<bool>,
 }
 
 impl GatewayBindingData {

--- a/golem-worker-service-base/src/api/api_definition.rs
+++ b/golem-worker-service-base/src/api/api_definition.rs
@@ -461,7 +461,7 @@ impl From<HttpMiddlewares> for MiddlewareData {
 
         for i in value.0.iter() {
             match i {
-                HttpMiddleware::AddCorsHeaders(cors0) => cors = Some(cors0.clone()),
+                HttpMiddleware::Cors(cors0) => cors = Some(cors0.clone()),
                 HttpMiddleware::AuthenticateRequest(auth0) => {
                     let security_scheme_reference = SecuritySchemeReferenceData::from(
                         auth0.security_scheme_with_metadata.clone(),

--- a/golem-worker-service-base/src/api/api_definition.rs
+++ b/golem-worker-service-base/src/api/api_definition.rs
@@ -101,9 +101,6 @@ impl HttpApiDefinitionRequest {
             crate::gateway_api_definition::http::HttpApiDefinitionRequest {
                 id: self.id,
                 version: self.version,
-                security: self
-                    .security
-                    .map(|x| x.into_iter().map(SecuritySchemeReference::new).collect()),
                 routes,
                 draft: self.draft,
             },

--- a/golem-worker-service-base/src/gateway_api_definition/http/api_definition.rs
+++ b/golem-worker-service-base/src/gateway_api_definition/http/api_definition.rs
@@ -113,10 +113,6 @@ impl HttpApiDefinition {
                 http_middlewares.push(HttpMiddleware::authenticate_request(security_scheme));
             }
 
-            if let Some(cors) = route.cors {
-                http_middlewares.push(HttpMiddleware::cors(cors));
-            }
-
             routes.push(Route {
                 method: route.method,
                 path: route.path,

--- a/golem-worker-service-base/src/gateway_api_definition/http/api_definition_request.rs
+++ b/golem-worker-service-base/src/gateway_api_definition/http/api_definition_request.rs
@@ -24,7 +24,6 @@ use golem_api_grpc::proto::golem::apidefinition as grpc_apidefinition;
 #[derive(Debug, Clone, PartialEq)]
 pub struct HttpApiDefinitionRequest {
     pub id: ApiDefinitionId,
-    pub security: Option<Vec<SecuritySchemeReference>>, // This is needed at global level only for request (user facing http api definition)
     pub version: ApiVersion,
     pub routes: Vec<RouteRequest>,
     pub draft: bool,
@@ -53,18 +52,11 @@ impl TryFrom<grpc_apidefinition::v1::ApiDefinitionRequest> for HttpApiDefinition
 
         let id = value.id.ok_or("Api Definition ID is missing")?;
 
-        let security = if global_securities.is_empty() {
-            None
-        } else {
-            Some(global_securities)
-        };
-
         let result = Self {
             id: ApiDefinitionId(id.value),
             version: ApiVersion(value.version),
             routes: route_requests,
             draft: value.draft,
-            security,
         };
 
         Ok(result)
@@ -72,7 +64,6 @@ impl TryFrom<grpc_apidefinition::v1::ApiDefinitionRequest> for HttpApiDefinition
 }
 
 // In a RouteRequest, security is defined at the outer level
-// to keep it consistent with the openAPI style of defining security at the root level.
 // Also this security has minimal information (and avoid details such as client-id, secret etc).
 // When `RouteRequest` is converted to `Route`, this security is pushed as middleware in the binding
 // along with fetching more details about the security scheme

--- a/golem-worker-service-base/src/gateway_api_definition/http/oas_api_definition.rs
+++ b/golem-worker-service-base/src/gateway_api_definition/http/oas_api_definition.rs
@@ -43,8 +43,6 @@ impl OpenApiHttpApiDefinition {
             GOLEM_API_DEFINITION_VERSION,
         )?);
 
-        let security = get_global_security(open_api);
-
         let routes = get_routes(&open_api.paths, conversion_context).await?;
 
         Ok(HttpApiDefinitionRequest {
@@ -52,7 +50,6 @@ impl OpenApiHttpApiDefinition {
             version: api_definition_version,
             routes,
             draft: true,
-            security,
         })
     }
 }
@@ -148,24 +145,6 @@ mod internal {
 
     pub(super) const GOLEM_API_GATEWAY_BINDING: &str = "x-golem-api-gateway-binding";
 
-    pub(super) fn get_global_security(open_api: &OpenAPI) -> Option<Vec<SecuritySchemeReference>> {
-        open_api.security.as_ref().and_then(|requirements| {
-            let global_security: Vec<_> = requirements
-                .iter()
-                .flat_map(|x| {
-                    x.keys().map(|key| SecuritySchemeReference {
-                        security_scheme_identifier: SecuritySchemeIdentifier::new(key.clone()),
-                    })
-                })
-                .collect();
-
-            if global_security.is_empty() {
-                Some(global_security)
-            } else {
-                None
-            }
-        })
-    }
     pub(super) fn get_root_extension_str(
         open_api: &OpenAPI,
         key_name: &str,

--- a/golem-worker-service-base/src/gateway_api_definition/http/oas_api_definition.rs
+++ b/golem-worker-service-base/src/gateway_api_definition/http/oas_api_definition.rs
@@ -267,7 +267,6 @@ mod internal {
                             path: path_pattern.clone(),
                             binding: GatewayBinding::static_binding(binding),
                             security,
-                            cors: None
                         })
                     }
 
@@ -279,7 +278,6 @@ mod internal {
                             method,
                             binding: GatewayBinding::Default(binding),
                             security,
-                            cors: None
                         })
                     }
                     (GatewayBindingType::FileServer, _) => {
@@ -290,7 +288,6 @@ mod internal {
                             method,
                             binding: GatewayBinding::Default(binding),
                             security,
-                            cors: None
                         })
                     }
                     (GatewayBindingType::HttpHandler, _) => {
@@ -301,7 +298,6 @@ mod internal {
                             method,
                             binding: GatewayBinding::HttpHandler(binding),
                             security,
-                            cors: None
                         })
                     }
                     (GatewayBindingType::CorsPreflight, method) => {
@@ -319,7 +315,6 @@ mod internal {
                         method,
                         binding: GatewayBinding::static_binding(binding),
                         security,
-                        cors: None,
                     })
                 } else {
                     Err(format!(
@@ -628,7 +623,6 @@ mod tests {
                 HttpCors::default(),
             )),
             security: None,
-            cors: None,
         }
     }
 
@@ -640,7 +634,6 @@ mod tests {
             method: MethodPattern::Options,
             binding: GatewayBinding::static_binding(StaticBinding::from_http_cors(cors_preflight)),
             security: None,
-            cors: None,
         }
     }
 

--- a/golem-worker-service-base/src/gateway_api_definition_transformer/cors_transformer.rs
+++ b/golem-worker-service-base/src/gateway_api_definition_transformer/cors_transformer.rs
@@ -169,9 +169,7 @@ mod tests {
             method: MethodPattern::Get,
             path: AllPathPatterns::parse("/test").unwrap(),
             binding: GatewayBinding::Default(worker_binding.clone()),
-            middlewares: Some(HttpMiddlewares(vec![
-                HttpMiddleware::AddCorsHeaders(cors()),
-            ])),
+            middlewares: Some(HttpMiddlewares(vec![HttpMiddleware::Cors(cors())])),
         }
     }
 

--- a/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
+++ b/golem-worker-service-base/src/gateway_execution/gateway_http_input_executor.rs
@@ -461,6 +461,7 @@ impl<Namespace: Clone> DefaultGatewayInputExecutor<Namespace> {
                     let response = err.to_response_from_safe_display(|error| match error {
                         MiddlewareError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                         MiddlewareError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+                        MiddlewareError::CorsError(_) => StatusCode::FORBIDDEN,
                     });
                     Err(response)?
                 }

--- a/golem-worker-service-base/src/gateway_middleware/http/cors.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/cors.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::gateway_execution::request::RichRequest;
+use crate::gateway_middleware::CorsError;
 use bigdecimal::BigDecimal;
 use http::header::*;
+use http::{header, Method};
 use poem_openapi::Object;
 use rib::{Expr, GetLiteralValue, RibInput, TypeName};
 use serde::{Deserialize, Serialize};
 
+// Optimise this further when we choose to break backward compatibility
+// where Cors headers will pre-store distinct headers, methods etc
+// instead of comma separated strings.
+// This is ok until then, as most of the time on CORS check is
+// done by browsers only for OPTIONS preflight
+// request, which is cached by the browsers
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Object)]
 #[serde(rename_all = "camelCase")]
 #[oai(rename_all = "camelCase")]
@@ -43,6 +52,12 @@ impl Default for HttpCors {
     }
 }
 
+enum OriginStatus {
+    AllowedExact,
+    AllowedWildcard,
+    NotAllowed,
+}
+
 impl HttpCors {
     pub fn new(
         allow_origin: &str,
@@ -59,6 +74,137 @@ impl HttpCors {
             expose_headers: expose_headers.map(|x| x.to_string()),
             allow_credentials,
             max_age,
+        }
+    }
+
+    fn check_origin(&self, origin: &HeaderValue) -> OriginStatus {
+        let origin_str = match origin.to_str() {
+            Ok(s) => s,
+            Err(_) => return OriginStatus::NotAllowed,
+        };
+
+        // Exact match
+        if Self::split_origin(&self.allow_origin).any(|o| o == origin_str) {
+            return OriginStatus::AllowedExact;
+        }
+
+        // Wildcard match (e.g., *.example.com)
+        if Self::split_origin(&self.allow_origin)
+            .any(|pattern| pattern.contains('*') && Self::wildcard_match(pattern, origin_str))
+        {
+            return OriginStatus::AllowedWildcard;
+        }
+
+        OriginStatus::NotAllowed
+    }
+
+    fn wildcard_match(pattern: &str, text: &str) -> bool {
+        if !pattern.contains('*') {
+            return pattern == text;
+        }
+
+        let parts: Vec<&str> = pattern.split('*').collect();
+        if parts.len() == 2 {
+            text.starts_with(parts[0]) && text.ends_with(parts[1])
+        } else {
+            false
+        }
+    }
+
+    fn split_origin(input: &str) -> impl Iterator<Item = &str> {
+        input.split(',').map(|s| s.trim()).filter(|s| !s.is_empty())
+    }
+
+    fn check_headers_allowed<'a>(
+        &self,
+        req: &'a RichRequest,
+    ) -> Result<Option<&'a HeaderValue>, CorsError> {
+        let request_headers = req.headers().get(header::ACCESS_CONTROL_REQUEST_HEADERS);
+
+        if let Some(headers_value) = request_headers {
+            let allow_list: Vec<_> = Self::split_origin(&self.allow_headers).collect();
+            if allow_list.is_empty() {
+                return Ok(Some(headers_value)); // everything allowed
+            }
+
+            let header_str = headers_value
+                .to_str()
+                .map_err(|_| CorsError::HeadersNotAllowed)?;
+
+            let all_allowed = Self::split_origin(header_str).all(|h| {
+                allow_list
+                    .iter()
+                    .any(|&allowed| allowed.eq_ignore_ascii_case(h))
+            });
+
+            if !all_allowed {
+                return Err(CorsError::HeadersNotAllowed);
+            }
+
+            Ok(Some(headers_value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn apply_cors(&self, request: &RichRequest) -> Result<(), CorsError> {
+        let origin = match request.headers().get(header::ORIGIN) {
+            Some(origin) => origin.clone(),
+            None => {
+                panic!("Origin header is missing in the request");
+            }
+        };
+
+        match self.check_origin(&origin) {
+            OriginStatus::NotAllowed => return Err(CorsError::OriginNotAllowed.into()),
+            _ => {} // otherwise allowed
+        }
+
+        if request.underlying.method() == Method::OPTIONS {
+            let allow_method = request
+                .headers()
+                .get(header::ACCESS_CONTROL_REQUEST_METHOD)
+                .and_then(|val| val.to_str().ok())
+                .and_then(|m| m.parse::<Method>().ok());
+
+            if let Some(method) = allow_method {
+                if !self.allow_methods.trim().is_empty()
+                    && !Self::split_origin(&self.allow_methods)
+                        .any(|m| m.eq_ignore_ascii_case(method.as_str()))
+                {
+                    return Err(CorsError::MethodNotAllowed.into());
+                }
+            } else {
+                return Err(CorsError::MethodNotAllowed.into());
+            }
+
+            self.check_headers_allowed(&request)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn add_header_in_response(&self, response: &mut poem::Response) {
+        response.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_ORIGIN,
+            // hot path, and this unwrap will not fail unless we bypassed it during configuration
+            self.get_allow_origin().clone().parse().unwrap(),
+        );
+
+        if let Some(allow_credentials) = &self.get_allow_credentials() {
+            response.headers_mut().insert(
+                ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                // hot path, and this unwrap will not fail unless we bypassed it during configuration
+                allow_credentials.to_string().clone().parse().unwrap(),
+            );
+        }
+
+        if let Some(expose_headers) = &self.get_expose_headers() {
+            response.headers_mut().insert(
+                ACCESS_CONTROL_EXPOSE_HEADERS,
+                // hot path, and this unwrap will not fail unless we bypassed it during configuration
+                expose_headers.clone().parse().unwrap(),
+            );
         }
     }
 

--- a/golem-worker-service-base/src/gateway_middleware/http/cors.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/cors.rs
@@ -156,7 +156,7 @@ impl HttpCors {
         };
 
         match self.check_origin(&origin) {
-            OriginStatus::NotAllowed => return Err(CorsError::OriginNotAllowed.into()),
+            OriginStatus::NotAllowed => return Err(CorsError::OriginNotAllowed),
             _ => {} // otherwise allowed
         }
 
@@ -172,13 +172,13 @@ impl HttpCors {
                     && !Self::split_origin(&self.allow_methods)
                         .any(|m| m.eq_ignore_ascii_case(method.as_str()))
                 {
-                    return Err(CorsError::MethodNotAllowed.into());
+                    return Err(CorsError::MethodNotAllowed);
                 }
             } else {
-                return Err(CorsError::MethodNotAllowed.into());
+                return Err(CorsError::MethodNotAllowed);
             }
 
-            self.check_headers_allowed(&request)?;
+            self.check_headers_allowed(request)?;
         }
 
         Ok(())

--- a/golem-worker-service-base/src/gateway_middleware/http/cors.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/cors.rs
@@ -21,13 +21,12 @@ use poem_openapi::Object;
 use rib::{Expr, GetLiteralValue, RibInput, TypeName};
 use serde::{Deserialize, Serialize};
 
-//
-// Optimise this further when we choose to break backward compatibility
-// where Cors headers will pre-store distinct headers, methods etc
-// instead of comma separated strings.
-// This is ok until then, as most of the time on CORS check is
-// done by browsers only for OPTIONS preflight
-// request, which is cached by the browsers
+// Make sure to store CORS headers as Vec<HeaderValue> and not as String
+// avoiding computation in the hot path
+// Other strings don't hurt as it is only done for pre-flight request, which gets cached in browsers,
+// however, good to change when we can break the backward
+// compatibility.
+// Tracked under: https://github.com/golemcloud/golem/issues/1512
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Object)]
 #[serde(rename_all = "camelCase")]
 #[oai(rename_all = "camelCase")]

--- a/golem-worker-service-base/src/gateway_middleware/http/http_middleware.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/http_middleware.rs
@@ -15,13 +15,9 @@
 use crate::gateway_middleware::http::authentication::HttpAuthenticationMiddleware;
 use std::ops::Deref;
 
-use crate::gateway_execution::request::RichRequest;
 use crate::gateway_middleware::http::cors::HttpCors;
-use crate::gateway_middleware::MiddlewareError;
+
 use crate::gateway_security::SecuritySchemeWithProviderMetadata;
-use http::header::{
-    ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS,
-};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum HttpMiddleware {

--- a/golem-worker-service-base/src/gateway_middleware/http/middleware_error.rs
+++ b/golem-worker-service-base/src/gateway_middleware/http/middleware_error.rs
@@ -19,13 +19,26 @@ use golem_common::SafeDisplay;
 #[derive(Debug)]
 pub enum MiddlewareError {
     Unauthorized(AuthorisationError),
+    CorsError(CorsError),
     InternalError(String),
+}
+
+#[derive(Debug)]
+pub enum CorsError {
+    OriginNotAllowed,
+    MethodNotAllowed,
+    HeadersNotAllowed,
 }
 
 impl SafeDisplay for MiddlewareError {
     fn to_safe_string(&self) -> String {
         match self {
             MiddlewareError::Unauthorized(msg) => format!("Unauthorized: {}", msg.to_safe_string()),
+            MiddlewareError::CorsError(error) => match error {
+                CorsError::OriginNotAllowed => "CORS Error: Origin not allowed".to_string(),
+                CorsError::MethodNotAllowed => "CORS Error: Method not allowed".to_string(),
+                CorsError::HeadersNotAllowed => "CORS Error: Headers not allowed".to_string(),
+            },
             MiddlewareError::InternalError(msg) => {
                 format!("Internal Server Error: {}", msg)
             }

--- a/golem-worker-service-base/src/gateway_middleware/mod.rs
+++ b/golem-worker-service-base/src/gateway_middleware/mod.rs
@@ -50,7 +50,7 @@ impl HttpMiddlewares {
             match middleware {
                 HttpMiddleware::Cors(cors) => {
                     cors.apply_cors(rich_request)
-                        .map_err(|error| MiddlewareError::CorsError(error))?;
+                        .map_err(MiddlewareError::CorsError)?;
                 }
                 HttpMiddleware::AuthenticateRequest(auth) => {
                     let result = auth

--- a/golem-worker-service-base/src/gateway_middleware/mod.rs
+++ b/golem-worker-service-base/src/gateway_middleware/mod.rs
@@ -48,7 +48,10 @@ impl HttpMiddlewares {
 
         for middleware in self.0.iter() {
             match middleware {
-                HttpMiddleware::AddCorsHeaders(_) => {}
+                HttpMiddleware::Cors(cors) => {
+                    cors.apply_cors(rich_request)
+                        .map_err(|error| MiddlewareError::CorsError(error))?;
+                }
                 HttpMiddleware::AuthenticateRequest(auth) => {
                     let result = auth
                         .apply_http_auth(rich_request, session_store, identity_provider)
@@ -77,8 +80,8 @@ impl HttpMiddlewares {
     ) -> Result<(), MiddlewareError> {
         for middleware in self.0.iter() {
             match middleware {
-                HttpMiddleware::AddCorsHeaders(cors) => {
-                    HttpMiddleware::apply_cors(response, cors);
+                HttpMiddleware::Cors(cors) => {
+                    cors.add_header_in_response(response);
                 }
                 HttpMiddleware::AuthenticateRequest(_) => {}
             }
@@ -134,7 +137,7 @@ impl TryFrom<HttpMiddlewares> for golem_api_grpc::proto::golem::apidefinition::M
 
         for http_middleware in value.0.iter() {
             match http_middleware {
-                HttpMiddleware::AddCorsHeaders(cors0) => {
+                HttpMiddleware::Cors(cors0) => {
                     cors = Some(golem_api_grpc::proto::golem::apidefinition::CorsPreflight::from(cors0.clone()));
                 }
                 HttpMiddleware::AuthenticateRequest(http_request_authentication) => {

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -694,7 +694,7 @@ async fn test_api_def_with_security() {
         &auth_call_back_url,
         &identity_provider,
     )
-        .await;
+    .await;
 
     let session_store = internal::get_session_store();
 
@@ -704,7 +704,7 @@ async fn test_api_def_with_security() {
         &session_store,
         &identity_provider,
     )
-        .await;
+    .await;
 
     let initial_redirect_response_headers = initial_response_to_identity_provider.headers();
 
@@ -756,7 +756,7 @@ async fn test_api_def_with_security() {
         &session_store,
         &identity_provider,
     )
-        .await;
+    .await;
 
     let redirect_response_headers = final_redirect_response.headers();
 
@@ -769,7 +769,7 @@ async fn test_api_def_with_security() {
         &session_store,
         &identity_provider,
     )
-        .await;
+    .await;
 
     let test_response = internal::get_details_from_response(response).await;
 


### PR DESCRIPTION
This is in-progress (this is not code refactor, but main intention is to make peripherals easier to understand and thereby make DX integration easier)

Code evaluation and simplifying certain fields to make DX integration easier
* Fixing comments about the fields in gateway binding fields. I will be adding more documentation here.
* Removing unused (unused after https://github.com/golemcloud/golem/pull/1444) on CORS in the request front-end data. 
* Removing redundant `cors` field anywhere else too (such as within the binding, and outside the binding, there was CORS - probably making it closer to OAS - but this is not needed in native API definition. This can be removed.
* (Yet to be done) Removing higher level security field to match Open API Specific format, where securities are listed globally, and every route should be picking only 1 among them. I think this is confusing and less user friendly. If user is importing OAS, they might need to do this (or they might have this already), but the native API definition doesn't need to follow it exactly. Export to OAS will still be lossless with this data.


TODO:
- [x] Make sure cors tests are expanded with request with and without origin.