### PR TITLE
Small CLI improvements

### DIFF
--- a/cli/golem-cli/src/command.rs
+++ b/cli/golem-cli/src/command.rs
@@ -134,6 +134,10 @@ pub struct GolemCliGlobalFlags {
     #[arg(long, global = true, display_order = 110)]
     pub show_sensitive: bool,
 
+    /// Enable experimental, development-only features
+    #[arg(long, short, global = true, display_order = 111)]
+    pub dev_mode: bool,
+
     #[command(flatten)]
     pub verbosity: Verbosity,
 

--- a/cli/golem-cli/src/command_handler/app.rs
+++ b/cli/golem-cli/src/command_handler/app.rs
@@ -162,7 +162,7 @@ impl AppCommandHandler {
             let common_templates = languages
                 .iter()
                 .map(|language| {
-                    self.get_template(&language.id())
+                    self.get_template(&language.id(), self.ctx.dev_mode())
                         .map(|(common, _component)| common)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -204,7 +204,8 @@ impl AppCommandHandler {
                             .log_color_highlight()
                     ),
                 );
-                let (common_template, component_template) = self.get_template(template)?;
+                let (common_template, component_template) =
+                    self.get_template(template, self.ctx.dev_mode())?;
                 match add_component_by_template(
                     common_template,
                     Some(component_template),
@@ -629,6 +630,7 @@ impl AppCommandHandler {
     pub fn get_template(
         &self,
         requested_template_name: &str,
+        dev_mode: bool,
     ) -> anyhow::Result<(Option<&Template>, &Template)> {
         let segments = requested_template_name.split("/").collect::<Vec<_>>();
         let (language, template_name): (String, Option<String>) = match segments.len() {
@@ -643,7 +645,7 @@ impl AppCommandHandler {
             }),
             _ => {
                 log_error("Failed to parse template name");
-                self.log_templates_help(None, None);
+                self.log_templates_help(None, None, self.ctx.dev_mode());
                 bail!(NonSuccessfulExit);
             }
         };
@@ -652,7 +654,7 @@ impl AppCommandHandler {
             Some(language) => language,
             None => {
                 log_error("Failed to parse language part of the template!");
-                self.log_templates_help(None, None);
+                self.log_templates_help(None, None, self.ctx.dev_mode());
                 bail!(NonSuccessfulExit);
             }
         };
@@ -660,9 +662,9 @@ impl AppCommandHandler {
             .map(TemplateName::from)
             .unwrap_or_else(|| TemplateName::from("default"));
 
-        let Some(lang_templates) = self.ctx.templates().get(&language) else {
+        let Some(lang_templates) = self.ctx.templates(dev_mode).get(&language) else {
             log_error(format!("No templates found for language: {language}").as_str());
-            self.log_templates_help(None, None);
+            self.log_templates_help(None, None, self.ctx.dev_mode());
             bail!(NonSuccessfulExit);
         };
 
@@ -675,7 +677,7 @@ impl AppCommandHandler {
                 "Template {} not found!",
                 requested_template_name.log_color_highlight()
             ));
-            self.log_templates_help(None, None);
+            self.log_templates_help(None, None, self.ctx.dev_mode());
             bail!(NonSuccessfulExit);
         };
 
@@ -697,6 +699,7 @@ impl AppCommandHandler {
         &self,
         language_filter: Option<GuestLanguage>,
         template_filter: Option<&str>,
+        dev_mode: bool,
     ) {
         if language_filter.is_none() && template_filter.is_none() {
             logln(format!(
@@ -709,7 +712,7 @@ impl AppCommandHandler {
 
         let templates = self
             .ctx
-            .templates()
+            .templates(dev_mode)
             .iter()
             .filter_map(|(language, templates)| {
                 templates

--- a/cli/golem-cli/src/command_handler/component/mod.rs
+++ b/cli/golem-cli/src/command_handler/component/mod.rs
@@ -188,7 +188,9 @@ impl ComponentCommandHandler {
                 "Both TEMPLATE and COMPONENT_PACKAGE_NAME are required in non-interactive mode",
             );
             logln("");
-            self.ctx.app_handler().log_templates_help(None, None);
+            self.ctx
+                .app_handler()
+                .log_templates_help(None, None, self.ctx.dev_mode());
             logln("");
             bail!(HintError::ShowClapHelp(ShowClapHelpTarget::ComponentNew));
         };
@@ -206,7 +208,8 @@ impl ComponentCommandHandler {
         }
 
         let app_handler = self.ctx.app_handler();
-        let (common_template, component_template) = app_handler.get_template(&template)?;
+        let (common_template, component_template) =
+            app_handler.get_template(&template, self.ctx.dev_mode())?;
 
         // Unloading app context, so we can reload after the new component is created
         self.ctx.unload_app_context().await;
@@ -296,16 +299,23 @@ impl ComponentCommandHandler {
         match filter {
             Some(filter) => {
                 if let Some(language) = GuestLanguage::from_string(filter.clone()) {
-                    self.ctx
-                        .app_handler()
-                        .log_templates_help(Some(language), None);
+                    self.ctx.app_handler().log_templates_help(
+                        Some(language),
+                        None,
+                        self.ctx.dev_mode(),
+                    );
                 } else {
-                    self.ctx
-                        .app_handler()
-                        .log_templates_help(None, Some(&filter));
+                    self.ctx.app_handler().log_templates_help(
+                        None,
+                        Some(&filter),
+                        self.ctx.dev_mode(),
+                    );
                 }
             }
-            None => self.ctx.app_handler().log_templates_help(None, None),
+            None => self
+                .ctx
+                .app_handler()
+                .log_templates_help(None, None, self.ctx.dev_mode()),
         }
     }
 

--- a/cli/golem-cli/src/command_handler/interactive.rs
+++ b/cli/golem-cli/src/command_handler/interactive.rs
@@ -597,9 +597,17 @@ impl InteractiveHandler {
         &self,
         existing_component_names: HashSet<String>,
     ) -> anyhow::Result<Option<(String, PackageName)>> {
+        let available_languages = self
+            .ctx
+            .templates(self.ctx.dev_mode())
+            .keys()
+            .collect::<HashSet<_>>();
+
         let Some(language) = Select::new(
             "Select language for the new component",
-            GuestLanguage::iter().collect(),
+            GuestLanguage::iter()
+                .filter(|lang| available_languages.contains(lang))
+                .collect(),
         )
         .prompt()
         .none_if_not_interactive_logged()?
@@ -609,7 +617,7 @@ impl InteractiveHandler {
 
         let template_options = self
             .ctx
-            .templates()
+            .templates(self.ctx.dev_mode())
             .get(&language)
             .unwrap()
             .get(&ComposableAppGroupName::default())

--- a/cli/golem-cli/src/command_handler/partial_match.rs
+++ b/cli/golem-cli/src/command_handler/partial_match.rs
@@ -251,7 +251,9 @@ impl ErrorHandler {
                         self.ctx.app_handler().log_languages_help();
                     }
                     ShowClapHelpTarget::ComponentNew => {
-                        self.ctx.app_handler().log_templates_help(None, None);
+                        self.ctx
+                            .app_handler()
+                            .log_templates_help(None, None, self.ctx.dev_mode());
                     }
                     ShowClapHelpTarget::ComponentAddDependency => {}
                 }

--- a/cli/golem-cli/src/context.rs
+++ b/cli/golem-cli/src/context.rs
@@ -79,6 +79,7 @@ pub struct Context {
     client_config: ClientConfig,
     yes: bool,
     show_sensitive: bool,
+    dev_mode: bool,
     #[allow(unused)]
     start_local_server: Box<dyn Fn() -> BoxFuture<'static, anyhow::Result<()>> + Send + Sync>,
 
@@ -110,6 +111,7 @@ impl Context {
         let show_sensitive = global_flags.show_sensitive;
 
         let mut yes = global_flags.yes;
+        let dev_mode = global_flags.dev_mode;
         let mut update_or_redeploy = UpdateOrRedeployArgs::none();
 
         let mut app_context_config = ApplicationContextConfig::new(global_flags);
@@ -218,6 +220,7 @@ impl Context {
             auth_token_override: auth_token,
             project,
             yes,
+            dev_mode,
             show_sensitive,
             start_local_server,
             client_config,
@@ -255,6 +258,10 @@ impl Context {
 
     pub fn yes(&self) -> bool {
         self.yes
+    }
+
+    pub fn dev_mode(&self) -> bool {
+        self.dev_mode
     }
 
     pub fn show_sensitive(&self) -> bool {
@@ -449,9 +456,10 @@ impl Context {
 
     pub fn templates(
         &self,
+        dev_mode: bool,
     ) -> &BTreeMap<GuestLanguage, BTreeMap<ComposableAppGroupName, ComposableAppTemplate>> {
         self.templates
-            .get_or_init(golem_templates::all_composable_app_templates)
+            .get_or_init(|| golem_templates::all_composable_app_templates(dev_mode))
     }
 
     pub async fn select_account_by_email_or_error(

--- a/cli/golem-cli/src/model/component.rs
+++ b/cli/golem-cli/src/model/component.rs
@@ -20,6 +20,9 @@ use chrono::{DateTime, Utc};
 use golem_client::model::{
     AnalysedType, ComponentMetadata, ComponentType, InitialComponentFile, VersionedComponentId,
 };
+use golem_common::model::agent::{
+    AgentType, ComponentModelElementSchema, DataSchema, ElementSchema,
+};
 use golem_common::model::component_metadata::DynamicLinkedInstance;
 use golem_common::model::trim_date::TrimDateTime;
 use golem_wasm_ast::analysis::wave::DisplayNamedFunc;
@@ -27,6 +30,7 @@ use golem_wasm_ast::analysis::{
     AnalysedExport, AnalysedFunction, AnalysedInstance, AnalysedResourceMode, NameOptionTypePair,
     NameTypePair, TypeEnum, TypeFlags, TypeRecord, TypeTuple, TypeVariant,
 };
+use itertools::Itertools;
 use rib::{ParsedFunctionName, ParsedFunctionSite};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -179,7 +183,11 @@ impl ComponentView {
             component_size: value.component_size,
             created_at: value.created_at,
             project_id: value.project_id,
-            exports: show_exported_functions(value.metadata.exports(), true),
+            exports: if value.metadata.is_agent() {
+                show_exported_agents(value.metadata.agent_types())
+            } else {
+                show_exported_functions(value.metadata.exports(), true)
+            },
             dynamic_linking: value
                 .metadata
                 .dynamic_linking()
@@ -276,6 +284,83 @@ pub fn render_type(typ: &AnalysedType) -> String {
             AnalysedResourceMode::Borrowed => format!("&handle<{}>", handle.resource_id.0),
             AnalysedResourceMode::Owned => format!("handle<{}>", handle.resource_id.0),
         },
+    }
+}
+
+pub fn show_exported_agents(agents: &[AgentType]) -> Vec<String> {
+    agents.iter().flat_map(render_exported_agent).collect()
+}
+
+fn render_exported_agent(agent: &AgentType) -> Vec<String> {
+    let mut result = Vec::new();
+    result.push(format!(
+        "{}({}) agent constructor",
+        agent.type_name,
+        render_data_schema(&agent.constructor.input_schema)
+    ));
+    for method in &agent.methods {
+        result.push(format!(
+            "{}.{}({}) -> {}",
+            agent.type_name,
+            method.name,
+            render_data_schema(&method.input_schema),
+            render_data_schema(&method.output_schema)
+        ));
+    }
+
+    result
+}
+
+fn render_data_schema(schema: &DataSchema) -> String {
+    match schema {
+        DataSchema::Tuple(elements) => elements
+            .elements
+            .iter()
+            .map(|named_elem| {
+                format!(
+                    "{}: {}",
+                    named_elem.name,
+                    render_element_schema(&named_elem.schema)
+                )
+            })
+            .join(", "),
+        DataSchema::Multimodal(elements) => elements
+            .elements
+            .iter()
+            .map(|named_elem| {
+                format!(
+                    "{}({})",
+                    named_elem.name,
+                    render_element_schema(&named_elem.schema)
+                )
+            })
+            .join(" | "),
+    }
+}
+
+fn render_element_schema(schema: &ElementSchema) -> String {
+    match schema {
+        ElementSchema::ComponentModel(ComponentModelElementSchema { element_type }) => {
+            render_type(element_type)
+        }
+        ElementSchema::UnstructuredText(text_descriptor) => {
+            let mut result = "text".to_string();
+            if let Some(restrictions) = &text_descriptor.restrictions {
+                result.push('[');
+                result.push_str(&restrictions.iter().map(|r| &r.language_code).join(", "));
+                result.push(']');
+            }
+            result
+        }
+        ElementSchema::UnstructuredBinary(binary_descriptor) => {
+            let mut result = "binary".to_string();
+            if let Some(restrictions) = &binary_descriptor.restrictions {
+                result.push('[');
+                result.push_str(&restrictions.iter().map(|r| &r.mime_type).join(", "));
+                result.push(']');
+            }
+            result
+        }
     }
 }
 

--- a/cli/golem-templates/src/lib.rs
+++ b/cli/golem-templates/src/lib.rs
@@ -54,7 +54,7 @@ static APP_MANIFEST_COMPONENT_HINTS_TEMPLATE: &str = indoc! {"
 #    type: wasm-rpc
 "};
 
-fn all_templates() -> Vec<Template> {
+fn all_templates(dev_mode: bool) -> Vec<Template> {
     let mut result: Vec<Template> = vec![];
     for entry in TEMPLATES.entries() {
         if let Some(lang_dir) = entry.as_dir() {
@@ -74,7 +74,9 @@ fn all_templates() -> Vec<Template> {
                                 template_dir.path(),
                             );
 
-                            result.push(template);
+                            if dev_mode || !template.dev_only {
+                                result.push(template);
+                            }
                         }
                     }
                 }
@@ -87,7 +89,7 @@ fn all_templates() -> Vec<Template> {
 }
 
 pub fn all_standalone_templates() -> Vec<Template> {
-    all_templates()
+    all_templates(true)
         .into_iter()
         .filter(|template| matches!(template.kind, TemplateKind::Standalone))
         .collect()
@@ -100,6 +102,7 @@ pub struct ComposableAppTemplate {
 }
 
 pub fn all_composable_app_templates(
+    dev_mode: bool,
 ) -> BTreeMap<GuestLanguage, BTreeMap<ComposableAppGroupName, ComposableAppTemplate>> {
     let mut templates =
         BTreeMap::<GuestLanguage, BTreeMap<ComposableAppGroupName, ComposableAppTemplate>>::new();
@@ -119,7 +122,7 @@ pub fn all_composable_app_templates(
         groups.get_mut(group).unwrap()
     }
 
-    for template in all_templates() {
+    for template in all_templates(dev_mode) {
         match &template.kind {
             TemplateKind::Standalone => continue,
             TemplateKind::ComposableAppCommon { group, .. } => {
@@ -648,5 +651,6 @@ fn parse_template(
             .map(|te| te.iter().cloned().collect())
             .unwrap_or_default(),
         transform: metadata.transform.unwrap_or(true),
+        dev_only: metadata.dev_only.unwrap_or(false),
     }
 }

--- a/cli/golem-templates/src/model.rs
+++ b/cli/golem-templates/src/model.rs
@@ -395,6 +395,7 @@ pub struct Template {
     pub exclude: HashSet<String>,
     pub transform_exclude: HashSet<String>,
     pub transform: bool,
+    pub dev_only: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -424,6 +425,8 @@ pub(crate) struct TemplateMetadata {
     #[serde(rename = "transformExclude")]
     pub transform_exclude: Option<Vec<String>>,
     pub transform: Option<bool>,
+    #[serde(rename = "devOnly")]
+    pub dev_only: Option<bool>,
 }
 
 #[cfg(test)]

--- a/cli/golem-templates/src/test/main.rs
+++ b/cli/golem-templates/src/test/main.rs
@@ -127,7 +127,7 @@ pub fn main() -> anyhow::Result<()> {
                 std::fs::remove_dir_all(&target_path)?;
             }
 
-            let app_templates = all_composable_app_templates();
+            let app_templates = all_composable_app_templates(true);
 
             let mut used_languages = HashSet::<GuestLanguage>::new();
             for (language, templates) in &app_templates {

--- a/cli/golem-templates/templates/rust/rust-app-common/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-common/metadata.json
@@ -7,5 +7,6 @@
   "witDepsPaths": [
     "wit/deps"
   ],
-  "transform": false
+  "transform": false,
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-async/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-async/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Rust component template with async support",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-custom-snapshot/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-custom-snapshot/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "A Rust component implementing the custom save/load snapshot interface",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-default/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-default/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "The default component template for Rust",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-example-gitpulse-agent/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-example-gitpulse-agent/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Example: a component implementing an AI application for improving GitHub notifications",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-example-shopping-cart/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-example-shopping-cart/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Example: a stateful Golem worker representing a shopping cart, implemented in Rust",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-example-todo-list/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-example-todo-list/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Example: a stateful Golem worker representing a todo list, implemented in Rust",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-minimal/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-minimal/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Minimal component template for Rust with no dependencies",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-oplog-processor/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-oplog-processor/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "Oplog processor plugin implemented in Rust",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }

--- a/cli/golem-templates/templates/rust/rust-app-component-wasi-http/metadata.json
+++ b/cli/golem-templates/templates/rust/rust-app-component-wasi-http/metadata.json
@@ -1,4 +1,5 @@
 {
   "description": "A Rust worker implementing wasi:http/incoming-handler. For use with the http-handler api gateway binding type",
-  "appComponentGroup": "default"
+  "appComponentGroup": "default",
+  "devOnly": true
 }


### PR DESCRIPTION
- Hiding the Rust templates by default (only show with `--dev-mode`)
- Showing an initial version of the "rendered agent exports" instead of the WIT interface:

```
╔═
║ Started Rib REPL for component my:agent using version 0
║
║ Component name:    my:agent
║ Component ID:      c2ab5b41-48f4-4c25-956f-177dd967d15b
║ Component type:    Durable
║ Component version: 0
║ Project ID:        77b4400d-2e7a-468e-9a57-c14be53d30eb
║ Component size:    2.82 MiB
║ Created at:        2025-09-02 08:29:49.321714 UTC
║ Exports:
║   assistant-agent() agent constructor
║   assistant-agent.ask(name: string) -> return-value: string
║   weather-agent(username: string) agent constructor
║   weather-agent.getWeather(name: string, param2: record { data: string, value: s32 }) -> return-value: string
╚═
```