### PR TITLE
Persisting created promise id

### DIFF
--- a/golem-worker-executor/src/model/public_oplog/mod.rs
+++ b/golem-worker-executor/src/model/public_oplog/mod.rs
@@ -1011,11 +1011,12 @@ fn encode_host_function_request_as_value(
         "monotonic_clock::subscribe_duration" => no_payload(),
         "wall_clock::now" => no_payload(),
         "wall_clock::resolution" => no_payload(),
-        "golem_delete_promise" => {
+        "golem::api::create_promise" => no_payload(),
+        "golem::api::delete_promise" => {
             let payload: PromiseId = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
-        "golem_complete_promise" => {
+        "golem::api::complete_promise" => {
             let payload: PromiseId = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
@@ -1386,11 +1387,15 @@ fn encode_host_function_response_as_value(
             let payload: Result<SerializableDateTime, SerializableError> = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
-        "golem_delete_promise" => {
+        "golem::api::create_promise" => {
+            let payload: Result<PromiseId, SerializableError> = try_deserialize(bytes)?;
+            Ok(payload.into_value_and_type())
+        }
+        "golem::api::delete_promise" => {
             let payload: Result<(), SerializableError> = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }
-        "golem_complete_promise" => {
+        "golem::api::complete_promise" => {
             let payload: Result<bool, SerializableError> = try_deserialize(bytes)?;
             Ok(payload.into_value_and_type())
         }


### PR DESCRIPTION
Resolves #1509 

Previously promise creation only emitted a `NoOp` oplog entry (to increase the oplog index, guaranteeing that multiple create-promise calls lead to different promise IDs) but the actual promise ID was not persisted, because it is just a combination of the `worker-id` and the `oplog-idx`, which was considered to be always reconstructible without any persisted information.

This broke when we introduced forking. When replaying the forked worker to recover its state, the worker ID is different so it was not possible to share a promise for communication between the forked and original worker, and there was also a possibility of divergence. 

This pull request fixes this by explicitly persisting the created promise's ID, so even in forked workers we always see the same one.