### PR TITLE
make sure cli integration with bootstrapped mcp works

### DIFF
--- a/cli/golem-cli/src/command_handler/api/deployment.rs
+++ b/cli/golem-cli/src/command_handler/api/deployment.rs
@@ -158,6 +158,24 @@ impl ApiDeploymentCommandHandler {
             .unwrap_or_default())
     }
 
+    pub async fn deployable_manifest_mcp_deployments(
+        &self,
+        environment_name: &EnvironmentName,
+    ) -> anyhow::Result<BTreeMap<Domain, crate::model::http_api::McpDeploymentDeployProperties>> {
+        let app_ctx = self.ctx.app_context_lock().await;
+        let app_ctx = app_ctx.some_or_err()?;
+        Ok(app_ctx
+            .application()
+            .mcp_deployments(environment_name)
+            .map(|deployments: &BTreeMap<golem_common::model::domain_registration::Domain, crate::model::app::WithSource<crate::model::http_api::McpDeploymentDeployProperties>>| {
+                deployments
+                    .iter()
+                    .map(|(domain, mcp_deployment)| (domain.clone(), mcp_deployment.value.clone()))
+                    .collect::<BTreeMap<_, _>>()
+            })
+            .unwrap_or_default())
+    }
+
     pub async fn get_http_api_deployment_revision_by_id(
         &self,
         http_api_deployment_id: &HttpApiDeploymentId,

--- a/cli/golem-cli/src/model/app.rs
+++ b/cli/golem-cli/src/model/app.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::http_api::HttpApiDeploymentDeployProperties;
+use super::http_api::{HttpApiDeploymentDeployProperties, McpDeploymentDeployProperties};
 use crate::bridge_gen::bridge_client_directory_name;
 use crate::fs;
 use crate::log::LogColorize;
@@ -338,6 +338,8 @@ pub struct Application {
     clean: Vec<WithSource<String>>,
     http_api_deployments:
         BTreeMap<EnvironmentName, BTreeMap<Domain, WithSource<HttpApiDeploymentDeployProperties>>>,
+    mcp_deployments:
+        BTreeMap<EnvironmentName, BTreeMap<Domain, WithSource<McpDeploymentDeployProperties>>>,
     bridge_sdks: WithSource<app_raw::BridgeSdks>,
 }
 
@@ -484,6 +486,13 @@ impl Application {
         environment: &EnvironmentName,
     ) -> Option<&BTreeMap<Domain, WithSource<HttpApiDeploymentDeployProperties>>> {
         self.http_api_deployments.get(environment)
+    }
+
+    pub fn mcp_deployments(
+        &self,
+        environment: &EnvironmentName,
+    ) -> Option<&BTreeMap<Domain, WithSource<McpDeploymentDeployProperties>>> {
+        self.mcp_deployments.get(environment)
     }
 }
 
@@ -1456,7 +1465,7 @@ mod app_builder {
     };
     use crate::model::app_raw;
     use crate::model::cascade::store::Store;
-    use crate::model::http_api::HttpApiDeploymentDeployProperties;
+    use crate::model::http_api::{HttpApiDeploymentDeployProperties, McpDeploymentDeployProperties, McpDeploymentAgentOptions};
     use crate::validation::{ValidatedResult, ValidationBuilder};
     use crate::{fs, fuzzy};
     use colored::Colorize;
@@ -1570,6 +1579,8 @@ mod app_builder {
             BTreeMap<Domain, WithSource<HttpApiDeploymentDeployProperties>>,
         >,
 
+        mcp_deployments: BTreeMap<EnvironmentName, BTreeMap<Domain, WithSource<McpDeploymentDeployProperties>>>,
+
         bridge_sdks: WithSource<app_raw::BridgeSdks>,
 
         all_sources: BTreeSet<PathBuf>,
@@ -1617,6 +1628,7 @@ mod app_builder {
                 custom_commands: builder.custom_commands,
                 clean: builder.clean,
                 http_api_deployments: builder.http_api_deployments,
+                mcp_deployments: builder.mcp_deployments,
                 bridge_sdks: builder.bridge_sdks,
             })
         }
@@ -1787,6 +1799,25 @@ mod app_builder {
                                         webhooks_url: api_deployment.webhook_url.unwrap_or_else(HttpApiDeploymentCreation::default_webhooks_url),
                                         agents
                                     },
+                                ));
+                            }
+                        }
+                    }
+
+                    if let Some(mcp) = app.application.mcp {
+                        for (environment, deployments) in mcp.deployments {
+                            for mcp_deployment in deployments {
+                                let mcp_deployments =
+                                    self.mcp_deployments.entry(environment.clone()).or_default();
+
+                                let agents = mcp_deployment.agents
+                                    .into_iter()
+                                    .map(|(k, _v)| (k, McpDeploymentAgentOptions {}))
+                                    .collect();
+
+                                mcp_deployments.entry(mcp_deployment.domain.clone()).or_insert(WithSource::new(
+                                    app.source.to_path_buf(),
+                                    McpDeploymentDeployProperties { agents },
                                 ));
                             }
                         }

--- a/cli/golem-cli/src/model/app_raw.rs
+++ b/cli/golem-cli/src/model/app_raw.rs
@@ -100,6 +100,8 @@ pub struct Application {
     pub clean: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_api: Option<HttpApi>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<Mcp>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub environments: IndexMap<String, Environment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -255,6 +257,27 @@ pub struct HttpApiDeployment {
     pub webhook_url: Option<String>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub agents: IndexMap<AgentTypeName, HttpApiDeploymentAgentOptions>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Mcp {
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub deployments: IndexMap<EnvironmentName, Vec<McpDeployment>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpDeployment {
+    pub domain: Domain,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub agents: IndexMap<AgentTypeName, McpDeploymentAgentOptions>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpDeploymentAgentOptions {
+    // MCP agent configuration options coming soon
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cli/golem-cli/src/model/http_api.rs
+++ b/cli/golem-cli/src/model/http_api.rs
@@ -21,3 +21,19 @@ pub struct HttpApiDeploymentDeployProperties {
     pub webhooks_url: String,
     pub agents: BTreeMap<AgentTypeName, HttpApiDeploymentAgentOptions>,
 }
+
+#[derive(Clone, Debug)]
+pub struct McpDeploymentDeployProperties {
+    pub agents: BTreeMap<AgentTypeName, McpDeploymentAgentOptions>,
+}
+
+#[derive(Clone, Debug)]
+pub struct McpDeploymentAgentOptions {
+    // MCP agent configuration options coming soon
+}
+
+impl McpDeploymentAgentOptions {
+    pub fn to_diffable(&self) -> golem_common::model::diff::McpDeploymentAgentOptions {
+        golem_common::model::diff::McpDeploymentAgentOptions {}
+    }
+}

--- a/cli/golem-cli/src/model/text/diff.rs
+++ b/cli/golem-cli/src/model/text/diff.rs
@@ -185,6 +185,39 @@ impl TextView for DeploymentDiff {
             }
             logln("");
         }
+        if !self.mcp_deployments.is_empty() {
+            logln(
+                "MCP deployment changes:"
+                    .log_color_help_group()
+                    .to_string(),
+            );
+            for (domain, mcp_deployment_diff) in &self.mcp_deployments {
+                match mcp_deployment_diff {
+                    BTreeMapDiffValue::Create => {
+                        logln(format!(
+                            "  - {} MCP deployment {}",
+                            "create".green(),
+                            domain.log_color_highlight()
+                        ));
+                    }
+                    BTreeMapDiffValue::Delete => {
+                        logln(format!(
+                            "  - {} MCP deployment {}",
+                            "delete".red(),
+                            domain.log_color_highlight()
+                        ));
+                    }
+                    BTreeMapDiffValue::Update(_diff) => {
+                        logln(format!(
+                            "  - {} MCP deployment {}",
+                            "update".yellow(),
+                            domain.log_color_highlight()
+                        ));
+                    }
+                }
+            }
+            logln("");
+        }
     }
 }
 

--- a/golem-common/src/base_model/mcp_deployment.rs
+++ b/golem-common/src/base_model/mcp_deployment.rs
@@ -27,6 +27,7 @@ declare_revision!(McpDeploymentRevision);
 declare_structs! {
     pub struct McpDeploymentCreation {
         pub domain: Domain,
+        pub agents: BTreeMap<AgentTypeName, crate::model::diff::McpDeploymentAgentOptions>,
     }
 
     pub struct McpDeploymentUpdate {

--- a/golem-common/src/model/diff/mcp_deployment.rs
+++ b/golem-common/src/model/diff/mcp_deployment.rs
@@ -15,8 +15,9 @@
 use crate::model::diff::{hash_from_serialized_value, BTreeMapDiff, Diffable, Hash, Hashable};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use desert_rust::BinaryCodec;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, BinaryCodec)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "full", derive(poem_openapi::Object))]
 pub struct McpDeploymentAgentOptions {

--- a/golem-registry-service/db/migration/postgres/005_mcp_deployment_agents.sql
+++ b/golem-registry-service/db/migration/postgres/005_mcp_deployment_agents.sql
@@ -1,0 +1,7 @@
+-- Add agents data column to mcp_deployment_revisions table
+ALTER TABLE mcp_deployment_revisions
+    ADD COLUMN data BYTEA NOT NULL DEFAULT '{"agents":{}}';
+
+-- Remove the default after adding the column
+ALTER TABLE mcp_deployment_revisions
+    ALTER COLUMN data DROP DEFAULT;

--- a/golem-registry-service/db/migration/sqlite/005_mcp_deployment_agents.sql
+++ b/golem-registry-service/db/migration/sqlite/005_mcp_deployment_agents.sql
@@ -1,0 +1,3 @@
+-- Add agents data column to mcp_deployment_revisions table
+ALTER TABLE mcp_deployment_revisions
+    ADD COLUMN data BLOB NOT NULL DEFAULT X'7B22616765767473223A7B7D7D';

--- a/golem-registry-service/src/api/error.rs
+++ b/golem-registry-service/src/api/error.rs
@@ -597,7 +597,8 @@ impl From<McpDeploymentError> for ApiError {
         match value {
             McpDeploymentError::ParentEnvironmentNotFound(_)
             | McpDeploymentError::McpDeploymentNotFound(_)
-            | McpDeploymentError::McpDeploymentByDomainNotFound(_) => {
+            | McpDeploymentError::McpDeploymentByDomainNotFound(_)
+            | McpDeploymentError::DomainNotRegistered(_) => {
                 Self::NotFound(Json(ErrorBody { error, cause: None }))
             }
 

--- a/golem-registry-service/src/bootstrap/mod.rs
+++ b/golem-registry-service/src/bootstrap/mod.rs
@@ -272,6 +272,7 @@ impl Services {
         let mcp_deployment_service = Arc::new(McpDeploymentService::new(
             repos.mcp_deployment_repo.clone(),
             environment_service.clone(),
+            domain_registration_service.clone(),
         ));
 
         let deployment_write_service = Arc::new(DeploymentWriteService::new(

--- a/golem-registry-service/src/repo/deployment.rs
+++ b/golem-registry-service/src/repo/deployment.rs
@@ -710,7 +710,9 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         .await?;
                 }
 
-                Self::create_deployment_mcp(tx, &deployment_creation.compiled_mcp).await?;
+                for compiled_mcp in &deployment_creation.compiled_mcp {
+                    Self::create_deployment_mcp(tx, compiled_mcp).await?;
+                }
 
                 let revision = Self::set_current_deployment_internal(
                     tx,

--- a/golem-registry-service/src/repo/model/deployment.rs
+++ b/golem-registry-service/src/repo/model/deployment.rs
@@ -387,7 +387,7 @@ pub struct DeploymentRevisionCreationRecord {
     pub http_api_deployments: Vec<DeploymentHttpApiDeploymentRevisionRecord>,
     pub mcp_deployments: Vec<DeploymentMcpDeploymentRevisionRecord>,
     pub compiled_routes: Vec<DeploymentCompiledRouteRecord>,
-    pub compiled_mcp: DeploymentMcpCapabilityRecord,
+    pub compiled_mcp: Vec<DeploymentMcpCapabilityRecord>,
     pub registered_agent_types: Vec<DeploymentRegisteredAgentTypeRecord>,
 }
 
@@ -401,7 +401,7 @@ impl DeploymentRevisionCreationRecord {
         http_api_deployments: Vec<HttpApiDeployment>,
         mcp_deployments: Vec<McpDeployment>,
         compiled_routes: Vec<UnboundCompiledRoute>,
-        compiled_mcp: CompiledMcp,
+        compiled_mcp: Vec<CompiledMcp>,
         registered_agent_types: Vec<DeployedRegisteredAgentType>,
     ) -> Self {
         Self {
@@ -450,7 +450,10 @@ impl DeploymentRevisionCreationRecord {
                     )
                 })
                 .collect(),
-            compiled_mcp: DeploymentMcpCapabilityRecord::from_model(compiled_mcp),
+            compiled_mcp: compiled_mcp
+                .into_iter()
+                .map(DeploymentMcpCapabilityRecord::from_model)
+                .collect(),
             registered_agent_types: registered_agent_types
                 .into_iter()
                 .map(|r| {

--- a/golem-registry-service/src/repo/model/mcp_deployment.rs
+++ b/golem-registry-service/src/repo/model/mcp_deployment.rs
@@ -15,16 +15,21 @@
 use super::audit::DeletableRevisionAuditFields;
 use super::hash::SqlBlake3Hash;
 use crate::repo::model::datetime::SqlDateTime;
+use golem_service_base::repo::blob::Blob;
 use golem_common::error_forwarding;
 use golem_common::model::account::AccountId;
+use golem_common::model::agent::AgentTypeName;
 use golem_common::model::deployment::DeploymentPlanMcpDeploymentEntry;
-use golem_common::model::diff::{Hashable, McpDeployment as DiffMcpDeployment};
+use golem_common::model::diff::{Hashable, McpDeployment as DiffMcpDeployment, McpDeploymentAgentOptions};
 use golem_common::model::domain_registration::Domain;
 use golem_common::model::environment::EnvironmentId;
 use golem_common::model::mcp_deployment::{McpDeployment, McpDeploymentId, McpDeploymentRevision};
 use golem_service_base::repo::RepoError;
+use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use std::collections::BTreeMap;
 use uuid::Uuid;
+use desert_rust::BinaryCodec;
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpDeploymentRepoError {
@@ -38,6 +43,11 @@ pub enum McpDeploymentRepoError {
 
 error_forwarding!(McpDeploymentRepoError, RepoError);
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, BinaryCodec)]
+pub struct McpDeploymentData {
+    pub agents: BTreeMap<AgentTypeName, McpDeploymentAgentOptions>,
+}
+
 #[derive(Debug, Clone, FromRow, PartialEq)]
 pub struct McpDeploymentRevisionRecord {
     pub mcp_deployment_id: Uuid,
@@ -46,16 +56,18 @@ pub struct McpDeploymentRevisionRecord {
     #[sqlx(flatten)]
     pub audit: DeletableRevisionAuditFields,
     pub domain: String,
+    pub data: Blob<McpDeploymentData>,
 }
 
 impl McpDeploymentRevisionRecord {
-    pub fn creation(mcp_deployment_id: McpDeploymentId, domain: Domain, actor: AccountId) -> Self {
+    pub fn creation(mcp_deployment_id: McpDeploymentId, domain: Domain, actor: AccountId, agents: BTreeMap<AgentTypeName, McpDeploymentAgentOptions>) -> Self {
         let mut value = Self {
             mcp_deployment_id: mcp_deployment_id.0,
             revision_id: McpDeploymentRevision::INITIAL.into(),
             hash: SqlBlake3Hash::empty(),
             audit: DeletableRevisionAuditFields::new(actor.0),
             domain: domain.0,
+            data: Blob::new(McpDeploymentData { agents }),
         };
         value.update_hash();
         value
@@ -68,6 +80,7 @@ impl McpDeploymentRevisionRecord {
             hash: SqlBlake3Hash::empty(),
             audit,
             domain: deployment.domain.0,
+            data: Blob::new(McpDeploymentData { agents: deployment.agents }),
         };
         value.update_hash();
         value
@@ -85,6 +98,7 @@ impl McpDeploymentRevisionRecord {
             hash: SqlBlake3Hash::empty(),
             audit: DeletableRevisionAuditFields::deletion(created_by),
             domain,
+            data: Blob::new(McpDeploymentData { agents: Default::default() }),
         };
         value.update_hash();
         value
@@ -92,7 +106,13 @@ impl McpDeploymentRevisionRecord {
 
     pub fn to_diffable(&self) -> DiffMcpDeployment {
         DiffMcpDeployment {
-            agents: Default::default(),
+            agents: self
+                .data
+                .value()
+                .agents
+                .iter()
+                .map(|(k, v)| (k.0.clone(), v.clone()))
+                .collect(),
         }
     }
 
@@ -125,7 +145,7 @@ impl TryFrom<McpDeploymentExtRevisionRecord> for McpDeployment {
             environment_id: EnvironmentId(value.environment_id),
             domain: Domain(value.domain),
             hash: value.revision.hash.into(),
-            agents: Default::default(),
+            agents: value.revision.data.value().agents.clone(),
             created_at: value.entity_created_at.into(),
         })
     }

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -41,7 +41,7 @@ use golem_registry_service::repo::model::http_api_deployment::{
     HttpApiDeploymentData, HttpApiDeploymentRepoError, HttpApiDeploymentRevisionRecord,
 };
 use golem_registry_service::repo::model::mcp_deployment::{
-    McpDeploymentRepoError, McpDeploymentRevisionRecord,
+    McpDeploymentData, McpDeploymentRepoError, McpDeploymentRevisionRecord,
 };
 use golem_registry_service::repo::model::new_repo_uuid;
 use golem_registry_service::repo::model::plugin::PluginRecord;
@@ -1166,6 +1166,7 @@ pub async fn test_mcp_deployment_create_and_update(deps: &Deps) {
         revision_id: 0,
         hash: SqlBlake3Hash::empty(),
         domain: domain.to_string(),
+        data: Blob::new(McpDeploymentData { agents: Default::default() }),
         audit: DeletableRevisionAuditFields::new(user.revision.account_id),
     };
 
@@ -1200,6 +1201,7 @@ pub async fn test_mcp_deployment_create_and_update(deps: &Deps) {
         revision_id: 1,
         hash: SqlBlake3Hash::empty(),
         domain: new_domain.to_string(),
+        data: Blob::new(McpDeploymentData { agents: Default::default() }),
         audit: DeletableRevisionAuditFields::new(user.revision.account_id),
     };
 
@@ -1243,6 +1245,7 @@ pub async fn test_mcp_deployment_list_and_delete(deps: &Deps) {
         revision_id: 0,
         hash: SqlBlake3Hash::empty(),
         domain: domain.to_string(),
+        data: Blob::new(McpDeploymentData { agents: Default::default() }),
         audit: DeletableRevisionAuditFields::new(user.revision.account_id),
     };
 
@@ -1266,6 +1269,7 @@ pub async fn test_mcp_deployment_list_and_delete(deps: &Deps) {
         revision_id: 1,
         hash: SqlBlake3Hash::empty(),
         domain: domain.to_string(),
+        data: Blob::new(McpDeploymentData { agents: Default::default() }),
         audit: DeletableRevisionAuditFields::new(user.revision.account_id),
     };
 
@@ -1291,6 +1295,7 @@ pub async fn test_mcp_deployment_list_and_delete(deps: &Deps) {
         revision_id: 0,
         hash: SqlBlake3Hash::empty(),
         domain: other_domain.to_string(),
+        data: Blob::new(McpDeploymentData { agents: Default::default() }),
         audit: DeletableRevisionAuditFields::new(user.revision.account_id),
     };
 

--- a/golem-worker-service/src/mcp/agent_mcp_capability.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_capability.rs
@@ -43,6 +43,12 @@ impl McpAgentCapability {
         match &method.input_schema {
             DataSchema::Tuple(schemas) => {
                 if !schemas.elements.is_empty() {
+                    tracing::debug!(
+                        "Method {} of agent type {} has input parameters, exposing as tool",
+                        method.name,
+                        agent_type_name.0
+                    );
+
                     let constructor_schema = constructor.input_schema.get_mcp_schema();
                     let mut tool_schema = method.get_mcp_tool_schema();
                     tool_schema.merge_input_schema(constructor_schema);
@@ -74,6 +80,12 @@ impl McpAgentCapability {
                         agent_type_name: agent_type_name.clone(),
                     }))
                 } else {
+                    tracing::debug!(
+                        "Method {} of agent type {} has no input parameters, exposing as resource",
+                        method.name,
+                        agent_type_name.0
+                    );
+
                     Self::Resource(AgentMcpResource {
                         resource: method.clone(),
                     })


### PR DESCRIPTION
Fixes #2837 (raised against https://github.com/golemcloud/golem/pull/2833)

CLI integration uncovered some server bugs which I had to fix it here.  Mostly fixes resulted in more consistency between http and mcp in the backend

```
httpApi:
  deployments:
    local:
    - domain: mcp-thing.localhost:9006
      agents:
        counter-agent: {}

mcp:
  deployments:
    local:
      - domain: cream-sheep-successful-garmin.trycloudflare.com
        agents:
          counter-agent: {}
```

A few screenshots of an agent with both http and mcp

<img width="1114" height="268" alt="image" src="https://github.com/user-attachments/assets/f2725e75-ffa6-446c-93b2-456afd8d5016" />

<img width="1227" height="294" alt="image" src="https://github.com/user-attachments/assets/996c9eed-6c7c-4562-8786-433244304e4d" />



