### PR TITLE
Serialization optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "desert_core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5260e1dc286b2bb7e4de5f6475ac25261b90b670aad4d82eb2d22c5c7372a5e"
+checksum = "39c4504d511cb25b8ebc4b3ef4e9e34eb236ff18e05966737b6fa548928c3cda"
 dependencies = [
  "bigdecimal",
  "bit-vec 0.6.3",
@@ -3012,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "desert_macro"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8030aa9493e9bfe934f29746ff6d53083bb78bcd0d3e8a26462175c4cd9210d"
+checksum = "4f5f0cf16e94e5a803661ea0efaa4948ed9c2bb510ff25b6164327cc1962defb"
 dependencies = [
  "bytes 1.10.1",
  "desert_core",
@@ -3026,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "desert_rust"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613c7a38c5910b58f6ecf2ee304787268e3aa8e93d3153f176510d3b4ad58c33"
+checksum = "50b0bcc8f33ce64dd8e17cd6167271c2d01d90cb008a7961a97426e5b0710f7d"
 dependencies = [
  "desert_core",
  "desert_macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ criterion = "0.5"
 crossterm = "0.28.1"
 darling = "0.20.11"
 derive_more = { version = "2.0.1", features = ["display", "into", "from_str"] }
-desert_rust = { version = "0.1.4", features = ["bigdecimal", "uuid", "chrono", "nonempty-collections", "serde-json", "bit-vec", "url", "mac_address"] }
+desert_rust = { version = "0.1.6", features = ["bigdecimal", "uuid", "chrono", "nonempty-collections", "serde-json", "bit-vec", "url", "mac_address"] }
 dir-diff = "0.3.3"
 dirs = "4.0.0"
 drop-stream = "0.3.2"

--- a/golem-common/src/model/oplog/payload/mod.rs
+++ b/golem-common/src/model/oplog/payload/mod.rs
@@ -127,7 +127,9 @@ oplog_payload! {
             function_name: String,
             function_params: Vec<ValueAndType>,
             #[from_value(skip)]
+            #[transient(None::<String>)]
             remote_agent_type: Option<String>, // enriched field, only filled when exposed as public oplog entry
+            #[transient(None::<DataValue>)]
             #[from_value(skip)]
             remote_agent_parameters: Option<DataValue>, // enriched field, only filled when exposed as public oplog entry
         },
@@ -138,8 +140,10 @@ oplog_payload! {
             function_params: Vec<ValueAndType>,
             datetime: SerializableDateTime,
             #[from_value(skip)]
+            #[transient(None::<String>)]
             remote_agent_type: Option<String>, // enriched field, only filled when exposed as public oplog entry
             #[from_value(skip)]
+            #[transient(None::<DataValue>)]
             remote_agent_parameters: Option<DataValue>, // enriched field, only filled when exposed as public oplog entry
         },
         GolemRpcScheduledInvocationCancellation {

--- a/golem-common/src/model/oplog/raw_types.rs
+++ b/golem-common/src/model/oplog/raw_types.rs
@@ -185,13 +185,21 @@ impl Display for WorkerResourceId {
 )]
 #[repr(u8)]
 pub enum LogLevel {
+    #[desert(transparent)]
     Stdout,
+    #[desert(transparent)]
     Stderr,
+    #[desert(transparent)]
     Trace,
+    #[desert(transparent)]
     Debug,
+    #[desert(transparent)]
     Info,
+    #[desert(transparent)]
     Warn,
+    #[desert(transparent)]
     Error,
+    #[desert(transparent)]
     Critical,
 }
 
@@ -302,12 +310,16 @@ pub struct TimestampedUpdateDescription {
 pub enum DurableFunctionType {
     /// The side-effect reads from the worker's local state (for example local file system,
     /// random generator, etc.)
+    #[desert(transparent)]
     ReadLocal,
     /// The side-effect writes to the worker's local state (for example local file system)
+    #[desert(transparent)]
     WriteLocal,
     /// The side-effect reads from external state (for example a key-value store)
+    #[desert(transparent)]
     ReadRemote,
     /// The side-effect manipulates external state (for example an RPC call)
+    #[desert(transparent)]
     WriteRemote,
     /// The side-effect manipulates external state through multiple invoked functions (for example
     /// a HTTP request where reading the response involves multiple host function calls)
@@ -316,8 +328,10 @@ pub enum DurableFunctionType {
     /// writing a `BeginRemoteWrite` entry in the oplog. Followup invocations should contain
     /// this entry's index as the parameter. In batched remote writes it is the caller's responsibility
     /// to manually write an `EndRemoteWrite` entry (using `end_function`) when the operation is completed.
+    #[desert(transparent)]
     WriteRemoteBatched(Option<OplogIndex>),
 
+    #[desert(transparent)]
     WriteRemoteTransaction(Option<OplogIndex>),
 }
 

--- a/golem-wasm/src/lib.rs
+++ b/golem-wasm/src/lib.rs
@@ -218,29 +218,49 @@ impl PartialEq for Uri {
 #[cfg_attr(feature = "host", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "host", derive(desert_rust::BinaryCodec))]
 pub enum Value {
+    #[cfg_attr(feature = "host", desert(transparent))]
     Bool(bool),
+    #[cfg_attr(feature = "host", desert(transparent))]
     U8(u8),
+    #[cfg_attr(feature = "host", desert(transparent))]
     U16(u16),
+    #[cfg_attr(feature = "host", desert(transparent))]
     U32(u32),
+    #[cfg_attr(feature = "host", desert(transparent))]
     U64(u64),
+    #[cfg_attr(feature = "host", desert(transparent))]
     S8(i8),
+    #[cfg_attr(feature = "host", desert(transparent))]
     S16(i16),
+    #[cfg_attr(feature = "host", desert(transparent))]
     S32(i32),
+    #[cfg_attr(feature = "host", desert(transparent))]
     S64(i64),
+    #[cfg_attr(feature = "host", desert(transparent))]
     F32(f32),
+    #[cfg_attr(feature = "host", desert(transparent))]
     F64(f64),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Char(char),
+    #[cfg_attr(feature = "host", desert(transparent))]
     String(String),
+    #[cfg_attr(feature = "host", desert(custom = crate::desert::VecValueWrapper))]
     List(Vec<Value>),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Tuple(Vec<Value>),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Record(Vec<Value>),
     Variant {
         case_idx: u32,
         case_value: Option<Box<Value>>,
     },
+    #[cfg_attr(feature = "host", desert(transparent))]
     Enum(u32),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Flags(Vec<bool>),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Option(Option<Box<Value>>),
+    #[cfg_attr(feature = "host", desert(transparent))]
     Result(Result<Option<Box<Value>>, Option<Box<Value>>>),
     Handle {
         uri: String,


### PR DESCRIPTION
- Gets significant general serialization/deserialization performance improvements from https://github.com/vigoo/desert-rust/pull/22
- Makes use of the new "transparent variant case" mode in some frequently used types such as `Value` and `LogLevel`. This makes the marked cases non-evolvable but much more performant. 
- Takes advantage of the new "customized transparent variant case" mode for `Value::List` and by that serializes a WIT `list<u8>` specially. This is a common case enough representing binary data, especially now that we use more dynamic interfaces, so it should help a lot.

Resolves #2289 
