### PR TITLE
make rib interpreter aware that the worker function invoke can return optional value handling `Unit` functions

### DIFF
--- a/golem-rib-repl/src/invoke.rs
+++ b/golem-rib-repl/src/invoke.rs
@@ -31,7 +31,7 @@ pub trait WorkerFunctionInvoke {
         worker_name: Option<String>,
         function_name: &str,
         args: Vec<ValueAndType>,
-    ) -> anyhow::Result<ValueAndType>;
+    ) -> anyhow::Result<Option<ValueAndType>>;
 }
 
 // Note: Currently, the Rib interpreter supports only one component, so the
@@ -48,7 +48,7 @@ impl ReplRibFunctionInvoke {
         Self { repl_state }
     }
 
-    fn get_cached_result(&self, instruction_id: &InstructionId) -> Option<ValueAndType> {
+    fn get_cached_result(&self, instruction_id: &InstructionId) -> Option<Option<ValueAndType>> {
         // If the current instruction index is greater than the last played index result,
         // then we shouldn't use the cache result no matter what.
         // This check is important because without this, loops end up reusing the cached invocation result

--- a/golem-rib-repl/src/repl_state.rs
+++ b/golem-rib-repl/src/repl_state.rs
@@ -41,7 +41,7 @@ impl ReplState {
         &self.invocation_results
     }
 
-    pub fn update_cache(&self, instruction_id: InstructionId, result: ValueAndType) {
+    pub fn update_cache(&self, instruction_id: InstructionId, result: Option<ValueAndType>) {
         self.invocation_results
             .results
             .write()
@@ -117,11 +117,11 @@ impl ReplState {
 
 #[derive(Debug)]
 pub struct InvocationResultCache {
-    pub results: RwLock<HashMap<InstructionId, ValueAndType>>,
+    pub results: RwLock<HashMap<InstructionId, Option<ValueAndType>>>,
 }
 
 impl InvocationResultCache {
-    pub fn get(&self, script_id: &InstructionId) -> Option<ValueAndType> {
+    pub fn get(&self, script_id: &InstructionId) -> Option<Option<ValueAndType>> {
         self.results.read().unwrap().get(script_id).cloned()
     }
 }

--- a/golem-rib/regression_tests/lib.rs
+++ b/golem-rib/regression_tests/lib.rs
@@ -2241,20 +2241,14 @@ mod mock_interpreter {
             _args: EvaluatedFnArgs,
         ) -> RibFunctionInvokeResult {
             let function_name = FunctionName(function_name.0);
-            let value = self
+
+            let result = self
                 .functions_and_result
                 .get(&function_name)
                 .cloned()
                 .flatten();
 
-            if let Some(value) = value {
-                Ok(ValueAndType::new(
-                    Value::Tuple(vec![value.value]),
-                    tuple(vec![value.typ]),
-                ))
-            } else {
-                Ok(ValueAndType::new(Value::Tuple(vec![]), tuple(vec![])))
-            }
+            Ok(result)
         }
     }
 }

--- a/golem-rib/regression_tests/lib.rs
+++ b/golem-rib/regression_tests/lib.rs
@@ -2027,9 +2027,9 @@ mod mock_interpreter {
         RibFunctionInvokeResult, RibInput,
     };
     use async_trait::async_trait;
-    use golem_wasm_ast::analysis::analysed_type::tuple;
+
     use golem_wasm_ast::analysis::{AnalysedType, TypeStr};
-    use golem_wasm_rpc::{Value, ValueAndType};
+    use golem_wasm_rpc::ValueAndType;
     use rib::InstructionId;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/golem-rib/src/interpreter/env.rs
+++ b/golem-rib/src/interpreter/env.rs
@@ -51,7 +51,7 @@ impl InterpreterEnv {
         worker_name: Option<String>,
         function_name: String,
         args: Vec<ValueAndType>,
-    ) -> Result<ValueAndType, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Option<ValueAndType>, Box<dyn std::error::Error + Send + Sync>> {
         self.call_worker_function_async
             .invoke(
                 instruction_id,
@@ -118,10 +118,10 @@ impl EnvironmentKey {
 
 mod internal {
     use crate::interpreter::env::RibFunctionInvoke;
-    use crate::{EvaluatedFnArgs, EvaluatedFqFn, EvaluatedWorkerName, InstructionId};
+    use crate::{
+        EvaluatedFnArgs, EvaluatedFqFn, EvaluatedWorkerName, InstructionId, RibFunctionInvokeResult,
+    };
     use async_trait::async_trait;
-    use golem_wasm_ast::analysis::analysed_type::tuple;
-    use golem_wasm_rpc::{Value, ValueAndType};
 
     pub(crate) struct NoopRibFunctionInvoke;
 
@@ -133,8 +133,8 @@ mod internal {
             _worker_name: Option<EvaluatedWorkerName>,
             _function_name: EvaluatedFqFn,
             _args: EvaluatedFnArgs,
-        ) -> Result<ValueAndType, Box<dyn std::error::Error + Send + Sync>> {
-            Ok(ValueAndType::new(Value::Tuple(vec![]), tuple(vec![])))
+        ) -> RibFunctionInvokeResult {
+            Ok(None)
         }
     }
 }

--- a/golem-rib/src/interpreter/rib_function_invoke.rs
+++ b/golem-rib/src/interpreter/rib_function_invoke.rs
@@ -13,7 +13,8 @@ pub trait RibFunctionInvoke {
     ) -> RibFunctionInvokeResult;
 }
 
-pub type RibFunctionInvokeResult = Result<ValueAndType, Box<dyn std::error::Error + Send + Sync>>;
+pub type RibFunctionInvokeResult =
+    Result<Option<ValueAndType>, Box<dyn std::error::Error + Send + Sync>>;
 
 #[derive(Debug)]
 pub struct EvaluatedFqFn(pub String);

--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -339,7 +339,7 @@ mod internal {
     };
     use crate::type_inference::GetTypeHint;
     use async_trait::async_trait;
-    use golem_wasm_ast::analysis::analysed_type::{tuple, u64};
+    use golem_wasm_ast::analysis::analysed_type::u64;
     use std::ops::Deref;
 
     pub(crate) struct NoopRibFunctionInvoke;

--- a/golem-rib/src/interpreter/rib_runtime_error.rs
+++ b/golem-rib/src/interpreter/rib_runtime_error.rs
@@ -198,7 +198,7 @@ impl Display for RibRuntimeError {
             RibRuntimeError::InvariantViolation(violation) => {
                 write!(f, "internal error: {:?}", violation)
             }
-            RibRuntimeError::ThrownError(message) => write!(f, "Thrown error: {}", message),
+            RibRuntimeError::ThrownError(message) => write!(f, "error: {}", message),
             RibRuntimeError::CastError { from, to } => {
                 write!(f, "cast error from {} to {}", from, to)
             }

--- a/golem-worker-service-base/src/gateway_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/gateway_rib_interpreter/mod.rs
@@ -178,17 +178,10 @@ impl<Namespace: Clone + Send + Sync + 'static> RibFunctionInvoke
             namespace,
         };
 
-        let tav = executor.execute(worker_request).await.map(|v| v.result)?;
+        let tav_opt = executor.execute(worker_request).await.map(|v| v.result)?;
 
-        match tav {
-            Some(tav) => tav.try_into().map_err(|err: String| err.into()),
-            None => {
-                // Representing the absence of return value as an empty record for Rib
-                Ok(ValueAndType::new(
-                    Value::Record(vec![]),
-                    analysed_type::record(vec![]),
-                ))
-            }
-        }
+        tav_opt
+            .map(|tav| ValueAndType::try_from(tav).map_err(|x| x.into()))
+            .transpose()
     }
 }

--- a/golem-worker-service-base/src/gateway_rib_interpreter/mod.rs
+++ b/golem-worker-service-base/src/gateway_rib_interpreter/mod.rs
@@ -17,9 +17,8 @@ use async_trait::async_trait;
 use golem_common::model::invocation_context::InvocationContextStack;
 use golem_common::model::{ComponentId, IdempotencyKey};
 use golem_common::SafeDisplay;
-use golem_wasm_ast::analysis::analysed_type;
 use golem_wasm_rpc::protobuf::type_annotated_value::TypeAnnotatedValue;
-use golem_wasm_rpc::{Value, ValueAndType};
+use golem_wasm_rpc::ValueAndType;
 use rib::{
     EvaluatedFnArgs, EvaluatedFqFn, EvaluatedWorkerName, InstructionId, RibByteCode,
     RibFunctionInvoke, RibFunctionInvokeResult, RibInput, RibResult,

--- a/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service-base/tests/api_gateway_end_to_end_tests.rs
@@ -2686,10 +2686,7 @@ mod internal {
                 );
 
                 let type_annotated_value = TypeAnnotatedValue::try_from(x).unwrap();
-
-                let worker_response = create_tuple(vec![type_annotated_value]);
-
-                return Ok(WorkerResponse::new(Some(worker_response)));
+                return Ok(WorkerResponse::new(Some(type_annotated_value)));
             } else if function_name == "bigw:shopping/api.{store(\"test-user\").get-currency}" {
                 let x = ValueAndType::new(
                     golem_wasm_rpc::Value::Result(Ok(Some(Box::new(
@@ -2700,9 +2697,7 @@ mod internal {
 
                 let type_annotated_value = TypeAnnotatedValue::try_from(x).unwrap();
 
-                let worker_response = create_tuple(vec![type_annotated_value]);
-
-                return Ok(WorkerResponse::new(Some(worker_response)));
+                return Ok(WorkerResponse::new(Some(type_annotated_value)));
             } else if function_name == "bigw:shopping/api.{store(\"test-user\").add-user}" {
                 let x = ValueAndType::new(
                     golem_wasm_rpc::Value::String("test-user-generated".to_string()),
@@ -2711,15 +2706,12 @@ mod internal {
 
                 let type_annotated_value = TypeAnnotatedValue::try_from(x).unwrap();
 
-                let worker_response = create_tuple(vec![type_annotated_value]);
-
-                return Ok(WorkerResponse::new(Some(worker_response)));
+                return Ok(WorkerResponse::new(Some(type_annotated_value)));
             }
 
             let type_annotated_value = convert_to_worker_response(&resolved_worker_request);
-            let worker_response = create_tuple(vec![type_annotated_value]);
 
-            Ok(WorkerResponse::new(Some(worker_response)))
+            Ok(WorkerResponse::new(Some(type_annotated_value)))
         }
     }
 

--- a/integration-tests/src/rib_repl/bootstrap.rs
+++ b/integration-tests/src/rib_repl/bootstrap.rs
@@ -69,7 +69,7 @@ impl WorkerFunctionInvoke for TestRibReplWorkerFunctionInvoke {
         worker_name: Option<String>,
         function_name: &str,
         args: Vec<ValueAndType>,
-    ) -> anyhow::Result<ValueAndType> {
+    ) -> anyhow::Result<Option<ValueAndType>> {
         let target_worker_id = worker_name
             .map(|w| TargetWorkerId {
                 component_id: ComponentId(component_id),
@@ -80,9 +80,12 @@ impl WorkerFunctionInvoke for TestRibReplWorkerFunctionInvoke {
                 worker_name: None,
             });
 
+        // RibREPL works already if we try `cargo run --bin rib-repl shopping-cart` in integration tests
+        // and experiment with values that returns unit
         self.embedded_worker_executor
             .invoke_and_await_typed(target_worker_id, function_name, args)
             .await
+            .map(Some)
             .map_err(|e| anyhow!("Failed to invoke function: {:?}", e))
     }
 }

--- a/integration-tests/src/rib_repl/bootstrap.rs
+++ b/integration-tests/src/rib_repl/bootstrap.rs
@@ -80,12 +80,10 @@ impl WorkerFunctionInvoke for TestRibReplWorkerFunctionInvoke {
                 worker_name: None,
             });
 
-        // RibREPL works already if we try `cargo run --bin rib-repl shopping-cart` in integration tests
-        // and experiment with values that returns unit
         self.embedded_worker_executor
             .invoke_and_await_typed(target_worker_id, function_name, args)
             .await
-            .map(Some)
+            .map(Some) // TODO; Remove this once the invoke_and_await_typed retrns Option
             .map_err(|e| anyhow!("Failed to invoke function: {:?}", e))
     }
 }

--- a/integration-tests/tests/rib_repl.rs
+++ b/integration-tests/tests/rib_repl.rs
@@ -314,7 +314,7 @@ impl WorkerFunctionInvoke for TestRibReplWorkerFunctionInvoke {
         worker_name: Option<String>,
         function_name: &str,
         args: Vec<ValueAndType>,
-    ) -> anyhow::Result<ValueAndType> {
+    ) -> anyhow::Result<Option<ValueAndType>> {
         let target_worker_id = worker_name
             .map(|w| TargetWorkerId {
                 component_id: ComponentId(component_id),
@@ -328,6 +328,7 @@ impl WorkerFunctionInvoke for TestRibReplWorkerFunctionInvoke {
         self.embedded_worker_executor
             .invoke_and_await_typed(target_worker_id, function_name, args)
             .await
+            .map(Some) // TODO; tests framework should be returning optional ValueAndType too
             .map_err(|e| anyhow!("Failed to invoke function: {:?}", e))
     }
 }


### PR DESCRIPTION
Raised against no-multi-return branch

This PR doesn't affect any other part of code other than golem-rib, repl, the tests in worker-service-base and will help continuing the original PR faster if this gets merged

- [x] golem-rib-interpreter small logical changes to properly handle optional value-and-type from function invocation
- [x] golem-worker-service-base api-gateway tests end to end is working (with fixes)
- [x] golem-rib tests are working with fixes in tests
- [x] golem-rib-repl tests integration tests working // an extra logic to be removed if the invoke_and_await_typed in test framework returns Option<AnalysedType>. If tests are not changed, keep it as is 

The integration tests that are failing is already failing in https://github.com/golemcloud/golem/tree/no-multi-return and hence not touching them for now