### PR TITLE
Allow package-less function names on the RPC interface

### DIFF
--- a/golem-worker-executor/src/services/component.rs
+++ b/golem-worker-executor/src/services/component.rs
@@ -50,6 +50,8 @@ pub struct ComponentMetadata {
     pub component_owner: ComponentOwner,
     pub dynamic_linking: HashMap<String, DynamicLinkedInstance>,
     pub env: HashMap<String, String>,
+    pub root_package_name: Option<String>,
+    pub root_package_version: Option<String>,
 }
 
 impl From<LocalFileSystemComponentMetadata> for ComponentMetadata {
@@ -68,6 +70,8 @@ impl From<LocalFileSystemComponentMetadata> for ComponentMetadata {
             },
             dynamic_linking: value.dynamic_linking,
             env: value.env,
+            root_package_name: None, // NOTE: we could extract this information from the WASM component metadata sections
+            root_package_version: None,
         }
     }
 }
@@ -1021,6 +1025,15 @@ mod grpc {
                         }
                     }?;
 
+                    let root_package_name = component
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.root_package_name.clone());
+                    let root_package_version = component
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.root_package_version.clone());
+
                     let result = ComponentMetadata {
                         version: component
                             .versioned_component_id
@@ -1105,6 +1118,8 @@ mod grpc {
                             ),
                         },
                         env: component.env,
+                        root_package_name,
+                        root_package_version,
                     };
 
                     record_external_call_response_size_bytes("components", "get_metadata", len);

--- a/golem-worker-executor/src/services/projects.rs
+++ b/golem-worker-executor/src/services/projects.rs
@@ -129,7 +129,7 @@ impl ProjectServiceGrpc {
         let project_name = project_name.to_string();
 
         with_retries(
-            "component",
+            "projects",
             "resolve_project_remotely",
             Some(format!("{account_id}/{project_name}").to_string()),
             &retry_config,
@@ -191,7 +191,7 @@ impl ProjectServiceGrpc {
         let access_token = self.access_token;
 
         with_retries(
-            "component",
+            "projects",
             "get_project_owner_remotely",
             Some(project_id.to_string()),
             &retry_config,


### PR DESCRIPTION
With this change function names used on the RPC host interface are not required to specify the package part of the fully qualified function name. If missing, the targeted component's root package name is going to be used.

This makes it easier for some generated RPC clients to use the interface, such as the code-first remote agent clients.