### PR TITLE
Split integration tests for faster CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,6 +264,10 @@ jobs:
             description: "IT #3"
           - name: integration-tests-group4
             description: "IT #4"
+          - name: integration-tests-group5
+            description: "IT #5"
+          - name: integration-tests-group6
+            description: "IT #6"
           - name: cli-integration-tests-group1
             description: "CLI tests #1"
           - name: cli-integration-tests-group2

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -441,27 +441,45 @@ dependencies = [
     "integration-tests-group2",
     "integration-tests-group3",
     "integration-tests-group4",
+    "integration-tests-group5",
+    "integration-tests-group6",
     "cli-integration-tests",
 ]
 
 [tasks.integration-tests-group1]
-description = "Runs integration tests (group 1/4)"
+description = "Runs integration tests (group 1/6 - worker, fork)"
 dependencies = ["build-bins-non-ci"]
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script = '''
-cargo-test-r run --package integration-tests --test integration -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
+cargo-test-r run --package integration-tests --test integration :tag:group1 -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
 '''
 
 [tasks.integration-tests-group2]
-description = "Runs integration tests (group 2/4)"
+description = "Runs integration tests (group 2/6 - worker_local_agent_config, api, custom_api)"
 dependencies = ["build-bins-non-ci"]
-env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM_TEST_DB" = "sqlite" }
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script = '''
-cargo-test-r run --package integration-tests --test integration -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
+cargo-test-r run --package integration-tests --test integration :tag:group2 -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
 '''
 
 [tasks.integration-tests-group3]
-description = "Runs integration tests (group 3/4)"
+description = "Runs integration tests (group 3/6 - worker, fork with sqlite)"
+dependencies = ["build-bins-non-ci"]
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM_TEST_DB" = "sqlite" }
+script = '''
+cargo-test-r run --package integration-tests --test integration :tag:group1 -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
+'''
+
+[tasks.integration-tests-group4]
+description = "Runs integration tests (group 4/6 - worker_local_agent_config, api, custom_api with sqlite)"
+dependencies = ["build-bins-non-ci"]
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM_TEST_DB" = "sqlite" }
+script = '''
+cargo-test-r run --package integration-tests --test integration :tag:group2 -- --nocapture --test-threads=1 --report-time $JUNIT_OPTS
+'''
+
+[tasks.integration-tests-group5]
+description = "Runs integration tests (group 5/6 - service tests)"
 dependencies = ["wit"]
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script = '''
@@ -471,8 +489,8 @@ cargo-test-r run --package golem-worker-service --test '*' -- --nocapture --repo
 cargo-test-r run --package golem-debugging-service --test '*' -- --report-time $JUNIT_OPTS
 '''
 
-[tasks.integration-tests-group4]
-description = "Runs integration tests (group 4/4)"
+[tasks.integration-tests-group6]
+description = "Runs integration tests (group 6/6 - sharding)"
 dependencies = ["build-bins-non-ci"]
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_ATTEMPTS" = "20", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_DELAY" = "1s" }
 script = '''

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -23,9 +23,16 @@ use golem_common::tracing::{init_tracing_with_default_debug_env_filter, TracingC
 use golem_test_framework::config::{
     EnvBasedTestDependencies, EnvBasedTestDependenciesConfig, TestDependencies,
 };
-use test_r::test_dep;
+use test_r::{tag_suite, test_dep};
 
 test_r::enable!();
+
+tag_suite!(worker, group1);
+tag_suite!(fork, group1);
+
+tag_suite!(worker_local_agent_config, group2);
+tag_suite!(api, group2);
+tag_suite!(custom_api, group2);
 
 #[derive(Debug)]
 pub struct Tracing;


### PR DESCRIPTION
The integration tests became significantly slower during the past months (many new tests) so let's split them to parallel CI sessions