### PR TITLE
throw agent-error instead of custom for http mount validations

### DIFF
--- a/sdks/ts/packages/golem-ts-sdk/src/internal/http/path.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/internal/http/path.ts
@@ -14,10 +14,11 @@
 
 import { PathSegment } from 'golem:agent/common@1.5.0';
 import { rejectEmptyString } from './validation';
+import { invalidInput } from '../agentError';
 
 export function parsePath(path: string): PathSegment[] {
   if (!path.startsWith('/')) {
-    throw new Error(`HTTP mount must start with "/"`);
+    throw invalidInput(`HTTP mount must start with "/"`);
   }
 
   if (path === '/') {
@@ -31,23 +32,23 @@ export function parsePath(path: string): PathSegment[] {
 
 function parseSegment(segment: string, isLast: boolean): PathSegment {
   if (!segment) {
-    throw new Error(`Empty path segment ("//") is not allowed`);
+    throw invalidInput(`Empty path segment ("//") is not allowed`);
   }
 
   if (segment !== segment.trim()) {
-    throw new Error(`Whitespace is not allowed in path segments`);
+    throw invalidInput(`Whitespace is not allowed in path segments`);
   }
 
   if (segment.startsWith('{') && segment.endsWith('}')) {
     const name = segment.slice(1, -1);
 
     if (!name) {
-      throw new Error(`Empty path variable "{}" is not allowed`);
+      throw invalidInput(`Empty path variable "{}" is not allowed`);
     }
 
     if (name.startsWith('*')) {
       if (!isLast) {
-        throw new Error(
+        throw invalidInput(
           `Remaining path variable "{${name}}" is only allowed as the last path segment`,
         );
       }
@@ -77,7 +78,7 @@ function parseSegment(segment: string, isLast: boolean): PathSegment {
   }
 
   if (segment.includes('{') || segment.includes('}')) {
-    throw new Error(
+    throw invalidInput(
       `Path segment "${segment}" must be a whole variable like "{id}" and cannot mix literals and variables`,
     );
   }

--- a/sdks/ts/packages/golem-ts-sdk/src/internal/http/query.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/internal/http/query.ts
@@ -14,6 +14,7 @@
 
 import { QueryVariable } from 'golem:agent/common@1.5.0';
 import { rejectEmptyString } from './validation';
+import { invalidInput } from '../agentError';
 
 // parseQuery is intended for HTTP endpoint definitions, not mounts
 export function parseQuery(query: string): QueryVariable[] {
@@ -23,15 +24,15 @@ export function parseQuery(query: string): QueryVariable[] {
     const [key, value] = pair.split('=');
 
     if (!key || !value) {
-      throw new Error(`Invalid query segment "${pair}"`);
+      throw invalidInput(`Invalid query segment "${pair}"`);
     }
 
     if (value !== value.trim()) {
-      throw new Error(`Whitespace is not allowed in query variables`);
+      throw invalidInput(`Whitespace is not allowed in query variables`);
     }
 
     if (!value.startsWith('{') || !value.endsWith('}')) {
-      throw new Error(`Query value for "${key}" must be a variable reference`);
+      throw invalidInput(`Query value for "${key}" must be a variable reference`);
     }
 
     const variableName = value.slice(1, -1);

--- a/sdks/ts/packages/golem-ts-sdk/src/internal/http/validation.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/internal/http/validation.ts
@@ -22,6 +22,7 @@ import {
 import { AgentMethodParamRegistry } from '../registry/agentMethodParamRegistry';
 import { AgentConstructorParamRegistry } from '../registry/agentConstructorParamRegistry';
 import { TypeInfoInternal } from '../typeInfoInternal';
+import { invalidInput } from '../agentError';
 
 export function validateHttpMount(
   agentClassName: string,
@@ -65,13 +66,13 @@ export function validateHttpEndpoint(
 
 export function rejectEmptyString(name: string, entityName: string) {
   if (name.length === 0) {
-    throw new Error(`HTTP ${entityName} must not be empty`);
+    throw invalidInput(`HTTP ${entityName} must not be empty`);
   }
 }
 
 export function rejectQueryParamsInPath(path: string, entityName: string) {
   if (path.includes('?')) {
-    throw new Error(`HTTP ${entityName} must not contain query parameters`);
+    throw invalidInput(`HTTP ${entityName} must not contain query parameters`);
   }
 }
 
@@ -85,7 +86,7 @@ function validateMountIsDefinedForHttpEndpoint(
   httpMountDetails: HttpMountDetails | undefined,
 ) {
   if (!httpMountDetails && agentMethod.httpEndpoint.length > 0) {
-    throw new Error(
+    throw invalidInput(
       `Agent method '${agentMethod.name}' of '${agentClassName}' defines HTTP endpoints ` +
         `but the agent is not mounted over HTTP. Please specify mount details in 'agent' decorator.`,
     );
@@ -98,7 +99,7 @@ function validateNoCatchAllInHttpMount(agentClassName: string, agentMount: HttpM
   );
 
   if (catchAllSegment) {
-    throw new Error(
+    throw invalidInput(
       `HTTP mount for agent '${agentClassName}' cannot contain catch-all path variable '${catchAllSegment.val.variableName}'`,
     );
   }
@@ -118,17 +119,17 @@ function validateEndpointVariables(
     binaryError: string,
   ) {
     if (principalParams.has(variableName)) {
-      throw new Error(
+      throw invalidInput(
         `HTTP endpoint ${location} variable '${variableName}' cannot be used for parameters of type 'Principal'`,
       );
     }
 
     if (unstructuredBinaryParams.has(variableName)) {
-      throw new Error(binaryError);
+      throw invalidInput(binaryError);
     }
 
     if (!methodVars.has(variableName)) {
-      throw new Error(
+      throw invalidInput(
         `HTTP endpoint ${location} variable '${variableName}' is not defined in method input parameters.`,
       );
     }
@@ -197,7 +198,7 @@ function validateConstructorParamsAreHttpSafe(
 ) {
   for (const [paramName, paramSchema] of agentConstructor.inputSchema.val) {
     if (paramSchema.tag === 'unstructured-binary') {
-      throw new Error(
+      throw invalidInput(
         `HTTP mount path variable '${paramName}' cannot be used for constructor parameters of type 'UnstructuredBinary'`,
       );
     }
@@ -212,7 +213,7 @@ function validateMountVariablesAreNotPrincipal(
     if (segment.tag === 'path-variable') {
       const variableName = segment.val.variableName;
       if (parametersForPrincipal.has(variableName)) {
-        throw new Error(
+        throw invalidInput(
           `HTTP mount path variable '${variableName}' cannot be used for constructor parameters of type 'Principal'`,
         );
       }
@@ -229,7 +230,7 @@ function validateMountVariablesExistInConstructor(
       const variableName = segment.val.variableName;
 
       if (!constructorVars.has(variableName)) {
-        throw new Error(
+        throw invalidInput(
           `HTTP mount path variable '${variableName}' ` +
             `(in path segment ${segmentIndex}) ` +
             `is not defined in the agent constructor.`,
@@ -247,7 +248,7 @@ function validateConstructorVarsAreSatisfied(
 
   for (const constructorVar of constructorVars) {
     if (!providedVars.has(constructorVar)) {
-      throw new Error(
+      throw invalidInput(
         `Agent constructor variable '${constructorVar}' ` +
           `is not provided by the HTTP mount path.`,
       );

--- a/sdks/ts/packages/golem-ts-sdk/tests/http.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/http.test.ts
@@ -18,6 +18,17 @@ import { AgentDecoratorOptions } from '../src';
 import { parseQuery } from '../src/internal/http/query';
 import { AgentMethod, HttpEndpointDetails, HttpMountDetails } from 'golem:agent/common@1.5.0';
 import { validateHttpEndpoint, validateHttpMount } from '../src/internal/http/validation';
+import { isAgentError } from '../src/internal/agentError';
+
+function expectAgentError(fn: () => void, expectedMessage: string) {
+  try {
+    fn();
+    expect.unreachable('Expected function to throw');
+  } catch (e) {
+    expect(isAgentError(e)).toBe(true);
+    expect((e as { val: string }).val).toContain(expectedMessage);
+  }
+}
 
 describe('getHttpMountDetails – basic behavior', () => {
   it('returns undefined when mount is not provided', () => {
@@ -106,30 +117,37 @@ describe('getHttpMountDetails – webhook suffix', () => {
 
 describe('getHttpMountDetails – validation errors', () => {
   it('rejects mount with query parameters', () => {
-    expect(() => getHttpMountDetails({ mount: '/chats?id={chatId}' })).toThrow(
+    expectAgentError(
+      () => getHttpMountDetails({ mount: '/chats?id={chatId}' }),
       'HTTP mount must not contain query parameters',
     );
   });
 
   it('rejects webhook suffix with query parameters', () => {
-    expect(() =>
-      getHttpMountDetails({
-        mount: '/chats',
-        webhookSuffix: '/hook?event={event}',
-      }),
-    ).toThrow('HTTP webhook suffix must not contain query parameters');
+    expectAgentError(
+      () =>
+        getHttpMountDetails({
+          mount: '/chats',
+          webhookSuffix: '/hook?event={event}',
+        }),
+      'HTTP webhook suffix must not contain query parameters',
+    );
   });
 
   it('rejects mount without leading slash', () => {
-    expect(() => getHttpMountDetails({ mount: 'chats' })).toThrow('HTTP mount must start with "/"');
+    expectAgentError(
+      () => getHttpMountDetails({ mount: 'chats' }),
+      'HTTP mount must start with "/"',
+    );
   });
 
   it('rejects empty path segments', () => {
-    expect(() => getHttpMountDetails({ mount: '/chats//foo' })).toThrow('Empty path segment');
+    expectAgentError(() => getHttpMountDetails({ mount: '/chats//foo' }), 'Empty path segment');
   });
 
   it('rejects unclosed path variable', () => {
-    expect(() => getHttpMountDetails({ mount: '/chats/{id' })).toThrow(
+    expectAgentError(
+      () => getHttpMountDetails({ mount: '/chats/{id' }),
       'Path segment "{id" must be a whole variable like "{id}" and cannot mix literals and variables',
     );
   });
@@ -179,7 +197,8 @@ describe('validateHttpMountWithConstructor', () => {
     const agentMount = mount(['chatId']);
     const agentConstructor = constructorVars('chatId', 'tenant');
 
-    expect(() => validateHttpMount('Foo', agentMount, agentConstructor)).toThrow(
+    expectAgentError(
+      () => validateHttpMount('Foo', agentMount, agentConstructor),
       "Agent constructor variable 'tenant' is not provided by the HTTP mount path.",
     );
   });
@@ -188,7 +207,8 @@ describe('validateHttpMountWithConstructor', () => {
     const agentMount = mount(['chatId']);
     const agentConstructor = constructorVars();
 
-    expect(() => validateHttpMount('Foo', agentMount, agentConstructor)).toThrow(
+    expectAgentError(
+      () => validateHttpMount('Foo', agentMount, agentConstructor),
       "HTTP mount path variable 'chatId' (in path segment 0) is not defined in the agent constructor.",
     );
   });
@@ -258,7 +278,8 @@ describe('validateHttpEndpoint', () => {
   it('fails when endpoint path variable is not part of method input', () => {
     const agentMethod = method([], [endpoint(['id'])]);
 
-    expect(() => validateHttpEndpoint(agentName, agentMethod, httpMountDetails)).toThrow(
+    expectAgentError(
+      () => validateHttpEndpoint(agentName, agentMethod, httpMountDetails),
       "HTTP endpoint path variable 'id' is not defined in method input parameters.",
     );
   });
@@ -266,7 +287,8 @@ describe('validateHttpEndpoint', () => {
   it('fails when endpoint query variable is not part of method input', () => {
     const agentMethod = method([], [endpoint([], ['limit'])]);
 
-    expect(() => validateHttpEndpoint(agentName, agentMethod, httpMountDetails)).toThrow(
+    expectAgentError(
+      () => validateHttpEndpoint(agentName, agentMethod, httpMountDetails),
       "HTTP endpoint query variable 'limit' is not defined in method input parameters.",
     );
   });
@@ -274,7 +296,8 @@ describe('validateHttpEndpoint', () => {
   it('fails when endpoint header variable is not part of method input', () => {
     const agentMethod = method([], [endpoint([], [], ['tenant'])]);
 
-    expect(() => validateHttpEndpoint(agentName, agentMethod, httpMountDetails)).toThrow(
+    expectAgentError(
+      () => validateHttpEndpoint(agentName, agentMethod, httpMountDetails),
       "HTTP endpoint header variable 'tenant' is not defined in method input parameters.",
     );
   });
@@ -288,7 +311,8 @@ describe('validateHttpEndpoint', () => {
       ],
     );
 
-    expect(() => validateHttpEndpoint(agentName, agentMethod, httpMountDetails)).toThrow(
+    expectAgentError(
+      () => validateHttpEndpoint(agentName, agentMethod, httpMountDetails),
       "HTTP endpoint path variable 'foo' is not defined in method input parameters.",
     );
   });
@@ -296,7 +320,8 @@ describe('validateHttpEndpoint', () => {
   it('endpoints with no mount details', () => {
     const agentMethod = method(['id'], [endpoint(['id'])]);
 
-    expect(() => validateHttpEndpoint(agentName, agentMethod, undefined)).toThrow(
+    expectAgentError(
+      () => validateHttpEndpoint(agentName, agentMethod, undefined),
       "Agent method 'doThing' of 'TestAgent' defines HTTP endpoints but the agent is not mounted over HTTP. Please specify mount details in 'agent' decorator.",
     );
   });

--- a/sdks/ts/packages/golem-ts-sdk/tests/invalid.agents.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/invalid.agents.test.ts
@@ -21,6 +21,17 @@ import { TypeScope } from '../src/internal/mapping/types/scope';
 import * as Either from '../src/newTypes/either';
 import { agent, AgentId, BaseAgent } from '../src';
 import { typeMapper } from '../src/internal/mapping/types/typeMapperImpl';
+import { isAgentError } from '../src/internal/agentError';
+
+async function expectAsyncAgentError(fn: () => Promise<unknown>, expectedMessage: string) {
+  try {
+    await fn();
+    expect.unreachable('Expected function to throw');
+  } catch (e) {
+    expect(isAgentError(e)).toBe(true);
+    expect((e as { val: string }).val).toContain(expectedMessage);
+  }
+}
 
 const invalidAgent = TypeMetadata.getAll().get('InvalidAgent');
 const fun1Params = invalidAgent?.methods.get('fun1')?.methodParams;
@@ -235,49 +246,55 @@ test('Agent method with empty tuple return type is rejected', async () => {
 });
 
 test('Agent with with unsatisfied http mount is rejected', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpMount1');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpMount1');
+    },
     "Agent constructor variable 'bar' is not provided by the HTTP mount path.",
   );
 });
 
 test('Agent with with http mount variable bound to Principal is rejected', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpMount2');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpMount2');
+    },
     "HTTP mount path variable 'bar' cannot be used for constructor parameters of type 'Principal'",
   );
 });
 
 test('Agent with with http mount variable bound to UnstructuredBinary is rejected', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpMount3');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpMount3');
+    },
     "HTTP mount path variable 'bar' cannot be used for constructor parameters of type 'UnstructuredBinary'",
   );
 });
 
 test('Agent with with http mount variable with catch-all variable', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpMount4');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpMount4');
+    },
     "HTTP mount for agent 'AgentWithInvalidHttpMount4' cannot contain catch-all path variable 'filePath'",
   );
 });
 
 test('Agent with with http endpoint query variables referring to Principal is rejected', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpEndpoint1');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpEndpoint1');
+    },
     "HTTP endpoint query variable 'user' cannot be used for parameters of type 'Principal'",
   );
 });
 
 test('Agent with with http endpoint path variables referring to Principal is rejected', async () => {
-  await expect(async () => {
-    await import('./agentWithInvalidHttpEndpoint2');
-  }).rejects.toThrowError(
+  await expectAsyncAgentError(
+    async () => {
+      await import('./agentWithInvalidHttpEndpoint2');
+    },
     "HTTP endpoint path variable 'user' cannot be used for parameters of type 'Principal'",
   );
 });


### PR DESCRIPTION
Fixes #2935 

I am feeling not much "outcome" from this change

```
  Adding metadata to my:ts
Preparing deployment
  Extracting my:ts agent types from /Users/afsalthaj/agent-http/components-ts/my-ts/../../golem-temp/agents/my_ts.wasm


thread '<unnamed>' (1) panicked at src/internal.rs:112:42:
Failed to finish importing user module user:
Error: invalid-input: Agent constructor variable 'name' is not provided by the HTTP mount path.
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```

Previous error is in issue description