### PR TITLE
Try to increase "open file limit" on "golem server" start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "prometheus 0.13.4",
  "regex",
  "reqwest 0.12.23",
+ "rlimit",
  "rustls 0.23.31",
  "serde",
  "tempfile",
@@ -9142,6 +9143,15 @@ dependencies = [
  "crossbeam-utils",
  "portable-atomic",
  "portable-atomic-util",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ redis = { version = "0.29.1", features = ["default", "tokio-comp"] }
 regex = "1.11.1"
 reqwest = { version = "0.12.13", features = ["gzip", "json", "multipart", "stream", ] }
 ringbuf = "0.4.7"
+rlimit = "0.10.2"
 rsa = "0.9.7"
 rusoto_acm = "0.48.0"
 rusoto_core = "0.48.0"

--- a/cli/golem-cli/src/command.rs
+++ b/cli/golem-cli/src/command.rs
@@ -160,6 +160,9 @@ pub struct GolemCliGlobalFlags {
 
     #[arg(skip)]
     pub local_server_auto_start: bool,
+
+    #[arg(skip)]
+    pub server_no_limit_change: bool,
 }
 
 impl GolemCliGlobalFlags {
@@ -230,6 +233,13 @@ impl GolemCliGlobalFlags {
 
         if let Ok(auto_start) = std::env::var("GOLEM_LOCAL_SERVER_AUTO_START") {
             self.local_server_auto_start = auto_start
+                .parse::<LenientBool>()
+                .map(|b| b.into())
+                .unwrap_or_default()
+        }
+
+        if let Ok(server_no_limit_change) = std::env::var("GOLEM_SERVER_NO_LIMIT_CHANGE") {
+            self.server_no_limit_change = server_no_limit_change
                 .parse::<LenientBool>()
                 .map(|b| b.into())
                 .unwrap_or_default()

--- a/cli/golem-cli/src/context.rs
+++ b/cli/golem-cli/src/context.rs
@@ -80,6 +80,7 @@ pub struct Context {
     yes: bool,
     show_sensitive: bool,
     dev_mode: bool,
+    server_no_limit_change: bool,
     #[allow(unused)]
     start_local_server: Box<dyn Fn() -> BoxFuture<'static, anyhow::Result<()>> + Send + Sync>,
 
@@ -109,6 +110,7 @@ impl Context {
         let config_dir = global_flags.config_dir();
         let local_server_auto_start = global_flags.local_server_auto_start;
         let show_sensitive = global_flags.show_sensitive;
+        let server_no_limit_change = global_flags.server_no_limit_change;
 
         let mut yes = global_flags.yes;
         let dev_mode = global_flags.dev_mode;
@@ -222,6 +224,7 @@ impl Context {
             yes,
             dev_mode,
             show_sensitive,
+            server_no_limit_change,
             start_local_server,
             client_config,
             golem_clients: tokio::sync::OnceCell::new(),
@@ -270,6 +273,10 @@ impl Context {
 
     pub fn update_or_redeploy(&self) -> &UpdateOrRedeployArgs {
         &self.update_or_redeploy
+    }
+
+    pub fn server_no_limit_change(&self) -> bool {
+        self.server_no_limit_change
     }
 
     pub async fn silence_app_context_init(&self) {

--- a/cli/golem/Cargo.toml
+++ b/cli/golem/Cargo.toml
@@ -46,6 +46,7 @@ poem = { workspace = true }
 prometheus = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+rlimit = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/golem/src/command_handler.rs
+++ b/cli/golem/src/command_handler.rs
@@ -20,17 +20,26 @@ use golem_cli::command_handler::CommandHandlerHooks;
 use golem_cli::context::Context;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tracing::debug;
 
 pub struct ServerCommandHandler;
 
 impl CommandHandlerHooks for ServerCommandHandler {
     async fn handler_server_commands(
         &self,
-        _ctx: Arc<Context>,
+        ctx: Arc<Context>,
         subcommand: ServerSubcommand,
     ) -> anyhow::Result<()> {
         match subcommand {
             ServerSubcommand::Run { args } => {
+                if !ctx.server_no_limit_change() {
+                    let file_limit_increase_result = rlimit::increase_nofile_limit(1000000);
+                    debug!(
+                        "File limit increase result: {:?}",
+                        file_limit_increase_result
+                    );
+                }
+
                 let data_dir = match &args.data_dir {
                     Some(data_dir) => data_dir.to_path_buf(),
                     None => default_data_dir()?,


### PR DESCRIPTION
On mac with defaults (which is 256 soft limit):
```
golem server run --clean -vvv
  2025-09-08T09:16:21.692653Z DEBUG golem_cli::context: Loaded profiles, profile_name: local, manifest_profile: None
    at cli/golem-cli/src/context.rs:141

  2025-09-08T09:16:21.692681Z DEBUG golem_cli::log: set log output, output: Stdout
    at cli/golem-cli/src/log.rs:134

Selected profile: local
  2025-09-08T09:16:21.695058Z DEBUG golem::command_handler: File limit increase result: Ok(138240)
    at cli/golem/src/command_handler.rs:37
    ```