### PR TITLE
cloud-service: Move auth to the edge and get rid of AccountAuthorization::admin

### DIFF
--- a/cloud-service/src/api/account.rs
+++ b/cloud-service/src/api/account.rs
@@ -15,7 +15,7 @@
 use super::dto;
 use crate::api::{ApiResult, ApiTags};
 use crate::model::*;
-use crate::service::account::AccountService;
+use crate::service::account::{AccountError, AccountService};
 use crate::service::auth::AuthService;
 use golem_common::model::AccountId;
 use golem_common::recorded_http_api_request;
@@ -58,7 +58,12 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<dto::FindAccountsResponse>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let values = self.account_service.find(email.as_deref(), &auth).await?;
+        let viewable_accounts = self.auth_service.viewable_accounts(&auth).await?;
+
+        let values = self
+            .account_service
+            .find(email.as_deref(), viewable_accounts)
+            .await?;
         Ok(Json(dto::FindAccountsResponse { values }))
     }
 
@@ -87,7 +92,11 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Account>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self.account_service.get(&account_id, &auth).await?;
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::ViewAccount)
+            .await?;
+
+        let response = self.account_service.get(&account_id).await?;
         Ok(Json(response))
     }
 
@@ -118,7 +127,11 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Plan>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self.account_service.get_plan(&account_id, &auth).await?;
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::ViewPlan)
+            .await?;
+
+        let response = self.account_service.get_plan(&account_id).await?;
         Ok(Json(response))
     }
 
@@ -152,10 +165,11 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Account>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self
-            .account_service
-            .update(&account_id, &data, &auth)
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::UpdateAccount)
             .await?;
+
+        let response = self.account_service.update(&account_id, &data).await?;
         Ok(Json(response))
     }
 
@@ -183,9 +197,13 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Account>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
+        self.auth_service
+            .authorize_global_action(&auth, &GlobalAction::CreateAccount)
+            .await?;
+
         let response = self
             .account_service
-            .create(&AccountId::generate(), &data, &auth)
+            .create(&AccountId::generate(), &data)
             .await?;
         Ok(Json(response))
     }
@@ -219,7 +237,17 @@ impl AccountApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<DeleteAccountResponse>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        self.account_service.delete(&account_id, &auth).await?;
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::DeleteAccount)
+            .await?;
+
+        if auth.token.account_id == account_id {
+            Err(AccountError::ArgValidation(vec![
+                "Cannot delete current account.".to_string(),
+            ]))?;
+        };
+
+        self.account_service.delete(&account_id).await?;
         Ok(Json(DeleteAccountResponse {}))
     }
 }

--- a/cloud-service/src/api/account_summary.rs
+++ b/cloud-service/src/api/account_summary.rs
@@ -119,7 +119,12 @@ impl AccountSummaryApi {
         token: GolemSecurityScheme,
     ) -> Result<Json<Vec<AccountSummary>>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self.account_summary_service.get(skip, limit, &auth).await?;
+
+        self.auth_service
+            .authorize_global_action(&auth, &GlobalAction::ViewAccountSummaries)
+            .await?;
+
+        let response = self.account_summary_service.get(skip, limit).await?;
         Ok(Json(response))
     }
 
@@ -136,7 +141,11 @@ impl AccountSummaryApi {
 
     async fn get_account_count_internal(&self, token: GolemSecurityScheme) -> Result<Json<i64>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self.account_summary_service.count(&auth).await?;
+        self.auth_service
+            .authorize_global_action(&auth, &GlobalAction::ViewAccountCount)
+            .await?;
+
+        let response = self.account_summary_service.count().await?;
         Ok(Json(response as i64))
     }
 }

--- a/cloud-service/src/api/grant.rs
+++ b/cloud-service/src/api/grant.rs
@@ -14,7 +14,7 @@
 
 use crate::api::{ApiError, ApiResult, ApiTags};
 use crate::model::*;
-use crate::service::account_grant::AccountGrantService;
+use crate::service::account_grant::{AccountGrantService, AccountGrantServiceError};
 use crate::service::auth::AuthService;
 use golem_common::model::auth::Role;
 use golem_common::model::error::ErrorBody;
@@ -60,7 +60,12 @@ impl GrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Vec<Role>>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let response = self.account_grant_service.get(&account_id, &auth).await?;
+
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::ViewAccountGrants)
+            .await?;
+
+        let response = self.account_grant_service.get(&account_id).await?;
         Ok(Json(response))
     }
 
@@ -92,7 +97,13 @@ impl GrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Role>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        let roles = self.account_grant_service.get(&account_id, &auth).await?;
+
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::ViewAccountGrants)
+            .await?;
+
+        let roles = self.account_grant_service.get(&account_id).await?;
+
         if roles.contains(&role) {
             Ok(Json(role))
         } else {
@@ -132,9 +143,13 @@ impl GrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Role>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        self.account_grant_service
-            .add(&account_id, &role, &auth)
+
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::CreateAccountGrant)
             .await?;
+
+        self.account_grant_service.add(&account_id, &role).await?;
+
         Ok(Json(role))
     }
 
@@ -168,9 +183,21 @@ impl GrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<DeleteGrantResponse>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
-        self.account_grant_service
-            .remove(&account_id, &role, &auth)
+
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::DeleteAccountGrant)
             .await?;
+
+        if auth.token.account_id == account_id && role == Role::Admin {
+            Err(AccountGrantServiceError::ArgValidation(vec![
+                "Cannot remove Admin role from current account.".to_string(),
+            ]))?
+        };
+
+        self.account_grant_service
+            .remove(&account_id, &role)
+            .await?;
+
         Ok(Json(DeleteGrantResponse {}))
     }
 }

--- a/cloud-service/src/api/mod.rs
+++ b/cloud-service/src/api/mod.rs
@@ -195,9 +195,6 @@ impl From<AccountError> for ApiError {
 impl From<TokenServiceError> for ApiError {
     fn from(value: TokenServiceError) -> Self {
         match value {
-            TokenServiceError::Unauthorized(_) => ApiError::Unauthorized(Json(ErrorBody {
-                error: value.to_safe_string(),
-            })),
             TokenServiceError::InternalRepoError(_)
             | TokenServiceError::InternalSecretAlreadyExists { .. } => {
                 ApiError::InternalError(Json(ErrorBody {

--- a/cloud-service/src/api/project_grant.rs
+++ b/cloud-service/src/api/project_grant.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use super::{ApiError, ApiResult, ApiTags};
-use crate::auth::AccountAuthorisation;
 use crate::model::*;
 use crate::service::account::AccountService;
-use crate::service::auth::AuthService;
+use crate::service::auth::{AuthService, ViewableAccounts};
 use crate::service::project_grant::ProjectGrantService;
 use crate::service::project_policy::ProjectPolicyService;
-use golem_common::model::auth::ProjectActions;
+use golem_common::model::auth::{ProjectAction, ProjectActions};
 use golem_common::model::error::{ErrorBody, ErrorsBody};
 use golem_common::model::ProjectId;
 use golem_common::model::{ProjectGrantId, ProjectPolicyId};
@@ -78,9 +77,13 @@ impl ProjectGrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<Vec<ProjectGrant>>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::ViewProjectGrants)
+            .await?;
+
         let grants = self
             .project_grant_service
-            .get_by_project(&project_id, &auth)
+            .get_by_project(&project_id)
             .await?;
         Ok(Json(grants))
     }
@@ -119,10 +122,15 @@ impl ProjectGrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<ProjectGrant>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::ViewProjectGrants)
+            .await?;
+
         let grant = self
             .project_grant_service
-            .get(&project_id, &grant_id, &auth)
+            .get(&project_id, &grant_id)
             .await?;
+
         match grant {
             Some(grant) => Ok(Json(grant)),
             None => Err(ApiError::NotFound(Json(ErrorBody {
@@ -168,6 +176,9 @@ impl ProjectGrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<ProjectGrant>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::CreateProjectGrants)
+            .await?;
 
         let account_id = match (request.grantee_account_id, request.grantee_email) {
             (Some(account_id), _) => account_id,
@@ -175,7 +186,7 @@ impl ProjectGrantApi {
                 info!("Looking up account by email {email}");
                 let mut accounts = self
                     .account_service
-                    .find(Some(&email), &AccountAuthorisation::admin())
+                    .find(Some(&email), ViewableAccounts::All)
                     .await?;
                 if accounts.len() == 1 {
                     accounts.swap_remove(0).id
@@ -220,7 +231,7 @@ impl ProjectGrantApi {
             data,
         };
 
-        self.project_grant_service.create(&grant, &auth).await?;
+        self.project_grant_service.create(&grant).await?;
         Ok(Json(grant))
     }
 
@@ -258,10 +269,14 @@ impl ProjectGrantApi {
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<DeleteProjectGrantResponse>> {
         let auth = self.auth_service.authorization(token.as_ref()).await?;
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::DeleteProjectGrants)
+            .await?;
 
         self.project_grant_service
-            .delete(&project_id, &grant_id, &auth)
+            .delete(&project_id, &grant_id)
             .await?;
+
         Ok(Json(DeleteProjectGrantResponse {}))
     }
 }

--- a/cloud-service/src/auth.rs
+++ b/cloud-service/src/auth.rs
@@ -28,10 +28,6 @@ impl AccountAuthorisation {
         Self { token, roles }
     }
 
-    pub fn admin() -> Self {
-        AccountAuthorisation::new(Token::admin(), vec![Role::Admin])
-    }
-
     pub fn has_account(&self, account_id: &AccountId) -> bool {
         self.token.account_id == *account_id
     }

--- a/cloud-service/src/bootstrap.rs
+++ b/cloud-service/src/bootstrap.rs
@@ -162,7 +162,6 @@ impl Services {
 
         let plan_limit_service: Arc<dyn service::plan_limit::PlanLimitService> =
             Arc::new(service::plan_limit::PlanLimitServiceDefault::new(
-                auth_service.clone(),
                 plan_repo.clone(),
                 account_repo.clone(),
                 account_workers_repo.clone(),
@@ -176,20 +175,17 @@ impl Services {
 
         let account_service: Arc<dyn service::account::AccountService> =
             Arc::new(service::account::AccountServiceDefault::new(
-                auth_service.clone(),
                 account_repo.clone(),
                 plan_service.clone(),
             ));
 
         let account_summary_service: Arc<dyn service::account_summary::AccountSummaryService> =
             Arc::new(service::account_summary::AccountSummaryServiceDefault::new(
-                auth_service.clone(),
                 account_summary_repo,
             ));
 
         let account_grant_service: Arc<dyn service::account_grant::AccountGrantService> =
             Arc::new(service::account_grant::AccountGrantServiceDefault::new(
-                auth_service.clone(),
                 account_grant_repo.clone(),
                 account_repo.clone(),
             ));
@@ -204,7 +200,6 @@ impl Services {
                 project_grant_repo.clone(),
                 project_policy_repo.clone(),
                 account_repo.clone(),
-                auth_service.clone(),
             ));
 
         let plugin_service_client =

--- a/cloud-service/src/grpcapi/project.rs
+++ b/cloud-service/src/grpcapi/project.rs
@@ -14,7 +14,7 @@
 
 use crate::auth::AccountAuthorisation;
 use crate::grpcapi::get_authorisation_token;
-use crate::model;
+use crate::model::{self, AccountAction};
 use crate::service::auth::{AuthService, AuthServiceError};
 use crate::service::project;
 use golem_api_grpc::proto::golem::common::{Empty, ErrorBody, ErrorsBody};
@@ -29,6 +29,7 @@ use golem_api_grpc::proto::golem::project::v1::{
 };
 use golem_api_grpc::proto::golem::project::Project;
 use golem_common::metrics::api::TraceErrorKind;
+use golem_common::model::auth::ProjectAction;
 use golem_common::model::{AccountId, ProjectId};
 use golem_common::recorded_grpc_api_request;
 use golem_common::SafeDisplay;
@@ -138,8 +139,15 @@ impl ProjectGrpcApi {
         metadata: MetadataMap,
     ) -> Result<Project, ProjectError> {
         let auth = self.auth(metadata).await?;
+        let account_id = &auth.token.account_id;
+        self.auth_service
+            .authorize_account_action(&auth, account_id, &AccountAction::ViewDefaultProject)
+            .await?;
 
-        let result = self.project_service.get_default(&auth).await?;
+        let result = self
+            .project_service
+            .get_default(&auth.token.account_id)
+            .await?;
         Ok(result.into())
     }
 
@@ -150,12 +158,16 @@ impl ProjectGrpcApi {
     ) -> Result<Project, ProjectError> {
         let auth = self.auth(metadata).await?;
 
-        let id: ProjectId = request
+        let project_id: ProjectId = request
             .project_id
             .and_then(|id| id.try_into().ok())
             .ok_or_else(|| bad_request_error("Missing project id"))?;
 
-        let result = self.project_service.get(&id, &auth).await?;
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::ViewProject)
+            .await?;
+
+        let result = self.project_service.get(&project_id).await?;
 
         match result {
             Some(project) => Ok(project.into()),
@@ -173,10 +185,15 @@ impl ProjectGrpcApi {
         metadata: MetadataMap,
     ) -> Result<Vec<Project>, ProjectError> {
         let auth = self.auth(metadata).await?;
+        let viewable_projects = self.auth_service.viewable_projects(&auth).await?;
 
         let projects = match request.project_name {
-            Some(name) => self.project_service.get_all_by_name(&name, &auth).await?,
-            None => self.project_service.get_all(&auth).await?,
+            Some(name) => {
+                self.project_service
+                    .get_all_by_name(&name, viewable_projects)
+                    .await?
+            }
+            None => self.project_service.get_all(viewable_projects).await?,
         };
 
         Ok(projects.into_iter().map(|p| p.into()).collect())
@@ -188,11 +205,16 @@ impl ProjectGrpcApi {
         metadata: MetadataMap,
     ) -> Result<(), ProjectError> {
         let auth = self.auth(metadata).await?;
-        let id: ProjectId = request
+        let project_id: ProjectId = request
             .project_id
             .and_then(|id| id.try_into().ok())
             .ok_or_else(|| bad_request_error("Missing project id"))?;
-        self.project_service.delete(&id, &auth).await?;
+
+        self.auth_service
+            .authorize_project_action(&auth, &project_id, &ProjectAction::DeleteProject)
+            .await?;
+
+        self.project_service.delete(&project_id).await?;
 
         Ok(())
     }
@@ -209,6 +231,10 @@ impl ProjectGrpcApi {
             .map(|id| id.into())
             .ok_or_else(|| bad_request_error("Missing account id"))?;
 
+        self.auth_service
+            .authorize_account_action(&auth, &owner_account_id, &AccountAction::CreateProject)
+            .await?;
+
         let project = model::Project {
             project_id: ProjectId::new_v4(),
             project_data: model::ProjectData {
@@ -220,7 +246,7 @@ impl ProjectGrpcApi {
             },
         };
 
-        self.project_service.create(&project, &auth).await?;
+        self.project_service.create(&project).await?;
 
         Ok(project.into())
     }

--- a/cloud-service/src/grpcapi/token.rs
+++ b/cloud-service/src/grpcapi/token.rs
@@ -67,11 +67,6 @@ impl From<AuthServiceError> for TokenError {
 impl From<token::TokenServiceError> for TokenError {
     fn from(value: token::TokenServiceError) -> Self {
         let error = match value {
-            token::TokenServiceError::Unauthorized(_) => {
-                token_error::Error::Unauthorized(ErrorBody {
-                    error: value.to_safe_string(),
-                })
-            }
             token::TokenServiceError::InternalRepoError(_)
             | token::TokenServiceError::InternalSecretAlreadyExists { .. } => {
                 token_error::Error::InternalError(ErrorBody {
@@ -151,11 +146,7 @@ impl TokenGrpcApi {
             .and_then(|id| id.try_into().ok())
             .ok_or_else(|| bad_request_error("Missing token id"))?;
 
-        match self
-            .token_service
-            .get(&token_id, &AccountAuthorisation::admin())
-            .await
-        {
+        match self.token_service.get(&token_id).await {
             Ok(existing) => {
                 self.auth_service
                     .authorize_account_action(
@@ -199,10 +190,12 @@ impl TokenGrpcApi {
             .create_token_dto
             .and_then(|d| chrono::DateTime::<chrono::Utc>::from_str(d.expires_at.as_str()).ok())
             .ok_or_else(|| bad_request_error("Missing expires at"))?;
-        let result = self
-            .token_service
-            .create(&account_id, &expires_at, &auth)
+
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::CreateToken)
             .await?;
+
+        let result = self.token_service.create(&account_id, &expires_at).await?;
         Ok(result.into())
     }
 
@@ -216,7 +209,13 @@ impl TokenGrpcApi {
             .token_id
             .and_then(|id| id.try_into().ok())
             .ok_or_else(|| bad_request_error("Missing token id"))?;
-        let result = self.token_service.get(&id, &auth).await?;
+
+        let result = self.token_service.get(&id).await?;
+
+        self.auth_service
+            .authorize_account_action(&auth, &result.account_id, &AccountAction::ViewTokens)
+            .await?;
+
         Ok(result.into())
     }
 
@@ -231,7 +230,11 @@ impl TokenGrpcApi {
             .map(|id| id.into())
             .ok_or_else(|| bad_request_error("Missing account id"))?;
 
-        let result = self.token_service.find(&account_id, &auth).await?;
+        self.auth_service
+            .authorize_account_action(&auth, &account_id, &AccountAction::ViewTokens)
+            .await?;
+
+        let result = self.token_service.find(&account_id).await?;
         Ok(result.into_iter().map(|p| p.into()).collect())
     }
 }

--- a/cloud-service/src/lib.rs
+++ b/cloud-service/src/lib.rs
@@ -23,7 +23,6 @@ pub mod model;
 pub mod repo;
 pub mod service;
 
-use self::auth::AccountAuthorisation;
 use self::config::{AccountConfig, AccountsConfig};
 use self::service::account::AccountService;
 use self::service::account_grant::AccountGrantService;
@@ -252,17 +251,12 @@ async fn create_initial_account(
                 name: account_config.name.clone(),
                 email: account_config.email.clone(),
             },
-            &AccountAuthorisation::admin(),
         )
         .await
         .ok();
 
     grant_service
-        .add(
-            &account_id,
-            &account_config.role,
-            &AccountAuthorisation::admin(),
-        )
+        .add(&account_id, &account_config.role)
         .await
         .ok();
 
@@ -271,7 +265,6 @@ async fn create_initial_account(
             &account_id,
             &DateTime::<Utc>::MAX_UTC,
             &TokenSecret::new(account_config.token),
-            &AccountAuthorisation::admin(),
         )
         .await
         .ok();

--- a/cloud-service/src/model.rs
+++ b/cloud-service/src/model.rs
@@ -787,15 +787,24 @@ pub enum GlobalAction {
 pub enum AccountAction {
     ViewAccount,
     UpdateAccount,
-    ViewPlan,
-    CreateProject,
     DeleteAccount,
+
+    ViewPlan,
+
+    CreateProject,
+
     ViewAccountGrants,
     CreateAccountGrant,
     DeleteAccountGrant,
+
     ViewDefaultProject,
+
     ListProjectGrants,
+
     ViewLimits,
     UpdateLimits,
+
+    CreateToken,
+    ViewTokens,
     DeleteToken,
 }

--- a/cloud-service/src/service/auth.rs
+++ b/cloud-service/src/service/auth.rs
@@ -97,6 +97,7 @@ pub enum ViewableProjects {
     /// Special case for admins, they can see all projects even if no grant is present.
     All,
     OwnedAndAdditional {
+        owner_account_id: AccountId,
         additional_project_ids: Vec<ProjectId>,
     },
 }
@@ -284,6 +285,12 @@ impl AuthService for AuthServiceDefault {
                 limit_to_account_or_roles(auth, account_id, &[Role::Admin])
             }
             AccountAction::UpdateLimits => limit_to_roles(auth, &[Role::Admin]),
+            AccountAction::ViewTokens => {
+                limit_to_account_or_roles(auth, account_id, &[Role::Admin])
+            }
+            AccountAction::CreateToken => {
+                limit_to_account_or_roles(auth, account_id, &[Role::Admin])
+            }
             AccountAction::DeleteToken => {
                 limit_to_account_or_roles(auth, account_id, &[Role::Admin])
             }
@@ -357,6 +364,7 @@ impl AuthService for AuthServiceDefault {
             .collect();
 
         Ok(ViewableProjects::OwnedAndAdditional {
+            owner_account_id: auth.token.account_id.clone(),
             additional_project_ids,
         })
     }

--- a/cloud-service/tests/it_tests.rs
+++ b/cloud-service/tests/it_tests.rs
@@ -106,11 +106,7 @@ async fn create_account(
         email: format!("{}@golem.cloud", account_id.value),
     };
 
-    let auth = create_auth(account_id, vec![Role::Admin]);
-
-    let create_result = account_service
-        .create(account_id, &account_data, &auth)
-        .await;
+    let create_result = account_service.create(account_id, &account_data).await;
 
     assert!(
         create_result.is_ok(),
@@ -136,8 +132,7 @@ async fn create_project(
             project_type: ProjectType::NonDefault,
         },
     };
-    let auth = create_auth(account_id, vec![]);
-    let create_result = project_service.create(&project, &auth).await;
+    let create_result = project_service.create(&project).await;
 
     assert!(
         create_result.is_ok(),
@@ -150,7 +145,7 @@ async fn create_project(
 async fn delete_project(
     project_id: &ProjectId,
     account_id: &AccountId,
-    project_service: Arc<dyn ProjectService + Sync + Send>,
+    project_service: Arc<dyn ProjectService>,
 ) -> Project {
     let project = Project {
         project_id: project_id.clone(),
@@ -162,9 +157,9 @@ async fn delete_project(
             project_type: ProjectType::NonDefault,
         },
     };
-    let auth = create_auth(account_id, vec![]);
-    let create_result = project_service.create(&project, &auth).await;
-    let delete_result = project_service.delete(project_id, &auth).await;
+
+    let create_result = project_service.create(&project).await;
+    let delete_result = project_service.delete(project_id).await;
 
     assert!(
         create_result.is_ok(),
@@ -204,7 +199,6 @@ async fn create_project_policy(
 async fn create_project_grant(
     id: &ProjectGrantId,
     data: &ProjectGrantData,
-    auth: &AccountAuthorisation,
     project_grant_service: Arc<dyn ProjectGrantService + Sync + Send>,
 ) -> ProjectGrant {
     let grant = ProjectGrant {
@@ -212,7 +206,7 @@ async fn create_project_grant(
         data: data.clone(),
     };
 
-    project_grant_service.create(&grant, auth).await.unwrap();
+    project_grant_service.create(&grant).await.unwrap();
 
     grant
 }
@@ -253,11 +247,7 @@ async fn test_services(config: &CloudServiceConfig) {
 
     // check user can get their own account
     {
-        let account_by_id = services
-            .account_service
-            .get(&account.id, &auth)
-            .await
-            .unwrap();
+        let account_by_id = services.account_service.get(&account.id).await.unwrap();
 
         assert_eq!(account_by_id, account);
     }
@@ -269,16 +259,12 @@ async fn test_services(config: &CloudServiceConfig) {
             .create(
                 &account.id,
                 &(chrono::Utc::now() + chrono::Duration::minutes(2)),
-                &auth,
             )
             .await
             .unwrap();
 
-        let token_by_id = services
-            .token_service
-            .get(&token.data.id, &auth)
-            .await
-            .unwrap();
+        let token_by_id = services.token_service.get(&token.data.id).await.unwrap();
+
         // assert!(token_by_id == token.data); // FIXME failing in CI - probably related to timestamps
         assert_eq!(token_by_id.account_id, token.data.account_id);
 
@@ -287,14 +273,16 @@ async fn test_services(config: &CloudServiceConfig) {
             .get_by_secret(&token.secret)
             .await
             .unwrap();
+
         // assert!(token_by_secret.is_some_and(|t| t == token_by_id));  // FIXME failing in CI - probably related to timestamps
         assert!(token_by_secret.is_some_and(|t| t.account_id == token_by_id.account_id));
 
         let tokens_by_account = services
             .token_service
-            .find(&token.data.account_id, &auth)
+            .find(&token.data.account_id)
             .await
             .unwrap();
+
         // assert!(tokens_by_account == vec![token.data]); // FIXME failing in CI - probably related to timestamps
 
         assert_eq!(tokens_by_account.len(), 1);
@@ -310,16 +298,31 @@ async fn test_services(config: &CloudServiceConfig) {
 
     // Check that we can only search for our own account
     {
-        let mut accounts = services.account_service.find(None, &auth).await.unwrap();
+        let viewable_accounts = services
+            .auth_service
+            .viewable_accounts(&auth)
+            .await
+            .unwrap();
+        let mut accounts = services
+            .account_service
+            .find(None, viewable_accounts)
+            .await
+            .unwrap();
         accounts.sort();
         assert_eq!(accounts, vec![account.clone()]);
     }
 
     // Check that admins can see all accounts
     {
+        let viewable_accounts = services
+            .auth_service
+            .viewable_accounts(&admin_auth)
+            .await
+            .unwrap();
+
         let mut accounts = services
             .account_service
-            .find(None, &admin_auth)
+            .find(None, viewable_accounts)
             .await
             .unwrap();
         accounts.sort();
@@ -340,11 +343,25 @@ async fn test_services(config: &CloudServiceConfig) {
         services.project_service.clone(),
     )
     .await;
-    let project_default = services.project_service.get_default(&auth).await.unwrap();
+
+    let project_default = services
+        .project_service
+        .get_default(&account_id)
+        .await
+        .unwrap();
 
     // Check that we can create and get projects
     {
-        let projects = services.project_service.get_all(&auth).await.unwrap();
+        let viewable_projects = services
+            .auth_service
+            .viewable_projects(&auth)
+            .await
+            .unwrap();
+        let projects = services
+            .project_service
+            .get_all(viewable_projects)
+            .await
+            .unwrap();
 
         assert_eq!(
             HashSet::from_iter(projects),
@@ -353,7 +370,7 @@ async fn test_services(config: &CloudServiceConfig) {
 
         let project_by_id = services
             .project_service
-            .get(&project.project_id, &auth)
+            .get(&project.project_id)
             .await
             .unwrap();
 
@@ -384,14 +401,13 @@ async fn test_services(config: &CloudServiceConfig) {
                 grantee_account_id: account2.id.clone(),
                 project_policy_id: project_policy.id.clone(),
             },
-            &auth,
             services.project_grant_service.clone(),
         )
         .await;
 
         let project_grant_by_id = services
             .project_grant_service
-            .get(&project.project_id, &project_grant.id, &auth2)
+            .get(&project.project_id, &project_grant.id)
             .await
             .unwrap();
 
@@ -399,7 +415,7 @@ async fn test_services(config: &CloudServiceConfig) {
 
         let project_grant_by_project = services
             .project_grant_service
-            .get_by_project(&project.project_id, &auth2)
+            .get_by_project(&project.project_id)
             .await
             .unwrap();
 
@@ -430,14 +446,32 @@ async fn test_services(config: &CloudServiceConfig) {
 
     // check that we can list the shared project after getting a grant
     {
-        let projects = services.project_service.get_all(&auth2).await.unwrap();
+        let viewable_projects = services
+            .auth_service
+            .viewable_projects(&auth2)
+            .await
+            .unwrap();
+        let projects = services
+            .project_service
+            .get_all(viewable_projects)
+            .await
+            .unwrap();
 
         assert_eq!(projects, vec![project.clone()]);
     }
 
     // check that admin can see all projects
     {
-        let projects = services.project_service.get_all(&admin_auth).await.unwrap();
+        let viewable_projects = services
+            .auth_service
+            .viewable_projects(&admin_auth)
+            .await
+            .unwrap();
+        let projects = services
+            .project_service
+            .get_all(viewable_projects)
+            .await
+            .unwrap();
 
         assert_eq!(
             HashSet::from_iter(projects),
@@ -447,7 +481,16 @@ async fn test_services(config: &CloudServiceConfig) {
 
     // check that an unrelated user cannot see the projects
     {
-        let projects = services.project_service.get_all(&auth3).await.unwrap();
+        let viewable_projects = services
+            .auth_service
+            .viewable_projects(&auth3)
+            .await
+            .unwrap();
+        let projects = services
+            .project_service
+            .get_all(viewable_projects)
+            .await
+            .unwrap();
 
         assert_eq!(projects, vec![]);
     }
@@ -464,30 +507,38 @@ async fn test_services(config: &CloudServiceConfig) {
         .await;
     }
 
-    // check that admin can get account summaries
+    // get account summaries
     {
-        let account_summaries = services
-            .account_summary_service
-            .get(0, 10, &admin_auth)
-            .await
-            .unwrap();
+        let account_summaries = services.account_summary_service.get(0, 10).await.unwrap();
         assert_eq!(account_summaries.len(), 1);
     }
 
     // Check that we can list accounts we have a grant from
     {
-        let auth = create_auth(&account2.id, vec![]);
-        let mut accounts = services.account_service.find(None, &auth).await.unwrap();
+        let viewable_accounts = services
+            .auth_service
+            .viewable_accounts(&auth2)
+            .await
+            .unwrap();
+        let mut accounts = services
+            .account_service
+            .find(None, viewable_accounts)
+            .await
+            .unwrap();
         accounts.sort();
         assert_eq!(accounts, vec![account.clone(), account2.clone()]);
     }
 
     // Check that we can filter accounts by email
     {
-        let auth = create_auth(&account2.id, vec![]);
+        let viewable_accounts = services
+            .auth_service
+            .viewable_accounts(&auth2)
+            .await
+            .unwrap();
         let mut accounts = services
             .account_service
-            .find(Some(&account.email), &auth)
+            .find(Some(&account.email), viewable_accounts)
             .await
             .unwrap();
         accounts.sort();


### PR DESCRIPTION
Just some small cleanups as the AccountAuthorization::admin makes it very hard to reason about auth being performed correctly for a given user action.