### PR TITLE
Use the generated wrapper constructor's parameter types in rib for agent constructors

### DIFF
--- a/golem-common/src/model/agent/mod.rs
+++ b/golem-common/src/model/agent/mod.rs
@@ -44,7 +44,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use bincode::{Decode, Encode};
 use golem_wasm_ast::analysis::analysed_type::{case, str, tuple, variant};
-use golem_wasm_ast::analysis::{AnalysedType, NameOptionTypePair, TypeStr};
+use golem_wasm_ast::analysis::AnalysedType;
 use golem_wasm_rpc::{parse_value_and_type, print_value_and_type, IntoValue, Value, ValueAndType};
 use golem_wasm_rpc_derive::IntoValue;
 use serde::{Deserialize, Serialize};
@@ -62,47 +62,6 @@ pub struct AgentConstructor {
     pub description: String,
     pub prompt_hint: Option<String>,
     pub input_schema: DataSchema,
-}
-
-impl AgentConstructor {
-    pub fn wit_arg_types(&self) -> Vec<AnalysedType> {
-        match &self.input_schema {
-            DataSchema::Tuple(element_schemas) => element_schemas
-                .elements
-                .iter()
-                .map(|named_schema| Self::get_analysed_type(&named_schema.schema))
-                .collect::<Vec<AnalysedType>>(),
-            DataSchema::Multimodal(named_element_schemas) => {
-                // the value is wrapped in names
-                named_element_schemas
-                    .elements
-                    .iter()
-                    .map(|named_schema| {
-                        let name = &named_schema.name;
-
-                        let analysed_type = Self::get_analysed_type(&named_schema.schema);
-
-                        let name_and_type = NameOptionTypePair {
-                            name: name.to_string(),
-                            typ: Some(analysed_type),
-                        };
-
-                        variant(vec![name_and_type])
-                    })
-                    .collect::<Vec<_>>()
-            }
-        }
-    }
-
-    fn get_analysed_type(schema: &ElementSchema) -> AnalysedType {
-        match schema {
-            ElementSchema::ComponentModel(component_model_elem_schema) => {
-                component_model_elem_schema.element_type.to_wit_naming()
-            }
-            ElementSchema::UnstructuredText(_) => AnalysedType::Str(TypeStr),
-            ElementSchema::UnstructuredBinary(_) => AnalysedType::Str(TypeStr),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, IntoValue)]

--- a/golem-worker-service/src/gateway_api_definition/http/api_definition.rs
+++ b/golem-worker-service/src/gateway_api_definition/http/api_definition.rs
@@ -34,11 +34,11 @@ use crate::service::gateway::api_definition_validator::ValidationErrors;
 use crate::service::gateway::security_scheme::SecuritySchemeService;
 use crate::service::gateway::BoxConversionContext;
 use bincode::{Decode, Encode};
-use golem_common::model::agent::AgentType;
 use golem_common::model::auth::Namespace;
 use golem_common::model::component::VersionedComponentId;
+use golem_common::model::component_metadata::ComponentMetadata;
 use golem_service_base::model::Component;
-use golem_wasm_ast::analysis::{AnalysedExport, AnalysedType};
+use golem_wasm_ast::analysis::AnalysedType;
 use poem_openapi::Enum;
 use rib::{ComponentDependencyKey, RibCompilationError, RibInputTypeInfo};
 use serde::de::Error;
@@ -671,8 +671,7 @@ pub struct ComponentMetadataDictionary {
 #[derive(Clone, Debug)]
 pub struct ComponentDetails {
     pub component_info: ComponentDependencyKey,
-    pub metadata: Vec<AnalysedExport>,
-    pub agent_types: Vec<AgentType>,
+    pub metadata: ComponentMetadata,
 }
 
 impl ComponentMetadataDictionary {
@@ -689,8 +688,7 @@ impl ComponentMetadataDictionary {
 
             let component_details = ComponentDetails {
                 component_info,
-                metadata: component.metadata.exports().to_vec(),
-                agent_types: component.metadata.agent_types().to_vec(),
+                metadata: component.metadata.clone(),
             };
 
             metadata.insert(component.versioned_component_id.clone(), component_details);
@@ -735,7 +733,6 @@ impl CompiledRoute {
                 let component_dependency = vec![ComponentDependencyWithAgentInfo::new(
                     component_details.component_info.clone(),
                     component_details.metadata.clone(),
-                    component_details.agent_types.clone(),
                 )];
 
                 let binding = WorkerBindingCompiled::from_raw_worker_binding(
@@ -773,7 +770,6 @@ impl CompiledRoute {
                     vec![ComponentDependencyWithAgentInfo::new(
                         component_details.component_info.clone(),
                         component_details.metadata.clone(),
-                        component_details.agent_types.clone(),
                     )];
 
                 let binding = FileServerBindingCompiled::from_raw_file_server_worker_binding(

--- a/golem-worker-service/src/gateway_rib_compiler/mod.rs
+++ b/golem-worker-service/src/gateway_rib_compiler/mod.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use golem_common::model::agent::AgentType;
-use golem_wasm_ast::analysis::AnalysedExport;
+use golem_common::model::component_metadata::ComponentMetadata;
 use golem_wasm_rpc::IntoValue;
 use rib::{
     CompilerOutput, ComponentDependency, ComponentDependencyKey, Expr, GlobalVariableTypeSpec,
@@ -24,22 +23,19 @@ use uuid::Uuid;
 // A wrapper over ComponentDependency which is coming from rib-module
 // to attach agent types to it.
 pub struct ComponentDependencyWithAgentInfo {
-    agent_types: Vec<AgentType>,
+    component_metadata: ComponentMetadata,
     component_dependency: ComponentDependency,
 }
 
 impl ComponentDependencyWithAgentInfo {
     pub fn new(
         component_dependency_key: ComponentDependencyKey,
-        component_exports: Vec<AnalysedExport>,
-        agent_types: Vec<AgentType>,
+        component_metadata: ComponentMetadata,
     ) -> Self {
+        let exports = component_metadata.exports().to_vec();
         Self {
-            agent_types,
-            component_dependency: ComponentDependency::new(
-                component_dependency_key,
-                component_exports,
-            ),
+            component_metadata,
+            component_dependency: ComponentDependency::new(component_dependency_key, exports),
         }
     }
 }
@@ -60,19 +56,30 @@ impl WorkerServiceRibCompiler for DefaultWorkerServiceRibCompiler {
         rib: &Expr,
         component_dependency: &[ComponentDependencyWithAgentInfo],
     ) -> Result<CompilerOutput, RibCompilationError> {
-        let agent_types = component_dependency
-            .iter()
-            .enumerate()
-            .map(|cd| (cd.0, cd.1.agent_types.clone()))
-            .collect::<Vec<_>>();
-
         let mut custom_instance_spec = vec![];
 
-        for (_component_index, agent_types) in agent_types {
-            for agent_type in agent_types {
+        for dep in component_dependency {
+            let metadata = &dep.component_metadata;
+
+            for agent_type in metadata.agent_types() {
+                let wrapper_function = metadata
+                    .find_wrapper_function_by_agent_constructor(&agent_type.type_name)
+                    .map_err(RibCompilationError::RibStaticAnalysisError)?
+                    .ok_or_else(|| {
+                        RibCompilationError::RibStaticAnalysisError(format!(
+                            "Missing static WIT wrapper for constructor of agent type {}",
+                            agent_type.type_name
+                        ))
+                    })?;
+
                 custom_instance_spec.push(rib::CustomInstanceSpec {
                     instance_name: agent_type.wrapper_type_name(),
-                    parameter_types: agent_type.constructor.wit_arg_types(),
+                    parameter_types: wrapper_function
+                        .analysed_export
+                        .parameters
+                        .iter()
+                        .map(|p| p.typ.clone())
+                        .collect(),
                     interface_name: Some(InterfaceName {
                         name: agent_type.wrapper_type_name(),
                         version: None,

--- a/golem-worker-service/tests/api_gateway_end_to_end_tests.rs
+++ b/golem-worker-service/tests/api_gateway_end_to_end_tests.rs
@@ -2580,6 +2580,7 @@ mod internal {
     };
     use golem_common::model::auth::Namespace;
     use golem_common::model::component::VersionedComponentId;
+    use golem_common::model::component_metadata::ComponentMetadata;
     use golem_common::model::{ComponentId, IdempotencyKey};
     use golem_common::virtual_exports::http_incoming_handler::IncomingHttpRequest;
     use golem_wasm_ast::analysis::analysed_type::{field, handle, record, result, str, tuple, u32};
@@ -2880,15 +2881,13 @@ mod internal {
         exports.extend(get_bigw_shopping_metadata_with_resource());
         exports.extend(get_golem_shopping_cart_metadata());
 
-        let component_details = ComponentDetails {
-            component_info: ComponentDependencyKey {
-                component_name: "agent-component".to_string(),
-                component_id: Uuid::new_v4(),
-                root_package_name: None,
-                root_package_version: None,
-            },
-            metadata: exports,
-            agent_types: vec![AgentType {
+        let metadata = ComponentMetadata::from_parts(
+            exports,
+            vec![],
+            HashMap::new(),
+            Some("my:agent".to_string()),
+            None,
+            vec![AgentType {
                 type_name: "weather-agent".to_string(),
                 description: "".to_string(),
                 constructor: AgentConstructor {
@@ -2907,6 +2906,16 @@ mod internal {
                 methods: vec![],
                 dependencies: vec![],
             }],
+        );
+
+        let component_details = ComponentDetails {
+            component_info: ComponentDependencyKey {
+                component_name: "agent-component".to_string(),
+                component_id: Uuid::new_v4(),
+                root_package_name: None,
+                root_package_version: None,
+            },
+            metadata,
         };
 
         metadata_dict.insert(versioned_component_id, component_details);
@@ -2927,6 +2936,15 @@ mod internal {
         exports.extend(get_bigw_shopping_metadata_with_resource());
         exports.extend(get_golem_shopping_cart_metadata());
 
+        let metadata = ComponentMetadata::from_parts(
+            exports,
+            vec![],
+            HashMap::new(),
+            Some("my:agent".to_string()),
+            None,
+            vec![],
+        );
+
         let component_details = ComponentDetails {
             component_info: ComponentDependencyKey {
                 component_name: "test-component".to_string(),
@@ -2934,8 +2952,7 @@ mod internal {
                 root_package_name: None,
                 root_package_version: None,
             },
-            metadata: exports,
-            agent_types: vec![],
+            metadata,
         };
 
         metadata_dict.insert(versioned_component_id, component_details);


### PR DESCRIPTION
Part 1/2 of improving agent constructor handling in Rib.

In this part the constructor's parameter types are no longer guessed from the `AgentConstructor` schema, instead it looks up the actual generated WIT wrapper that golem is going to call under the hood and uses the parameter types of that.

This is more correct until we use the WIT wrappers for invocation.