### PR TITLE
Improve plugin definition and installation in shared projects

### DIFF
--- a/golem-api-grpc/proto/golem/component/plugin_definition.proto
+++ b/golem-api-grpc/proto/golem/component/plugin_definition.proto
@@ -19,7 +19,7 @@ message PluginDefinitionCreation {
   bytes icon = 4;
   string homepage = 5;
   golem.component.PluginTypeSpecificDefinition specs = 6;
-  golem.component.CloudPluginScope scope = 7;
+  golem.component.PluginScope scope = 7;
 }
 
 message PluginDefinition {
@@ -30,12 +30,12 @@ message PluginDefinition {
   bytes icon = 5;
   string homepage = 6;
   golem.component.PluginTypeSpecificDefinition specs = 7;
-  golem.component.CloudPluginScope scope = 8;
+  golem.component.PluginScope scope = 8;
   golem.common.AccountId account_id = 9;
   bool deleted = 10;
 }
 
-message CloudPluginScope {
+message PluginScope {
   oneof scope {
     golem.common.Empty global = 1;
     golem.component.ComponentPluginScope component = 2;

--- a/golem-api-grpc/proto/golem/component/v1/plugin_service.proto
+++ b/golem-api-grpc/proto/golem/component/v1/plugin_service.proto
@@ -17,7 +17,7 @@ service PluginService {
 }
 
 message ListPluginsRequest {
-  optional golem.component.CloudPluginScope scope = 1;
+  golem.component.PluginScope scope = 1;
 }
 
 message ListPluginVersionsRequest {

--- a/golem-api-grpc/proto/golem/component/v1/plugin_service.proto
+++ b/golem-api-grpc/proto/golem/component/v1/plugin_service.proto
@@ -9,7 +9,6 @@ import "golem/component/plugin_definition.proto";
 
 service PluginService {
   rpc ListPlugins (ListPluginsRequest) returns (ListPluginsResponse);
-  rpc ListPluginVersions (ListPluginVersionsRequest) returns (ListPluginsResponse);
   rpc CreatePlugin (CreatePluginRequest) returns (CreatePluginResponse);
   rpc GetPlugin (GetPluginRequest) returns (GetPluginResponse);
   rpc DeletePlugin (DeletePluginRequest) returns (DeletePluginResponse);
@@ -18,10 +17,6 @@ service PluginService {
 
 message ListPluginsRequest {
   golem.component.PluginScope scope = 1;
-}
-
-message ListPluginVersionsRequest {
-  string name = 1;
 }
 
 message ListPluginsResponse {
@@ -75,8 +70,9 @@ message GetPluginByIdResponse {
 }
 
 message DeletePluginRequest {
-  string name = 1;
-  string version = 2;
+  golem.common.AccountId account_id = 1;
+  string name = 2;
+  string version = 3;
 }
 
 message DeletePluginResponse {

--- a/golem-common/src/model/plugin.rs
+++ b/golem-common/src/model/plugin.rs
@@ -585,24 +585,34 @@ mod protobuf {
         fn from(scope: PluginScope) -> Self {
             match scope {
                 PluginScope::Global(_) => golem_api_grpc::proto::golem::component::PluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(
-                        golem_api_grpc::proto::golem::common::Empty {},
-                    )),
+                    scope: Some(
+                        golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(
+                            golem_api_grpc::proto::golem::common::Empty {},
+                        ),
+                    ),
                 },
-                PluginScope::Component(scope) => golem_api_grpc::proto::golem::component::PluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
-                        golem_api_grpc::proto::golem::component::ComponentPluginScope {
-                            component_id: Some(scope.component_id.into()),
-                        },
-                    )),
-                },
-                PluginScope::Project(scope) => golem_api_grpc::proto::golem::component::PluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
-                        golem_api_grpc::proto::golem::component::ProjectPluginScope {
-                            project_id: Some(scope.project_id.into()),
-                        },
-                    )),
-                },
+                PluginScope::Component(scope) => {
+                    golem_api_grpc::proto::golem::component::PluginScope {
+                        scope: Some(
+                            golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
+                                golem_api_grpc::proto::golem::component::ComponentPluginScope {
+                                    component_id: Some(scope.component_id.into()),
+                                },
+                            ),
+                        ),
+                    }
+                }
+                PluginScope::Project(scope) => {
+                    golem_api_grpc::proto::golem::component::PluginScope {
+                        scope: Some(
+                            golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
+                                golem_api_grpc::proto::golem::component::ProjectPluginScope {
+                                    project_id: Some(scope.project_id.into()),
+                                },
+                            ),
+                        ),
+                    }
+                }
             }
         }
     }
@@ -614,24 +624,20 @@ mod protobuf {
             proto: golem_api_grpc::proto::golem::component::PluginScope,
         ) -> Result<Self, Self::Error> {
             match proto.scope {
-                Some(
-                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(_),
-                ) => Ok(Self::global()),
-                Some(
-                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
-                        scope,
-                    ),
-                ) => Ok(Self::component(
+                Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(_)) => {
+                    Ok(Self::global())
+                }
+                Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
+                    scope,
+                )) => Ok(Self::component(
                     scope
                         .component_id
                         .ok_or("Missing component_id")?
                         .try_into()?,
                 )),
-                Some(
-                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
-                        scope,
-                    ),
-                ) => Ok(Self::project(
+                Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
+                    scope,
+                )) => Ok(Self::project(
                     scope.project_id.ok_or("Missing project_id")?.try_into()?,
                 )),
                 None => Err("Missing scope".to_string()),

--- a/golem-common/src/model/plugin.rs
+++ b/golem-common/src/model/plugin.rs
@@ -581,23 +581,23 @@ mod protobuf {
         }
     }
 
-    impl From<PluginScope> for golem_api_grpc::proto::golem::component::CloudPluginScope {
+    impl From<PluginScope> for golem_api_grpc::proto::golem::component::PluginScope {
         fn from(scope: PluginScope) -> Self {
             match scope {
-                PluginScope::Global(_) => golem_api_grpc::proto::golem::component::CloudPluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Global(
+                PluginScope::Global(_) => golem_api_grpc::proto::golem::component::PluginScope {
+                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(
                         golem_api_grpc::proto::golem::common::Empty {},
                     )),
                 },
-                PluginScope::Component(scope) => golem_api_grpc::proto::golem::component::CloudPluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Component(
+                PluginScope::Component(scope) => golem_api_grpc::proto::golem::component::PluginScope {
+                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
                         golem_api_grpc::proto::golem::component::ComponentPluginScope {
                             component_id: Some(scope.component_id.into()),
                         },
                     )),
                 },
-                PluginScope::Project(scope) => golem_api_grpc::proto::golem::component::CloudPluginScope {
-                    scope: Some(golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Project(
+                PluginScope::Project(scope) => golem_api_grpc::proto::golem::component::PluginScope {
+                    scope: Some(golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
                         golem_api_grpc::proto::golem::component::ProjectPluginScope {
                             project_id: Some(scope.project_id.into()),
                         },
@@ -607,18 +607,18 @@ mod protobuf {
         }
     }
 
-    impl TryFrom<golem_api_grpc::proto::golem::component::CloudPluginScope> for PluginScope {
+    impl TryFrom<golem_api_grpc::proto::golem::component::PluginScope> for PluginScope {
         type Error = String;
 
         fn try_from(
-            proto: golem_api_grpc::proto::golem::component::CloudPluginScope,
+            proto: golem_api_grpc::proto::golem::component::PluginScope,
         ) -> Result<Self, Self::Error> {
             match proto.scope {
                 Some(
-                    golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Global(_),
+                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Global(_),
                 ) => Ok(Self::global()),
                 Some(
-                    golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Component(
+                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Component(
                         scope,
                     ),
                 ) => Ok(Self::component(
@@ -628,7 +628,7 @@ mod protobuf {
                         .try_into()?,
                 )),
                 Some(
-                    golem_api_grpc::proto::golem::component::cloud_plugin_scope::Scope::Project(
+                    golem_api_grpc::proto::golem::component::plugin_scope::Scope::Project(
                         scope,
                     ),
                 ) => Ok(Self::project(

--- a/golem-component-service/src/api/plugin.rs
+++ b/golem-component-service/src/api/plugin.rs
@@ -49,6 +49,10 @@ impl PluginApi {
         let record = recorded_http_api_request!("list_plugins",);
         let auth = AuthCtx::new(token.secret());
 
+        // FIXME: This endpoint behaves weirdly depending on the parameters passed to it.
+        // When a scope is provided it will return all plugins that are available in that scope, even if they are owned by other accounts.
+        // If no scope is provided all plugins _owned by the current account_
+
         let response = if let Some(scope) = scope.0 {
             self.plugin_service
                 .list_plugins_for_scope(&auth, &scope)

--- a/golem-component-service/src/authed/plugin.rs
+++ b/golem-component-service/src/authed/plugin.rs
@@ -42,14 +42,6 @@ impl AuthedPluginService {
         }
     }
 
-    pub async fn list_plugins(
-        &self,
-        auth: &AuthCtx,
-    ) -> Result<Vec<PluginDefinition>, ComponentError> {
-        let owner = self.get_owner(auth).await?;
-        self.plugin_service.list_plugins(&owner).await
-    }
-
     pub async fn list_plugins_for_scope(
         &self,
         auth: &AuthCtx,
@@ -65,6 +57,7 @@ impl AuthedPluginService {
     pub async fn list_plugin_versions(
         &self,
         auth: &AuthCtx,
+        account_id: AccountId,
         name: &str,
     ) -> Result<Vec<PluginDefinition>, ComponentError> {
         let owner = self.get_owner(auth).await?;

--- a/golem-component-service/src/error.rs
+++ b/golem-component-service/src/error.rs
@@ -18,7 +18,7 @@ use golem_api_grpc::proto::golem::common::{ErrorBody, ErrorsBody};
 use golem_api_grpc::proto::golem::component::v1::component_error;
 use golem_common::model::component::VersionedComponentId;
 use golem_common::model::component_metadata::ComponentProcessingError;
-use golem_common::model::ComponentId;
+use golem_common::model::{AccountId, ComponentId};
 use golem_common::model::{ComponentFilePath, InitialComponentFileKey};
 use golem_common::SafeDisplay;
 use golem_service_base::clients::auth::AuthServiceError;
@@ -85,8 +85,9 @@ pub enum ComponentError {
     InternalProjectError(ProjectError),
     #[error("Plugin does not implement golem:api/oplog-processor")]
     InvalidOplogProcessorPlugin,
-    #[error("Plugin not found: {plugin_name}@{plugin_version}")]
+    #[error("Plugin not found: {account_id}/{plugin_name}@{plugin_version}")]
     PluginNotFound {
+        account_id: AccountId,
         plugin_name: String,
         plugin_version: String,
     },

--- a/golem-component-service/src/grpcapi/plugin.rs
+++ b/golem-component-service/src/grpcapi/plugin.rs
@@ -21,7 +21,6 @@ use golem_api_grpc::proto::golem::component::v1::plugin_service_server::PluginSe
 use golem_api_grpc::proto::golem::component::v1::{
     component_error, create_plugin_response, delete_plugin_response, ComponentError,
     CreatePluginResponse, DeletePluginRequest, DeletePluginResponse, GetPluginRequest,
-    ListPluginVersionsRequest,
 };
 use golem_api_grpc::proto::golem::component::v1::{
     get_plugin_by_id_response, get_plugin_response, list_plugins_response, CreatePluginRequest,
@@ -57,23 +56,9 @@ impl PluginGrpcApi {
             .try_into()
             .map_err(|err| bad_request_error(&format!("Invalid plugin scope: {err}")))?;
 
-        let plugins = self.plugin_service
-            .list_plugins_for_scope(&auth, &scope)
-            .await?;
-
-        Ok(plugins.into_iter().map(|pd| pd.into()).collect())
-    }
-
-    async fn list_plugin_versions(
-        &self,
-        request: &ListPluginVersionsRequest,
-        metadata: MetadataMap,
-    ) -> Result<Vec<PluginDefinition>, ComponentError> {
-        let auth = auth(metadata)?;
-
         let plugins = self
             .plugin_service
-            .list_plugin_versions(&auth, &request.name)
+            .list_plugins_for_scope(&auth, &scope)
             .await?;
 
         Ok(plugins.into_iter().map(|pd| pd.into()).collect())
@@ -131,8 +116,14 @@ impl PluginGrpcApi {
     ) -> Result<(), ComponentError> {
         let auth = auth(metadata)?;
 
+        let account_id = request
+            .account_id
+            .clone()
+            .ok_or(bad_request_error("Missing account id"))?
+            .into();
+
         self.plugin_service
-            .delete(&auth, &request.name, &request.version)
+            .delete(&auth, account_id, &request.name, &request.version)
             .await?;
 
         Ok(())
@@ -175,32 +166,6 @@ impl PluginService for PluginGrpcApi {
 
         let response = match self
             .list_plugins(&request, metadata)
-            .instrument(record.span.clone())
-            .await
-        {
-            Ok(plugins) => record.succeed(list_plugins_response::Result::Success(
-                ListPluginsSuccessResponse { plugins },
-            )),
-            Err(error) => record.fail(
-                list_plugins_response::Result::Error(error.clone()),
-                &ComponentTraceErrorKind(&error),
-            ),
-        };
-
-        Ok(Response::new(ListPluginsResponse {
-            result: Some(response),
-        }))
-    }
-
-    async fn list_plugin_versions(
-        &self,
-        request: Request<ListPluginVersionsRequest>,
-    ) -> Result<Response<ListPluginsResponse>, Status> {
-        let (metadata, _, request) = request.into_parts();
-        let record = recorded_grpc_api_request!("list_plugin_versions",);
-
-        let response = match self
-            .list_plugin_versions(&request, metadata)
             .instrument(record.span.clone())
             .await
         {

--- a/golem-component-service/src/service/component.rs
+++ b/golem-component-service/src/service/component.rs
@@ -1900,6 +1900,7 @@ impl ComponentService for ComponentServiceDefault {
                             )
                             .await?
                             .ok_or(ComponentError::PluginNotFound {
+                                account_id: owner.account_id.clone(),
                                 plugin_name: installation.name.clone(),
                                 plugin_version: installation.version.clone(),
                             })?;

--- a/golem-component-service/src/service/plugin.rs
+++ b/golem-component-service/src/service/plugin.rs
@@ -156,7 +156,7 @@ impl PluginService {
 
     pub async fn list_plugins_for_scopes(
         &self,
-        owner: &PluginOwner,
+        owner: PluginOwner,
         scopes: Vec<PluginScope>,
     ) -> Result<Vec<PluginDefinition>, ComponentError> {
         let owner_record: PluginOwnerRow = owner.clone().into();

--- a/golem-test-framework/src/components/component_service/mod.rs
+++ b/golem-test-framework/src/components/component_service/mod.rs
@@ -145,7 +145,7 @@ pub trait ComponentService: Send + Sync {
             GolemClientProtocol::Http => {
                 let client = self.plugin_http_client(token).await;
 
-                let result = client.get_plugin(name, version).await;
+                let result = client.get_plugin(&owner.value, name, version).await;
 
                 match result {
                     Ok(def) => Ok(Some(PluginId(def.id))),
@@ -948,7 +948,7 @@ pub trait ComponentService: Send + Sync {
     async fn delete_plugin(
         &self,
         token: &Uuid,
-        account_id: AccountId,
+        owner: AccountId,
         name: &str,
         version: &str,
     ) -> crate::Result<()> {
@@ -958,7 +958,7 @@ pub trait ComponentService: Send + Sync {
 
                 let request = authorised_request(
                     DeletePluginRequest {
-                        account_id: Some(account_id.into()),
+                        account_id: Some(owner.into()),
                         name: name.to_string(),
                         version: version.to_string(),
                     },
@@ -980,7 +980,7 @@ pub trait ComponentService: Send + Sync {
             GolemClientProtocol::Http => {
                 let client = self.plugin_http_client(token).await;
 
-                let result = client.delete_plugin(name, version).await;
+                let result = client.delete_plugin(&owner.value, name, version).await;
 
                 match result {
                     Ok(_) => Ok(()),

--- a/golem-test-framework/src/components/component_service/mod.rs
+++ b/golem-test-framework/src/components/component_service/mod.rs
@@ -945,13 +945,20 @@ pub trait ComponentService: Send + Sync {
         }
     }
 
-    async fn delete_plugin(&self, token: &Uuid, name: &str, version: &str) -> crate::Result<()> {
+    async fn delete_plugin(
+        &self,
+        token: &Uuid,
+        account_id: AccountId,
+        name: &str,
+        version: &str,
+    ) -> crate::Result<()> {
         match self.client_protocol() {
             GolemClientProtocol::Grpc => {
                 let mut client = self.plugin_grpc_client().await;
 
                 let request = authorised_request(
                     DeletePluginRequest {
+                        account_id: Some(account_id.into()),
                         name: name.to_string(),
                         version: version.to_string(),
                     },

--- a/golem-test-framework/src/dsl/mod.rs
+++ b/golem-test-framework/src/dsl/mod.rs
@@ -445,7 +445,12 @@ pub trait TestDsl {
 
     async fn create_plugin(&self, definition: PluginDefinitionCreation) -> crate::Result<()>;
 
-    async fn delete_plugin(&self, name: &str, version: &str) -> crate::Result<()>;
+    async fn delete_plugin(
+        &self,
+        account_id: AccountId,
+        name: &str,
+        version: &str,
+    ) -> crate::Result<()>;
 
     async fn install_plugin_to_component(
         &self,
@@ -1607,10 +1612,15 @@ impl<Deps: TestDependencies> TestDsl for TestDependenciesDsl<Deps> {
             .await
     }
 
-    async fn delete_plugin(&self, name: &str, version: &str) -> crate::Result<()> {
+    async fn delete_plugin(
+        &self,
+        account_id: AccountId,
+        name: &str,
+        version: &str,
+    ) -> crate::Result<()> {
         self.deps
             .component_service()
-            .delete_plugin(&self.token, name, version)
+            .delete_plugin(&self.token, account_id, name, version)
             .await
     }
 
@@ -2284,7 +2294,7 @@ pub trait TestDslUnsafe {
 
     async fn create_plugin(&self, definition: PluginDefinitionCreation);
 
-    async fn delete_plugin(&self, name: &str, version: &str);
+    async fn delete_plugin(&self, account_id: AccountId, name: &str, version: &str);
 
     async fn install_plugin_to_component(
         &self,
@@ -2667,8 +2677,8 @@ impl<T: TestDsl + Sync> TestDslUnsafe for T {
             .expect("Failed to create plugin")
     }
 
-    async fn delete_plugin(&self, name: &str, version: &str) {
-        <T as TestDsl>::delete_plugin(self, name, version)
+    async fn delete_plugin(&self, account_id: AccountId, name: &str, version: &str) {
+        <T as TestDsl>::delete_plugin(self, account_id, name, version)
             .await
             .expect("Failed to delete plugin")
     }

--- a/integration-tests/tests/api/plugins.rs
+++ b/integration-tests/tests/api/plugins.rs
@@ -935,7 +935,7 @@ async fn querying_plugins_return_only_plugins_valid_in_scope(
             .component_service()
             .plugin_http_client(&user.token)
             .await
-            .list_plugins(Some(&PluginScope::project(project_1.clone())))
+            .list_plugins(&PluginScope::project(project_1.clone()))
             .await
             .unwrap()
             .into_iter()
@@ -958,7 +958,7 @@ async fn querying_plugins_return_only_plugins_valid_in_scope(
             .component_service()
             .plugin_http_client(&user.token)
             .await
-            .list_plugins(Some(&PluginScope::component(component_id.clone())))
+            .list_plugins(&PluginScope::component(component_id.clone()))
             .await
             .unwrap()
             .into_iter()
@@ -988,7 +988,7 @@ async fn querying_plugins_return_only_plugins_valid_in_scope(
                 .component_service()
                 .plugin_http_client(&user_2.token)
                 .await
-                .list_plugins(Some(&PluginScope::project(project_1)))
+                .list_plugins(&PluginScope::project(project_1))
                 .await
                 .unwrap()
                 .into_iter()
@@ -1011,7 +1011,7 @@ async fn querying_plugins_return_only_plugins_valid_in_scope(
                 .component_service()
                 .plugin_http_client(&user_2.token)
                 .await
-                .list_plugins(Some(&PluginScope::component(component_id)))
+                .list_plugins(&PluginScope::component(component_id))
                 .await
                 .unwrap()
                 .into_iter()

--- a/integration-tests/tests/api/plugins.rs
+++ b/integration-tests/tests/api/plugins.rs
@@ -34,7 +34,7 @@ use golem_wasm_ast::analysis::{AnalysedExport, AnalysedInstance};
 use golem_wasm_rpc::{IntoValueAndType, Value};
 use reqwest::StatusCode;
 use std::collections::HashMap;
-use test_r::{inherit_test_dep, test};
+use test_r::{inherit_test_dep, tag, test};
 use tracing::{debug, info};
 use wac_graph::types::Package;
 use wac_graph::{plug, CompositionGraph, EncodeOptions, Processor};
@@ -856,6 +856,7 @@ async fn invoke_after_deleting_plugin(deps: &EnvBasedTestDependencies, _tracing:
 }
 
 #[test]
+#[tag(http_only)]
 async fn querying_plugins_return_only_plugins_valid_in_scope(
     deps: &EnvBasedTestDependencies,
     _tracing: &Tracing,
@@ -1032,6 +1033,7 @@ async fn querying_plugins_return_only_plugins_valid_in_scope(
 }
 
 #[test]
+#[tag(http_only)]
 async fn install_global_plugin_in_shared_project(
     deps: &EnvBasedTestDependencies,
     _tracing: &Tracing,
@@ -1087,6 +1089,7 @@ async fn install_global_plugin_in_shared_project(
 }
 
 #[test]
+#[tag(http_only)]
 async fn install_project_plugin_in_shared_project(
     deps: &EnvBasedTestDependencies,
     _tracing: &Tracing,
@@ -1148,6 +1151,7 @@ async fn install_project_plugin_in_shared_project(
 }
 
 #[test]
+#[tag(http_only)]
 async fn install_component_plugin_in_shared_project(
     deps: &EnvBasedTestDependencies,
     _tracing: &Tracing,

--- a/integration-tests/tests/api/plugins.rs
+++ b/integration-tests/tests/api/plugins.rs
@@ -784,7 +784,9 @@ async fn recreate_plugin(deps: &EnvBasedTestDependencies, _tracing: &Tracing) {
 
     admin.create_plugin(plugin_definition.clone()).await;
 
-    admin.delete_plugin("library-plugin-2", "v1").await;
+    admin
+        .delete_plugin(admin.account_id.clone(), "library-plugin-2", "v1")
+        .await;
 
     admin.create_plugin(plugin_definition.clone()).await;
 
@@ -836,7 +838,9 @@ async fn invoke_after_deleting_plugin(deps: &EnvBasedTestDependencies, _tracing:
         .install_plugin_to_component(&component_id, "library-plugin-3", "v1", 0, HashMap::new())
         .await;
 
-    admin.delete_plugin("library-plugin-3", "v1").await;
+    admin
+        .delete_plugin(admin.account_id.clone(), "library-plugin-3", "v1")
+        .await;
 
     let worker = admin.start_worker(&component_id, "worker1").await;
 

--- a/openapi/golem-component-service.yaml
+++ b/openapi/golem-component-service.yaml
@@ -1115,7 +1115,7 @@ paths:
         schema:
           $ref: '#/components/schemas/PluginScope'
         in: query
-        required: false
+        required: true
         deprecated: false
         explode: true
       responses:
@@ -1224,13 +1224,27 @@ paths:
       - Cookie: []
       - Token: []
       operationId: create_plugin
-  /v1/plugins/{name}:
+  /v1/plugins/{account_id}/{name}/{version}:
     get:
       tags:
       - Plugin
-      summary: Lists all the registered versions of a specific plugin identified by its name
+      summary: Gets a registered plugin by its name and version
       parameters:
+      - name: account_id
+        schema:
+          type: string
+        in: path
+        required: true
+        deprecated: false
+        explode: true
       - name: name
+        schema:
+          type: string
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      - name: version
         schema:
           type: string
         in: path
@@ -1243,9 +1257,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PluginDefinition'
+                $ref: '#/components/schemas/PluginDefinition'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -1285,7 +1297,80 @@ paths:
       security:
       - Cookie: []
       - Token: []
-      operationId: list_plugin_versions
+      operationId: get_plugin
+    delete:
+      tags:
+      - Plugin
+      summary: Deletes a registered plugin by its name and version
+      parameters:
+      - name: account_id
+        schema:
+          type: string
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      - name: name
+        schema:
+          type: string
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      - name: version
+        schema:
+          type: string
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Empty'
+        '400':
+          description: Invalid request, returning with a list of issues detected in the request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: Unauthorized
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: Maximum number of components exceeded
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: Component not found
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: Component already exists
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      security:
+      - Cookie: []
+      - Token: []
+      operationId: delete_plugin
   /v1/plugins/library-plugins:
     post:
       tags:
@@ -1452,139 +1537,6 @@ paths:
       - Cookie: []
       - Token: []
       operationId: create_app_plugin
-  /v1/plugins/{name}/{version}:
-    get:
-      tags:
-      - Plugin
-      summary: Gets a registered plugin by its name and version
-      parameters:
-      - name: name
-        schema:
-          type: string
-        in: path
-        required: true
-        deprecated: false
-        explode: true
-      - name: version
-        schema:
-          type: string
-        in: path
-        required: true
-        deprecated: false
-        explode: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/PluginDefinition'
-        '400':
-          description: Invalid request, returning with a list of issues detected in the request
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorsBody'
-        '401':
-          description: Unauthorized
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '403':
-          description: Maximum number of components exceeded
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '404':
-          description: Component not found
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '409':
-          description: Component already exists
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '500':
-          description: Internal server error
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-      security:
-      - Cookie: []
-      - Token: []
-      operationId: get_plugin
-    delete:
-      tags:
-      - Plugin
-      summary: Deletes a registered plugin by its name and version
-      parameters:
-      - name: name
-        schema:
-          type: string
-        in: path
-        required: true
-        deprecated: false
-        explode: true
-      - name: version
-        schema:
-          type: string
-        in: path
-        required: true
-        deprecated: false
-        explode: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/Empty'
-        '400':
-          description: Invalid request, returning with a list of issues detected in the request
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorsBody'
-        '401':
-          description: Unauthorized
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '403':
-          description: Maximum number of components exceeded
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '404':
-          description: Component not found
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '409':
-          description: Component already exists
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '500':
-          description: Internal server error
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-      security:
-      - Cookie: []
-      - Token: []
-      operationId: delete_plugin
 components:
   schemas:
     AnalysedExport:

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -3801,6 +3801,7 @@ paths:
       parameters:
       - in: query
         name: scope
+        required: true
         deprecated: false
         schema:
           $ref: '#/components/schemas/PluginScope'
@@ -3911,15 +3912,31 @@ paths:
       security:
       - Cookie: []
       - Token: []
-  /v1/plugins/{name}:
+  /v1/plugins/{account_id}/{name}/{version}:
     get:
       tags:
       - Plugin
-      summary: Lists all the registered versions of a specific plugin identified by its name
-      operationId: list_plugin_versions
+      summary: Gets a registered plugin by its name and version
+      operationId: get_plugin
       parameters:
       - in: path
+        name: account_id
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      - in: path
         name: name
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      - in: path
+        name: version
         required: true
         deprecated: false
         schema:
@@ -3932,9 +3949,83 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PluginDefinition'
+                $ref: '#/components/schemas/PluginDefinition'
+        '400':
+          description: Invalid request, returning with a list of issues detected in the request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: Unauthorized
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: Maximum number of components exceeded
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: Component not found
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: Component already exists
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      security:
+      - Cookie: []
+      - Token: []
+    delete:
+      tags:
+      - Plugin
+      summary: Deletes a registered plugin by its name and version
+      operationId: delete_plugin
+      parameters:
+      - in: path
+        name: account_id
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      - in: path
+        name: name
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      - in: path
+        name: version
+        required: true
+        deprecated: false
+        schema:
+          type: string
+        explode: true
+        style: simple
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Empty'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -4094,143 +4185,6 @@ paths:
               - scope
               - wasm
         required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/Empty'
-        '400':
-          description: Invalid request, returning with a list of issues detected in the request
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorsBody'
-        '401':
-          description: Unauthorized
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '403':
-          description: Maximum number of components exceeded
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '404':
-          description: Component not found
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '409':
-          description: Component already exists
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '500':
-          description: Internal server error
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-      security:
-      - Cookie: []
-      - Token: []
-  /v1/plugins/{name}/{version}:
-    get:
-      tags:
-      - Plugin
-      summary: Gets a registered plugin by its name and version
-      operationId: get_plugin
-      parameters:
-      - in: path
-        name: name
-        required: true
-        deprecated: false
-        schema:
-          type: string
-        explode: true
-        style: simple
-      - in: path
-        name: version
-        required: true
-        deprecated: false
-        schema:
-          type: string
-        explode: true
-        style: simple
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/PluginDefinition'
-        '400':
-          description: Invalid request, returning with a list of issues detected in the request
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorsBody'
-        '401':
-          description: Unauthorized
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '403':
-          description: Maximum number of components exceeded
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '404':
-          description: Component not found
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '409':
-          description: Component already exists
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-        '500':
-          description: Internal server error
-          content:
-            application/json; charset=utf-8:
-              schema:
-                $ref: '#/components/schemas/ErrorBody'
-      security:
-      - Cookie: []
-      - Token: []
-    delete:
-      tags:
-      - Plugin
-      summary: Deletes a registered plugin by its name and version
-      operationId: delete_plugin
-      parameters:
-      - in: path
-        name: name
-        required: true
-        deprecated: false
-        schema:
-          type: string
-        explode: true
-        style: simple
-      - in: path
-        name: version
-        required: true
-        deprecated: false
-        schema:
-          type: string
-        explode: true
-        style: simple
       responses:
         '200':
           description: ''


### PR DESCRIPTION
resolves #1756 

Plugins with component and project scope are now always owned by the account of the project / component.
Plugins with global scope can only be used in projects / components that are in the same account.

Had to remove a few routes that do not make sense / cannot be properly implemented with the cleaned up owners. Checked both the cli and console and they are not using them, so updates should be easy.