### PR TITLE
Fix some edge case of worker recovery

### DIFF
--- a/golem-worker-executor-base/src/durable_host/mod.rs
+++ b/golem-worker-executor-base/src/durable_host/mod.rs
@@ -1677,17 +1677,6 @@ impl<Ctx: WorkerCtx + DurableWorkerCtxView<Ctx>> ExternalOperations<Ctx> for Dur
 
             Ok(RetryDecision::None)
         } else {
-            // Handle the case when recovery immediately starts in a deleted region
-            // (for example due to a manual update)
-            store
-                .as_context_mut()
-                .data_mut()
-                .durable_ctx_mut()
-                .state
-                .replay_state
-                .get_out_of_skipped_region()
-                .await;
-
             let result = Self::resume_replay(store, instance).await;
 
             record_resume_worker(start.elapsed());


### PR DESCRIPTION
Previously it was possible that if initializing a worker takes relatively long, a _pending worker invocation_ entry has been written immediately after the first (_create_) entry into the oplog.
The worker recovery loop was not properly skipping these kind of hint entries from the beginning of the oplog.

Note: This issue was reproducible easily with WASMs created by the new Go tooling for some reason.