### PR TITLE
Component update fixes

### DIFF
--- a/golem-component-service-base/src/repo/component.rs
+++ b/golem-component-service-base/src/repo/component.rs
@@ -261,9 +261,10 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
         &self,
         owner: &Owner::Row,
         namespace: &str,
-        component_id: &Uuid,
-        data: Vec<u8>,
+        component_id: Uuid,
+        size: i32,
         metadata: Vec<u8>,
+        root_package_version: Option<&str>,
         component_type: Option<i32>,
         files: Option<Vec<FileRecord>>,
         env: Json<HashMap<String, String>>,
@@ -276,7 +277,7 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
     async fn activate(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         component_version: i64,
         object_store_key: &str,
         transformed_object_store_key: &str,
@@ -286,7 +287,7 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
     async fn get(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Vec<ComponentRecord<Owner>>, RepoError>;
 
     async fn get_all(&self, namespace: &str) -> Result<Vec<ComponentRecord<Owner>>, RepoError>;
@@ -294,13 +295,13 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
     async fn get_latest_version(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError>;
 
     async fn get_by_version(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError>;
 
@@ -318,9 +319,9 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
 
     async fn get_id_by_name(&self, namespace: &str, name: &str) -> Result<Option<Uuid>, RepoError>;
 
-    async fn get_namespace(&self, component_id: &Uuid) -> Result<Option<String>, RepoError>;
+    async fn get_namespace(&self, component_id: Uuid) -> Result<Option<String>, RepoError>;
 
-    async fn delete(&self, namespace: &str, component_id: &Uuid) -> Result<(), RepoError>;
+    async fn delete(&self, namespace: &str, component_id: Uuid) -> Result<(), RepoError>;
 
     async fn create_or_update_constraint(
         &self,
@@ -330,20 +331,20 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
     async fn delete_constraints(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         constraints_to_remove: &[FunctionSignature],
     ) -> Result<(), RepoError>;
 
     async fn get_constraint(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<FunctionConstraints>, RepoError>;
 
     async fn get_installed_plugins(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<
         Vec<PluginInstallationRecord<Owner::PluginOwner, ComponentPluginInstallationTarget>>,
@@ -353,7 +354,7 @@ pub trait ComponentRepo<Owner: ComponentOwner>: Debug + Send + Sync {
     async fn apply_plugin_installation_changes(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         actions: &[PluginInstallationRepoAction<Owner>],
     ) -> Result<u64, RepoError>;
 }
@@ -391,7 +392,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner>> LoggedComponentRepo<Owne
         }
     }
 
-    fn span(component_id: &Uuid) -> Span {
+    fn span(component_id: Uuid) -> Span {
         let span = info_span!("component repository", component_id = %component_id);
         span
     }
@@ -404,7 +405,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn create(&self, component: &ComponentRecord<Owner>) -> Result<(), RepoError> {
         self.repo
             .create(component)
-            .instrument(Self::span(&component.component_id))
+            .instrument(Self::span(component.component_id))
             .await
     }
 
@@ -412,9 +413,10 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
         &self,
         owner: &Owner::Row,
         namespace: &str,
-        component_id: &Uuid,
-        data: Vec<u8>,
+        component_id: Uuid,
+        size: i32,
         metadata: Vec<u8>,
+        root_package_version: Option<&str>,
         component_type: Option<i32>,
         files: Option<Vec<FileRecord>>,
         env: Json<HashMap<String, String>>,
@@ -424,8 +426,9 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
                 owner,
                 namespace,
                 component_id,
-                data,
+                size,
                 metadata,
+                root_package_version,
                 component_type,
                 files,
                 env,
@@ -437,7 +440,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn activate(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         component_version: i64,
         object_store_key: &str,
         transformed_object_store_key: &str,
@@ -459,7 +462,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn get(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Vec<ComponentRecord<Owner>>, RepoError> {
         self.repo
             .get(namespace, component_id)
@@ -474,7 +477,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn get_latest_version(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         self.repo
             .get_latest_version(namespace, component_id)
@@ -485,7 +488,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn get_by_version(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         self.repo
@@ -517,11 +520,11 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
         self.repo.get_id_by_name(namespace, name).await
     }
 
-    async fn get_namespace(&self, component_id: &Uuid) -> Result<Option<String>, RepoError> {
+    async fn get_namespace(&self, component_id: Uuid) -> Result<Option<String>, RepoError> {
         self.repo.get_namespace(component_id).await
     }
 
-    async fn delete(&self, namespace: &str, component_id: &Uuid) -> Result<(), RepoError> {
+    async fn delete(&self, namespace: &str, component_id: Uuid) -> Result<(), RepoError> {
         self.repo.delete(namespace, component_id).await
     }
 
@@ -531,7 +534,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     ) -> Result<(), RepoError> {
         self.repo
             .create_or_update_constraint(component_constraint_record)
-            .instrument(Self::span(&component_constraint_record.component_id))
+            .instrument(Self::span(component_constraint_record.component_id))
             .await
     }
 
@@ -541,7 +544,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn delete_constraints(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         constraints_to_remove: &[FunctionSignature],
     ) -> Result<(), RepoError> {
         self.repo
@@ -553,7 +556,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn get_constraint(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<FunctionConstraints>, RepoError> {
         self.repo
             .get_constraint(namespace, component_id)
@@ -564,7 +567,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn get_installed_plugins(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<
         Vec<PluginInstallationRecord<Owner::PluginOwner, ComponentPluginInstallationTarget>>,
@@ -579,7 +582,7 @@ impl<Owner: ComponentOwner, Repo: ComponentRepo<Owner> + Send + Sync> ComponentR
     async fn apply_plugin_installation_changes(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         actions: &[PluginInstallationRepoAction<Owner>],
     ) -> Result<u64, RepoError> {
         self.repo
@@ -632,7 +635,7 @@ impl<Owner: ComponentOwner, DB: Pool> Debug for DbComponentRepo<DB, Owner> {
 impl<Owner: ComponentOwner> DbComponentRepo<golem_service_base::db::postgres::PostgresPool, Owner> {
     async fn get_files(
         &self,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<Vec<FileRecord>, RepoError> {
         let query = sqlx::query_as::<_, FileRecord>(
@@ -664,7 +667,7 @@ impl<Owner: ComponentOwner> DbComponentRepo<golem_service_base::db::postgres::Po
             .into_iter()
             .map(|component| async move {
                 let files = self
-                    .get_files(&component.component_id, component.version as u64)
+                    .get_files(component.component_id, component.version as u64)
                     .await?;
                 Ok(ComponentRecord { files, ..component })
             })
@@ -826,9 +829,10 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
         &self,
         owner: &Owner::Row,
         namespace: &str,
-        component_id: &Uuid,
-        data: Vec<u8>,
+        component_id: Uuid,
+        size: i32,
         metadata: Vec<u8>,
+        root_package_version: Option<&str>,
         component_type: Option<i32>,
         files: Option<Vec<FileRecord>>,
         env: Json<HashMap<String, String>>,
@@ -852,42 +856,25 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
                 ))
             } else {
                 let now = Utc::now();
-                let new_version = if let Some(component_type) = component_type {
+                let new_version = {
                     let query = sqlx::query(
                         r#"
-                              WITH prev AS (SELECT component_id, version, object_store_key, transformed_object_store_key, root_package_name, root_package_version
-                                   FROM component_versions WHERE component_id = $1
-                                   ORDER BY version DESC
-                                   LIMIT 1)
-                              INSERT INTO component_versions
-                              SELECT prev.component_id, prev.version + 1, $2, $3, $4, $5, FALSE, prev.object_store_key, prev.transformed_object_store_key, prev.root_package_name, prev.root_package_version, $6 FROM prev
-                              RETURNING *
-                              "#,
+                        WITH prev AS (SELECT component_id, version, root_package_name, component_type
+                           FROM component_versions WHERE component_id = $1
+                           ORDER BY version DESC
+                           LIMIT 1)
+                        INSERT INTO component_versions
+                          (component_id, version, size, metadata, created_at, component_type, available, object_store_key, transformed_object_store_key, root_package_name, root_package_version, env)
+                          SELECT prev.component_id, prev.version + 1, $2, $3, $4, COALESCE($5, prev.component_type), FALSE, NULL, NULL, prev.root_package_name, $6, $7 FROM prev
+                        RETURNING version
+                        "#,
                     )
                         .bind(component_id)
-                        .bind(data.len() as i32)
-                        .bind(now)
+                        .bind(size)
                         .bind(metadata)
+                        .bind(now)
                         .bind(component_type)
-                        .bind(env);
-
-                    transaction.fetch_one(query).await?.get("version")
-                } else {
-                    let query = sqlx::query(
-                        r#"
-                              WITH prev AS (SELECT component_id, version, component_type, object_store_key, transformed_object_store_key, root_package_name, root_package_version
-                                   FROM component_versions WHERE component_id = $1
-                                   ORDER BY version DESC
-                                   LIMIT 1)
-                              INSERT INTO component_versions
-                              SELECT prev.component_id, prev.version + 1, $2, $3, $4, prev.component_type, FALSE, prev.object_store_key, prev.transformed_object_store_key, prev.root_package_name, prev.root_package_version, $5 FROM prev
-                              RETURNING *
-                              "#,
-                    )
-                        .bind(component_id)
-                        .bind(data.len() as i32)
-                        .bind(now)
-                        .bind(metadata)
+                        .bind(root_package_version)
                         .bind(env);
 
                     transaction.fetch_one(query).await?.get("version")
@@ -896,7 +883,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
                 debug!("update created new component version {new_version}");
 
                 let old_target = ComponentPluginInstallationRow {
-                    component_id: *component_id,
+                    component_id,
                     component_version: new_version - 1,
                 };
 
@@ -913,7 +900,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
                 let existing_installations = transaction.fetch_all(query).await?;
 
                 let new_target = ComponentPluginInstallationRow {
-                    component_id: *component_id,
+                    component_id,
                     component_version: new_version,
                 };
 
@@ -1005,7 +992,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn activate(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         component_version: i64,
         object_store_key: &str,
         transformed_object_store_key: &str,
@@ -1037,7 +1024,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_postgres(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Vec<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
             r#"
@@ -1079,7 +1066,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_sqlite(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Vec<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
             r#"
@@ -1201,7 +1188,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_latest_version_postgres(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
             r#"
@@ -1246,7 +1233,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_latest_version_sqlite(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
             r#"
@@ -1268,8 +1255,8 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
                 FROM components c
                     JOIN component_versions cv ON c.component_id = cv.component_id
                 WHERE c.component_id = $1 AND c.namespace = $2 AND cv.available = TRUE
-                ORDER BY cv.version
-                DESC LIMIT 1
+                ORDER BY cv.version DESC
+                LIMIT 1
                 "#,
         )
         .bind(component_id)
@@ -1291,7 +1278,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_by_version_postgres(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
@@ -1336,7 +1323,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_by_version_sqlite(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<Option<ComponentRecord<Owner>>, RepoError> {
         let query = sqlx::query_as::<_, ComponentRecord<Owner>>(
@@ -1692,7 +1679,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
         Ok(result.map(|x| x.get("component_id")))
     }
 
-    async fn get_namespace(&self, component_id: &Uuid) -> Result<Option<String>, RepoError> {
+    async fn get_namespace(&self, component_id: Uuid) -> Result<Option<String>, RepoError> {
         let query = sqlx::query("SELECT namespace FROM components WHERE component_id = $1")
             .bind(component_id);
 
@@ -1705,7 +1692,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
         Ok(result.map(|x| x.get("namespace")))
     }
 
-    async fn delete(&self, namespace: &str, component_id: &Uuid) -> Result<(), RepoError> {
+    async fn delete(&self, namespace: &str, component_id: Uuid) -> Result<(), RepoError> {
         // TODO: delete plugin installations
 
         let mut transaction = self.db_pool.with_rw("component", "delete").begin().await?;
@@ -1748,7 +1735,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn delete_constraints(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
         constraints: &[FunctionSignature],
     ) -> Result<(), RepoError> {
         let mut transaction = self
@@ -1902,7 +1889,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_constraint(
         &self,
         namespace: &str,
-        component_id: &Uuid,
+        component_id: Uuid,
     ) -> Result<Option<FunctionConstraints>, RepoError> {
         let query = sqlx::query_as::<_, ComponentConstraintsRecord>(
             r#"
@@ -1935,14 +1922,14 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn get_installed_plugins(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         version: u64,
     ) -> Result<
         Vec<PluginInstallationRecord<Owner::PluginOwner, ComponentPluginInstallationTarget>>,
         RepoError,
     > {
         let target = ComponentPluginInstallationRow {
-            component_id: *component_id,
+            component_id,
             component_version: version as i64,
         };
         let mut query = self.plugin_installation_queries.get_all(owner, &target);
@@ -1958,7 +1945,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
     async fn apply_plugin_installation_changes(
         &self,
         owner: &<<Owner as ComponentOwner>::PluginOwner as PluginOwner>::Row,
-        component_id: &Uuid,
+        component_id: Uuid,
         actions: &[PluginInstallationRepoAction<Owner>],
     ) -> Result<u64, RepoError> {
         let mut transaction = self
@@ -1974,7 +1961,8 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
                    ORDER BY version DESC
                    LIMIT 1)
               INSERT INTO component_versions
-              SELECT prev.component_id, prev.version + 1, prev.size, $2, prev.metadata, prev.component_type, FALSE, prev.object_store_key, prev.transformed_object_store_key, prev.root_package_name, prev.root_package_version, prev.env FROM prev
+                  (component_id, version, size, metadata, created_at, component_type, available, object_store_key, transformed_object_store_key, root_package_name, root_package_version, env)
+                  SELECT prev.component_id, prev.version + 1, prev.size, $2, prev.metadata, prev.component_type, FALSE, prev.object_store_key, prev.transformed_object_store_key, prev.root_package_name, prev.root_package_version, prev.env FROM prev
               RETURNING *
               "#,
         ).bind(component_id).bind(Utc::now());
@@ -1986,7 +1974,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
         );
 
         let old_target = ComponentPluginInstallationRow {
-            component_id: *component_id,
+            component_id,
             component_version: new_version - 1,
         };
         let mut query = self.plugin_installation_queries.get_all(owner, &old_target);
@@ -1995,7 +1983,7 @@ impl<Owner: ComponentOwner> ComponentRepo<Owner>
         let existing_installations = transaction.fetch_all(query).await?;
 
         let new_target = ComponentPluginInstallationRow {
-            component_id: *component_id,
+            component_id,
             component_version: new_version,
         };
 

--- a/golem-component-service-base/src/service/component.rs
+++ b/golem-component-service-base/src/service/component.rs
@@ -802,7 +802,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentServiceDefault<Owner, S
 
         let constraints = self
             .component_repo
-            .get_constraint(&owner.to_string(), &component_id.0)
+            .get_constraint(&owner.to_string(), component_id.0)
             .await?;
 
         let new_type_registry = FunctionTypeRegistry::from_export_metadata(&metadata.exports);
@@ -837,11 +837,12 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentServiceDefault<Owner, S
             .update(
                 &owner_record,
                 &owner.to_string(),
-                &component_id.0,
-                data.clone(),
+                component_id.0,
+                data.len() as i32,
                 record_metadata_serde::serialize(&metadata)
                     .map_err(|err| ComponentError::conversion_error("metadata", err))?
                     .to_vec(),
+                metadata.root_package_version.as_deref(),
                 component_type.map(|ct| ct as i32),
                 files,
                 Json(env),
@@ -867,14 +868,10 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentServiceDefault<Owner, S
             self.upload_protected_component(&component, transformed_data)
         )?;
 
-        self.component_compilation
-            .enqueue_compilation(component_id, component.versioned_component_id.version)
-            .await;
-
         self.component_repo
             .activate(
                 &owner.to_string(),
-                &component_id.0,
+                component_id.0,
                 component.versioned_component_id.version as i64,
                 &object_store_key,
                 &object_store_key,
@@ -883,6 +880,10 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentServiceDefault<Owner, S
                     .to_vec(),
             )
             .await?;
+
+        self.component_compilation
+            .enqueue_compilation(component_id, component.versioned_component_id.version)
+            .await;
 
         Ok(component)
     }
@@ -1084,7 +1085,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentServiceDefault<Owner, S
         self.component_repo
             .activate(
                 namespace,
-                &new_component.versioned_component_id.component_id.0,
+                new_component.versioned_component_id.component_id.0,
                 new_component.versioned_component_id.version as i64,
                 &new_component
                     .object_store_key
@@ -1326,10 +1327,17 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
         };
 
         if let Some(component) = component {
-            info!(owner = %owner, component_id = %component.versioned_component_id, "Download component as stream");
+            let protected_object_store_key = component.protected_object_store_key();
+
+            info!(
+                owner = %owner,
+                component_id = %component.versioned_component_id,
+                protected_object_store_key = %protected_object_store_key,
+                "Download component as stream",
+            );
 
             self.object_store
-                .get_stream(&component.protected_object_store_key())
+                .get_stream(&protected_object_store_key)
                 .await
                 .map_err(|e| {
                     ComponentError::component_store_error("Error downloading component", e)
@@ -1458,7 +1466,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
             .component_repo
             .get_by_version(
                 &owner.to_string(),
-                &component_id.component_id.0,
+                component_id.component_id.0,
                 component_id.version,
             )
             .await?;
@@ -1482,7 +1490,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
         info!(owner = %owner, "Get latest component");
         let result = self
             .component_repo
-            .get_latest_version(&owner.to_string(), &component_id.0)
+            .get_latest_version(&owner.to_string(), component_id.0)
             .await?;
 
         match result {
@@ -1504,7 +1512,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
         info!(owner = %owner, component_id = %component_id ,"Get component");
         let records = self
             .component_repo
-            .get(&owner.to_string(), &component_id.0)
+            .get(&owner.to_string(), component_id.0)
             .await?;
 
         let values: Vec<Component<Owner>> = records
@@ -1518,7 +1526,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
 
     async fn get_owner(&self, component_id: &ComponentId) -> Result<Option<Owner>, ComponentError> {
         info!(component_id = %component_id, "Get component owner");
-        let result = self.component_repo.get_namespace(&component_id.0).await?;
+        let result = self.component_repo.get_namespace(component_id.0).await?;
         if let Some(result) = result {
             let value = result
                 .parse()
@@ -1538,7 +1546,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
 
         let records = self
             .component_repo
-            .get(&owner.to_string(), &component_id.0)
+            .get(&owner.to_string(), component_id.0)
             .await?;
         let components = records
             .iter()
@@ -1562,7 +1570,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
                 })?;
             }
             self.component_repo
-                .delete(&owner.to_string(), &component_id.0)
+                .delete(&owner.to_string(), component_id.0)
                 .await?;
             Ok(())
         } else {
@@ -1586,7 +1594,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
             .component_repo
             .get_constraint(
                 &component_constraint.owner.to_string(),
-                &component_constraint.component_id.0,
+                component_constraint.component_id.0,
             )
             .await?
             .ok_or(ComponentError::ComponentConstraintCreateError(format!(
@@ -1612,12 +1620,12 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
         info!(owner = %owner, component_id = %component_id, "Delete constraint");
 
         self.component_repo
-            .delete_constraints(&owner.to_string(), &component_id.0, constraints_to_remove)
+            .delete_constraints(&owner.to_string(), component_id.0, constraints_to_remove)
             .await?;
 
         let result = self
             .component_repo
-            .get_constraint(&owner.to_string(), &component_id.0)
+            .get_constraint(&owner.to_string(), component_id.0)
             .await?
             .ok_or(ComponentError::ComponentConstraintCreateError(format!(
                 "Failed to get constraints for {}",
@@ -1642,7 +1650,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
 
         let result = self
             .component_repo
-            .get_constraint(&owner.to_string(), &component_id.0)
+            .get_constraint(&owner.to_string(), component_id.0)
             .await?;
         Ok(result)
     }
@@ -1657,7 +1665,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
         let plugin_owner_record = owner_record.into();
         let records = self
             .component_repo
-            .get_installed_plugins(&plugin_owner_record, &component_id.0, component_version)
+            .get_installed_plugins(&plugin_owner_record, component_id.0, component_version)
             .await?;
 
         records
@@ -1736,7 +1744,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
 
         let latest = self
             .component_repo
-            .get_latest_version(&owner.to_string(), &component_id.0)
+            .get_latest_version(&owner.to_string(), component_id.0)
             .await?;
 
         if let Some(latest) = latest {
@@ -1812,7 +1820,7 @@ impl<Owner: ComponentOwner, Scope: PluginScope> ComponentService<Owner>
                 .component_repo
                 .apply_plugin_installation_changes(
                     &plugin_owner_record,
-                    &component_id.0,
+                    component_id.0,
                     &repo_actions,
                 )
                 .await?;

--- a/golem-component-service-base/tests/all/repo/mod.rs
+++ b/golem-component-service-base/tests/all/repo/mod.rs
@@ -314,11 +314,12 @@ async fn test_repo_component_find_by_names(
         .update(
             &DefaultComponentOwnerRow {},
             "default",
-            &component2.versioned_component_id.component_id.0,
-            data,
+            component2.versioned_component_id.component_id.0,
+            data.len() as i32,
             record_metadata_serde::serialize(&component2.metadata)
                 .unwrap()
                 .to_vec(),
+            component2.metadata.root_package_version.as_deref(),
             Some(0),
             None,
             Json(HashMap::new()),
@@ -330,7 +331,7 @@ async fn test_repo_component_find_by_names(
     component_repo
         .activate(
             "default",
-            &component2.versioned_component_id.component_id.0,
+            component2.versioned_component_id.component_id.0,
             1,
             "",
             "",
@@ -563,21 +564,21 @@ async fn test_repo_component_delete(
     let result2 = component_repo
         .get(
             &DefaultComponentOwner.to_string(),
-            &component1.versioned_component_id.component_id.0,
+            component1.versioned_component_id.component_id.0,
         )
         .await;
 
     let result3 = component_repo
         .delete(
             &DefaultComponentOwner.to_string(),
-            &component1.versioned_component_id.component_id.0,
+            component1.versioned_component_id.component_id.0,
         )
         .await;
 
     let result4 = component_repo
         .get(
             &DefaultComponentOwner.to_string(),
-            &component1.versioned_component_id.component_id.0,
+            component1.versioned_component_id.component_id.0,
         )
         .await;
 
@@ -894,7 +895,7 @@ async fn test_default_component_plugin_installation(
     let target1_row: ComponentPluginInstallationRow = target1.clone().into();
 
     let installations1 = component_repo
-        .get_installed_plugins(&plugin_owner_row, &component_id.0, 0)
+        .get_installed_plugins(&plugin_owner_row, component_id.0, 0)
         .await?;
 
     let installation1 = PluginInstallation {
@@ -913,7 +914,7 @@ async fn test_default_component_plugin_installation(
     component_repo
         .apply_plugin_installation_changes(
             &plugin_owner_row,
-            &component_id.0,
+            component_id.0,
             &[PluginInstallationRepoAction::Install {
                 record: installation1_row,
             }],
@@ -936,7 +937,7 @@ async fn test_default_component_plugin_installation(
     component_repo
         .apply_plugin_installation_changes(
             &plugin_owner_row,
-            &component_id.0,
+            component_id.0,
             &[PluginInstallationRepoAction::Install {
                 record: installation2_row,
             }],
@@ -944,7 +945,7 @@ async fn test_default_component_plugin_installation(
         .await?;
 
     let installations2 = component_repo
-        .get_installed_plugins(&plugin_owner_row, &component_id.0, 2)
+        .get_installed_plugins(&plugin_owner_row, component_id.0, 2)
         .await?;
 
     info!("{:?}", installations2);
@@ -960,7 +961,7 @@ async fn test_default_component_plugin_installation(
     component_repo
         .apply_plugin_installation_changes(
             &plugin_owner_row,
-            &component_id.0,
+            component_id.0,
             &[PluginInstallationRepoAction::Update {
                 plugin_installation_id: latest_installation2_id,
                 new_priority: 600,
@@ -970,7 +971,7 @@ async fn test_default_component_plugin_installation(
         .await?;
 
     let installations3 = component_repo
-        .get_installed_plugins(&plugin_owner_row, &component_id.0, 3)
+        .get_installed_plugins(&plugin_owner_row, component_id.0, 3)
         .await?;
 
     let latest_installation1_id = installations3
@@ -982,7 +983,7 @@ async fn test_default_component_plugin_installation(
     component_repo
         .apply_plugin_installation_changes(
             &plugin_owner_row,
-            &component_id.0,
+            component_id.0,
             &[PluginInstallationRepoAction::Uninstall {
                 plugin_installation_id: latest_installation1_id,
             }],
@@ -990,7 +991,7 @@ async fn test_default_component_plugin_installation(
         .await?;
 
     let installations4 = component_repo
-        .get_installed_plugins(&plugin_owner_row, &component_id.0, 4)
+        .get_installed_plugins(&plugin_owner_row, component_id.0, 4)
         .await?;
 
     assert_eq!(installations1.len(), 0);

--- a/golem-component-service-base/tests/all/repo/mod.rs
+++ b/golem-component-service-base/tests/all/repo/mod.rs
@@ -639,7 +639,7 @@ async fn test_repo_component_constraints(
     let result_constraint_get = component_repo
         .get_constraint(
             &owner1.to_string(),
-            &component1.versioned_component_id.component_id.0,
+            component1.versioned_component_id.component_id.0,
         )
         .await
         .unwrap();
@@ -663,7 +663,7 @@ async fn test_repo_component_constraints(
     let result_constraint_get_updated = component_repo
         .get_constraint(
             &owner1.to_string(),
-            &component1.versioned_component_id.component_id.0,
+            component1.versioned_component_id.component_id.0,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Resolves https://github.com/golemcloud/golem/issues/1728

Fixes:
 - copy UUIDs instead of referencing them
 - only pass the size of the component instead of coping the whole WASM into the repo layer
 - always explicitly specify column names for INSERTs
 - set root_package_version for updates
 - do not copy object_store_key, transformed_object_store_key, root_package_name, root_package_version when creating a new version with a new WASM (note: the component plugn activiation uses a different code path and update)
 - only enqueue compilation after component is available
 
 Note: for now I did not change how available is filtered, as changing the order should be enough as a quick fix (it would result in blob storage errors), given this layer will be changed a lot with atomic deployment