### PR TITLE
Cancel pending invocations and updates on fork

### DIFF
--- a/golem-debugging-service/tests/debug_tests.rs
+++ b/golem-debugging-service/tests/debug_tests.rs
@@ -445,7 +445,24 @@ async fn test_playback_and_fork(
     assert_eq!(connect_result.agent_id, agent_id);
     assert_eq!(playback_result.agent_id, agent_id);
     assert!(fork_result.is_ok());
-    assert_eq!(forked_oplog_len_before, u64::from(first_boundary) as usize);
+
+    // The forked oplog should contain the entries up to first_boundary, plus
+    // any CancelPendingInvocation/FailedUpdate entries appended by the fork to
+    // cancel pending work inherited from the source worker's oplog.
+    let cancel_count = forked_oplogs
+        .iter()
+        .filter(|e| {
+            matches!(
+                &e.entry,
+                PublicOplogEntry::CancelPendingInvocation(_) | PublicOplogEntry::FailedUpdate(_)
+            )
+        })
+        .count();
+    assert_eq!(
+        forked_oplog_len_before,
+        u64::from(first_boundary) as usize + cancel_count
+    );
+
     assert!(forked_oplogs_after.len() > forked_oplog_len_before);
 
     Ok(())

--- a/golem-worker-executor/src/services/worker_fork.rs
+++ b/golem-worker-executor/src/services/worker_fork.rs
@@ -39,6 +39,8 @@ use crate::services::{rdbms, HasOplog, HasRdbmsService, HasWorkerForkService};
 use crate::worker::Worker;
 use crate::workerctx::WorkerCtx;
 use async_trait::async_trait;
+use golem_common::base_model::component::ComponentRevision;
+use golem_common::base_model::regions::DeletedRegionsBuilder;
 use golem_common::model::account::AccountId;
 use golem_common::model::agent::Principal;
 use golem_common::model::environment::EnvironmentId;
@@ -48,7 +50,7 @@ use golem_common::model::oplog::{
     DurableFunctionType, HostPayloadPair, HostRequest, HostRequestNoInput, HostResponse,
     HostResponseGolemApiFork, OplogEntry, OplogIndex, OplogIndexRange,
 };
-use golem_common::model::{AgentId, OwnedAgentId};
+use golem_common::model::{AgentId, IdempotencyKey, OwnedAgentId};
 use golem_common::model::{AgentMetadata, Timestamp};
 use golem_common::read_only_lock;
 use golem_service_base::error::worker_executor::WorkerExecutorError;
@@ -538,9 +540,89 @@ impl<Ctx: WorkerCtx> DefaultWorkerFork<Ctx> {
 
         let oplog_range = OplogIndexRange::new(OplogIndex::INITIAL.next(), oplog_index_cut_off);
 
+        // Track pending invocations and updates while copying, so we can cancel
+        // any that remain unmatched. This prevents the forked worker from inheriting
+        // and re-executing pending work from the source worker.
+        let mut pending_invocation_keys: Vec<IdempotencyKey> = Vec::new();
+        let mut pending_update_revisions: Vec<ComponentRevision> = Vec::new();
+        let mut deleted_regions_builder = DeletedRegionsBuilder::new();
+
         for oplog_index in oplog_range {
             let entry = source_oplog.read(oplog_index).await;
             new_oplog.add(entry.clone()).await;
+
+            if let OplogEntry::Revert { dropped_region, .. } = &entry {
+                deleted_regions_builder.add(dropped_region.clone());
+            }
+
+            // For pending invocations, deleted regions don't matter - both inputs
+            // and outputs in deleted regions are still accounted for (see calculate_pending_invocations).
+            match &entry {
+                OplogEntry::PendingAgentInvocation {
+                    idempotency_key, ..
+                } => {
+                    pending_invocation_keys.push(idempotency_key.clone());
+                }
+                OplogEntry::AgentInvocationStarted {
+                    idempotency_key, ..
+                } => {
+                    pending_invocation_keys.retain(|key| key != idempotency_key);
+                }
+                OplogEntry::CancelPendingInvocation {
+                    idempotency_key, ..
+                } => {
+                    pending_invocation_keys.retain(|key| key != idempotency_key);
+                }
+                _ => {}
+            }
+        }
+
+        // For pending updates, we need to respect deleted regions (see calculate_update_fields).
+        let deleted_regions = deleted_regions_builder.build();
+        let oplog_range = OplogIndexRange::new(OplogIndex::INITIAL.next(), oplog_index_cut_off);
+        for oplog_index in oplog_range {
+            if deleted_regions.is_in_deleted_region(oplog_index) {
+                continue;
+            }
+            let entry = source_oplog.read(oplog_index).await;
+            match &entry {
+                OplogEntry::PendingUpdate { description, .. } => {
+                    pending_update_revisions.push(*description.target_revision());
+                }
+                OplogEntry::SuccessfulUpdate { .. } | OplogEntry::FailedUpdate { .. } => {
+                    // Pop front to match calculate_update_fields semantics
+                    if !pending_update_revisions.is_empty() {
+                        pending_update_revisions.remove(0);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Append cancellation entries for any remaining pending invocations and updates
+        let now = Timestamp::now_utc();
+
+        for idempotency_key in pending_invocation_keys {
+            tracing::debug!("Cancelling pending invocation {idempotency_key} in forked worker");
+            new_oplog
+                .add(OplogEntry::CancelPendingInvocation {
+                    timestamp: now,
+                    idempotency_key,
+                })
+                .await;
+        }
+
+        for target_revision in pending_update_revisions {
+            tracing::debug!(
+                "Cancelling pending update to revision {target_revision} in forked worker"
+            );
+            new_oplog
+                .add(OplogEntry::FailedUpdate {
+                    timestamp: now,
+                    target_revision,
+                    details: Some("cancelled by fork".to_string()),
+                })
+                .await;
         }
 
         Ok(new_oplog)


### PR DESCRIPTION
Fork was copying the oplog as-is up until a given index, including the oplog entries that enqueue invocations and updates. This means the forked agent inherited these pending commands and immediately started executing them. 

This is not the desired behavior for any of the fork use cases:

- If you fork in a debugging session at a given point, if it was idle, you want the forked agent to be idle at the fork point. If it was in the middle of an invocation, you want the invocation to continue from there, but then become idle.
- If you fork from code in a "fork/join" pattern, for example, you want the forked agent to continue running from the fork point, do something and then potentially stay idle forever

In none of these cases you want to the forked agents to continue processing things that were enqueued for the original agent.

This was causing flaky debugger tests as well.

The fix is: after copying the oplog for the fork, append cancel items to clear up its queue (this way it is not necessary to modify the copied oplog in any way).