### PR TITLE
Export and swagger commands in golem-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "multer",
+ "multer 3.1.0",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -1712,6 +1712,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -4026,6 +4032,8 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "warp",
+ "webbrowser",
 ]
 
 [[package]]
@@ -4122,7 +4130,7 @@ dependencies = [
  "textwrap",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.25.0",
  "toml 0.9.5",
  "toml_edit 0.23.3",
  "tracing",
@@ -4132,6 +4140,7 @@ dependencies = [
  "version-compare",
  "wac-graph",
  "walkdir",
+ "warp",
  "wasm-encoder 0.235.0",
  "wasm-metadata 0.235.0",
  "wasm-rquickjs",
@@ -4139,6 +4148,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wax",
+ "webbrowser",
  "wit-bindgen-rust 0.43.0",
  "wit-component 0.235.0",
  "wit-encoder",
@@ -4344,7 +4354,7 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.25.0",
  "tokio-util",
  "tonic",
  "tracing",
@@ -4444,7 +4454,7 @@ dependencies = [
  "golem-wasm-ast",
  "golem-wasm-rpc",
  "golem-wasm-rpc-derive",
- "headers",
+ "headers 0.4.1",
  "hex",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -4576,7 +4586,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.25.0",
  "tonic",
  "tracing",
  "tryhard",
@@ -4758,7 +4768,7 @@ dependencies = [
  "golem-service-base",
  "golem-wasm-ast",
  "golem-wasm-rpc",
- "headers",
+ "headers 0.4.1",
  "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -4964,17 +4974,41 @@ dependencies = [
 
 [[package]]
 name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.10.1",
+ "headers-core 0.2.0",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
- "headers-core",
+ "headers-core 0.3.0",
  "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -5213,7 +5247,7 @@ checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
 dependencies = [
  "bytes 1.10.1",
  "futures-util",
- "headers",
+ "headers 0.4.1",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-rustls 0.27.7",
@@ -5818,6 +5852,28 @@ checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -6581,6 +6637,24 @@ dependencies = [
 
 [[package]]
 name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes 1.10.1",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
+name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
@@ -6628,6 +6702,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "newline-converter"
@@ -6873,6 +6953,31 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.9.1",
+ "objc2",
 ]
 
 [[package]]
@@ -7668,13 +7773,13 @@ dependencies = [
  "chrono",
  "cookie",
  "futures-util",
- "headers",
+ "headers 0.4.1",
  "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
  "mime",
- "multer",
+ "multer 3.1.0",
  "nix 0.29.0",
  "opentelemetry 0.29.1",
  "opentelemetry-http",
@@ -7700,7 +7805,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.25.0",
  "tokio-util",
  "tracing",
  "wildmatch",
@@ -10821,6 +10926,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28562dd8aea311048ed1ab9372a6b9a59977e1b308afb87c985c1f2b3206938"
@@ -10830,7 +10947,7 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.25.0",
 ]
 
 [[package]]
@@ -11247,6 +11364,25 @@ checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
 dependencies = [
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes 1.10.1",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
 ]
 
 [[package]]
@@ -11754,6 +11890,35 @@ dependencies = [
  "thiserror 1.0.69",
  "warg-crypto",
  "warg-protobuf",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-channel",
+ "futures-util",
+ "headers 0.3.9",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer 2.1.0",
+ "percent-encoding",
+ "pin-project 1.1.10",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -12642,6 +12807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf4f3c0ba838e82b4e5ccc4157003fb8c324ee24c058470ffb82820becbde98"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12986,6 +13167,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -13018,6 +13208,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -13079,6 +13284,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -13097,6 +13308,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -13112,6 +13329,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13145,6 +13368,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -13160,6 +13389,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -13181,6 +13416,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -13196,6 +13437,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,8 @@ sysinfo = "0.33.1"
 tonic-build = "0.12.3"
 try_match = "0.4.2"
 wasmprinter = "0.219.1"
+webbrowser = "1.0.4"
+warp = "0.3.7"
 wit-bindgen-rt = "=0.40.0"
 zstd = "0.13"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -145,7 +145,7 @@ glob_cp wit/deps/**/* cli/template-golem-agent-ts/wit/deps
 private = true
 script_runner = "@duckscript"
 script = """
-components = array blob-store-service component-resolve 'component-transformer-example1/adapter' custom-durability file-service high-volume-logging http-client ifs-update ifs-update-inside-exported-fucntion invocation-context js-1 js-4 key-value-service networking oplog-processor promise python-http-client rdbms-service rpc runtime-service scheduled-invocation shopping-cart tinygo-wasi tinygo-wasi-http ts-rpc update-test-env-var update-test-v2-11 update-test-v3-11 update-test-v3-sdk update-test-v4 wasi-config wasi-http-incoming-request-handler wasi-http-incoming-request-handler-echo wasi-http-incoming-request-handler-state
+components = array blob-store-service component-resolve component-transformer-example1/adapter custom-durability file-service high-volume-logging http-client ifs-update ifs-update-inside-exported-function invocation-context js-1 js-4 key-value-service networking oplog-processor promise python-http-client rdbms-service rpc runtime-service scheduled-invocation shopping-cart tinygo-wasi tinygo-wasi-http ts-rpc update-test-env-var update-test-v2-11 update-test-v3-11 update-test-v3-sdk update-test-v4 wasi-config wasi-http-incoming-request-handler wasi-http-incoming-request-handler-echo wasi-http-incoming-request-handler-state
 
 for component in ${components}
     echo "Updating wit directory for test component ${component}"

--- a/cli/golem-cli/Cargo.toml
+++ b/cli/golem-cli/Cargo.toml
@@ -119,6 +119,8 @@ wit-bindgen-rust = { workspace = true }
 wit-component = { workspace = true }
 wit-encoder = { workspace = true }
 wit-parser = { workspace = true }
+webbrowser = { workspace = true }
+warp = { workspace = true }
 
 [dev-dependencies]
 

--- a/cli/golem-cli/src/command.rs
+++ b/cli/golem-cli/src/command.rs
@@ -1176,6 +1176,7 @@ pub mod api {
         use crate::command::shared_args::{ProjectOptionalFlagArg, UpdateOrRedeployArgs};
         use crate::model::api::{ApiDefinitionId, ApiDefinitionVersion};
         use crate::model::app::HttpApiDefinitionName;
+        use crate::model::OpenApiDefinitionOutputFormat;
         use clap::Subcommand;
 
         #[derive(Debug, Subcommand)]
@@ -1216,6 +1217,37 @@ pub mod api {
                 /// Version of the api definition
                 #[arg(long)]
                 version: ApiDefinitionVersion,
+            },
+            /// Exports an api definition in OpenAPI format
+            Export {
+                #[command(flatten)]
+                project: ProjectOptionalFlagArg,
+                /// Api definition id
+                #[arg(short, long)]
+                id: ApiDefinitionId,
+                /// Version of the api definition
+                #[arg(short = 'V', long)]
+                version: ApiDefinitionVersion,
+                /// Output format (json or yaml)
+                #[arg(long = "def-format", default_value = "yaml", name = "def-format")]
+                format: OpenApiDefinitionOutputFormat,
+                /// Custom output file name (without extension)
+                #[arg(short, long)]
+                output_name: Option<String>,
+            },
+            /// Opens Swagger UI for an API definition
+            Swagger {
+                #[command(flatten)]
+                project: ProjectOptionalFlagArg,
+                /// Api definition id
+                #[arg(short, long)]
+                id: ApiDefinitionId,
+                /// Version of the api definition
+                #[arg(short = 'V', long)]
+                version: ApiDefinitionVersion,
+                /// Port to open Swagger UI on (defaults to 9007)
+                #[arg(short = 'P', long, default_value_t = 9007)]
+                port: u16,
             },
         }
     }

--- a/cli/golem-cli/src/command_handler/api/definition.rs
+++ b/cli/golem-cli/src/command_handler/api/definition.rs
@@ -30,17 +30,19 @@ use crate::model::app_raw::HttpApiDefinition;
 use crate::model::component::Component;
 use crate::model::deploy_diff::api_definition::DiffableHttpApiDefinition;
 use crate::model::text::api_definition::{
-    ApiDefinitionGetView, ApiDefinitionNewView, ApiDefinitionUpdateView,
+    ApiDefinitionExportView, ApiDefinitionGetView, ApiDefinitionNewView, ApiDefinitionUpdateView,
 };
 use crate::model::text::fmt::{log_deploy_diff, log_error, log_warn};
-use crate::model::{ComponentName, ProjectRefAndId};
+use crate::model::{ComponentName, OpenApiDefinitionOutputFormat, ProjectRefAndId};
 use anyhow::{bail, Context as AnyhowContext};
-use golem_client::api::ApiDefinitionClient;
+use golem_client::api::{ApiDefinitionClient, ApiDeploymentClient};
 use golem_client::model::{HttpApiDefinitionRequest, HttpApiDefinitionResponseData};
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use warp;
+use webbrowser;
 
 pub struct ApiDefinitionCommandHandler {
     ctx: Arc<Context>,
@@ -71,6 +73,22 @@ impl ApiDefinitionCommandHandler {
                 version,
             } => self.cmd_delete(project, id, version).await,
             ApiDefinitionSubcommand::List { project, id } => self.cmd_list(project, id).await,
+            ApiDefinitionSubcommand::Export {
+                project,
+                id,
+                version,
+                format,
+                output_name,
+            } => {
+                self.cmd_export(project, id, version, format, output_name)
+                    .await
+            }
+            ApiDefinitionSubcommand::Swagger {
+                project,
+                id,
+                version,
+                port,
+            } => self.cmd_swagger(project, id, version, port).await,
         }
     }
 
@@ -248,6 +266,260 @@ impl ApiDefinitionCommandHandler {
                 version.0.log_color_highlight()
             ),
         );
+
+        Ok(())
+    }
+
+    async fn cmd_export(
+        &self,
+        project: ProjectOptionalFlagArg,
+        id: ApiDefinitionId,
+        version: ApiDefinitionVersion,
+        format: OpenApiDefinitionOutputFormat,
+        output_name: Option<String>,
+    ) -> anyhow::Result<()> {
+        let project = self
+            .ctx
+            .cloud_project_handler()
+            .opt_select_project(project.project.as_ref())
+            .await?;
+
+        let clients = self.ctx.golem_clients().await?;
+
+        let response = clients
+            .api_definition
+            .export_definition(
+                &self
+                    .ctx
+                    .cloud_project_handler()
+                    .selected_project_id_or_default(project.as_ref())
+                    .await?
+                    .0,
+                &id.0,
+                &version.0,
+            )
+            .await
+            .map_service_error()?;
+
+        let openapi_spec = response.openapi_yaml;
+        let file_name = output_name.unwrap_or_else(|| format!("{}_{}", id.0, version.0));
+        let file_path = match format {
+            OpenApiDefinitionOutputFormat::Json => format!("{file_name}.json"),
+            OpenApiDefinitionOutputFormat::Yaml => format!("{file_name}.yaml"),
+        };
+
+        match format {
+            OpenApiDefinitionOutputFormat::Json => {
+                // Convert YAML to JSON for the JSON format option
+                let yaml_obj: serde_yaml::Value = serde_yaml::from_str(&openapi_spec)?;
+                let json_obj: serde_json::Value = serde_json::to_value(yaml_obj)?;
+                let json_str = serde_json::to_string_pretty(&json_obj)?;
+                std::fs::write(&file_path, json_str)?;
+            }
+            OpenApiDefinitionOutputFormat::Yaml => {
+                // Use YAML directly for the YAML format option
+                std::fs::write(&file_path, openapi_spec)?;
+            }
+        }
+
+        let result = format!("Exported to {file_path}");
+
+        self.ctx
+            .log_handler()
+            .log_view(&ApiDefinitionExportView(result));
+
+        Ok(())
+    }
+
+    async fn cmd_swagger(
+        &self,
+        project: ProjectOptionalFlagArg,
+        id: ApiDefinitionId,
+        version: ApiDefinitionVersion,
+        port: u16,
+    ) -> anyhow::Result<()> {
+        let project = self
+            .ctx
+            .cloud_project_handler()
+            .opt_select_project(project.project.as_ref())
+            .await?;
+
+        let clients = self.ctx.golem_clients().await?;
+
+        // First export the API spec
+        let response = clients
+            .api_definition
+            .export_definition(
+                &self
+                    .ctx
+                    .cloud_project_handler()
+                    .selected_project_id_or_default(project.as_ref())
+                    .await?
+                    .0,
+                &id.0,
+                &version.0,
+            )
+            .await
+            .map_service_error()?;
+
+        let openapi_spec = response.openapi_yaml;
+
+        // Parse the YAML spec into JSON Value
+        let mut spec: serde_json::Value = serde_yaml::from_str(&openapi_spec)?;
+
+        // Filter paths to only include methods with binding-type: default
+        filter_routes(&mut spec);
+
+        // Fetch deployments
+        let project_id = self
+            .ctx
+            .cloud_project_handler()
+            .selected_project_id_or_default(project.as_ref())
+            .await?
+            .0;
+
+        let deployments = clients
+            .api_deployment
+            .list_deployments(&project_id, Some(&id.0))
+            .await
+            .map_service_error()?;
+
+        // Add server information if deployments exist
+        if !deployments.is_empty() {
+            // Initialize servers array if it doesn't exist
+            if !spec.as_object().unwrap().contains_key("servers") {
+                spec.as_object_mut()
+                    .unwrap()
+                    .insert("servers".to_string(), serde_json::Value::Array(Vec::new()));
+            }
+
+            // Add servers to the spec
+            if let Some(servers) = spec.get_mut("servers") {
+                if let Some(servers) = servers.as_array_mut() {
+                    // Add deployment servers with HTTP
+                    for deployment in &deployments {
+                        let url = match &deployment.site.subdomain {
+                            Some(subdomain) => {
+                                format!("http://{}.{}", subdomain, deployment.site.host)
+                            }
+                            None => format!("http://{}", deployment.site.host),
+                        };
+                        servers.push(serde_json::json!({
+                            "url": url,
+                            "description": "Deployed instance"
+                        }));
+                    }
+                }
+            }
+        }
+
+        // Validate port
+        if port == 0 {
+            return Err(anyhow::anyhow!(
+                "Port number must be greater than 0. Provided: {}",
+                port
+            ));
+        }
+
+        // Start local Swagger UI server
+        self.start_local_swagger_ui(serde_yaml::to_string(&spec)?, port)
+            .await?;
+
+        self.ctx
+            .log_handler()
+            .log_view(&ApiDefinitionExportView(format!(
+                "Swagger UI running at http://localhost:{}\n{}",
+                port,
+                if deployments.is_empty() {
+                    "No deployments found - displaying API schema without server information"
+                        .to_string()
+                } else {
+                    format!("API is deployed at {} locations", deployments.len())
+                }
+            )));
+
+        // Wait for ctrl+c
+        tokio::signal::ctrl_c().await?;
+
+        Ok(())
+    }
+
+    async fn start_local_swagger_ui(&self, spec: String, port: u16) -> anyhow::Result<()> {
+        use std::net::TcpListener;
+        use std::sync::Arc;
+        use warp::Filter;
+
+        // First check if the port is available
+        let listener = TcpListener::bind(("127.0.0.1", port));
+        if listener.is_err() {
+            return Err(anyhow::anyhow!(
+                "Port {} is already in use. Please choose a different port.",
+                port
+            ));
+        }
+        drop(listener); // Close the test connection
+
+        // Parse the YAML to ensure it's valid
+        let spec_value: serde_yaml::Value = serde_yaml::from_str(&spec)?;
+
+        // Convert to JSON for Swagger UI
+        let spec_json = serde_json::to_value(&spec_value)?;
+
+        // Create a shared spec for the server
+        let spec = Arc::new(spec_json);
+
+        // Serve the OpenAPI spec as JSON
+        let openapi_route =
+            warp::path("openapi.json").map(move || warp::reply::json(spec.clone().as_ref()));
+
+        // Serve the Swagger UI HTML
+        let swagger_ui_html = r#"
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>Swagger UI</title>
+                <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
+                <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+                <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+            </head>
+            <body>
+                <div id="swagger-ui"></div>
+                <script>
+                    window.onload = () => {
+                        window.ui = SwaggerUIBundle({
+                            url: '/openapi.json',
+                            dom_id: '#swagger-ui',
+                            deepLinking: true,
+                            presets: [
+                                SwaggerUIBundle.presets.apis,
+                                SwaggerUIStandalonePreset
+                            ],
+                            layout: "StandaloneLayout"
+                        });
+                    };
+                </script>
+            </body>
+            </html>
+        "#;
+
+        let swagger_route = warp::path::end().map(move || warp::reply::html(swagger_ui_html));
+
+        // Combine routes
+        let routes = openapi_route.or(swagger_route);
+
+        // Start server in a background task
+        tokio::spawn(async move {
+            warp::serve(routes).run(([127, 0, 0, 1], port)).await;
+        });
+
+        // Try to open browser
+        match webbrowser::open(&format!("http://localhost:{port}")) {
+            Ok(_) => println!("Browser opened successfully."),
+            Err(_) => println!(
+                "Could not open browser automatically. You can access the Swagger UI at: http://localhost:{port}"
+            ),
+        }
 
         Ok(())
     }
@@ -642,4 +914,48 @@ impl ApiDefinitionCommandHandler {
 
 fn parse_api_definition<T: DeserializeOwned>(input: &str) -> anyhow::Result<T> {
     serde_yaml::from_str(input).context("Failed to parse API definition")
+}
+
+/// Filters the OpenAPI specification to only include methods with `binding-type: default`.
+fn filter_routes(spec: &mut serde_json::Value) {
+    if let Some(paths) = spec.get_mut("paths").and_then(|p| p.as_object_mut()) {
+        let paths_to_remove: Vec<String> = paths
+            .iter_mut()
+            .filter_map(|(path, methods)| {
+                if let Some(methods) = methods.as_object_mut() {
+                    // Filter methods within this path
+                    let methods_to_remove: Vec<String> = methods
+                        .iter()
+                        .filter_map(|(method, details)| {
+                            // Check if the method has a binding-type and if it's not "default"
+                            if let Some(binding) = details.get("x-golem-api-gateway-binding") {
+                                if let Some(binding_type) = binding.get("binding-type") {
+                                    if binding_type != "default" {
+                                        return Some(method.clone());
+                                    }
+                                }
+                            }
+                            None
+                        })
+                        .collect();
+
+                    // Remove filtered methods
+                    for method in methods_to_remove {
+                        methods.remove(&method);
+                    }
+
+                    // If no methods left in this path, mark it for removal
+                    if methods.is_empty() {
+                        return Some(path.clone());
+                    }
+                }
+                None
+            })
+            .collect();
+
+        // Remove empty paths
+        for path in paths_to_remove {
+            paths.remove(&path);
+        }
+    }
 }

--- a/cli/golem-cli/src/model/app.rs
+++ b/cli/golem-cli/src/model/app.rs
@@ -2542,6 +2542,12 @@ mod app_builder {
                                             check_not_allowed(validation, "invocation_context", &route.binding.invocation_context);
                                             check_not_allowed(validation, "response", &route.binding.response);
                                         }
+                                        app_raw::HttpApiDefinitionBindingType::SwaggerUi => {
+                                                check_not_allowed(validation, "component_name", &route.binding.component_name);
+                                                check_not_allowed(validation, "idempotency_key", &route.binding.idempotency_key);
+                                                check_not_allowed(validation, "invocation_context", &route.binding.invocation_context);
+                                                check_not_allowed(validation, "response", &route.binding.response); 
+                                        }
                                     }
                                 },
                             );

--- a/cli/golem-cli/src/model/app_raw.rs
+++ b/cli/golem-cli/src/model/app_raw.rs
@@ -181,6 +181,7 @@ pub enum HttpApiDefinitionBindingType {
     CorsPreflight,
     FileServer,
     HttpHandler,
+    SwaggerUi,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/cli/golem-cli/src/model/deploy_diff/api_definition.rs
+++ b/cli/golem-cli/src/model/deploy_diff/api_definition.rs
@@ -125,6 +125,7 @@ fn normalize_http_api_route(
                         HttpApiDefinitionBindingType::HttpHandler => {
                             GatewayBindingType::HttpHandler
                         }
+                        HttpApiDefinitionBindingType::SwaggerUi => GatewayBindingType::SwaggerUi,
                     })
                     .unwrap_or_else(|| GatewayBindingType::Default),
             ),

--- a/cli/golem-cli/src/model/mod.rs
+++ b/cli/golem-cli/src/model/mod.rs
@@ -845,3 +845,32 @@ impl Display for ProjectId {
         write!(f, "{}", self.0)
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenApiDefinitionOutputFormat {
+    Json,
+    Yaml,
+}
+
+impl FromStr for OpenApiDefinitionOutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(OpenApiDefinitionOutputFormat::Json),
+            "yaml" | "yml" => Ok(OpenApiDefinitionOutputFormat::Yaml),
+            _ => Err(format!(
+                "Invalid API definition format: {s}. Expected one of \"json\", \"yaml\""
+            )),
+        }
+    }
+}
+
+impl Display for OpenApiDefinitionOutputFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenApiDefinitionOutputFormat::Json => write!(f, "json"),
+            OpenApiDefinitionOutputFormat::Yaml => write!(f, "yaml"),
+        }
+    }
+}

--- a/cli/golem-cli/src/model/text/api_definition.rs
+++ b/cli/golem-cli/src/model/text/api_definition.rs
@@ -165,3 +165,16 @@ impl TextView for Vec<HttpApiDefinitionResponseData> {
         log_table::<_, HttpApiDefinitionTableView>(self);
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiDefinitionExportView(pub String);
+
+impl MessageWithFields for ApiDefinitionExportView {
+    fn message(&self) -> String {
+        self.0.clone()
+    }
+
+    fn fields(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}

--- a/cli/golem/Cargo.toml
+++ b/cli/golem/Cargo.toml
@@ -52,6 +52,8 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+webbrowser = { workspace = true }
+warp = { workspace = true }
 
 [dev-dependencies]
 test-r = { workspace = true }


### PR DESCRIPTION
This adds `swagger` and `export` commands to cli, api definition

swagger

```bash
golem api definition swagger [OPTIONS] --id <ID> --version <VERSION>
 -i, --id <ID>
          Api definition id
  -V, --version <VERSION>
          Version of the api definition
  -P, --port <PORT>
          Port to open Swagger UI on (defaults to 9007) [default: 9007]
```

export 

```bash
 golem api definition export [OPTIONS] --id <ID> --version <VERSION>
  -i, --id <ID>
          Api definition id
  -V, --version <VERSION>
          Version of the api definition
      --def-format <def-format>
          Output format (json or yaml) [default: yaml]
  -o, --output-name <OUTPUT_NAME>
          Custom output file name (without extension)
```


