### PR TITLE
Minor fixes on Repl APIs

### DIFF
--- a/golem-rib-repl/src/compiler.rs
+++ b/golem-rib-repl/src/compiler.rs
@@ -173,12 +173,14 @@ pub fn fetch_instance_variables(inferred_expr: &InferredExpr) -> InstanceVariabl
                         InstanceType::Resource { .. } => {
                             let key = InstanceKey::Resource(variable_id.name());
                             instance_variables
-                                .insert(key, instance_type.function_dict_for_resource());
+                                .insert(key, instance_type.resource_method_dictionary());
                         }
                         _ => {
                             let key = InstanceKey::Worker(variable_id.name());
-                            instance_variables
-                                .insert(key, instance_type.function_dict_without_resource());
+                            instance_variables.insert(
+                                key,
+                                instance_type.function_dict_without_resource_methods(),
+                            );
                         }
                     };
                 }

--- a/golem-rib-repl/src/compiler.rs
+++ b/golem-rib-repl/src/compiler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::repl_state::ReplState;
+use golem_wasm_ast::analysis::{TypeEnum, TypeVariant};
 use rib::{
     Expr, FunctionDictionary, FunctionTypeRegistry, InferredExpr, InferredType, RibByteCode,
     RibError, VariableId,
@@ -36,6 +37,9 @@ pub fn compile_rib_script(
 
     let identifiers = get_identifiers(&inferred_expr);
 
+    let variants = function_registry.get_variants();
+    let enums = function_registry.get_enums();
+
     let new_byte_code = RibByteCode::from_expr(&inferred_expr)
         .map_err(|e| RibError::InternalError(e.to_string()))?;
 
@@ -47,6 +51,8 @@ pub fn compile_rib_script(
         rib_byte_code: byte_code,
         instance_variables,
         identifiers,
+        variants,
+        enums,
     })
 }
 
@@ -55,6 +61,8 @@ pub struct CompilerOutput {
     pub rib_byte_code: RibByteCode,
     pub instance_variables: InstanceVariables,
     pub identifiers: Vec<VariableId>,
+    pub variants: Vec<TypeVariant>,
+    pub enums: Vec<TypeEnum>,
 }
 
 #[derive(Default, Clone)]

--- a/golem-rib-repl/src/compiler.rs
+++ b/golem-rib-repl/src/compiler.rs
@@ -45,15 +45,14 @@ pub fn compile_rib_script(
 
     Ok(CompilerOutput {
         rib_byte_code: byte_code,
-        inferred_expr,
         instance_variables,
         identifiers,
     })
 }
 
+#[derive(Clone)]
 pub struct CompilerOutput {
     pub rib_byte_code: RibByteCode,
-    pub inferred_expr: InferredExpr,
     pub instance_variables: InstanceVariables,
     pub identifiers: Vec<VariableId>,
 }

--- a/golem-rib-repl/src/compiler.rs
+++ b/golem-rib-repl/src/compiler.rs
@@ -171,16 +171,16 @@ pub fn fetch_instance_variables(inferred_expr: &InferredExpr) -> InstanceVariabl
                 if let InferredType::Instance { instance_type } = expr.inferred_type() {
                     match *instance_type {
                         InstanceType::Resource { .. } => {
-                            let key= InstanceKey::Resource(variable_id.name());
-                            instance_variables.insert(key, instance_type.function_dict_for_resource());
-
-                        },
+                            let key = InstanceKey::Resource(variable_id.name());
+                            instance_variables
+                                .insert(key, instance_type.function_dict_for_resource());
+                        }
                         _ => {
                             let key = InstanceKey::Worker(variable_id.name());
-                            instance_variables.insert(key, instance_type.function_dict_without_resource());
-                        },
+                            instance_variables
+                                .insert(key, instance_type.function_dict_without_resource());
+                        }
                     };
-
                 }
 
                 queue.push_front(expr)

--- a/golem-rib-repl/src/compiler.rs
+++ b/golem-rib-repl/src/compiler.rs
@@ -69,6 +69,13 @@ impl InstanceVariables {
             .map(|k| k.to_string())
             .collect()
     }
+
+    pub fn method_names(&self) -> Vec<String> {
+        self.instance_variables
+            .values()
+            .flat_map(|dict| dict.function_names())
+            .collect()
+    }
 }
 
 pub fn get_identifiers(inferred_expr: &InferredExpr) -> Vec<VariableId> {

--- a/golem-rib-repl/src/dependency_manager.rs
+++ b/golem-rib-repl/src/dependency_manager.rs
@@ -26,7 +26,7 @@ pub trait RibDependencyManager {
     ///
     /// Note: It is the responsibility of the REPL client to resolve component paths.
     /// In the future, Rib may support multiple components.
-    async fn get_dependencies(&self) -> Result<ReplDependencies, String>;
+    async fn get_dependencies(&self) -> anyhow::Result<ReplDependencies>;
 
     /// Deploys a specific component if the REPL was started with a reference to it.
     ///
@@ -44,7 +44,7 @@ pub trait RibDependencyManager {
         &self,
         source_path: &Path,
         component_name: String,
-    ) -> Result<RibComponentMetadata, String>;
+    ) -> anyhow::Result<RibComponentMetadata>;
 }
 
 pub struct ReplDependencies {
@@ -54,5 +54,6 @@ pub struct ReplDependencies {
 #[derive(Clone, Debug)]
 pub struct RibComponentMetadata {
     pub component_id: Uuid,
+    pub component_name: String,
     pub metadata: Vec<AnalysedExport>,
 }

--- a/golem-rib-repl/src/invoke.rs
+++ b/golem-rib-repl/src/invoke.rs
@@ -14,7 +14,6 @@
 
 use async_trait::async_trait;
 use golem_wasm_rpc::ValueAndType;
-use rib::{EvaluatedFnArgs, EvaluatedFqFn, EvaluatedWorkerName};
 use uuid::Uuid;
 
 #[async_trait]
@@ -22,8 +21,9 @@ pub trait WorkerFunctionInvoke {
     async fn invoke(
         &self,
         component_id: Uuid,
-        worker_name: Option<EvaluatedWorkerName>,
-        function_name: EvaluatedFqFn,
-        args: EvaluatedFnArgs,
-    ) -> Result<ValueAndType, String>;
+        component_name: &str,
+        worker_name: Option<String>,
+        function_name: &str,
+        args: Vec<ValueAndType>,
+    ) -> anyhow::Result<ValueAndType>;
 }

--- a/golem-rib-repl/src/lib.rs
+++ b/golem-rib-repl/src/lib.rs
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use dependency_manager::*;
+pub use invoke::*;
+pub use repl_printer::*;
+pub use rib_repl::*;
+
 mod compiler;
-pub mod dependency_manager;
-pub mod invoke;
-pub mod repl_printer;
+mod dependency_manager;
+mod invoke;
+mod repl_printer;
 mod repl_state;
 mod rib_edit;
-pub mod rib_repl;
+mod rib_repl;
 mod value_generator;
 
 #[cfg(test)]

--- a/golem-rib-repl/src/rib_edit.rs
+++ b/golem-rib-repl/src/rib_edit.rs
@@ -345,7 +345,7 @@ impl Validator for RibEdit {
 
         match expr {
             Ok(_) => Ok(ValidationResult::Valid(None)),
-            Err(e) => Ok(ValidationResult::Invalid(Some(e))),
+            Err(err) => Ok(ValidationResult::Invalid(Some(format!("\n{}\n", err)))),
         }
     }
 }

--- a/golem-rib-repl/src/rib_edit.rs
+++ b/golem-rib-repl/src/rib_edit.rs
@@ -104,7 +104,7 @@ impl RibEdit {
         if let Some(worker_instance_func_dict) =
             instance_vars.get_worker_instance_method_dict(instance_var_name)
         {
-            for (function, tpe) in &worker_instance_func_dict.map {
+            for (function, tpe) in &worker_instance_func_dict.name_and_types {
                 let name_with_paren = format!("{}(", function.name());
 
                 // If user has typed in `(`, complete the method call with arguments
@@ -137,7 +137,7 @@ impl RibEdit {
         if let Some(resource_instance_func_dict) =
             instance_vars.get_resource_instance_method_dict(instance_var_name)
         {
-            for (resource_method_name, tpe) in &resource_instance_func_dict.map {
+            for (resource_method_name, tpe) in &resource_instance_func_dict.name_and_types {
                 let resource_method_with_paren = format!("{}(", resource_method_name.name());
 
                 // If user has typed in `(`, complete the method call with arguments
@@ -395,7 +395,7 @@ fn highlight_word(
 ) -> String {
     // Keyword
     if context.key_words.contains(&word) {
-        return word.blue().to_string();
+        return word.cyan().to_string();
     }
 
     // Method call (e.g., obj.method)

--- a/golem-rib-repl/src/rib_edit.rs
+++ b/golem-rib-repl/src/rib_edit.rs
@@ -68,17 +68,15 @@ impl RibEdit {
     }
 
     fn backtrack_and_get_start_pos(line: &str, end_pos: usize) -> usize {
-        let mut start = end_pos;
-
-        while start > 0
-            && line[start - 1..start].chars().all(|c| {
-                c.is_alphanumeric() || c == '_' || c == '.' || c == '-' || c == '(' || c == ')'
+        line[0..end_pos]
+            .char_indices()
+            .rev()
+            .find_map(|(pos, c)| {
+                let is_token_char =
+                    c.is_alphanumeric() || c == '_' || c == '.' || c == '-' || c == '(' || c == ')';
+                (!is_token_char).then(|| pos + c.len_utf8())
             })
-        {
-            start -= 1;
-        }
-
-        start
+            .unwrap_or(0)
     }
 
     fn complete_method_calls(

--- a/golem-rib-repl/src/rib_edit.rs
+++ b/golem-rib-repl/src/rib_edit.rs
@@ -72,8 +72,8 @@ impl RibEdit {
 
         while start > 0
             && line[start - 1..start].chars().all(|c| {
-            c.is_alphanumeric() || c == '_' || c == '.' || c == '-' || c == '(' || c == ')'
-        })
+                c.is_alphanumeric() || c == '_' || c == '.' || c == '-' || c == '(' || c == ')'
+            })
         {
             start -= 1;
         }
@@ -102,8 +102,8 @@ impl RibEdit {
         let mut completions = Vec::new();
 
         if let Some(worker_instance_func_dict) =
-            instance_vars.get_worker_instance_method_dict(instance_var_name) {
-
+            instance_vars.get_worker_instance_method_dict(instance_var_name)
+        {
             for (function, tpe) in &worker_instance_func_dict.map {
                 let name_with_paren = format!("{}(", function.name());
 
@@ -135,8 +135,8 @@ impl RibEdit {
         }
 
         if let Some(resource_instance_func_dict) =
-            instance_vars.get_resource_instance_method_dict(instance_var_name){
-
+            instance_vars.get_resource_instance_method_dict(instance_var_name)
+        {
             for (resource_method_name, tpe) in &resource_instance_func_dict.map {
                 let resource_method_with_paren = format!("{}(", resource_method_name.name());
 
@@ -166,16 +166,13 @@ impl RibEdit {
                     completions.push(resource_method_name.name());
                 }
             }
-
         }
 
         if completions.is_empty() {
             Ok(None)
         } else {
             Ok(Some((start + dot_pos + 1, completions)))
-
         }
-
     }
 
     pub fn complete_variants(
@@ -403,8 +400,9 @@ fn highlight_word(
 
     // Method call (e.g., obj.method)
     if let Some((obj, method)) = word.split_once('.') {
-        let is_instance =
-            instance_vars.map_or(false, |vars| vars.instance_keys().contains(&obj.to_string()));
+        let is_instance = instance_vars.map_or(false, |vars| {
+            vars.instance_keys().contains(&obj.to_string())
+        });
 
         let is_method = instance_vars.map_or(false, |vars| {
             vars.method_names().contains(&method.to_string())
@@ -425,8 +423,9 @@ fn highlight_word(
     }
 
     // Instance variable
-    let is_instance_var =
-        instance_vars.map_or(false, |vars| vars.instance_keys().contains(&word.to_string()));
+    let is_instance_var = instance_vars.map_or(false, |vars| {
+        vars.instance_keys().contains(&word.to_string())
+    });
 
     if is_instance_var {
         return word.cyan().to_string();

--- a/golem-rib-repl/src/rib_repl.rs
+++ b/golem-rib-repl/src/rib_repl.rs
@@ -142,6 +142,8 @@ impl RibRepl {
     /// For a built-in REPL loop, see [`Self::run`].
     pub async fn execute_rib(&mut self, rib: &str) -> Result<Option<RibResult>, RibError> {
         if !rib.is_empty() {
+            let rib = rib.strip_suffix(";").unwrap_or(rib);
+
             self.update_rib(rib);
 
             // Add every rib script into the history (in memory) and save it

--- a/golem-rib-repl/src/rib_repl.rs
+++ b/golem-rib-repl/src/rib_repl.rs
@@ -271,6 +271,8 @@ pub enum ReplBootstrapError {
     ReplHistoryFileError(String),
 }
 
+impl std::error::Error for ReplBootstrapError {}
+
 impl Display for ReplBootstrapError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/golem-rib-repl/src/rib_repl.rs
+++ b/golem-rib-repl/src/rib_repl.rs
@@ -94,11 +94,11 @@ impl RibRepl {
 
                 match dependencies {
                     Ok(dependencies) => {
-                        let component_dependencies = dependencies.component_dependencies;
+                        let mut component_dependencies = dependencies.component_dependencies;
 
                         match &component_dependencies.len() {
                             0 => Err(ReplBootstrapError::NoComponentsFound),
-                            1 => Ok(component_dependencies[0].clone()),
+                            1 => Ok(component_dependencies.pop().unwrap()),
                             _ => Err(ReplBootstrapError::MultipleComponentsFound(
                                 "multiple components detected. rib repl currently support only a single component".to_string(),
                             )),

--- a/golem-rib-repl/src/rib_repl.rs
+++ b/golem-rib-repl/src/rib_repl.rs
@@ -332,6 +332,6 @@ impl RibFunctionInvoke for ReplRibFunctionInvoke {
                 args.0,
             )
             .await
-            .map_err(|e| format!("Failed to invoke function: {}", e.to_string()))
+            .map_err(|e| format!("Failed to invoke function: {}", e))
     }
 }

--- a/golem-rib-repl/src/rib_repl.rs
+++ b/golem-rib-repl/src/rib_repl.rs
@@ -132,7 +132,7 @@ impl RibRepl {
     /// This method is exposed for users who want to manage their own REPL loop
     /// instead of using the built-in [`Self::run`] method.
     pub fn read_line(&mut self) -> rustyline::Result<String> {
-        self.editor.readline(">>> ".magenta().to_string().as_str())
+        self.editor.readline(">>> ".cyan().to_string().as_str())
     }
 
     /// Executes a single line of Rib code and returns the result.
@@ -201,7 +201,7 @@ impl RibRepl {
     /// use [`Self::read_line`] and [`Self::execute_rib`] directly.
     pub async fn run(&mut self) {
         loop {
-            let readline = self.editor.readline(">>> ".magenta().to_string().as_str());
+            let readline = self.read_line();
             match readline {
                 Ok(rib) => {
                     let _ = self.execute_rib(&rib).await;

--- a/golem-rib/src/compiler/mod.rs
+++ b/golem-rib/src/compiler/mod.rs
@@ -16,6 +16,7 @@ pub use byte_code::*;
 pub use compiler_output::*;
 use golem_wasm_ast::analysis::AnalysedExport;
 pub use ir::*;
+use std::error::Error;
 use std::fmt::Display;
 pub use type_with_unit::*;
 pub use worker_functions_in_rib::*;
@@ -125,3 +126,5 @@ impl Display for RibError {
         }
     }
 }
+
+impl Error for RibError {}

--- a/golem-rib/src/instance_type.rs
+++ b/golem-rib/src/instance_type.rs
@@ -354,6 +354,42 @@ impl InstanceType {
         }
     }
 
+    pub fn function_dict_for_resource(
+        &self,
+    ) -> FunctionDictionary {
+        match self {
+            InstanceType::Resource {
+                resource_method_dict,
+                ..
+            } => resource_method_dict.into(),
+            _ => FunctionDictionary::default(),
+        }
+    }
+
+    pub fn function_dict_without_resource(
+        &self,
+    ) -> FunctionDictionary {
+        match self {
+            InstanceType::Global {
+                functions_global: function_dict,
+                ..
+            } => function_dict.clone(),
+            InstanceType::Package {
+                functions_in_package: function_dict,
+                ..
+            } => function_dict.clone(),
+            InstanceType::Interface {
+                functions_in_interface: function_dict,
+                ..
+            } => function_dict.clone(),
+            InstanceType::PackageInterface {
+                functions_in_package_interface: function_dict,
+                ..
+            } => function_dict.clone(),
+            InstanceType::Resource { .. } => FunctionDictionary::default(),
+        }
+    }
+
     pub fn function_dict(&self) -> FunctionDictionary {
         match self {
             InstanceType::Global {
@@ -454,7 +490,7 @@ pub struct Function {
     pub function_type: FunctionType,
 }
 
-#[derive(Debug, Hash, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub struct FunctionDictionary {
     pub map: Vec<(FunctionName, FunctionType)>,
 }

--- a/golem-rib/src/instance_type.rs
+++ b/golem-rib/src/instance_type.rs
@@ -354,9 +354,7 @@ impl InstanceType {
         }
     }
 
-    pub fn function_dict_for_resource(
-        &self,
-    ) -> FunctionDictionary {
+    pub fn function_dict_for_resource(&self) -> FunctionDictionary {
         match self {
             InstanceType::Resource {
                 resource_method_dict,
@@ -366,9 +364,7 @@ impl InstanceType {
         }
     }
 
-    pub fn function_dict_without_resource(
-        &self,
-    ) -> FunctionDictionary {
+    pub fn function_dict_without_resource(&self) -> FunctionDictionary {
         match self {
             InstanceType::Global {
                 functions_global: function_dict,

--- a/golem-rib/src/type_registry.rs
+++ b/golem-rib/src/type_registry.rs
@@ -14,8 +14,8 @@
 
 use crate::call_type::CallType;
 use crate::DynamicParsedFunctionName;
-use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_ast::analysis::{AnalysedExport, TypeVariant};
+use golem_wasm_ast::analysis::{AnalysedType, TypeEnum};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 
@@ -51,6 +51,20 @@ impl FunctionTypeRegistry {
         }
 
         variants
+    }
+
+    pub fn get_enums(&self) -> Vec<TypeEnum> {
+        let mut enums = vec![];
+
+        for registry_value in self.types.values() {
+            if let RegistryValue::Value(analysed_type) = registry_value {
+                if let AnalysedType::Enum(type_enum) = analysed_type {
+                    enums.push(type_enum.clone())
+                }
+            }
+        }
+
+        enums
     }
 
     pub fn get(&self, key: &CallType) -> Option<&RegistryValue> {

--- a/golem-rib/src/type_registry.rs
+++ b/golem-rib/src/type_registry.rs
@@ -57,10 +57,8 @@ impl FunctionTypeRegistry {
         let mut enums = vec![];
 
         for registry_value in self.types.values() {
-            if let RegistryValue::Value(analysed_type) = registry_value {
-                if let AnalysedType::Enum(type_enum) = analysed_type {
-                    enums.push(type_enum.clone())
-                }
+            if let RegistryValue::Value(AnalysedType::Enum(type_enum)) = registry_value {
+                enums.push(type_enum.clone())
             }
         }
 

--- a/integration-tests/src/rib_repl/main.rs
+++ b/integration-tests/src/rib_repl/main.rs
@@ -1,4 +1,4 @@
-use golem_rib_repl::rib_repl::{ComponentSource, RibRepl};
+use golem_rib_repl::{ComponentSource, RibRepl};
 use golem_test_framework::config::{
     EnvBasedTestDependencies, EnvBasedTestDependenciesConfig, TestDependencies,
 };

--- a/integration-tests/src/rib_repl/main.rs
+++ b/integration-tests/src/rib_repl/main.rs
@@ -1,4 +1,4 @@
-use golem_rib_repl::{ComponentSource, RibRepl};
+use golem_rib_repl::{ComponentSource, RibRepl, RibReplConfig};
 use golem_test_framework::config::{
     EnvBasedTestDependencies, EnvBasedTestDependenciesConfig, TestDependencies,
 };
@@ -13,18 +13,19 @@ async fn main() {
         .nth(1)
         .unwrap_or_else(|| "shopping-cart".to_string());
 
-    let mut rib_repl = RibRepl::bootstrap(
-        None,
-        Arc::new(TestRibReplDependencyManager::new(deps.clone())),
-        Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
-        None,
-        Some(ComponentSource {
+    let mut rib_repl = RibRepl::bootstrap(RibReplConfig {
+        history_file: None,
+        dependency_manager: Arc::new(TestRibReplDependencyManager::new(deps.clone())),
+        worker_function_invoke: Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
+        printer: None,
+        component_source: Some(ComponentSource {
             component_name: component_name.to_string(),
             source_path: deps
                 .component_directory()
                 .join(format!("{}.wasm", component_name)),
         }),
-    )
+        prompt: None,
+    })
     .await
     .expect("Failed to bootstrap REPL");
 

--- a/integration-tests/tests/rib_repl.rs
+++ b/integration-tests/tests/rib_repl.rs
@@ -17,9 +17,9 @@ use crate::Tracing;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use golem_common::model::{ComponentId, TargetWorkerId};
-use golem_rib_repl::WorkerFunctionInvoke;
 use golem_rib_repl::{ComponentSource, RibRepl};
 use golem_rib_repl::{ReplDependencies, RibComponentMetadata, RibDependencyManager};
+use golem_rib_repl::{RibReplConfig, WorkerFunctionInvoke};
 use golem_test_framework::config::{EnvBasedTestDependencies, TestDependencies};
 use golem_test_framework::dsl::TestDslUnsafe;
 use golem_wasm_ast::analysis::analysed_type::{f32, field, list, record, str, u32};
@@ -36,16 +36,17 @@ inherit_test_dep!(EnvBasedTestDependencies);
 #[test]
 #[tracing::instrument]
 async fn test_rib_repl(deps: &EnvBasedTestDependencies) {
-    let mut rib_repl = RibRepl::bootstrap(
-        None,
-        Arc::new(TestRibReplDependencyManager::new(deps.clone())),
-        Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
-        None,
-        Some(ComponentSource {
+    let mut rib_repl = RibRepl::bootstrap(RibReplConfig {
+        history_file: None,
+        dependency_manager: Arc::new(TestRibReplDependencyManager::new(deps.clone())),
+        worker_function_invoke: Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
+        printer: None,
+        component_source: Some(ComponentSource {
             component_name: "shopping-cart".to_string(),
             source_path: deps.component_directory().join("shopping-cart.wasm"),
         }),
-    )
+        prompt: None,
+    })
     .await
     .expect("Failed to bootstrap REPL");
 
@@ -143,18 +144,19 @@ async fn test_rib_repl(deps: &EnvBasedTestDependencies) {
 #[test]
 #[tracing::instrument]
 async fn test_rib_repl_with_resource(deps: &EnvBasedTestDependencies) {
-    let mut rib_repl = RibRepl::bootstrap(
-        None,
-        Arc::new(TestRibReplDependencyManager::new(deps.clone())),
-        Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
-        None,
-        Some(ComponentSource {
+    let mut rib_repl = RibRepl::bootstrap(RibReplConfig {
+        history_file: None,
+        dependency_manager: Arc::new(TestRibReplDependencyManager::new(deps.clone())),
+        worker_function_invoke: Arc::new(TestRibReplWorkerFunctionInvoke::new(deps.clone())),
+        printer: None,
+        component_source: Some(ComponentSource {
             component_name: "shopping-cart-resource".to_string(),
             source_path: deps
                 .component_directory()
                 .join("shopping-cart-resource.wasm"),
         }),
-    )
+        prompt: None,
+    })
     .await
     .expect("Failed to bootstrap REPL");
 


### PR DESCRIPTION
Rib_Repl crate is succesfully [integrated](https://github.com/golemcloud/golem-cli/commit/bdb6f7d42ca8ecaa6a7e3dcf4828cf82ffb0e22a) and is running with CLI, however, we found a few (very) minor things. This PR mostly just addresses them, plus more features/fixes

#### API improvements
* Function invoke  and component load implementation returns `anyhow::Result` instead of deciding it is always a `String`
* Adding component name in APIs along with ComponentId for logging purpose
* Display for ReplBootstrapError (currently CLI uses debug)
* This wasn't spotted, but fixed the imports: Example: `golem_rib_repl::WorkerFunctionInvoke` instead of `golem_rib_repl::invoke::WorkerFunctionInvoke` - everything is under `golem_rib_repl`. 
* Extracted bootstrap parameters as RibReplConfig and added prompt as a config options

#### Features and Fixes
* method invocation syntax highlighting
*  No parse errors even if it ends with `;` - the validation is on the fly/inline - that you can't `return` if the Rib is invalid. This allows users to fix the script then and there itself
* variant and enum auto complete
* fix bugs in resource method argument generation (it was failing since the first argument to be discarded as it is a handle)
* avoid auto complete of methods that are part of an actual resource instance and not a worker instance
* fixed completion UTF-8 handling
* added newlines to parse errors to make them look cleaner


PS: Not sure if the crate should be `golem_rib_repl` or just `rib_repl`. Probably the latter, but not changing it now