### PR TITLE
Fix worker enumeration

### DIFF
--- a/golem-worker-executor/src/services/oplog/tests.rs
+++ b/golem-worker-executor/src/services/oplog/tests.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info};
 use uuid::Uuid;
 
 use golem_common::config::RedisConfig;
-use golem_common::model::oplog::{SpanData, WorkerError};
+use golem_common::model::oplog::{LogLevel, SpanData, WorkerError};
 use golem_common::model::regions::OplogRegion;
 use golem_common::model::{ComponentId, ComponentType, WorkerStatusRecord};
 use golem_common::redis::RedisPool;
@@ -1734,13 +1734,47 @@ async fn multilayer_scan_for_component(_tracing: &Tracing) {
                 secondary_workers.push(worker_id.clone());
                 debug!("Archiving {worker_id} to secondary layer");
                 MultiLayerOplog::try_archive_blocking(&oplog).await;
+
+                if i % 2 == 1 {
+                    debug!("Adding more oplog entries to primary");
+                    oplog
+                        .add_and_commit(OplogEntry::log(
+                            LogLevel::Debug,
+                            "test".to_string(),
+                            "test".to_string(),
+                        ))
+                        .await;
+                }
             }
             2 => {
                 tertiary_workers.push(worker_id.clone());
                 debug!("Archiving {worker_id} to secondary layer");
                 let r = MultiLayerOplog::try_archive_blocking(&oplog).await;
+
+                if i % 2 == 1 {
+                    debug!("Adding more oplog entries to primary going to be moved to the secondary layer");
+                    oplog
+                        .add_and_commit(OplogEntry::log(
+                            LogLevel::Debug,
+                            "test".to_string(),
+                            "test".to_string(),
+                        ))
+                        .await;
+                }
+
                 debug!("[{r:?}] => archiving {worker_id} to tertiary layer");
                 MultiLayerOplog::try_archive_blocking(&oplog).await;
+
+                if i % 2 == 1 {
+                    debug!("Adding more oplog entries to primary");
+                    oplog
+                        .add_and_commit(OplogEntry::log(
+                            LogLevel::Debug,
+                            "test".to_string(),
+                            "test".to_string(),
+                        ))
+                        .await;
+                }
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
Resolves #1789 

This fix makes the worker enumeration slower, but it already was considered a slow operation. Because of its paginated nature we have no other way to keep track of what we've enumerated on different oplog layers.

With the fix we only enumerate IDs from layer N if it is not existent on any of the lower layers.