### PR TITLE
golem-router - port fix

### DIFF
--- a/golem-router/golem-services.conf.template
+++ b/golem-router/golem-services.conf.template
@@ -44,7 +44,7 @@ http {
         }
 
         location / {
-            proxy_pass http://$GOLEM_COMPONENT_SERVICE_HOST:$GOLEM_CLOUD_SERVICE_PORT;
+            proxy_pass http://$GOLEM_COMPONENT_SERVICE_HOST:$GOLEM_COMPONENT_SERVICE_PORT;
         }
     }
 }


### PR DESCRIPTION
port fix for default route

docker compose startup failing on error

```
2025/07/29 11:48:41 [emerg] 1#1: invalid port in upstream "golem-component-service:" in /etc/nginx/nginx.conf:47

nginx: [emerg] invalid port in upstream "golem-component-service:" in /etc/nginx/nginx.conf:47
```