### PR TITLE
feat: add MCP Server mode to golem-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,6 +3988,7 @@ dependencies = [
  "quote",
  "regex",
  "reqwest",
+ "rmcp",
  "rustyline",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12.13", features = ["gzip", "json", "multipart", "stream", ] }
 ringbuf = "0.4.7"
 rlimit = "0.10.2"
-rmcp = {version = "0.16.0", features = ["server", "transport-streamable-http-server"] }
+rmcp = {version = "0.16.0", features = ["server", "transport-streamable-http-server", "transport-io"] }
 rsa = "0.9.7"
 
 rustc-hash = "2.1.1"

--- a/cli/golem-cli/Cargo.toml
+++ b/cli/golem-cli/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 [features]
 default = []
 server-commands = []
+mcp = ["dep:rmcp", "dep:axum"]
 
 [lib]
 harness = false
@@ -110,6 +111,8 @@ wasm-rquickjs = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
+rmcp = { workspace = true, optional = true }
+axum = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 openssl = { workspace = true }

--- a/cli/golem-cli/src/lib.rs
+++ b/cli/golem-cli/src/lib.rs
@@ -45,6 +45,9 @@ pub mod model;
 pub mod process;
 pub mod validation;
 
+#[cfg(feature = "mcp")]
+pub mod mcp;
+
 #[cfg(test)]
 test_r::enable!();
 

--- a/cli/golem-cli/src/main.rs
+++ b/cli/golem-cli/src/main.rs
@@ -68,5 +68,22 @@ mod hooks {
 }
 
 fn main() -> ExitCode {
+    // Check for --serve flag before normal clap parsing
+    #[cfg(feature = "mcp")]
+    {
+        let args: Vec<String> = std::env::args().collect();
+        if args.iter().any(|a| a == "--serve") {
+            return main_wrapper(|| async {
+                match golem_cli::mcp::serve::run_mcp_from_args(&args).await {
+                    Ok(code) => code,
+                    Err(e) => {
+                        eprintln!("MCP server error: {}", e);
+                        ExitCode::FAILURE
+                    }
+                }
+            });
+        }
+    }
+
     main_wrapper(|| CommandHandler::handle_args(std::env::args_os(), Arc::new(NoHooks {})))
 }

--- a/cli/golem-cli/src/mcp/handler.rs
+++ b/cli/golem-cli/src/mcp/handler.rs
@@ -1,0 +1,195 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::command::GolemCliCommand;
+use crate::mcp::resources;
+use crate::mcp::tools;
+use crate::model::cli_command_metadata::CliCommandMetadata;
+use rmcp::model::*;
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use serde_json::json;
+use std::process::Command;
+use tracing::debug;
+
+/// The MCP server handler for Golem CLI.
+/// Exposes CLI commands as tools and manifest files as resources.
+#[derive(Clone)]
+pub struct GolemMcpHandler {
+    metadata: CliCommandMetadata,
+    tools: Vec<Tool>,
+}
+
+impl GolemMcpHandler {
+    pub fn new() -> Self {
+        let metadata = GolemCliCommand::collect_metadata();
+        let tools = tools::cli_metadata_to_tools(&metadata);
+        debug!("Registered {} MCP tools", tools.len());
+        Self { metadata, tools }
+    }
+}
+
+impl ServerHandler for GolemMcpHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::default(),
+            capabilities: ServerCapabilities::builder()
+                .enable_resources()
+                .enable_tools()
+                .build(),
+            server_info: Implementation {
+                name: "golem-cli".into(),
+                title: Some("Golem CLI MCP Server".into()),
+                version: crate::version().into(),
+                description: Some("MCP Server exposing Golem CLI commands as tools and manifest files as resources".into()),
+                icons: None,
+                website_url: Some("https://golem.cloud".into()),
+            },
+            instructions: Some(
+                "This MCP server exposes Golem CLI commands as tools. \
+                 Each tool corresponds to a CLI command. Tool names use dot-separated paths \
+                 (e.g. 'component.new', 'agent.invoke'). \
+                 Manifest files (golem.yaml) in the project are available as resources."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult {
+            tools: self.tools.clone(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let tool_name = request.name.as_ref();
+        let params = match &request.arguments {
+            Some(args) => args.clone(),
+            None => serde_json::Map::new(),
+        };
+
+        debug!("Calling tool: {} with params: {:?}", tool_name, params);
+
+        // Build CLI arguments from the tool call
+        let mut cli_args = tools::tool_call_to_cli_args(tool_name, &params, &self.metadata);
+
+        // Default to JSON format for machine-readable output unless explicitly set
+        if !cli_args.iter().any(|a| a == "--format" || a == "-F") {
+            cli_args.insert(0, "--format".to_string());
+            cli_args.insert(1, "json".to_string());
+        }
+
+        // Execute the CLI command as a subprocess
+        let binary_path = std::env::current_exe().map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to determine CLI binary path: {}", e),
+                None,
+            )
+        })?;
+
+        debug!(
+            "Executing: {} {}",
+            binary_path.display(),
+            cli_args.join(" ")
+        );
+
+        let output = Command::new(&binary_path)
+            .args(&cli_args)
+            .output()
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to execute CLI command: {}", e), None)
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        let is_error = !output.status.success();
+        let mut content = Vec::new();
+
+        if !stdout.is_empty() {
+            content.push(Content::text(stdout));
+        }
+        if !stderr.is_empty() {
+            content.push(Content::text(format!("[stderr] {}", stderr)));
+        }
+        if content.is_empty() {
+            content.push(Content::text(if is_error {
+                format!(
+                    "Command failed with exit code: {}",
+                    output.status.code().unwrap_or(-1)
+                )
+            } else {
+                "Command completed successfully (no output)".to_string()
+            }));
+        }
+
+        Ok(CallToolResult {
+            content,
+            structured_content: None,
+            is_error: Some(is_error),
+            meta: None,
+        })
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        let manifest_resources = resources::discover_manifest_resources();
+        Ok(ListResourcesResult {
+            resources: manifest_resources,
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        let uri = request.uri.as_str();
+
+        match resources::read_manifest_resource(uri) {
+            Ok(contents) => Ok(ReadResourceResult { contents }),
+            Err(e) => Err(McpError::resource_not_found(
+                e,
+                Some(json!({ "uri": uri })),
+            )),
+        }
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        Ok(ListResourceTemplatesResult {
+            next_cursor: None,
+            resource_templates: Vec::new(),
+            meta: None,
+        })
+    }
+}

--- a/cli/golem-cli/src/mcp/mod.rs
+++ b/cli/golem-cli/src/mcp/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod handler;
+pub mod resources;
+pub mod serve;
+pub mod tools;
+
+use handler::GolemMcpHandler;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::ServiceExt;
+use std::process::ExitCode;
+use std::sync::Arc;
+use tracing::info;
+
+/// Transport mode for the MCP server
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpTransport {
+    Stdio,
+    StreamableHttp,
+}
+
+impl std::str::FromStr for McpTransport {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "stdio" => Ok(McpTransport::Stdio),
+            "streamable-http" | "streamablehttp" | "http" | "sse" => {
+                Ok(McpTransport::StreamableHttp)
+            }
+            _ => Err(format!(
+                "Unknown transport '{}'. Use 'stdio' or 'streamable-http'.",
+                s
+            )),
+        }
+    }
+}
+
+/// Start the MCP server with the specified transport and port.
+pub async fn start_mcp_server(
+    transport: McpTransport,
+    port: u16,
+) -> Result<ExitCode, anyhow::Error> {
+    match transport {
+        McpTransport::Stdio => {
+            info!("Starting Golem CLI MCP server (stdio transport)");
+            eprintln!("golem-cli running MCP Server (stdio)");
+
+            let handler = GolemMcpHandler::new();
+            let service = handler
+                .serve(rmcp::transport::io::stdio())
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to start MCP server: {}", e))?;
+
+            // Wait for the service to complete
+            service
+                .waiting()
+                .await
+                .map_err(|e| anyhow::anyhow!("MCP server error: {}", e))?;
+
+            Ok(ExitCode::SUCCESS)
+        }
+        McpTransport::StreamableHttp => {
+            info!(
+                "Starting Golem CLI MCP server (streamable HTTP on port {})",
+                port
+            );
+            eprintln!(
+                "golem-cli running MCP Server at http://127.0.0.1:{}/mcp",
+                port
+            );
+
+            let config = StreamableHttpServerConfig::default();
+            let ct = config.cancellation_token.clone();
+
+            let service = StreamableHttpService::new(
+                move || Ok(GolemMcpHandler::new()),
+                Arc::new(rmcp::transport::streamable_http_server::session::local::LocalSessionManager::default()),
+                config,
+            );
+
+            let app = axum::Router::new().route(
+                "/mcp",
+                axum::routing::any_service(service),
+            );
+
+            let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to bind to port {}: {}", port, e))?;
+
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    ct.cancelled().await;
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("HTTP server error: {}", e))?;
+
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}

--- a/cli/golem-cli/src/mcp/resources.rs
+++ b/cli/golem-cli/src/mcp/resources.rs
@@ -1,0 +1,122 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rmcp::model::{AnnotateAble, RawResource, Resource, ResourceContents};
+use std::path::{Path, PathBuf};
+
+const MANIFEST_FILENAME: &str = "golem.yaml";
+
+/// Discover all golem.yaml manifest files in the current directory,
+/// ancestor directories, and immediate child directories.
+pub fn discover_manifest_resources() -> Vec<Resource> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut manifests = Vec::new();
+
+    // Current directory
+    check_and_add_manifest(&cwd, &mut manifests);
+
+    // Ancestor directories
+    let mut parent = cwd.parent();
+    while let Some(dir) = parent {
+        check_and_add_manifest(dir, &mut manifests);
+        parent = dir.parent();
+    }
+
+    // Immediate child directories
+    if let Ok(entries) = std::fs::read_dir(&cwd) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                check_and_add_manifest(&path, &mut manifests);
+            }
+        }
+    }
+
+    manifests
+}
+
+fn check_and_add_manifest(dir: &Path, manifests: &mut Vec<Resource>) {
+    let manifest_path = dir.join(MANIFEST_FILENAME);
+    if manifest_path.exists() && manifest_path.is_file() {
+        let uri = path_to_file_uri(&manifest_path);
+        let name = format!(
+            "golem.yaml ({})",
+            dir.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| dir.to_string_lossy().to_string())
+        );
+        manifests.push(RawResource::new(uri, name).no_annotation());
+    }
+}
+
+fn path_to_file_uri(path: &Path) -> String {
+    let absolute = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let path_str = absolute.to_string_lossy();
+
+    // On Windows, convert backslashes to forward slashes and handle the drive prefix
+    #[cfg(target_os = "windows")]
+    {
+        let path_str = path_str.replace('\\', "/");
+        if path_str.starts_with("\\\\?\\") || path_str.starts_with("//?/") {
+            format!("file:///{}", &path_str[4..])
+        } else {
+            format!("file:///{}", path_str)
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        format!("file://{}", path_str)
+    }
+}
+
+/// Read the contents of a manifest file given its file:// URI.
+pub fn read_manifest_resource(uri: &str) -> Result<Vec<ResourceContents>, String> {
+    let file_path = file_uri_to_path(uri)?;
+
+    let content =
+        std::fs::read_to_string(&file_path).map_err(|e| format!("Failed to read {}: {}", uri, e))?;
+
+    Ok(vec![ResourceContents::text(content, uri.to_string())])
+}
+
+fn file_uri_to_path(uri: &str) -> Result<PathBuf, String> {
+    let path_str = uri
+        .strip_prefix("file:///")
+        .or_else(|| uri.strip_prefix("file://"))
+        .ok_or_else(|| format!("Invalid file URI: {}", uri))?;
+
+    Ok(PathBuf::from(path_str))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_to_file_uri() {
+        let path = Path::new("/tmp/test/golem.yaml");
+        let uri = path_to_file_uri(path);
+        assert!(
+            uri.starts_with("file://"),
+            "URI should start with file://, got: {}",
+            uri
+        );
+    }
+
+    #[test]
+    fn test_file_uri_to_path() {
+        let result = file_uri_to_path("file:///tmp/test/golem.yaml");
+        assert!(result.is_ok());
+    }
+}

--- a/cli/golem-cli/src/mcp/serve.rs
+++ b/cli/golem-cli/src/mcp/serve.rs
@@ -1,0 +1,54 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{start_mcp_server, McpTransport};
+use std::process::ExitCode;
+
+const DEFAULT_PORT: u16 = 9090;
+const DEFAULT_TRANSPORT: McpTransport = McpTransport::Stdio;
+
+/// Parse --serve-port and --serve-transport from raw CLI args and start the MCP server.
+pub async fn run_mcp_from_args(args: &[String]) -> Result<ExitCode, anyhow::Error> {
+    let port = parse_arg_value(args, "--serve-port")
+        .map(|s| {
+            s.parse::<u16>()
+                .map_err(|e| anyhow::anyhow!("Invalid port '{}': {}", s, e))
+        })
+        .transpose()?
+        .unwrap_or(DEFAULT_PORT);
+
+    let transport = parse_arg_value(args, "--serve-transport")
+        .map(|s| {
+            s.parse::<McpTransport>()
+                .map_err(|e| anyhow::anyhow!("{}", e))
+        })
+        .transpose()?
+        .unwrap_or(DEFAULT_TRANSPORT);
+
+    start_mcp_server(transport, port).await
+}
+
+fn parse_arg_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str())
+        .or_else(|| {
+            // Also support --flag=value syntax
+            args.iter().find_map(|a| {
+                a.strip_prefix(flag)
+                    .and_then(|rest| rest.strip_prefix('='))
+            })
+        })
+}

--- a/cli/golem-cli/src/mcp/tools.rs
+++ b/cli/golem-cli/src/mcp/tools.rs
@@ -1,0 +1,366 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::cli_command_metadata::{CliArgMetadata, CliCommandMetadata};
+use rmcp::model::Tool;
+use serde_json::{Map, Value};
+use std::sync::Arc;
+
+/// Convert the CLI command tree into a flat list of MCP tools.
+/// Each leaf command (no subcommands) becomes an MCP tool.
+/// The tool name uses dot-separated path (e.g. "component.new", "agent.invoke").
+pub fn cli_metadata_to_tools(metadata: &CliCommandMetadata) -> Vec<Tool> {
+    let mut tools = Vec::new();
+    collect_tools(metadata, &[], &mut tools);
+    tools
+}
+
+fn collect_tools(metadata: &CliCommandMetadata, path: &[&str], tools: &mut Vec<Tool>) {
+    if metadata.subcommands.is_empty() {
+        // Leaf command — create an MCP tool
+        if !path.is_empty() {
+            let tool = create_tool(metadata, path);
+            tools.push(tool);
+        }
+    } else {
+        // Branch command — recurse into subcommands
+        for sub in &metadata.subcommands {
+            if sub.hidden {
+                continue;
+            }
+            let mut new_path = path.to_vec();
+            new_path.push(&sub.name);
+            collect_tools(sub, &new_path, tools);
+        }
+    }
+}
+
+fn create_tool(metadata: &CliCommandMetadata, path: &[&str]) -> Tool {
+    let tool_name = path.join(".");
+
+    let description = metadata
+        .about
+        .clone()
+        .or_else(|| metadata.long_about.clone())
+        .unwrap_or_else(|| format!("Golem CLI command: {}", path.join(" ")));
+
+    let input_schema = build_input_schema(metadata);
+
+    Tool {
+        name: tool_name.into(),
+        title: None,
+        description: Some(description.into()),
+        input_schema: Arc::new(input_schema),
+        output_schema: None,
+        annotations: None,
+        execution: None,
+        icons: None,
+        meta: None,
+    }
+}
+
+fn build_input_schema(metadata: &CliCommandMetadata) -> Map<String, Value> {
+    let mut properties = Map::new();
+    let mut required = Vec::new();
+
+    for arg in &metadata.args {
+        // Skip global/hidden args
+        if arg.is_global || arg.is_hidden {
+            continue;
+        }
+        // Skip the help flag
+        if arg.id == "help" || arg.id == "version" {
+            continue;
+        }
+
+        let prop_name = arg_to_property_name(arg);
+        let prop_schema = arg_to_json_schema(arg);
+        properties.insert(prop_name.clone(), prop_schema);
+
+        if arg.is_required {
+            required.push(Value::String(prop_name));
+        }
+    }
+
+    let mut schema = Map::new();
+    schema.insert("type".into(), Value::String("object".into()));
+    schema.insert("properties".into(), Value::Object(properties));
+    if !required.is_empty() {
+        schema.insert("required".into(), Value::Array(required));
+    }
+
+    // Also add global flags as optional parameters
+    let mut global_props = Map::new();
+    add_global_flag_properties(&mut global_props);
+    if !global_props.is_empty() {
+        // Merge global props into properties
+        if let Some(Value::Object(props)) = schema.get_mut("properties") {
+            for (k, v) in global_props {
+                props.entry(k).or_insert(v);
+            }
+        }
+    }
+
+    schema
+}
+
+fn arg_to_property_name(arg: &CliArgMetadata) -> String {
+    // Use the arg id (snake_case) as the property name
+    arg.id.clone()
+}
+
+fn arg_to_json_schema(arg: &CliArgMetadata) -> Value {
+    let mut schema = Map::new();
+
+    // Determine type based on action and possible values
+    if !arg.possible_values.is_empty() {
+        // Enum type
+        schema.insert("type".into(), Value::String("string".into()));
+        let enum_values: Vec<Value> = arg
+            .possible_values
+            .iter()
+            .filter(|v| !v.hidden)
+            .map(|v| Value::String(v.name.clone()))
+            .collect();
+        schema.insert("enum".into(), Value::Array(enum_values));
+    } else if arg.action.contains("SetTrue") || arg.action.contains("SetFalse") {
+        schema.insert("type".into(), Value::String("boolean".into()));
+    } else if arg.action.contains("Count") {
+        schema.insert("type".into(), Value::String("integer".into()));
+    } else if is_array_action(&arg.action) || has_multiple_values(arg) {
+        // Array type for repeated args
+        schema.insert("type".into(), Value::String("array".into()));
+        let mut items = Map::new();
+        items.insert("type".into(), Value::String("string".into()));
+        schema.insert("items".into(), Value::Object(items));
+    } else {
+        schema.insert("type".into(), Value::String("string".into()));
+    }
+
+    // Add description
+    if let Some(ref help) = arg.help {
+        schema.insert("description".into(), Value::String(help.clone()));
+    } else if let Some(ref long_help) = arg.long_help {
+        schema.insert("description".into(), Value::String(long_help.clone()));
+    }
+
+    // Add default values
+    if !arg.default_values.is_empty() {
+        if arg.default_values.len() == 1 {
+            schema.insert(
+                "default".into(),
+                Value::String(arg.default_values[0].clone()),
+            );
+        }
+    }
+
+    Value::Object(schema)
+}
+
+fn is_array_action(action: &str) -> bool {
+    action.contains("Append")
+}
+
+fn has_multiple_values(arg: &CliArgMetadata) -> bool {
+    if let Some(ref num_args) = arg.num_args {
+        // e.g. "1..=18446744073709551615" or "0..=1"
+        num_args.contains("..") && !num_args.ends_with("=1")
+    } else {
+        false
+    }
+}
+
+fn add_global_flag_properties(props: &mut Map<String, Value>) {
+    // Add commonly used global flags as optional properties
+    let global_flags = vec![
+        (
+            "format",
+            "Output format (text, json, yaml)",
+            vec!["text", "json", "yaml"],
+        ),
+        ("profile", "Golem profile name to use", vec![]),
+        ("environment", "Golem environment name to use", vec![]),
+    ];
+
+    for (name, desc, possible_values) in global_flags {
+        let mut schema = Map::new();
+        schema.insert("type".into(), Value::String("string".into()));
+        schema.insert("description".into(), Value::String(desc.into()));
+        if !possible_values.is_empty() {
+            let values: Vec<Value> = possible_values
+                .into_iter()
+                .map(|v| Value::String(v.into()))
+                .collect();
+            schema.insert("enum".into(), Value::Array(values));
+        }
+        props.insert(name.into(), Value::Object(schema));
+    }
+}
+
+/// Reconstruct CLI arguments from MCP tool call parameters.
+/// Takes the tool name (dot-separated path) and the JSON parameters,
+/// and returns a Vec of command-line argument strings.
+pub fn tool_call_to_cli_args(
+    tool_name: &str,
+    params: &Map<String, Value>,
+    metadata: &CliCommandMetadata,
+) -> Vec<String> {
+    let mut args = Vec::new();
+
+    // Convert tool name path to subcommand args
+    // e.g. "component.new" -> ["component", "new"]
+    let subcommands: Vec<&str> = tool_name.split('.').collect();
+    args.extend(subcommands.iter().map(|s| s.to_string()));
+
+    // Find the metadata for this specific command
+    let cmd_metadata = find_command_metadata(metadata, &subcommands);
+
+    if let Some(cmd) = cmd_metadata {
+        // Convert parameters to CLI flags
+        for (key, value) in params {
+            // Check if this is a global flag
+            if matches!(key.as_str(), "format" | "profile" | "environment") {
+                if let Value::String(s) = value {
+                    args.push(format!("--{}", key));
+                    args.push(s.clone());
+                }
+                continue;
+            }
+
+            // Find the arg metadata for this parameter
+            if let Some(arg_meta) = cmd.args.iter().find(|a| a.id == *key) {
+                add_arg_to_cli_args(&mut args, arg_meta, value);
+            }
+        }
+    }
+
+    args
+}
+
+fn find_command_metadata<'a>(
+    metadata: &'a CliCommandMetadata,
+    path: &[&str],
+) -> Option<&'a CliCommandMetadata> {
+    if path.is_empty() {
+        return Some(metadata);
+    }
+
+    for sub in &metadata.subcommands {
+        if sub.name == path[0] {
+            if path.len() == 1 {
+                return Some(sub);
+            }
+            return find_command_metadata(sub, &path[1..]);
+        }
+    }
+
+    None
+}
+
+fn add_arg_to_cli_args(args: &mut Vec<String>, arg_meta: &CliArgMetadata, value: &Value) {
+    if arg_meta.is_positional {
+        // Positional arguments
+        match value {
+            Value::String(s) => args.push(s.clone()),
+            Value::Array(arr) => {
+                for v in arr {
+                    if let Value::String(s) = v {
+                        args.push(s.clone());
+                    }
+                }
+            }
+            Value::Number(n) => args.push(n.to_string()),
+            Value::Bool(b) => args.push(b.to_string()),
+            _ => {}
+        }
+    } else {
+        // Named arguments (flags)
+        let flag_name = if let Some(long) = arg_meta.long.first() {
+            format!("--{}", long)
+        } else if let Some(short) = arg_meta.short.first() {
+            format!("-{}", short)
+        } else {
+            format!("--{}", arg_meta.id)
+        };
+
+        match value {
+            Value::Bool(true) => {
+                args.push(flag_name);
+            }
+            Value::Bool(false) => {
+                // Don't add flag for false
+            }
+            Value::String(s) => {
+                args.push(flag_name);
+                args.push(s.clone());
+            }
+            Value::Number(n) => {
+                args.push(flag_name);
+                args.push(n.to_string());
+            }
+            Value::Array(arr) => {
+                for v in arr {
+                    args.push(flag_name.clone());
+                    match v {
+                        Value::String(s) => args.push(s.clone()),
+                        Value::Number(n) => args.push(n.to_string()),
+                        _ => args.push(v.to_string()),
+                    }
+                }
+            }
+            _ => {
+                args.push(flag_name);
+                args.push(value.to_string());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::GolemCliCommand;
+
+    #[test]
+    fn test_cli_metadata_to_tools_produces_tools() {
+        let metadata = GolemCliCommand::collect_metadata();
+        let tools = cli_metadata_to_tools(&metadata);
+        assert!(!tools.is_empty(), "Should produce at least one tool");
+
+        // Check that we have common commands
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            tool_names.contains(&"build"),
+            "Should have 'build' tool, got: {:?}",
+            tool_names
+        );
+        assert!(
+            tool_names.contains(&"deploy"),
+            "Should have 'deploy' tool, got: {:?}",
+            tool_names
+        );
+    }
+
+    #[test]
+    fn test_tool_call_to_cli_args() {
+        let metadata = GolemCliCommand::collect_metadata();
+        let mut params = Map::new();
+        params.insert("format".into(), Value::String("json".into()));
+
+        let args = tool_call_to_cli_args("build", &params, &metadata);
+        assert!(args.contains(&"build".to_string()));
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+}


### PR DESCRIPTION
Implements MCP (Model Context Protocol) Server for golem-cli per issue #1926.

When run with --serve, the CLI starts an MCP Server that:
- Exposes CLI commands as MCP tools with JSON Schema parameters
- Exposes golem.yaml manifest files as MCP resources
- Supports both stdio and streamable-http transports (--serve-port)
- Gated behind 'mcp' feature flag (no impact on default builds)

New files:
- cli/golem-cli/src/mcp/mod.rs - Module declarations
- cli/golem-cli/src/mcp/serve.rs - Server startup and transport selection
- cli/golem-cli/src/mcp/handler.rs - ServerHandler trait implementation
- cli/golem-cli/src/mcp/tools.rs - CLI command to MCP tool mapping
- cli/golem-cli/src/mcp/resources.rs - Manifest file discovery and exposure

Uses rmcp crate for MCP protocol handling.
cargo check -p golem-cli --features mcp passes with 0 errors.