### PR TITLE
Support wit/moonbit keywords in agent type definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6731,7 +6731,9 @@ dependencies = [
 
 [[package]]
 name = "moonbit-component-generator"
-version = "0.0.0"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4c3629be37f329b22ec71bcd0d5edd8bad00518da434ce537287f852ddabb5"
 dependencies = [
  "anyhow",
  "camino",
@@ -10797,9 +10799,9 @@ dependencies = [
 
 [[package]]
 name = "test-r"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a250edb45c30e3911a5d8c9117fd494b980daa7bf3d12df0a15466c4b1146e90"
+checksum = "8bbab8358cff750ac33349836f8f98a361373d482f259ece27afd733a30ab54f"
 dependencies = [
  "ctor",
  "test-r-core",
@@ -10809,9 +10811,9 @@ dependencies = [
 
 [[package]]
 name = "test-r-core"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a4bbf5aabc86a040da6d02c8395a485bf8d106ed2eb2a16c3cf07cd4ba3a5"
+checksum = "47bed75c007800e882fc5f0749ff11399dc7ed69a7df4bab017e0fe1262e8740"
 dependencies = [
  "anstream",
  "anstyle",
@@ -10832,9 +10834,9 @@ dependencies = [
 
 [[package]]
 name = "test-r-macro"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a1357747913d4e66cf97d3f2af25c6fad928339f5139d9d60e5e9b725f679"
+checksum = "5c931eeaf755e36b90143fbdcd54439825dda310bc877e6d76edcd65a6fa42fd"
 dependencies = [
  "darling 0.21.2",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6731,9 +6731,7 @@ dependencies = [
 
 [[package]]
 name = "moonbit-component-generator"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1013195ac854f17aee72898a4cec5aeed600b4b7d9bc8861b0482c32688f3a"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 mime = "0.3.17"
 mime_guess = "2.0.5"
 minijinja = "2.7.0"
-moonbit-component-generator = { version = "0.0.3", features = ["get-script"] }
+moonbit-component-generator = { version = "0.0.4", features = ["get-script"] }
 nanoid = "0.4.0"
 native-tls = "0.2.13"
 nom = "7.1.3"
@@ -283,7 +283,7 @@ system-interface = "0.27.3"
 tap = "1.0.1"
 tempfile = "3.18.0"
 terminal_size = "0.4.2"
-test-r = { version = "2.2.1", default-features = true }
+test-r = { version = "2.2.2", default-features = true }
 testcontainers = { version = "0.23.3" }
 testcontainers-modules = { version = "0.11.6", features = ["postgres", "redis", "minio", "mysql", ] }
 textwrap = "0.16.1"

--- a/cli/golem-cli/src/model/agent/moonbit.rs
+++ b/cli/golem-cli/src/model/agent/moonbit.rs
@@ -29,15 +29,15 @@ pub fn generate_moonbit_wrapper(
 ) -> anyhow::Result<()> {
     let wit = &ctx.single_file_wrapper_wit_source;
     let mut component = MoonBitComponent::empty_from_wit(wit, Some("agent-wrapper"))?;
-    component.disable_cleanup(); // TODO: remove
+    component.disable_cleanup(); // TODO: remove!!!
 
     component
         .define_bindgen_packages()
         .context("Defining bindgen packages")?;
 
     let moonbit_root_package = component.moonbit_root_package()?;
-    let pkg_namespace = component.root_pkg_namespace()?.to_snake_case();
-    let pkg_name = component.root_pkg_name()?.to_snake_case();
+    let pkg_namespace = to_moonbit_ident(component.root_pkg_namespace()?);
+    let pkg_name = to_moonbit_ident(component.root_pkg_name()?);
 
     // Adding the builder and extractor packages
     add_builder_package(&mut component, &moonbit_root_package)?;
@@ -45,6 +45,7 @@ pub fn generate_moonbit_wrapper(
 
     setup_dependencies(
         &mut component,
+        ctx.has_types,
         &moonbit_root_package,
         &pkg_namespace,
         &pkg_name,
@@ -68,14 +69,23 @@ pub fn generate_moonbit_wrapper(
         AGENT_GUEST_MBT,
     )?;
 
-    component.write_interface_stub(
-        &PackageName {
-            namespace: pkg_namespace.clone(),
-            name: pkg_name.clone(),
-            version: None,
-        },
-        "types",
-        "",
+    if ctx.has_types {
+        component.write_interface_stub(
+            &PackageName {
+                namespace: pkg_namespace.clone(),
+                name: pkg_name.clone(),
+                version: None,
+            },
+            "types",
+            "",
+        )?;
+    }
+
+    component.set_warning_control(
+        &format!("{moonbit_root_package}/interface/golem/agent/guest"),
+        vec![
+            WarningControl::Disable(Warning::Specific(35)), //  Warning: The word `constructor` is reserved for possible future use. Please consider using another name.
+        ],
     )?;
 
     for agent in &ctx.agent_types {
@@ -93,6 +103,8 @@ pub fn generate_moonbit_wrapper(
                 WarningControl::Disable(Warning::Specific(11)),
                 // Unused package warning (can be that @agentTypes is not used)
                 WarningControl::Disable(Warning::Specific(29)),
+                //  Warning: The word `constructor` is reserved for possible future use. Please consider using another name.
+                WarningControl::Disable(Warning::Specific(35)),
             ],
         )?;
 
@@ -141,6 +153,19 @@ fn add_builder_package(
     component.write_file(Utf8Path::new("builder/tests.mbt"), BUILDER_TESTS_MBT)?;
     component.write_file(Utf8Path::new("builder/top.mbt"), BUILDER_TOP_MBT)?;
 
+    let dependencies = vec![(
+        Utf8Path::new("target")
+            .join("wasm")
+            .join("release")
+            .join("build")
+            .join("interface")
+            .join("golem")
+            .join("rpc")
+            .join("types")
+            .join("types.mi"),
+        "types".to_string(),
+    )];
+
     let builder_package = MoonBitPackage {
         name: format!("{moonbit_root_package}/builder"),
         mbt_files: vec![
@@ -156,18 +181,7 @@ fn add_builder_package(
             .join("build")
             .join("builder")
             .join("builder.core"),
-        dependencies: vec![(
-            Utf8Path::new("target")
-                .join("wasm")
-                .join("release")
-                .join("build")
-                .join("interface")
-                .join("golem")
-                .join("rpc")
-                .join("types")
-                .join("types.mi"),
-            "types".to_string(),
-        )],
+        dependencies,
         package_sources: vec![(
             format!("{moonbit_root_package}/builder"),
             Utf8Path::new("builder").to_path_buf(),
@@ -187,6 +201,42 @@ fn add_extractor_package(
     component.write_file(Utf8Path::new("extractor/tests.mbt"), EXTRACTOR_TESTS_MBT)?;
     component.write_file(Utf8Path::new("extractor/top.mbt"), EXTRACTOR_TOP_MBT)?;
 
+    let dependencies = vec![
+        (
+            Utf8Path::new("target")
+                .join("wasm")
+                .join("release")
+                .join("build")
+                .join("interface")
+                .join("golem")
+                .join("rpc")
+                .join("types")
+                .join("types.mi"),
+            "types".to_string(),
+        ),
+        (
+            Utf8Path::new("target")
+                .join("wasm")
+                .join("release")
+                .join("build")
+                .join("interface")
+                .join("golem")
+                .join("agent")
+                .join("common")
+                .join("common.mi"),
+            "common".to_string(),
+        ),
+        (
+            Utf8Path::new("target")
+                .join("wasm")
+                .join("release")
+                .join("build")
+                .join("builder")
+                .join("builder.mi"),
+            "builder".to_string(),
+        ),
+    ];
+
     let extractor_package = MoonBitPackage {
         name: format!("{moonbit_root_package}/extractor"),
         mbt_files: vec![
@@ -200,41 +250,7 @@ fn add_extractor_package(
             .join("build")
             .join("extractor")
             .join("extractor.core"),
-        dependencies: vec![
-            (
-                Utf8Path::new("target")
-                    .join("wasm")
-                    .join("release")
-                    .join("build")
-                    .join("interface")
-                    .join("golem")
-                    .join("rpc")
-                    .join("types")
-                    .join("types.mi"),
-                "types".to_string(),
-            ),
-            (
-                Utf8Path::new("target")
-                    .join("wasm")
-                    .join("release")
-                    .join("build")
-                    .join("interface")
-                    .join("golem")
-                    .join("agent")
-                    .join("common")
-                    .join("common.mi"),
-                "common".to_string(),
-            ),
-            (
-                Utf8Path::new("target")
-                    .join("wasm")
-                    .join("release")
-                    .join("build")
-                    .join("builder")
-                    .join("builder.mi"),
-                "builder".to_string(),
-            ),
-        ],
+        dependencies,
         package_sources: vec![(
             format!("{moonbit_root_package}/extractor"),
             Utf8Path::new("extractor").to_path_buf(),
@@ -246,6 +262,7 @@ fn add_extractor_package(
 
 fn setup_dependencies(
     component: &mut MoonBitComponent,
+    has_types: bool,
     moonbit_root_package: &str,
     pkg_namespace: &str,
     pkg_name: &str,
@@ -284,8 +301,12 @@ fn setup_dependencies(
         )
     };
 
-    let depends_on_types =
-        |component: &mut MoonBitComponent, pkg_namespace: &str, pkg_name: &str, name: &str| {
+    let depends_on_types = |component: &mut MoonBitComponent,
+                            has_types: bool,
+                            pkg_namespace: &str,
+                            pkg_name: &str,
+                            name: &str| {
+        if has_types {
             component.add_dependency(
                 &format!("{moonbit_root_package}/{name}"),
                 &Utf8Path::new("target")
@@ -300,7 +321,10 @@ fn setup_dependencies(
                     .join("types.mi"),
                 "types",
             )
-        };
+        } else {
+            Ok(())
+        }
+    };
 
     let depends_on_wasm_rpc_types = |component: &mut MoonBitComponent, name: &str| {
         component.add_dependency(
@@ -319,10 +343,13 @@ fn setup_dependencies(
     };
 
     depends_on_golem_agent_common(component, "interface/golem/agent/guest")?;
-    depends_on_golem_agent_common(
-        component,
-        &format!("gen/interface/{pkg_namespace}/{pkg_name}/types"),
-    )?;
+
+    if has_types {
+        depends_on_golem_agent_common(
+            component,
+            &format!("gen/interface/{pkg_namespace}/{pkg_name}/types"),
+        )?;
+    }
 
     for agent in agent_types {
         let agent_name = agent.type_name.to_lower_camel_case();
@@ -337,6 +364,7 @@ fn setup_dependencies(
         )?;
         depends_on_types(
             component,
+            has_types,
             pkg_namespace,
             pkg_name,
             &format!("gen/interface/{pkg_namespace}/{pkg_name}/{agent_name}"),
@@ -447,7 +475,7 @@ fn generate_agent_stub(
 
     for method in &agent.methods {
         let original_method_name = &method.name;
-        let method_name = method.name.to_snake_case();
+        let method_name = to_moonbit_ident(&method.name);
 
         let moonbit_param_defs =
             to_moonbit_parameter_list(ctx, &method.input_schema, original_method_name, false)?;
@@ -501,7 +529,7 @@ fn to_moonbit_parameter_list(
                     write!(result, ", ")?;
                 }
 
-                let param_name = parameter.name.to_snake_case();
+                let param_name = to_moonbit_ident(&parameter.name);
                 match &parameter.schema {
                     ElementSchema::ComponentModel(typ) => {
                         write!(
@@ -722,7 +750,7 @@ fn build_data_value(
             writeln!(result, "    @common.DataValue::Tuple([")?;
 
             for element in elements {
-                let param_name = element.name.to_snake_case();
+                let param_name = to_moonbit_ident(&element.name);
                 build_element_value(result, ctx, &element.schema, &param_name, "      ")?;
                 writeln!(result, ",")?;
             }
@@ -922,7 +950,7 @@ fn write_builder(
         AnalysedType::Record(record) => {
             writeln!(result, "{indent}{builder}.record(builder => {{")?;
             for field in &record.fields {
-                let field_name = field.name.to_snake_case();
+                let field_name = to_moonbit_ident(&field.name);
                 write_builder(
                     result,
                     ctx,
@@ -1266,7 +1294,7 @@ fn extract_wit_value(
             writeln!(result, "{indent}{record_name}::{{")?;
 
             for (idx, field) in record.fields.iter().enumerate() {
-                let field_name = field.name.to_snake_case();
+                let field_name = to_moonbit_ident(&field.name);
 
                 writeln!(result, "{indent}  {field_name}: {{")?;
                 extract_wit_value(
@@ -1355,6 +1383,31 @@ fn extract_wit_value(
     Ok(())
 }
 
+fn to_moonbit_ident(name: impl AsRef<str>) -> String {
+    // Escape MoonBit keywords and reserved keywords
+    let name = name.as_ref();
+    match name {
+        // Keywords
+        "as" | "else" | "extern" | "fn" | "fnalias" | "if" | "let" | "const" | "match" | "using"
+        | "mut" | "type" | "typealias" | "struct" | "enum" | "trait" | "traitalias" | "derive"
+        | "while" | "break" | "continue" | "import" | "return" | "throw" | "raise" | "try" | "catch"
+        | "pub" | "priv" | "readonly" | "true" | "false" | "_" | "test" | "loop" | "for" | "in" | "impl"
+        | "with" | "guard" | "async" | "is" | "suberror" | "and" | "letrec" | "enumview" | "noraise"
+        | "defer" | "init" | "main"
+        // Reserved keywords
+        | "module" | "move" | "ref" | "static" | "super" | "unsafe" | "use" | "where" | "await"
+        | "dyn" | "abstract" | "do" | "final" | "macro" | "override" | "typeof" | "virtual" | "yield"
+        | "local" | "method" | "alias" | "assert" | "recur" | "isnot" | "define" | "downcast"
+            | "inherit" | "member" | "namespace" | "upcast" | "void" | "lazy" | "include" | "mixin"
+            | "protected" | "sealed" | "constructor" | "atomic" | "volatile" | "anyframe" | "anytype"
+            | "asm" | "comptime" | "errdefer" | "export" | "opaque" | "orelse" | "resume" | "threadlocal"
+            | "unreachable" | "dynclass" | "dynobj" | "dynrec" | "var" | "finally" | "noasync" => {
+        format ! ("{name}_")
+        }
+        _ => name.to_snake_case(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::model::agent::moonbit::generate_moonbit_wrapper;
@@ -1381,6 +1434,16 @@ mod tests {
     fn multi_agent_example(_trace: &Trace) {
         let component_name: AppComponentName = "example:multi1".into();
         let agent_types = test::multi_agent_wrapper_2_types();
+        let ctx = generate_agent_wrapper_wit(&component_name, &agent_types).unwrap();
+
+        let target = NamedTempFile::new().unwrap();
+        generate_moonbit_wrapper(ctx, target.path()).unwrap();
+    }
+
+    #[test]
+    fn single_agent_with_wit_keywords(_trace: &Trace) {
+        let component_name: AppComponentName = "example:single1".into();
+        let agent_types = test::agent_type_with_wit_keywords();
         let ctx = generate_agent_wrapper_wit(&component_name, &agent_types).unwrap();
 
         let target = NamedTempFile::new().unwrap();

--- a/cli/golem-cli/src/model/agent/moonbit.rs
+++ b/cli/golem-cli/src/model/agent/moonbit.rs
@@ -175,6 +175,7 @@ fn add_builder_package(
             Utf8Path::new("builder").join("top.mbt"),
         ],
         warning_control: vec![],
+        alert_control: vec![],
         output: Utf8Path::new("target")
             .join("wasm")
             .join("release")
@@ -244,6 +245,7 @@ fn add_extractor_package(
             Utf8Path::new("extractor").join("top.mbt"),
         ],
         warning_control: vec![],
+        alert_control: vec![],
         output: Utf8Path::new("target")
             .join("wasm")
             .join("release")

--- a/cli/golem-cli/src/model/agent/test.rs
+++ b/cli/golem-cli/src/model/agent/test.rs
@@ -145,3 +145,65 @@ pub fn multi_agent_wrapper_2_types() -> Vec<AgentType> {
 
     agent_types
 }
+
+pub fn agent_type_with_wit_keywords() -> Vec<AgentType> {
+    vec![AgentType {
+        type_name: "agent1".to_string(),
+        description: "An example agent using WIT keywords as names".to_string(),
+        constructor: AgentConstructor {
+            name: None,
+            description: "Creates an example agent instance".into(),
+            prompt_hint: None,
+            input_schema: DataSchema::Tuple(NamedElementSchemas {
+                elements: vec![
+                    NamedElementSchema {
+                        name: "export".to_string(),
+                        schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                            element_type: u32(),
+                        }),
+                    },
+                    NamedElementSchema {
+                        name: "func".to_string(),
+                        schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                            element_type: option(str()),
+                        }),
+                    },
+                ],
+            }),
+        },
+        methods: vec![
+            AgentMethod {
+                name: "import".to_string(),
+                description: "returns a random string".to_string(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas { elements: vec![] }),
+                output_schema: DataSchema::Tuple(NamedElementSchemas {
+                    elements: vec![NamedElementSchema {
+                        name: "interface".to_string(),
+                        schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                            element_type: str(),
+                        }),
+                    }],
+                }),
+            },
+            AgentMethod {
+                name: "package".to_string(),
+                description: "adds two numbers".to_string(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas {
+                    elements: crate::model::agent::wit::WIT_KEYWORDS
+                        .iter()
+                        .map(|keyword| NamedElementSchema {
+                            name: keyword.to_string(),
+                            schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                                element_type: u32(),
+                            }),
+                        })
+                        .collect(),
+                }),
+                output_schema: DataSchema::Tuple(NamedElementSchemas { elements: vec![] }),
+            },
+        ],
+        dependencies: vec![],
+    }]
+}


### PR DESCRIPTION
Resolves #1919 
(Partially) resolves #1992 

Note that the ` [E2000] Warning (Alert deprecated): Use `Int::unsafe_to_char` instead, and use `Int::to_char` for safe conversion` warning does not seem to be removable.