### PR TITLE
Auto completion of variant arguments

### DIFF
--- a/golem-rib-repl/src/rib_edit.rs
+++ b/golem-rib-repl/src/rib_edit.rs
@@ -194,7 +194,8 @@ impl RibEdit {
                 if word == name_with_paren {
                     if let Some(variant_arg_type) = &case.typ {
                         let generated_value = generate_value(variant_arg_type);
-                        let value_and_type = ValueAndType::new(generated_value, variant_arg_type.clone());
+                        let value_and_type =
+                            ValueAndType::new(generated_value, variant_arg_type.clone());
                         let arg_str = value_and_type.to_string();
                         completions.push(format!("{})", arg_str));
                         return Ok(Some((end_pos, completions)));


### PR DESCRIPTION
Automatically completing variant arguments
With this everything in your WIT is auto completed with Repl. This auto completion is important across the board to reduce users face compile time errors, that they only need to edit the args everywhere.

https://github.com/user-attachments/assets/7a084857-a9e8-43d5-b96f-815fc145f5e6


This was for the following WIT

```
package pack:name;

interface component-name-api {

  enum status {
    backlog,
    in-progress,
    done,
  }

  enum priority {
    low,
    medium,
    high,
  }

  enum query-sort {
    priority,
    deadline,
  }

  record new-item {
    title: string,
    priority: priority,
    deadline: option<string>,
  }

  record update-item {
    title: option<string>,
    priority: option<priority>,
    status: option<status>,
    deadline: option<string>,
  }

  record item {
    id: string,
    title: string,
    priority: priority,
    status: status,
    created-timestamp: s64,
    updated-timestamp: s64,
    deadline: option<s64>,
  }

  record query {
    keyword: option<string>,
    priority: option<priority>,
    status: option<status>,
    deadline: option<string>,
    sort: option<query-sort>,
    limit: option<u32>,
  }

  variant bid-result {
    success(string),
    failure(string)
  }

  process: func(res: bid-result) -> string;

  process-user: func(status: status, priority: priority, user-id: string) -> string;

  add: func(item: new-item) -> result<item, string>;

  update: func(id: string, change: update-item) -> result<item, string>;

  search: func(query: query) -> result<list<item>, string>;

  count: func() -> u32;

  delete: func(id: string) -> result<_, string>;

  delete-done-items: func();

  delete-all: func();

  get: func(id: string) -> result<item, string>;

}

world component-name {
  export component-name-api;
}
```