### PR TITLE
Make sure `none` as constructor argument for agents is inferred correctly in Rib

### DIFF
--- a/golem-rib/src/interpreter/rib_interpreter.rs
+++ b/golem-rib/src/interpreter/rib_interpreter.rs
@@ -4741,6 +4741,7 @@ mod tests {
                 let number = "usa";
                 let boolean = true;
                 let optional-str = some("optional");
+                let optional-number = some(2);
                 let list-of-str = ["a", "b", "c"];
                 let tuple = (text, 1, boolean, optional-str);
                 let record = {city: text, country: number};
@@ -4748,7 +4749,7 @@ mod tests {
                 let result-ok = ok(text);
                 let result-err = err(1);
                 let variant = foo("bar");
-                let weather-agent = weather-agent("text", 1, true, optional-str, list-of-str, tuple, record, result, result-ok, result-err, variant);
+                let weather-agent = weather-agent("text", 1, true, optional-str, optional-number, none, none, list-of-str, tuple, record, result, result-ok, result-err, variant);
                 let first-result = weather-agent.get-weather("bar");
                 let assistant-agent = assistant-agent("my assistant");
                 let second-result = assistant-agent.ask("foo", "bar");
@@ -4760,6 +4761,9 @@ mod tests {
             s32(),
             bool(),
             option(str()),
+            option(u64()),
+            option(str()),
+            option(u64()),
             list(str()),
             tuple(vec![str(), s32(), bool(), option(str())]),
             record(vec![field("city", str()), field("country", str())]),
@@ -4813,7 +4817,7 @@ mod tests {
             Value::Record(vec![
                 // worker-name
                 Value::String(
-                    "weather-agent(\"text\",1,true,some(\"optional\"),[\"a\", \"b\", \"c\"],(\"nyc\", 1, true, some(\"optional\")),{city: \"nyc\", country: \"usa\"},ok(\"nyc\"),ok(\"nyc\"),err(1),foo(\"bar\"))".to_string(),
+                    "weather-agent(\"text\",1,true,some(\"optional\"),some(2),none,none,[\"a\", \"b\", \"c\"],(\"nyc\", 1, true, some(\"optional\")),{city: \"nyc\", country: \"usa\"},ok(\"nyc\"),ok(\"nyc\"),err(1),foo(\"bar\"))".to_string(),
                 ),
                 // function-name
                 Value::String("my:agent/weather-agent.{get-weather}".to_string()),

--- a/golem-rib/src/type_inference/identify_instance_creation.rs
+++ b/golem-rib/src/type_inference/identify_instance_creation.rs
@@ -160,7 +160,7 @@ pub fn identify_instance_creation_with_worker(
 fn get_instance_creation_details(
     call_type: &CallType,
     type_parameter: Option<TypeParameter>,
-    args: &[Expr],
+    args: &mut [Expr],
     component_dependency: &ComponentDependencies,
     custom_instance_spec: &[CustomInstanceSpec],
 ) -> Result<(Option<InstanceCreationType>, Option<TypeParameter>), String> {
@@ -206,11 +206,14 @@ fn get_instance_creation_details(
                             }
 
                             let mut args_iter = args
-                                .iter()
+                                .iter_mut()
                                 .zip(custom_instance_spec.parameter_types)
                                 .peekable();
 
                             while let Some((arg, analysed_type)) = args_iter.next() {
+                                let inferred_type = InferredType::from(&analysed_type);
+                                arg.add_infer_type_mut(inferred_type);
+
                                 match arg {
                                     // chances of being a string after interpretation
                                     Expr::Literal { .. }


### PR DESCRIPTION
Fixes #2087 

Fixes the following issue:

```
>>> let x = weather-agent(none)
[compilation error]
[position] 23
[expression] none
[help] cannot determine type

// and we forced to do
>>> let r: option<string> = none
()
>>> let x = weather-agent(r)
()
>>>

```

It's a minor fix that we forgot to tag required types into constructor arguments. There is a separate ticket that will involve more testing
