### PR TITLE
registry-service: reject components with duplicate environment plugin grant id

### DIFF
--- a/golem-registry-service/src/api/error.rs
+++ b/golem-registry-service/src/api/error.rs
@@ -266,7 +266,6 @@ impl From<ComponentError> for ApiError {
             | ComponentError::MalformedComponentArchive { .. }
             | ComponentError::PluginInstallationNotFound { .. }
             | ComponentError::EnvironmentPluginNotFound(_)
-            | ComponentError::ConflictingPluginPriority(_)
             | ComponentError::ComponentTransformerPluginFailed { .. } => {
                 Self::BadRequest(Json(ErrorsBody {
                     errors: vec![error],
@@ -282,6 +281,8 @@ impl From<ComponentError> for ApiError {
 
             ComponentError::ComponentWithNameAlreadyExists(_)
             | ComponentError::ComponentVersionAlreadyExists(_)
+            | ComponentError::ConflictingPluginPriority(_)
+            | ComponentError::ConflictingEnvironmentPluginGrantId(_)
             | ComponentError::ConcurrentUpdate => {
                 Self::Conflict(Json(ErrorBody { error, cause: None }))
             }

--- a/golem-registry-service/src/services/component/error.rs
+++ b/golem-registry-service/src/services/component/error.rs
@@ -76,6 +76,8 @@ pub enum ComponentError {
     PluginInstallationNotFound(EnvironmentPluginGrantId),
     #[error("Multiple plugins with same priority {0}")]
     ConflictingPluginPriority(PluginPriority),
+    #[error("Multiple plugins with same environment plugin grant id {0}")]
+    ConflictingEnvironmentPluginGrantId(EnvironmentPluginGrantId),
     #[error("Failed to componse component with plugin with priority {plugin_priority}")]
     PluginCompositionFailed {
         plugin_priority: PluginPriority,
@@ -114,6 +116,7 @@ impl SafeDisplay for ComponentError {
             Self::PluginInstallationNotFound(_) => self.to_string(),
             Self::ParentEnvironmentNotFound(_) => self.to_string(),
             Self::DeploymentRevisionNotFound(_) => self.to_string(),
+            Self::ConflictingEnvironmentPluginGrantId(_) => self.to_string(),
             Self::ConflictingPluginPriority(_) => self.to_string(),
             Self::PluginCompositionFailed { .. } => self.to_string(),
             Self::ComponentTransformerPluginFailed { .. } => self.to_string(),

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -523,6 +523,14 @@ impl ComponentWriteService {
                 ));
             };
 
+            if result.iter().any(|p| {
+                p.environment_plugin_grant_id == plugin_installation.environment_plugin_grant_id
+            }) {
+                return Err(ComponentError::ConflictingEnvironmentPluginGrantId(
+                    plugin_installation.environment_plugin_grant_id,
+                ));
+            };
+
             // get the plugin details and ensure the plugin is installed to the environment
             let environment_plugin_grant = self
                 .environment_plugin_grant_service
@@ -612,9 +620,18 @@ impl ComponentWriteService {
                     };
                 }
                 PluginInstallationAction::Install(inner) => {
-                    // ensure the plugin priority is not already used
+                    // ensure the plugin priority and environment_plugin_grant_id is not already used
                     if updated.iter().any(|p| p.priority == inner.priority) {
                         return Err(ComponentError::ConflictingPluginPriority(inner.priority));
+                    };
+
+                    if updated
+                        .iter()
+                        .any(|p| p.environment_plugin_grant_id == inner.environment_plugin_grant_id)
+                    {
+                        return Err(ComponentError::ConflictingEnvironmentPluginGrantId(
+                            inner.environment_plugin_grant_id,
+                        ));
                     };
 
                     // get the plugin details and ensure the plugin is installed to the environment

--- a/integration-tests/tests/api/component.rs
+++ b/integration-tests/tests/api/component.rs
@@ -15,7 +15,7 @@
 use anyhow::anyhow;
 use assert2::assert;
 use golem_client::api::{
-    RegistryServiceClient, RegistryServiceGetComponentError,
+    RegistryServiceClient, RegistryServiceCreateComponentError, RegistryServiceGetComponentError,
     RegistryServiceGetEnvironmentComponentError, RegistryServiceUpdateComponentError,
 };
 use golem_common::model::agent::{
@@ -625,6 +625,380 @@ async fn list_agent_types(deps: &EnvBasedTestDependencies) -> anyhow::Result<()>
                     component_revision: component.revision,
                 }
             }]
+    );
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
+async fn create_component_with_duplicate_plugin_priorities_fails(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?.with_auto_deploy(false);
+    let client = user.registry_service_client().await;
+    let (_, env) = user.app_and_env().await?;
+
+    let plugin_1 = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin-1".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let plugin_2 = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin-2".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let grant_1 = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin_1.id,
+            },
+        )
+        .await?;
+
+    let grant_2 = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin_2.id,
+            },
+        )
+        .await?;
+
+    let result = client
+        .create_component(
+            &env.id.0,
+            &ComponentCreation {
+                component_name: ComponentName("duplicate-priority".to_string()),
+                file_options: BTreeMap::new(),
+                dynamic_linking: HashMap::new(),
+                env: BTreeMap::new(),
+                agent_types: Vec::new(),
+                plugins: vec![
+                    PluginInstallation {
+                        environment_plugin_grant_id: grant_1.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    },
+                    PluginInstallation {
+                        environment_plugin_grant_id: grant_2.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    },
+                ],
+            },
+            tokio::fs::File::open(deps.component_directory().join("app_and_library_app.wasm"))
+                .await?,
+            None::<Vec<u8>>,
+        )
+        .await;
+
+    assert!(
+        let Err(golem_client::Error::Item(
+            RegistryServiceCreateComponentError::Error409(_)
+        )) = result
+    );
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
+async fn create_component_with_duplicate_plugin_grant_ids_fails(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?.with_auto_deploy(false);
+    let client = user.registry_service_client().await;
+    let (_, env) = user.app_and_env().await?;
+
+    let plugin = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let grant = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin.id,
+            },
+        )
+        .await?;
+
+    let result = client
+        .create_component(
+            &env.id.0,
+            &ComponentCreation {
+                component_name: ComponentName("duplicate-grant".to_string()),
+                file_options: BTreeMap::new(),
+                dynamic_linking: HashMap::new(),
+                env: BTreeMap::new(),
+                agent_types: Vec::new(),
+                plugins: vec![
+                    PluginInstallation {
+                        environment_plugin_grant_id: grant.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    },
+                    PluginInstallation {
+                        environment_plugin_grant_id: grant.id,
+                        priority: PluginPriority(1),
+                        parameters: BTreeMap::new(),
+                    },
+                ],
+            },
+            tokio::fs::File::open(deps.component_directory().join("app_and_library_app.wasm"))
+                .await?,
+            None::<Vec<u8>>,
+        )
+        .await;
+
+    assert!(
+        let Err(golem_client::Error::Item(
+            RegistryServiceCreateComponentError::Error409(_)
+        )) = result
+    );
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
+async fn update_component_with_duplicate_plugin_priorities_fails(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?.with_auto_deploy(false);
+    let client = user.registry_service_client().await;
+    let (_, env) = user.app_and_env().await?;
+
+    let plugin_1 = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin-1".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let plugin_2 = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin-2".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let grant_1 = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin_1.id,
+            },
+        )
+        .await?;
+
+    let grant_2 = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin_2.id,
+            },
+        )
+        .await?;
+
+    let component = user
+        .component(&env.id, "app_and_library_app")
+        .store()
+        .await?;
+
+    let result = client
+        .update_component(
+            &component.id.0,
+            &ComponentUpdate {
+                current_revision: component.revision,
+                removed_files: Vec::new(),
+                new_file_options: BTreeMap::new(),
+                dynamic_linking: None,
+                env: None,
+                agent_types: None,
+                plugin_updates: vec![
+                    PluginInstallationAction::Install(PluginInstallation {
+                        environment_plugin_grant_id: grant_1.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    }),
+                    PluginInstallationAction::Install(PluginInstallation {
+                        environment_plugin_grant_id: grant_2.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    }),
+                ],
+            },
+            None::<Vec<u8>>,
+            None::<Vec<u8>>,
+        )
+        .await;
+
+    assert!(
+        let Err(golem_client::Error::Item(
+            RegistryServiceUpdateComponentError::Error409(_)
+        )) = result
+    );
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
+async fn update_component_with_duplicate_plugin_grant_ids_fails(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?.with_auto_deploy(false);
+    let client = user.registry_service_client().await;
+    let (_, env) = user.app_and_env().await?;
+
+    let plugin = client
+        .create_plugin(
+            &user.account_id.0,
+            &PluginRegistrationCreation {
+                name: "plugin".to_string(),
+                version: "1.0.0".to_string(),
+                description: "".to_string(),
+                icon: Base64(Vec::new()),
+                homepage: "".to_string(),
+                spec: PluginSpecDto::Library(Empty {}),
+            },
+            Some(
+                tokio::fs::read(
+                    deps.component_directory()
+                        .join("app_and_library_library.wasm"),
+                )
+                .await?,
+            ),
+        )
+        .await?;
+
+    let grant = client
+        .create_environment_plugin_grant(
+            &env.id.0,
+            &EnvironmentPluginGrantCreation {
+                plugin_registration_id: plugin.id,
+            },
+        )
+        .await?;
+
+    let component = user
+        .component(&env.id, "app_and_library_app")
+        .store()
+        .await?;
+
+    let result = client
+        .update_component(
+            &component.id.0,
+            &ComponentUpdate {
+                current_revision: component.revision,
+                removed_files: Vec::new(),
+                new_file_options: BTreeMap::new(),
+                dynamic_linking: None,
+                env: None,
+                agent_types: None,
+                plugin_updates: vec![
+                    PluginInstallationAction::Install(PluginInstallation {
+                        environment_plugin_grant_id: grant.id,
+                        priority: PluginPriority(0),
+                        parameters: BTreeMap::new(),
+                    }),
+                    PluginInstallationAction::Install(PluginInstallation {
+                        environment_plugin_grant_id: grant.id,
+                        priority: PluginPriority(1),
+                        parameters: BTreeMap::new(),
+                    }),
+                ],
+            },
+            None::<Vec<u8>>,
+            None::<Vec<u8>>,
+        )
+        .await;
+
+    assert!(
+        let Err(golem_client::Error::Item(
+            RegistryServiceUpdateComponentError::Error409(_)
+        )) = result
     );
 
     Ok(())


### PR DESCRIPTION
followup to #2525 as the update api / delete component plugin apis will otherwise misbehave with duplicate environment plugin grant ids