### PR TITLE
Rust template improvements

### DIFF
--- a/cli/golem-templates/templates/rust/rust-app-common/Cargo.toml._
+++ b/cli/golem-templates/templates/rust/rust-app-common/Cargo.toml._
@@ -7,7 +7,16 @@ opt-level = "s"
 lto = true
 
 [workspace.dependencies]
-golem-rust = { GOLEM_RUST_VERSION_OR_PATH, features = ["export_golem_agentic"] } # Enable feature "golem_ai" to work with various AI providers
-golem-wasi-http = { version = "0.1.0", features = ["json"] }
+
+golem-rust = { GOLEM_RUST_VERSION_OR_PATH, features = [
+    "export_golem_agentic",
+#    "golem_ai" # Uncomment to use Golem AI libraries
+] }
+
+# Advanced HTTP client, alternative of wstd::http
+# golem-wasi-http = { version = "0.1.0", features = ["json"] }
+
+log = { version = "0.4.29", features = ["kv"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+wstd = {version = "=0.5.4", features = ["default", "json"] }

--- a/cli/golem-templates/templates/rust/rust-app-common/common-rust/golem.yaml
+++ b/cli/golem-templates/templates/rust/rust-app-common/common-rust/golem.yaml
@@ -11,6 +11,7 @@ componentTemplates:
           - src
           - ../../common-rust
           - Cargo.toml
+          - ../../Cargo.toml
           targets:
           - ../../target/wasm32-wasip1/debug/{{ component_name | to_snake_case }}.wasm
         - generateAgentWrapper: ../../golem-temp/agents/{{ component_name | to_snake_case }}.wrapper.wasm
@@ -31,6 +32,7 @@ componentTemplates:
           - src
           - ../../common-rust
           - Cargo.toml
+          - ../../Cargo.toml
           targets:
           - ../../target/wasm32-wasip1/release/{{ component_name | to_snake_case }}.wasm
         - generateAgentWrapper: ../../golem-temp/agents/{{ component_name | to_snake_case }}.wrapper.wasm

--- a/cli/golem-templates/templates/rust/rust-app-component-default/components-rust/component-name/Cargo.toml._
+++ b/cli/golem-templates/templates/rust/rust-app-component-default/components-rust/component-name/Cargo.toml._
@@ -11,7 +11,8 @@ path = "src/lib.rs"
 # To use common shared agent definitions, place them in common_lib and uncomment the line below
 # common-lib = { path = "../../common-rust/common-lib" }
 
+log = { workspace = true }
 golem-rust = { workspace = true }
-golem-wasi-http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+wstd = { workspace = true }

--- a/cli/golem-templates/templates/rust/rust-app-component-default/components-rust/component-name/src/lib.rs
+++ b/cli/golem-templates/templates/rust/rust-app-component-default/components-rust/component-name/src/lib.rs
@@ -2,20 +2,26 @@ use golem_rust::{agent_definition, agent_implementation};
 
 #[agent_definition]
 pub trait CounterAgent {
+    // The agent constructor, it's parameters identify the agent
     fn new(name: String) -> Self;
+
     fn increment(&mut self) -> u32;
 }
 
 struct CounterImpl {
-    count: u32,
     _name: String,
+    count: u32,
 }
 
 #[agent_implementation]
 impl CounterAgent for CounterImpl {
     fn new(name: String) -> Self {
-        CounterImpl {_name: name, count: 0 }
+        Self {
+            _name: name,
+            count: 0,
+        }
     }
+
     fn increment(&mut self) -> u32 {
         self.count += 1;
         self.count

--- a/sdks/rust/golem-rust/Cargo.toml
+++ b/sdks/rust/golem-rust/Cargo.toml
@@ -22,11 +22,13 @@ golem-wasm = {version = "1.3.2-dev.2", default-features = false, features = ["st
 
 async-trait = {version = "0.1.89", optional = true}
 ctor = {version = "0.4.3", optional = true}
+log = { version = "0.4.29", features = ["kv"] }
 serde = {version = "1", optional = true}
 serde_json = {version = "1", optional = true}
 uuid = {version = "1", features = ["v4"]}
 wasi = {version = "=0.14.1+wasi-0.2.3"}
 wstd = {version = "=0.5.4"}
+wasi-logger = { version = "0.1.2", features = ["kv"] }
 wit-bindgen = {version = "=0.40.0"}
 
 [features]

--- a/sdks/rust/golem-rust/src/agentic/agent_impl.rs
+++ b/sdks/rust/golem-rust/src/agentic/agent_impl.rs
@@ -28,6 +28,9 @@ pub struct Component;
 
 impl Guest for Component {
     fn initialize(agent_type: String, input: DataValue) -> Result<(), AgentError> {
+        wasi_logger::Logger::install().expect("failed to install wasi_logger::Logger");
+        log::set_max_level(log::LevelFilter::Trace);
+
         let agent_types = agent_registry::get_all_agent_types();
 
         let agent_type = agent_types
@@ -81,6 +84,9 @@ impl LoadSnapshotGuest for Component {
     // https://github.com/golemcloud/golem/issues/2374#issuecomment-3618565370
     #[allow(clippy::await_holding_refcell_ref)]
     fn load(bytes: Vec<u8>) -> Result<(), String> {
+        wasi_logger::Logger::install().expect("failed to install wasi_logger::Logger");
+        log::set_max_level(log::LevelFilter::Trace);
+
         let agent_id = get_resolved_agent();
 
         if agent_id.is_some() {


### PR DESCRIPTION
Resolves #2471 

- use `Self` in the constructor (one less thing to rename when renaming the initial agent
- has `wstd` added by default to the dependencies 
- only has `golem-wasi-http` as commented out dependency, as the recommended one is `wstd`
- configures the `wasi-logger` backend for the `log` crate and adds it by default, so there is working rust logging out of the box
- up-to-date check should consider the workspace `Cargo.toml`
- some minor comment / formatting changes