### PR TITLE
Removed result<_, agent-error> from agent wrapper interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6733,9 +6733,9 @@ dependencies = [
 
 [[package]]
 name = "moonbit-component-generator"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5ccc7fa3d846202ac3866c2c27dc8eaafac0559fec4dcb7fd65dbaf24ac65d"
+checksum = "d2c7bd660ec5129ad786ffeb2b904a996125e908f47434893efe68bd70c9794a"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 mime = "0.3.17"
 mime_guess = "2.0.5"
 minijinja = "2.7.0"
-moonbit-component-generator = { version = "0.0.5", features = ["get-script"] }
+moonbit-component-generator = { version = "0.0.6", features = ["get-script"] }
 nanoid = "0.4.0"
 native-tls = "0.2.13"
 nom = "7.1.3"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -130,6 +130,7 @@ cp wit/deps/io cli/golem-cli/wit/deps
 cp wit/deps/golem-1.x cli/golem-cli/wit/deps
 cp wit/deps/golem-rpc cli/golem-cli/wit/deps
 cp wit/deps/golem-agent cli/golem-cli/wit/deps
+cp wit/deps/logging cli/golem-cli/wit/deps
 """
 
 [tasks.wit-template-golem-agent-ts]

--- a/cli/golem-cli/wit/deps/logging/logging.wit
+++ b/cli/golem-cli/wit/deps/logging/logging.wit
@@ -1,0 +1,37 @@
+package wasi:logging;
+
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}

--- a/golem-common/src/model/agent/mod.rs
+++ b/golem-common/src/model/agent/mod.rs
@@ -194,6 +194,15 @@ pub enum DataSchema {
     Multimodal(NamedElementSchemas),
 }
 
+impl DataSchema {
+    pub fn is_unit(&self) -> bool {
+        match self {
+            DataSchema::Tuple(element_schemas) => element_schemas.elements.is_empty(),
+            DataSchema::Multimodal(element_schemas) => element_schemas.elements.is_empty(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
 #[cfg_attr(feature = "poem", derive(poem_openapi::Union))]
 #[cfg_attr(feature = "poem", oai(discriminator_name = "type", one_of = true))]

--- a/golem-common/src/model/mod.rs
+++ b/golem-common/src/model/mod.rs
@@ -1669,7 +1669,7 @@ impl FromStr for ScanCursor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Encode, Decode, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Encode, Decode, Serialize, Deserialize)]
 pub enum LogLevel {
     Trace,
     Debug,
@@ -1677,6 +1677,20 @@ pub enum LogLevel {
     Warn,
     Error,
     Critical,
+}
+
+impl Display for LogLevel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+            LogLevel::Critical => "critical",
+        };
+        write!(f, "{}", s)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
Resolves #2041 

Also adds the wasi:logging messages to the invocation failure above warning level (previously it only contained the captured `stderr`)