### PR TITLE
Fix bug with debugging indices and improve debugging performace

### DIFF
--- a/golem-common/src/base_model.rs
+++ b/golem-common/src/base_model.rs
@@ -373,6 +373,11 @@ impl OplogIndex {
     pub fn range_end(&self, count: u64) -> OplogIndex {
         OplogIndex(self.0 + count - 1)
     }
+
+    /// Check whether the oplog index is not None.
+    pub fn is_defined(&self) -> bool {
+        self.0 > 0
+    }
 }
 
 impl Display for OplogIndex {

--- a/golem-debugging-service/src/auth.rs
+++ b/golem-debugging-service/src/auth.rs
@@ -112,7 +112,7 @@ impl GrpcAuthService {
         component_service_grpc_config: ComponentServiceGrpcConfig,
     ) -> Self {
         let component_service_client = GrpcClient::new(
-            "auth_service",
+            "component_service",
             |channel| {
                 ComponentServiceClient::new(channel)
                     .send_compressed(CompressionEncoding::Gzip)

--- a/golem-debugging-service/src/config.rs
+++ b/golem-debugging-service/src/config.rs
@@ -83,7 +83,7 @@ impl DebugConfig {
             resource_limits: self.resource_limits,
             component_service: ComponentServiceConfig::Grpc(self.component_service),
             component_cache: self.component_cache,
-            project_service: Default::default(),
+            project_service: self.project_service,
             // unused
             grpc_address: default_golem_config.grpc_address,
             // unused

--- a/golem-debugging-service/src/debug_context.rs
+++ b/golem-debugging-service/src/debug_context.rs
@@ -129,8 +129,9 @@ impl ExternalOperations<Self> for DebugContext {
     async fn resume_replay(
         store: &mut (impl AsContextMut<Data = Self> + Send),
         instance: &Instance,
+        refresh_replay_target: bool,
     ) -> Result<RetryDecision, WorkerExecutorError> {
-        DurableWorkerCtx::<Self>::resume_replay(store, instance).await
+        DurableWorkerCtx::<Self>::resume_replay(store, instance, refresh_replay_target).await
     }
 
     async fn prepare_instance(

--- a/golem-debugging-service/src/model/params.rs
+++ b/golem-debugging-service/src/model/params.rs
@@ -28,7 +28,6 @@ pub struct PlaybackParams {
     pub target_index: OplogIndex,
     pub overrides: Option<Vec<PlaybackOverride>>,
     pub ensure_invocation_boundary: Option<bool>,
-    pub time_out_in_seconds: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -41,7 +40,6 @@ pub struct PlaybackOverride {
 pub struct RewindParams {
     pub target_index: OplogIndex,
     pub ensure_invocation_boundary: Option<bool>,
-    pub time_out_in_seconds: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -53,7 +51,6 @@ pub struct ForkParams {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ConnectResult {
     pub worker_id: WorkerId,
-    pub success: bool,
     pub message: String,
 }
 
@@ -61,15 +58,14 @@ pub struct ConnectResult {
 pub struct PlaybackResult {
     pub worker_id: WorkerId,
     pub current_index: OplogIndex,
-    pub success: bool,
     pub message: String,
+    pub incremental_playback: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RewindResult {
     pub worker_id: WorkerId,
     pub current_index: OplogIndex,
-    pub success: bool,
     pub message: String,
 }
 
@@ -77,7 +73,6 @@ pub struct RewindResult {
 pub struct ForkResult {
     pub source_worker_id: WorkerId,
     pub target_worker_id: WorkerId,
-    pub success: bool,
     pub message: String,
 }
 

--- a/golem-debugging-service/src/services/debug_service.rs
+++ b/golem-debugging-service/src/services/debug_service.rs
@@ -503,7 +503,7 @@ impl DebugService for DebugServiceDefault {
             incremental_playback,
             message: format!(
                 "Playback worker {} stopped at index {}",
-                owned_worker_id.worker_id, current_oplog_index
+                owned_worker_id.worker_id, stopped_at_index
             ),
         })
     }
@@ -600,7 +600,7 @@ impl DebugService for DebugServiceDefault {
 
         let _ = worker.await_ready_to_process_commands().await;
 
-        let last_index = self
+        let stopped_at_index = self
             .debug_session
             .get(&debug_session_id)
             .await
@@ -609,7 +609,7 @@ impl DebugService for DebugServiceDefault {
 
         Ok(RewindResult {
             worker_id: owned_worker_id.worker_id.clone(),
-            current_index: last_index,
+            current_index: stopped_at_index,
             message: format!("Rewinding the worker to index {target_index}"),
         })
     }

--- a/golem-debugging-service/tests/debug_mode/dsl.rs
+++ b/golem-debugging-service/tests/debug_mode/dsl.rs
@@ -15,14 +15,9 @@ pub trait TestDslDebugMode {
         &mut self,
         target_index: OplogIndex,
         overrides: Option<Vec<PlaybackOverride>>,
-        wait_time_in_seconds: u64,
     ) -> anyhow::Result<PlaybackResult>;
 
-    async fn rewind(
-        &mut self,
-        target_index: OplogIndex,
-        wait_time_in_seconds: u64,
-    ) -> anyhow::Result<RewindResult>;
+    async fn rewind(&mut self, target_index: OplogIndex) -> anyhow::Result<RewindResult>;
 
     async fn fork(
         &mut self,
@@ -52,7 +47,6 @@ impl TestDslDebugMode for DebugWorkerExecutorClient {
         &mut self,
         target_index: OplogIndex,
         overrides: Option<Vec<PlaybackOverride>>,
-        wait_time_in_seconds: u64,
     ) -> anyhow::Result<PlaybackResult> {
         let id = self
             .send_jrpc_msg(
@@ -61,7 +55,6 @@ impl TestDslDebugMode for DebugWorkerExecutorClient {
                     target_index,
                     overrides,
                     ensure_invocation_boundary: None,
-                    time_out_in_seconds: Some(wait_time_in_seconds),
                 },
             )
             .await?;
@@ -69,18 +62,13 @@ impl TestDslDebugMode for DebugWorkerExecutorClient {
         self.read_jrpc_response(id).await
     }
 
-    async fn rewind(
-        &mut self,
-        target_index: OplogIndex,
-        wait_time_in_seconds: u64,
-    ) -> anyhow::Result<RewindResult> {
+    async fn rewind(&mut self, target_index: OplogIndex) -> anyhow::Result<RewindResult> {
         let id = self
             .send_jrpc_msg(
                 "rewind",
                 RewindParams {
                     target_index,
                     ensure_invocation_boundary: None,
-                    time_out_in_seconds: Some(wait_time_in_seconds),
                 },
             )
             .await?;

--- a/golem-debugging-service/tests/regular_mode/worker_ctx.rs
+++ b/golem-debugging-service/tests/regular_mode/worker_ctx.rs
@@ -437,8 +437,10 @@ impl ExternalOperations<TestWorkerCtx> for TestWorkerCtx {
     async fn resume_replay(
         store: &mut (impl AsContextMut<Data = TestWorkerCtx> + Send),
         instance: &Instance,
+        refresh_replay_target: bool,
     ) -> Result<RetryDecision, WorkerExecutorError> {
-        DurableWorkerCtx::<TestWorkerCtx>::resume_replay(store, instance).await
+        DurableWorkerCtx::<TestWorkerCtx>::resume_replay(store, instance, refresh_replay_target)
+            .await
     }
 
     async fn prepare_instance(

--- a/golem-worker-executor/src/durable_host/replay_state.rs
+++ b/golem-worker-executor/src/durable_host/replay_state.rs
@@ -108,6 +108,10 @@ impl ReplayState {
         self.replay_target.get()
     }
 
+    pub fn set_replay_target(&mut self, new_target: OplogIndex) {
+        self.replay_target.set(new_target)
+    }
+
     pub async fn skipped_regions(&self) -> DeletedRegions {
         let internal = self.internal.read().await;
         internal.skipped_regions.clone()

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -307,7 +307,7 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     async fn resume_replay(&self) -> CommandOutcome {
         let mut store = self.store.lock().await;
 
-        let resume_replay_result = Ctx::resume_replay(&mut *store, self.instance).await;
+        let resume_replay_result = Ctx::resume_replay(&mut *store, self.instance, true).await;
 
         match resume_replay_result {
             Ok(RetryDecision::None) => CommandOutcome::Continue,
@@ -385,6 +385,10 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
             }
             QueuedWorkerInvocation::ReadFile { path, sender } => {
                 self.read_file(path, sender).await;
+                CommandOutcome::Continue
+            }
+            QueuedWorkerInvocation::AwaitReadyToProcessCommands { sender } => {
+                let _ = sender.send(Ok(()));
                 CommandOutcome::Continue
             }
         }

--- a/golem-worker-executor/src/workerctx/cloud.rs
+++ b/golem-worker-executor/src/workerctx/cloud.rs
@@ -330,8 +330,9 @@ impl ExternalOperations<Context> for Context {
     async fn resume_replay(
         store: &mut (impl AsContextMut<Data = Context> + Send),
         instance: &Instance,
+        refresh_replay_target: bool,
     ) -> Result<RetryDecision, WorkerExecutorError> {
-        DurableWorkerCtx::<Context>::resume_replay(store, instance).await
+        DurableWorkerCtx::<Context>::resume_replay(store, instance, refresh_replay_target).await
     }
 
     async fn prepare_instance(

--- a/golem-worker-executor/src/workerctx/mod.rs
+++ b/golem-worker-executor/src/workerctx/mod.rs
@@ -390,6 +390,7 @@ pub trait ExternalOperations<Ctx: WorkerCtx> {
     async fn resume_replay(
         store: &mut (impl AsContextMut<Data = Ctx> + Send),
         instance: &Instance,
+        refresh_replay_target: bool,
     ) -> Result<RetryDecision, WorkerExecutorError>;
 
     /// Prepares a wasmtime instance after it has been created, but before it can be invoked.

--- a/golem-worker-executor/tests/common/mod.rs
+++ b/golem-worker-executor/tests/common/mod.rs
@@ -426,8 +426,10 @@ impl ExternalOperations<TestWorkerCtx> for TestWorkerCtx {
     async fn resume_replay(
         store: &mut (impl AsContextMut<Data = TestWorkerCtx> + Send),
         instance: &Instance,
+        refresh_replay_target: bool,
     ) -> Result<RetryDecision, WorkerExecutorError> {
-        DurableWorkerCtx::<TestWorkerCtx>::resume_replay(store, instance).await
+        DurableWorkerCtx::<TestWorkerCtx>::resume_replay(store, instance, refresh_replay_target)
+            .await
     }
 
     async fn prepare_instance(


### PR DESCRIPTION
resolves #1855 

Changes:
* time_out_in_seconds parameter is removed. All commands will deterministically wait exactly as long as needed
success response field removed (it was always true anyway)
* playback now doesn't always restore the worker from the beginning. Instead the behaviour depends on the position at which a worker stopped. If it stopped at an invocation boundary (for example by passing ensure_invocation_boundary), it will only do an incremental replay between the previous index and the current index. If it stopped in the middle of an invocation we need to do a full replay from the beginning (due to the mechanism that is used to stop workers in the middle of an invocation)
* There is now a incremental_playback boolean field in the playback response. This communicates which behaviour was picked for the replay and has repercussions for the emitted logs. If the parameter is true, it was an incremental playback and only the new logs were emitted. In this case there should be appended to the previous logs. If it is false, all logs were emitted and the previous logs should be replaced.
* For rewind the previous logs should always be replace