### PR TITLE
Handle query and path parameters with spaces in api gateway

### DIFF
--- a/golem-rib/src/parser/record.rs
+++ b/golem-rib/src/parser/record.rs
@@ -264,4 +264,35 @@ mod tests {
             )]))
         );
     }
+
+    #[test]
+    fn test_record_nested() {
+        let expr = r#"
+      {
+         headers: { ContentType: "json", userid: "foo" },
+         body: "foo",
+         status: status
+       }
+        "#;
+
+        let result = Expr::from_text(expr);
+
+        assert_eq!(
+            result,
+            Ok(Expr::record(vec![
+                (
+                    "headers".to_string(),
+                    Expr::record(vec![
+                        ("ContentType".to_string(), Expr::literal("json")),
+                        ("userid".to_string(), Expr::literal("foo"))
+                    ])
+                ),
+                ("body".to_string(), Expr::literal("foo")),
+                (
+                    "status".to_string(),
+                    Expr::identifier_global("status", None)
+                )
+            ]))
+        );
+    }
 }

--- a/golem-rib/src/parser/rib_expr.rs
+++ b/golem-rib/src/parser/rib_expr.rs
@@ -30,7 +30,6 @@ use crate::parser::identifier::identifier;
 use crate::parser::integer::integer;
 use crate::parser::let_binding::let_binding;
 use crate::parser::literal::literal;
-use crate::parser::multi_line_code_block::multi_line_block;
 use crate::parser::not::not;
 use crate::parser::optional::option;
 use crate::parser::pattern_match::pattern_match;
@@ -41,6 +40,7 @@ use crate::rib_source_span::{GetSourcePosition, SourceSpan};
 
 use crate::parser::list_aggregation::list_aggregation;
 use crate::parser::list_comprehension::list_comprehension;
+use crate::parser::multi_line_code_block::multi_line_block;
 use crate::parser::record::record;
 use crate::parser::result::result;
 use crate::parser::type_name::type_name;

--- a/golem-worker-service-base/src/gateway_api_definition/http/path_pattern_parser.rs
+++ b/golem-worker-service-base/src/gateway_api_definition/http/path_pattern_parser.rs
@@ -56,9 +56,9 @@ fn path_parser(input: &str) -> IResult<&str, Vec<PathPattern>> {
     let indexed_patterns = patterns
         .into_iter()
         .map(|pattern| match pattern {
-            ParsedPattern::Literal(literal) => PathPattern::literal(literal),
-            ParsedPattern::Var(var) => PathPattern::var(var),
-            ParsedPattern::CatchAllVar(var) => PathPattern::catch_all_var(var),
+            ParsedPattern::Literal(literal) => PathPattern::literal(literal.trim()),
+            ParsedPattern::Var(var) => PathPattern::var(var.trim()),
+            ParsedPattern::CatchAllVar(var) => PathPattern::catch_all_var(var.trim()),
         })
         .collect();
 
@@ -71,7 +71,7 @@ fn query_parser(input: &str) -> IResult<&str, Vec<QueryInfo>> {
 
 fn query_param_parser(input: &str) -> IResult<&str, QueryInfo> {
     map(place_holder_parser::parse_place_holder, |x| QueryInfo {
-        key_name: x.to_string(),
+        key_name: x.trim().to_string(),
     })(input)
 }
 

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -467,6 +467,53 @@ async fn test_api_def_with_invalid_query_and_path_lookup() {
 }
 
 #[test]
+async fn test_api_def_with_path_parameters_in_space() {
+    let response_mapping = r#"
+       let user_id = request.path.user-id;
+       let country = request.query.country;
+       let worker-name = "shopping-cart-${user_id}-${country}";
+       let worker-instance = instance(worker-name);
+       let response = worker-instance.get-cart-contents(user_id, country);
+      response
+    "#;
+
+    // user-id and country is having space before and after
+    let api_specification: HttpApiDefinition = get_api_def_with_worker_binding(
+        "/foo/{ user-id   }?{    country }",
+        None,
+        response_mapping,
+    )
+    .await;
+
+    let api_request =
+        get_gateway_request("/foo/jon?country=usa", None, &HeaderMap::new(), Value::Null);
+
+    let session_store: Arc<dyn GatewaySession + Sync + Send> = internal::get_session_store();
+
+    let response = execute(
+        api_request,
+        &api_specification,
+        &session_store,
+        &TestIdentityProvider::default(),
+    )
+    .await;
+
+    let test_response = internal::get_details_from_response(response).await;
+
+    let result = (test_response.function_name, test_response.function_params);
+
+    let expected = (
+        "golem:it/api.{get-cart-contents}".to_string(),
+        Value::Array(vec![
+            Value::String("jon".to_string()),
+            Value::String("usa".to_string()),
+        ]),
+    );
+
+    assert_eq!(result, expected);
+}
+
+#[test]
 async fn test_api_def_with_invalid_query_lookup() {
     let response_mapping = r#"
        let user-id = request.query.user-id;

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -444,11 +444,11 @@ async fn test_api_def_with_invalid_query_and_path_lookup() {
       response
     "#;
 
-    let api_specification: HttpApiDefinition =
+    let api_specification1: HttpApiDefinition =
         get_api_def_with_worker_binding("/foo/bar", None, response_mapping).await;
 
-    let result = CompiledHttpApiDefinition::from_http_api_definition(
-        &api_specification,
+    let result1 = CompiledHttpApiDefinition::from_http_api_definition(
+        &api_specification1,
         &internal::get_component_metadata(),
         &DefaultNamespace::default(),
     )
@@ -463,7 +463,20 @@ async fn test_api_def_with_invalid_query_and_path_lookup() {
         }
     );
 
-    assert_eq!(result, expected)
+    assert_eq!(&result1, &expected);
+
+    let api_specification2 =
+        get_api_def_with_worker_binding("/foo/{user  -  id}?{cou ntry}", None, response_mapping)
+            .await;
+
+    let result2 = CompiledHttpApiDefinition::from_http_api_definition(
+        &api_specification2,
+        &internal::get_component_metadata(),
+        &DefaultNamespace::default(),
+    )
+    .unwrap_err();
+
+    assert_eq!(&result2, &expected)
 }
 
 #[test]

--- a/integration-tests/tests/api/api_deployment.rs
+++ b/integration-tests/tests/api/api_deployment.rs
@@ -684,9 +684,7 @@ async fn create_api_definition(
                                             let result = worker.get-cart-contents();
                                             let status: u64 = 200;
                                             {
-                                              headers: {
-                                                {ContentType: "json", userid: "foo"}
-                                              },
+                                              headers: { ContentType: "json", userid: "foo" },
                                               body: "foo",
                                               status: status
                                             }


### PR DESCRIPTION
This change is based on some observations shared by @noise64 