### PR TITLE
Fix plugin installation id regeneration during batch plugin installation update

### DIFF
--- a/cloud-service/src/api/project.rs
+++ b/cloud-service/src/api/project.rs
@@ -483,9 +483,9 @@ impl ProjectApi {
     #[oai(
         path = "/:project_id/latest/plugins/installs/batch",
         method = "post",
-        operation_id = "bath_update_installed_plugins_of_project"
+        operation_id = "batch_update_installed_plugins_of_project"
     )]
-    async fn bath_update_installed_plugins(
+    async fn batch_update_installed_plugins(
         &self,
         project_id: Path<ProjectId>,
         updates: Json<BatchPluginInstallationUpdates>,

--- a/golem-component-service/db/migration/postgres/016__plugin_installation_pkey.sql
+++ b/golem-component-service/db/migration/postgres/016__plugin_installation_pkey.sql
@@ -1,0 +1,5 @@
+alter table component_plugin_installation alter column component_id set not null;
+alter table component_plugin_installation alter column component_version set not null;
+
+alter table component_plugin_installation drop constraint component_plugin_installation_pkey;
+alter table component_plugin_installation add constraint component_plugin_installation_pkey primary key (installation_id, component_id, component_version);

--- a/golem-component-service/db/migration/sqlite/014__plugin_installation_pkey.sql
+++ b/golem-component-service/db/migration/sqlite/014__plugin_installation_pkey.sql
@@ -1,0 +1,18 @@
+alter table component_plugin_installation rename to component_plugin_installation_temp;
+
+CREATE TABLE component_plugin_installation
+(
+    installation_id   uuid    NOT NULL,
+    plugin_id            uuid    NOT NULL,
+    priority          integer NOT NULL,
+    parameters        blob    NOT NULL,
+    component_id      uuid REFERENCES components (component_id) NOT NULL,
+    component_version bigint NOT NULL,
+    account_id       text NOT NULL,
+
+    PRIMARY KEY (installation_id, component_id, component_version)
+    FOREIGN KEY (account_id, plugin_id) REFERENCES "plugins" (account_id, id)
+);
+
+INSERT INTO component_plugin_installation SELECT * FROM component_plugin_installation_temp;
+DROP TABLE component_plugin_installation_temp;

--- a/golem-component-service/src/api/component.rs
+++ b/golem-component-service/src/api/component.rs
@@ -706,9 +706,9 @@ impl ComponentApi {
     #[oai(
         path = "/:component_id/versions/latest/plugins/installs/batch",
         method = "post",
-        operation_id = "bath_update_installed_plugins"
+        operation_id = "batch_update_installed_plugins"
     )]
-    async fn bath_update_installed_plugins(
+    async fn batch_update_installed_plugins(
         &self,
         component_id: Path<ComponentId>,
         updates: Json<BatchPluginInstallationUpdates>,

--- a/golem-component-service/src/model/component.rs
+++ b/golem-component-service/src/model/component.rs
@@ -91,7 +91,7 @@ impl Component {
         format!("{}:user", self.object_store_key)
     }
 
-    pub fn protected_object_store_key(&self) -> String {
+    pub fn transformed_object_store_key(&self) -> String {
         format!("{}:protected", self.transformed_object_store_key)
     }
 

--- a/golem-component-service/src/service/component.rs
+++ b/golem-component-service/src/service/component.rs
@@ -1914,6 +1914,7 @@ impl ComponentService for ComponentServiceDefault {
                         })?
                     };
 
+                    existing.id = PluginInstallationId::new_v4();
                     existing.priority = update.priority;
                     existing.parameters = update.parameters.clone();
 

--- a/integration-tests/tests/api/plugins.rs
+++ b/integration-tests/tests/api/plugins.rs
@@ -21,8 +21,11 @@ use axum::Router;
 use base64::Engine;
 use golem_api_grpc::proto::golem::worker::{log_event, Log};
 use golem_client::api::{ComponentClient, PluginClient};
+use golem_client::model::BatchPluginInstallationUpdates;
 use golem_common::model::plugin::{
-    AppPluginDefinition, ComponentTransformerDefinition, LibraryPluginDefinition, OplogProcessorDefinition, PluginInstallationAction, PluginInstallationCreation, PluginInstallationUpdateWithId, PluginTypeSpecificDefinition, PluginUninstallation
+    AppPluginDefinition, ComponentTransformerDefinition, LibraryPluginDefinition,
+    OplogProcessorDefinition, PluginInstallationAction, PluginInstallationCreation,
+    PluginInstallationUpdateWithId, PluginTypeSpecificDefinition, PluginUninstallation,
 };
 use golem_common::model::plugin::{PluginScope, ProjectPluginScope};
 use golem_common::model::{ComponentFilePermissions, Empty, ScanCursor};
@@ -40,7 +43,6 @@ use test_r::{inherit_test_dep, tag, test};
 use tracing::{debug, info};
 use wac_graph::types::Package;
 use wac_graph::{plug, CompositionGraph, EncodeOptions, Processor};
-use golem_client::model::BatchPluginInstallationUpdates;
 
 inherit_test_dep!(Tracing);
 inherit_test_dep!(EnvBasedTestDependencies);
@@ -1484,69 +1486,61 @@ async fn install_component_plugin_in_shared_project(
 #[test]
 async fn batch_update_plugin_installations(deps: &EnvBasedTestDependencies, _tracing: &Tracing) {
     let user = deps.user().await;
-    let component_id = user
-        .component("app_and_library_app")
-        .unique()
-        .store()
-        .await;
+    let component_id = user.component("app_and_library_app").unique().store().await;
 
     let plugin_wasm_key = user.add_plugin_wasm("app_and_library_library").await;
 
-    user
-        .create_plugin(PluginDefinitionCreation {
-            name: "library-plugin-1".to_string(),
-            version: "v1".to_string(),
-            description: "A test".to_string(),
-            icon: vec![],
-            homepage: "none".to_string(),
-            specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
-                blob_storage_key: plugin_wasm_key.clone(),
-            }),
-            scope: PluginScope::Global(Empty {}),
-        })
-        .await;
+    user.create_plugin(PluginDefinitionCreation {
+        name: "library-plugin-1".to_string(),
+        version: "v1".to_string(),
+        description: "A test".to_string(),
+        icon: vec![],
+        homepage: "none".to_string(),
+        specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
+            blob_storage_key: plugin_wasm_key.clone(),
+        }),
+        scope: PluginScope::Global(Empty {}),
+    })
+    .await;
 
-    user
-        .create_plugin(PluginDefinitionCreation {
-            name: "library-plugin-2".to_string(),
-            version: "v1".to_string(),
-            description: "A test".to_string(),
-            icon: vec![],
-            homepage: "none".to_string(),
-            specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
-                blob_storage_key: plugin_wasm_key.clone(),
-            }),
-            scope: PluginScope::Global(Empty {}),
-        })
-        .await;
+    user.create_plugin(PluginDefinitionCreation {
+        name: "library-plugin-2".to_string(),
+        version: "v1".to_string(),
+        description: "A test".to_string(),
+        icon: vec![],
+        homepage: "none".to_string(),
+        specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
+            blob_storage_key: plugin_wasm_key.clone(),
+        }),
+        scope: PluginScope::Global(Empty {}),
+    })
+    .await;
 
-    user
-        .create_plugin(PluginDefinitionCreation {
-            name: "library-plugin-3".to_string(),
-            version: "v1".to_string(),
-            description: "A test".to_string(),
-            icon: vec![],
-            homepage: "none".to_string(),
-            specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
-                blob_storage_key: plugin_wasm_key.clone(),
-            }),
-            scope: PluginScope::Global(Empty {}),
-        })
-        .await;
+    user.create_plugin(PluginDefinitionCreation {
+        name: "library-plugin-3".to_string(),
+        version: "v1".to_string(),
+        description: "A test".to_string(),
+        icon: vec![],
+        homepage: "none".to_string(),
+        specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
+            blob_storage_key: plugin_wasm_key.clone(),
+        }),
+        scope: PluginScope::Global(Empty {}),
+    })
+    .await;
 
-    user
-        .create_plugin(PluginDefinitionCreation {
-            name: "library-plugin-4".to_string(),
-            version: "v1".to_string(),
-            description: "A test".to_string(),
-            icon: vec![],
-            homepage: "none".to_string(),
-            specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
-                blob_storage_key: plugin_wasm_key,
-            }),
-            scope: PluginScope::Global(Empty {}),
-        })
-        .await;
+    user.create_plugin(PluginDefinitionCreation {
+        name: "library-plugin-4".to_string(),
+        version: "v1".to_string(),
+        description: "A test".to_string(),
+        icon: vec![],
+        homepage: "none".to_string(),
+        specs: PluginTypeSpecificDefinition::Library(LibraryPluginDefinition {
+            blob_storage_key: plugin_wasm_key,
+        }),
+        scope: PluginScope::Global(Empty {}),
+    })
+    .await;
 
     let installation_id_1 = user
         .install_plugin_to_component(&component_id, "library-plugin-1", "v1", 0, HashMap::new())
@@ -1557,11 +1551,10 @@ async fn batch_update_plugin_installations(deps: &EnvBasedTestDependencies, _tra
         .await;
 
     let installation_id_3 = user
-        .install_plugin_to_component(&component_id, "library-plugin-3", "v1", 1, HashMap::new())
+        .install_plugin_to_component(&component_id, "library-plugin-3", "v1", 2, HashMap::new())
         .await;
 
-    deps
-        .component_service()
+    deps.component_service()
         .component_http_client(&user.token)
         .await
         .batch_update_installed_plugins(
@@ -1573,43 +1566,58 @@ async fn batch_update_plugin_installations(deps: &EnvBasedTestDependencies, _tra
                     }),
                     PluginInstallationAction::Update(PluginInstallationUpdateWithId {
                         installation_id: installation_id_3.clone(),
-                        priority: 2,
-                        parameters: HashMap::from_iter(vec![("foo".to_string(), "bar".to_string())])
+                        priority: 3,
+                        parameters: HashMap::from_iter(vec![(
+                            "foo".to_string(),
+                            "bar".to_string(),
+                        )]),
                     }),
                     PluginInstallationAction::Install(PluginInstallationCreation {
                         name: "library-plugin-4".to_string(),
                         version: "v1".to_string(),
-                        priority: 3,
-                        parameters: HashMap::new()
+                        priority: 4,
+                        parameters: HashMap::new(),
                     }),
-
-                ]
-            }
+                ],
+            },
         )
         .await
         .unwrap();
+
+    let latest_version = deps
+        .component_service()
+        .component_http_client(&user.token)
+        .await
+        .get_latest_component_metadata(&component_id.0)
+        .await
+        .unwrap()
+        .versioned_component_id
+        .version;
 
     let installed_plugins = deps
         .component_service()
         .component_http_client(&user.token)
         .await
-        .get_installed_plugins(
-            &component_id.0,
-            "2",
-        )
+        .get_installed_plugins(&component_id.0, &latest_version.to_string())
         .await
         .unwrap();
 
-    assert_eq!(installed_plugins.len(), 2);
+    assert_eq!(installed_plugins.len(), 3);
     {
-        let mut priorities = installed_plugins.iter().map(|ip| ip.priority).collect::<Vec<_>>();
+        let mut priorities = installed_plugins
+            .iter()
+            .map(|ip| ip.priority)
+            .collect::<Vec<_>>();
         priorities.sort();
-        assert_eq!(priorities, vec![2, 3]);
+        assert_eq!(priorities, vec![0, 3, 4]);
     }
     {
-        let installation_ids = installed_plugins.iter().map(|ip| ip.id).collect::<HashSet<_>>();
-        assert!(installation_ids.contains(&installation_id_1.0));
+        let installation_ids = installed_plugins
+            .iter()
+            .map(|ip| ip.id)
+            .collect::<HashSet<_>>();
+        assert!(installation_ids.contains(&installation_id_1.0)); // untouched
         assert!(!installation_ids.contains(&installation_id_2.0)); // uninstalled
-        assert!(!installation_ids.contains(&installation_id_3.0)); // updated
+        assert!(installation_ids.contains(&installation_id_3.0)); // updated
     }
 }

--- a/openapi/cloud-spec.yaml
+++ b/openapi/cloud-spec.yaml
@@ -2015,7 +2015,7 @@ paths:
       security:
       - Cookie: []
       - Token: []
-      operationId: bath_update_installed_plugins_of_project
+      operationId: batch_update_installed_plugins_of_project
   /v1/projects/{project_id}/grants:
     get:
       tags:

--- a/openapi/golem-component-service.yaml
+++ b/openapi/golem-component-service.yaml
@@ -1057,7 +1057,7 @@ paths:
       security:
       - Cookie: []
       - Token: []
-      operationId: bath_update_installed_plugins
+      operationId: batch_update_installed_plugins
   /v1/components/{component_id}/versions/{version}/file-contents/{file_path}:
     get:
       tags:

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -1950,7 +1950,7 @@ paths:
       tags:
       - Project
       summary: Applies a batch of changes to the installed plugins of a component
-      operationId: bath_update_installed_plugins_of_project
+      operationId: batch_update_installed_plugins_of_project
       parameters:
       - in: path
         name: project_id
@@ -3650,7 +3650,7 @@ paths:
       tags:
       - Component
       summary: Applies a batch of changes to the installed plugins of a component
-      operationId: bath_update_installed_plugins
+      operationId: batch_update_installed_plugins
       parameters:
       - in: path
         name: component_id


### PR DESCRIPTION
Regression cause by one of my previous PRs, also added regression test for it.

The problem was that I missed that plugin installations are supposed to change their IDs in a new component version even if the installation itself did not change.
While writing tests for this, I found the old behavior to be extremely difficult to work with (as you always need to query the latest component after each update and get the new ids), so I decided to change it to be inline with my previous misunderstanding.

The index is now on (installation_id, component_id, component_version) and the installation id does never change until a plugin is uninstalled from a component.

