### PR TITLE
Feature/add cli read worker files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +236,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +271,17 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -294,6 +350,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "async-fs"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +372,21 @@ dependencies = [
  "async-lock",
  "blocking",
  "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -314,6 +399,24 @@ dependencies = [
  "hex",
  "num_cpus",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -334,6 +437,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73112ce9e1059d8604242af62c7ec8e5975ac58ac251686c8403b45e8a6fe778"
 dependencies = [
  "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -366,6 +496,52 @@ dependencies = [
  "futures",
  "pin-project 1.1.10",
  "tokio",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.7",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1058,6 +1234,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bcder"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,7 +1374,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -2478,6 +2665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2758,12 @@ name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docker_credential"
@@ -2749,6 +2948,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2979,6 +3187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,7 +3259,7 @@ dependencies = [
  "bytes 1.10.1",
  "bytes-utils",
  "crossbeam-queue",
- "float-cmp",
+ "float-cmp 0.9.0",
  "fred-macros",
  "futures",
  "log",
@@ -3410,6 +3627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goldenfile"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,9 +3672,14 @@ dependencies = [
 name = "golem-cli"
 version = "0.0.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "golem-client",
+ "httpmock",
+ "predicates",
+ "protoc-rust",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -3453,6 +3687,7 @@ dependencies = [
 name = "golem-client"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes 1.10.1",
  "chrono",
@@ -3466,7 +3701,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "test-r",
  "thiserror 2.0.12",
  "tracing",
  "uuid",
@@ -4391,6 +4625,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,6 +5223,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -5211,6 +5482,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.8.5",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.9",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,6 +5549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,7 +5579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5338,6 +5655,9 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "logos"
@@ -5583,6 +5903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5630,6 +5956,12 @@ name = "nonempty-collections"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f301452dbaf00f14ca0c8204e46cf0c9a96f53543ac72cefa9b4d91c19e0ac"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -6227,6 +6559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,6 +6803,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6568,6 +6920,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp 0.10.0",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -6809,12 +7197,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf 2.28.0",
+]
+
+[[package]]
 name = "protobuf-support"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protoc"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
+dependencies = [
+ "log",
+ "which",
+]
+
+[[package]]
+name = "protoc-rust"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f8a182bb17c485f20bdc4274a8c39000a61024cfe461c799b50fec77267838"
+dependencies = [
+ "protobuf 2.28.0",
+ "protobuf-codegen",
+ "protoc",
+ "tempfile",
 ]
 
 [[package]]
@@ -7884,6 +8303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8418,6 +8847,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8628,6 +9069,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8635,6 +9087,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-r"
@@ -8805,6 +9263,15 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -9556,6 +10023,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -10592,7 +11065,7 @@ checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.4",
  "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -10659,6 +11132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10691,9 +11173,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,7 @@ dependencies = [
  "golem-wasm-ast",
  "golem-wasm-rpc",
  "http 1.3.1",
+ "percent-encoding",
  "reqwest 0.12.18",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,6 +3440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "golem-cli"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "golem-client",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "golem-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "wasm-ast",
     "wasm-rpc",
     "wasm-rpc-derive",
+    "golem-cli",
 ]
 
 exclude = [

--- a/golem-api-grpc/build.rs
+++ b/golem-api-grpc/build.rs
@@ -8,7 +8,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wasm_rpc_root = find_package_root("golem-wasm-rpc");
     let wasm_ast_root = find_package_root("golem-wasm-ast");
 
-    tonic_build::configure()
+    let builder = tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional");
+    builder
         .file_descriptor_set_path(out_dir.join("services.bin"))
         .extern_path(".wasm.rpc", "::golem_wasm_rpc::protobuf")
         .extern_path(".wasm.ast", "::golem_wasm_ast::analysis::protobuf")

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "golem-cli"
+version = "0.0.0"
+edition = "2021"
+
+[[bin]]
+name = "golem"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+golem-client = { path = "../golem-client", version = "=0.0.0" }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/golem-cli/Cargo.toml
+++ b/golem-cli/Cargo.toml
@@ -8,7 +8,16 @@ name = "golem"
 path = "src/main.rs"
 
 [dependencies]
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 golem-client = { path = "../golem-client", version = "=0.0.0" }
+protoc-rust = "2.28.0"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+httpmock = "0.7"
+tokio = { workspace = true, features = ["rt", "macros"] }
+serde_json = { workspace = true }
+tempfile = "3.8"

--- a/golem-cli/config/worker-service.toml
+++ b/golem-cli/config/worker-service.toml
@@ -1,0 +1,17 @@
+[http]
+address = "127.0.0.1"
+port = 8080
+
+[grpc]
+address = "127.0.0.1"
+port = 9090
+
+[blob_storage]
+type = "InMemory"
+
+[database]
+type = "sqlite"
+file = ":memory:"
+
+[tracing]
+level = "info"

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -1,9 +1,15 @@
 use clap::{Parser, Subcommand};
+use golem_client::worker_files::WorkerFilesClient;
+use tokio::io::{AsyncWriteExt, stdout};
 
 #[derive(Parser)]
 #[command(name = "golem")]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    #[arg(long, env = "GOLEM_URL", default_value = "http://localhost:8080")]
+    url: String,
+    #[arg(long, env = "GOLEM_TOKEN")]
+    token: Option<String>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -29,34 +35,63 @@ enum WorkerFilesCommands {
     List {
         component_id: String,
         worker_name: String,
+        #[arg(long)]
+        file: Option<String>,
+        #[arg(long)]
+        json: bool,
     },
     Get {
         component_id: String,
         worker_name: String,
         file_name: String,
+        #[arg(long)]
+        output: Option<String>,
     },
 }
 
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    match cli.command {
+    let client = WorkerFilesClient::new(cli.url, cli.token);
+    let result = match cli.command {
         Commands::Worker { command } => match command {
             WorkerCommands::Files { command } => match command {
-                WorkerFilesCommands::List {
-                    component_id: _,
-                    worker_name: _,
-                } => {
-                    println!("Not implemented yet");
+                WorkerFilesCommands::List { component_id, worker_name, file, json } => {
+                    let file_name = file.unwrap_or_default();
+                    match client.list_files(&component_id, &worker_name, &file_name).await {
+                        Ok(resp) => {
+                            if json {
+                                println!("{}", serde_json::to_string_pretty(&resp).unwrap());
+                            } else {
+                                for n in resp.nodes {
+                                    let kind = if n.is_dir { "dir" } else { "file" };
+                                    println!("{}\t{}\t{}", kind, n.path, n.name);
+                                }
+                            }
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
                 }
-                WorkerFilesCommands::Get {
-                    component_id: _,
-                    worker_name: _,
-                    file_name: _,
-                } => {
-                    println!("Not implemented yet");
+                WorkerFilesCommands::Get { component_id, worker_name, file_name, output } => {
+                    match client.get_file_content(&component_id, &worker_name, &file_name).await {
+                        Ok(bytes) => {
+                            if let Some(path) = output {
+                                tokio::fs::write(path, &bytes).await.unwrap();
+                            } else {
+                                let mut out = stdout();
+                                out.write_all(&bytes).await.unwrap();
+                            }
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
                 }
             },
         },
+    };
+    if let Err(err) = result {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
     }
 }

--- a/golem-cli/src/main.rs
+++ b/golem-cli/src/main.rs
@@ -1,0 +1,62 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "golem")]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Worker {
+        #[command(subcommand)]
+        command: WorkerCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorkerCommands {
+    Files {
+        #[command(subcommand)]
+        command: WorkerFilesCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorkerFilesCommands {
+    List {
+        component_id: String,
+        worker_name: String,
+    },
+    Get {
+        component_id: String,
+        worker_name: String,
+        file_name: String,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Worker { command } => match command {
+            WorkerCommands::Files { command } => match command {
+                WorkerFilesCommands::List {
+                    component_id: _,
+                    worker_name: _,
+                } => {
+                    println!("Not implemented yet");
+                }
+                WorkerFilesCommands::Get {
+                    component_id: _,
+                    worker_name: _,
+                    file_name: _,
+                } => {
+                    println!("Not implemented yet");
+                }
+            },
+        },
+    }
+}

--- a/golem-cli/tests/worker_files.rs
+++ b/golem-cli/tests/worker_files.rs
@@ -1,0 +1,37 @@
+use assert_cmd::Command;
+use httpmock::prelude::*;
+use predicates::str::contains;
+use tempfile::NamedTempFile;
+
+#[test]
+fn cli_list_files_json() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/comp/workers/worker/files/");
+        then.status(200).json_body_obj(&serde_json::json!({
+            "nodes": [{"name":"file.txt","path":"/file.txt","is_dir":false}]
+        }));
+    });
+    let mut cmd = Command::cargo_bin("golem").unwrap();
+    cmd.env("GOLEM_URL", server.url(""))
+        .args(["worker", "files", "list", "comp", "worker", "--json"]);
+    cmd.assert().success().stdout(contains("file.txt"));
+}
+
+#[test]
+fn cli_get_file_output() {
+    let server = MockServer::start();
+    let content = b"hello".to_vec();
+    server.mock(|when, then| {
+        when.method(GET).path("/comp/workers/worker/file-contents/file%2Etxt");
+        then.status(200).body(content.clone());
+    });
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+    let mut cmd = Command::cargo_bin("golem").unwrap();
+    cmd.env("GOLEM_URL", server.url(""))
+        .args(["worker", "files", "get", "comp", "worker", "file.txt", "--output", &path]);
+    cmd.assert().success();
+    let saved = std::fs::read(path).unwrap();
+    assert_eq!(saved, content);
+}

--- a/golem-client/Cargo.toml
+++ b/golem-client/Cargo.toml
@@ -28,16 +28,14 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 percent-encoding = "2.3.0"
-
-[dev-dependencies]
-test-r = { workspace = true }
+anyhow = { workspace = true }
 
 [build-dependencies]
 golem-openapi-client-generator = "=0.0.16"

--- a/golem-client/Cargo.toml
+++ b/golem-client/Cargo.toml
@@ -34,6 +34,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+percent-encoding = "2.3.0"
 
 [dev-dependencies]
 test-r = { workspace = true }

--- a/golem-client/src/lib.rs
+++ b/golem-client/src/lib.rs
@@ -16,3 +16,5 @@ include!(concat!(env!("OUT_DIR"), "/src/lib.rs"));
 
 #[cfg(test)]
 test_r::enable!();
+
+pub mod worker_files;

--- a/golem-client/src/worker_files.rs
+++ b/golem-client/src/worker_files.rs
@@ -1,0 +1,76 @@
+use bytes::Bytes;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[derive(Clone)]
+pub struct WorkerFilesClient {
+    client: Client,
+    base_url: String,
+    token: Option<String>,
+}
+
+impl WorkerFilesClient {
+    pub fn new(base_url: impl Into<String>, token: Option<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            token,
+        }
+    }
+
+    pub async fn list_files(
+        &self,
+        component_id: &str,
+        worker_name: &str,
+        file_name: &str,
+    ) -> anyhow::Result<GetFilesResponse> {
+        let url = format!(
+            "{}/{}/workers/{}/files/{}",
+            self.base_url,
+            percent_encoding::utf8_percent_encode(component_id, percent_encoding::NON_ALPHANUMERIC),
+            percent_encoding::utf8_percent_encode(worker_name, percent_encoding::NON_ALPHANUMERIC),
+            percent_encoding::utf8_percent_encode(file_name, percent_encoding::NON_ALPHANUMERIC)
+        );
+        let mut req = self.client.get(url);
+        if let Some(t) = &self.token {
+            req = req.bearer_auth(t);
+        }
+        let res = req.send().await?.error_for_status()?;
+        let body = res.json::<GetFilesResponse>().await?;
+        Ok(body)
+    }
+
+    pub async fn get_file_content(
+        &self,
+        component_id: &str,
+        worker_name: &str,
+        file_name: &str,
+    ) -> anyhow::Result<Bytes> {
+        let url = format!(
+            "{}/{}/workers/{}/file-contents/{}",
+            self.base_url,
+            percent_encoding::utf8_percent_encode(component_id, percent_encoding::NON_ALPHANUMERIC),
+            percent_encoding::utf8_percent_encode(worker_name, percent_encoding::NON_ALPHANUMERIC),
+            percent_encoding::utf8_percent_encode(file_name, percent_encoding::NON_ALPHANUMERIC)
+        );
+        let mut req = self.client.get(url);
+        if let Some(t) = &self.token {
+            req = req.bearer_auth(t);
+        }
+        let res = req.send().await?.error_for_status()?;
+        let bytes = res.bytes().await?;
+        Ok(bytes)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct GetFilesResponse {
+    pub nodes: Vec<Node>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Node {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+}

--- a/golem-client/src/worker_files.rs
+++ b/golem-client/src/worker_files.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone)]
 pub struct WorkerFilesClient {
@@ -63,12 +63,12 @@ impl WorkerFilesClient {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct GetFilesResponse {
     pub nodes: Vec<Node>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Node {
     pub name: String,
     pub path: String,

--- a/wasm-ast/build.rs
+++ b/wasm-ast/build.rs
@@ -3,6 +3,7 @@ use std::io::Result;
 #[cfg(feature = "protobuf")]
 fn main() -> Result<()> {
     let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
     config.type_attribute(".", "#[cfg(feature = \"protobuf\")]");
     config.type_attribute(
         ".",

--- a/wasm-rpc/build.rs
+++ b/wasm-rpc/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<()> {
         env::var("GOLEM_WASM_AST_ROOT").unwrap_or_else(|_| find_package_root("golem-wasm-ast"));
 
     let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
     config.extern_path(".wasm.ast", "::golem_wasm_ast::analysis::protobuf");
     config.type_attribute(".", "#[cfg(feature = \"protobuf\")]");
     config.type_attribute(


### PR DESCRIPTION
### PR: Introduce `golem-cli`

Adds a new binary crate with two worker-file commands:

1. `golem worker files list  <component-id> <worker-name> [--json]`
2. `golem worker files get   <component-id> <worker-name> <file-name> [--output <path>]`

Internals:
• Extends `golem-client` (`list_files`, `get_file_content`).  
• Supports `--url` / `GOLEM_URL` and `--token` / `GOLEM_TOKEN`.  