### PR TITLE
Fix shard manager using hardcoded port 8080 for registry service in single-executable mode

### DIFF
--- a/cli/golem/src/launch.rs
+++ b/cli/golem/src/launch.rs
@@ -157,7 +157,8 @@ async fn start_components(
     )
     .await?;
 
-    let shard_manager = run_shard_manager(shard_manager_config(args, &registry_service), join_set).await?;
+    let shard_manager =
+        run_shard_manager(shard_manager_config(args, &registry_service), join_set).await?;
 
     let worker_service = run_worker_service(
         worker_service_config(args, &shard_manager, &registry_service),


### PR DESCRIPTION
@vigoo I ran into this issue during testing - claude suggested this fix that seems to work