### PR TITLE
fix: release concurrent agent permit when agent goes idle

### DIFF
--- a/golem-worker-executor/src/services/active_workers/concurrent_agents_semaphore.rs
+++ b/golem-worker-executor/src/services/active_workers/concurrent_agents_semaphore.rs
@@ -21,14 +21,14 @@ use tracing::debug;
 /// Per-account concurrent agent limit semaphore.
 ///
 /// Each account has its own tokio `Semaphore` sized to
-/// `AtomicResourceEntry::max_concurrent_agents_per_executor()`. When an agent
-/// starts it must acquire one permit; when it stops the permit is returned
-/// automatically via `Drop`.
+/// `AtomicResourceEntry::max_concurrent_agents_per_executor()`. Only
+/// **actively running** agents hold permits; idle agents release theirs back
+/// to the pool so new agents can start without eviction.
 ///
-/// Permits are only ever requested at agent startup (`WaitingWorker::new`).
-/// Running agents never request additional permits, so there is no need for a
-/// priority lock or non-blocking `try_acquire` — all callers are on equal
-/// footing in the startup path.
+/// Permits are acquired at agent startup (`WaitingWorker::new`) and each time
+/// an idle agent wakes up to process a command. They are released when the
+/// agent goes idle (via `Drop` of the `OwnedSemaphorePermit` in the
+/// invocation loop) or when the agent is stopped.
 ///
 /// Extracted as a standalone struct (no `WorkerCtx` generic) so it can be
 /// unit-tested in isolation, following the same pattern as

--- a/golem-worker-executor/src/services/active_workers/mod.rs
+++ b/golem-worker-executor/src/services/active_workers/mod.rs
@@ -309,49 +309,20 @@ impl<Ctx: WorkerCtx> ActiveWorkers<Ctx> {
 
     /// Blocking acquire of one concurrent-agent permit for `account_id`.
     ///
-    /// Before blocking, attempts to evict the oldest idle agent belonging to the
-    /// same account to free up a slot. If no idle agent exists, waits until a
-    /// running agent from the same account stops and returns its permit.
+    /// Only actively running agents hold permits — idle agents release theirs
+    /// back to the pool. In the common case permits are already available and
+    /// the acquire succeeds immediately.
+    ///
+    /// If all permits are held by actively running agents, waits efficiently on
+    /// the semaphore until one of them finishes its current invocation and
+    /// releases its permit by going idle.
     ///
     /// Returns immediately (zero-cost permit) for accounts whose plan limit is
     /// at or above the unlimited sentinel.
     pub async fn acquire_concurrent_agent(&self, account_id: AccountId) -> OwnedSemaphorePermit {
-        let workers = self.workers.clone();
         self.concurrent_agents
-            .acquire(account_id, move || async move {
-                Self::try_free_up_concurrent_agent_slot(&workers, account_id).await
-            })
+            .acquire(account_id, || async { false })
             .await
-    }
-
-    /// Evict the oldest idle agent belonging to `account_id` to free a
-    /// concurrent-agent slot. Returns `true` if an agent was successfully
-    /// stopped (its permit will be returned to the semaphore via `Drop`).
-    async fn try_free_up_concurrent_agent_slot(
-        workers: &Cache<AgentId, (), Arc<Worker<Ctx>>, WorkerExecutorError>,
-        account_id: AccountId,
-    ) -> bool {
-        let mut possibilities = Vec::new();
-
-        for (_agent_id, worker) in workers.iter().await {
-            // Only consider idle agents belonging to the same account.
-            if worker.get_initial_worker_metadata().created_by == account_id
-                && worker.is_currently_idle_but_running().await
-            {
-                let last_changed = worker.last_execution_state_change();
-                possibilities.push((worker, last_changed));
-            }
-        }
-
-        // Evict the oldest idle agent (smallest timestamp).
-        possibilities.sort_by_key(|(_, last_changed)| last_changed.to_millis());
-
-        for (worker, _) in possibilities {
-            if worker.stop_if_idle().await {
-                return true;
-            }
-        }
-        false
     }
 
     async fn try_free_up_filesystem_storage(

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -71,6 +71,9 @@ pub struct InvocationLoop<Ctx: WorkerCtx> {
     /// Only actively running agents hold a permit. Dropped automatically when
     /// the task is aborted (e.g. `RunningWorker::stop()`).
     pub concurrent_agent_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    /// `ResumeReplay` is not represented in the internal queue, so we track it
+    /// explicitly to avoid evicting a worker that is blocked waking up for it.
+    pub resume_replay_pending: Arc<AtomicBool>,
 }
 
 impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
@@ -112,6 +115,7 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                     invocations_since_snapshot: 0,
                     idle_snapshot_task: None,
                     concurrent_agent_permit: &mut self.concurrent_agent_permit,
+                    resume_replay_pending: self.resume_replay_pending.clone(),
                 };
 
                 final_decision = inner_loop.run().await;
@@ -294,6 +298,7 @@ struct InnerInvocationLoop<'a, Ctx: WorkerCtx> {
     /// `InvocationLoop`. Set to `None` when entering idle (releasing the
     /// permit back to the semaphore pool) and re-acquired on wake.
     concurrent_agent_permit: &'a mut Option<tokio::sync::OwnedSemaphorePermit>,
+    resume_replay_pending: Arc<AtomicBool>,
 }
 
 impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
@@ -358,7 +363,10 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                         }
                     }
                 }
-                WorkerCommand::ResumeReplay => self.resume_replay().await,
+                WorkerCommand::ResumeReplay => {
+                    self.resume_replay_pending.store(false, Ordering::Release);
+                    self.resume_replay().await
+                }
             };
             match outcome {
                 CommandOutcome::BreakOuterLoop => {

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -16,7 +16,7 @@ use crate::model::{ReadFileResult, TrapType};
 use crate::services::events::Event;
 use crate::services::golem_config::SnapshotPolicy;
 use crate::services::oplog::{CommitLevel, OplogOps};
-use crate::services::{HasEvents, HasOplog, HasWorker};
+use crate::services::{HasActiveWorkers, HasEvents, HasOplog, HasWorker};
 use crate::worker::invocation::{
     InvocationMode, InvokeResult, invoke_observed_and_traced, lower_invocation,
 };
@@ -66,6 +66,11 @@ pub struct InvocationLoop<Ctx: WorkerCtx> {
     pub waiting_for_command: Arc<AtomicBool>,
     pub interrupt_signal: Arc<Mutex<Option<InterruptKind>>>,
     pub oom_retry_count: u32,
+    /// Concurrent-agent permit owned by this invocation loop task. Released
+    /// (set to `None`) when the agent goes idle, re-acquired when it wakes up.
+    /// Only actively running agents hold a permit. Dropped automatically when
+    /// the task is aborted (e.g. `RunningWorker::stop()`).
+    pub concurrent_agent_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
@@ -106,6 +111,7 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                     store: &store,
                     invocations_since_snapshot: 0,
                     idle_snapshot_task: None,
+                    concurrent_agent_permit: &mut self.concurrent_agent_permit,
                 };
 
                 final_decision = inner_loop.run().await;
@@ -284,6 +290,10 @@ struct InnerInvocationLoop<'a, Ctx: WorkerCtx> {
     store: &'a Mutex<Store<Ctx>>,
     invocations_since_snapshot: u64,
     idle_snapshot_task: Option<JoinHandle<()>>,
+    /// Mutable reference to the concurrent-agent permit held by the outer
+    /// `InvocationLoop`. Set to `None` when entering idle (releasing the
+    /// permit back to the semaphore pool) and re-acquired on wake.
+    concurrent_agent_permit: &'a mut Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
@@ -306,9 +316,14 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
 
         let mut final_decision = None;
 
-        // Exits when RunningWorker is dropped
+        // Entering idle: release the concurrent-agent permit so other agents
+        // from the same account can start without evicting this one.
         self.waiting_for_command.store(true, Ordering::Release);
+        self.release_concurrent_agent_permit();
         while let Some(cmd) = self.next_wakeup().await {
+            // Waking from idle: re-acquire the concurrent-agent permit before
+            // processing any commands.
+            self.acquire_concurrent_agent_permit().await;
             self.waiting_for_command.store(false, Ordering::Release);
             let outcome = match cmd {
                 WorkerCommand::Unblock => {
@@ -357,7 +372,9 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                 CommandOutcome::Continue | CommandOutcome::WaitForWakeup => {}
             }
 
+            // Returning to idle: release the concurrent-agent permit.
             self.waiting_for_command.store(true, Ordering::Release);
+            self.release_concurrent_agent_permit();
         }
         self.abort_idle_snapshot_task();
         self.waiting_for_command.store(false, Ordering::Release);
@@ -365,6 +382,30 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
         debug!(final_decision = ?final_decision, "Invocation queue loop finished");
 
         final_decision
+    }
+
+    /// Release the concurrent-agent permit back to the semaphore pool.
+    /// Called when the agent enters idle state. No-op if already released.
+    fn release_concurrent_agent_permit(&mut self) {
+        if let Some(permit) = self.concurrent_agent_permit.take() {
+            debug!("Releasing concurrent-agent permit (entering idle)");
+            drop(permit);
+        }
+    }
+
+    /// Re-acquire the concurrent-agent permit from the semaphore.
+    /// Called when the agent wakes from idle to process a command.
+    async fn acquire_concurrent_agent_permit(&mut self) {
+        if self.concurrent_agent_permit.is_none() {
+            let account_id = self.parent.get_initial_worker_metadata().created_by;
+            debug!("Re-acquiring concurrent-agent permit (waking from idle)");
+            let permit = self
+                .parent
+                .active_workers()
+                .acquire_concurrent_agent(account_id)
+                .await;
+            *self.concurrent_agent_permit = Some(permit);
+        }
     }
 
     async fn next_wakeup(&mut self) -> Option<WorkerCommand> {

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -440,7 +440,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         let mut instance_guard = self.lock_non_stopping_worker().await;
         let stop_result = match &*instance_guard {
             WorkerInstance::Running(running) => {
-                if is_running_agent_idle(running).await {
+                if self.is_running_worker_idle(running).await {
                     let stop_result = self
                         .stop_internal_locked(
                             &mut instance_guard,
@@ -576,6 +576,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     pub async fn resume_replay(&self) -> Result<(), WorkerExecutorError> {
         match &*self.lock_non_stopping_worker().await {
             WorkerInstance::Running(running) => {
+                running.resume_replay_pending.store(true, Ordering::Release);
                 running
                     .sender
                     .send(WorkerCommand::ResumeReplay)
@@ -788,20 +789,13 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     }
 
     /// Returns true if the worker is running, but it is not performing any invocations at the moment
-    /// (ExecutionStatus::Suspended) and has no pending invocation in its invocation queue.
+    /// (ExecutionStatus::Suspended) and has no pending work that should keep the
+    /// loaded worker resident while memory and filesystem pressure is low.
     ///
     /// These workers can be stopped to free up available worker memory.
     pub async fn is_currently_idle_but_running(&self) -> bool {
         match &*self.instance.lock().await {
-            WorkerInstance::Running(running) => {
-                let waiting_for_command = running.waiting_for_command.load(Ordering::Acquire);
-                let has_invocations = !self.pending_invocations().await.is_empty();
-                debug!(
-                    "Worker {} is running, waiting_for_command: {waiting_for_command} has_invocations: {has_invocations}",
-                    self.owned_agent_id
-                );
-                waiting_for_command && !has_invocations
-            }
+            WorkerInstance::Running(running) => self.is_running_worker_idle(running).await,
             WorkerInstance::WaitingForPermit(_) => {
                 debug!(
                     "Worker {} is waiting for permit, cannot be used to free up memory",
@@ -833,6 +827,25 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 false
             }
         }
+    }
+
+    async fn is_running_worker_idle(&self, running: &RunningWorker) -> bool {
+        let waiting_for_command = running.waiting_for_command.load(Ordering::Acquire);
+        let has_pending_invocations = !self.pending_invocations().await.is_empty();
+        let has_queued_internal_work = !running.queue.read().await.is_empty();
+        let has_resume_replay = running.resume_replay_pending.load(Ordering::Acquire);
+        let has_interrupt = running.interrupt_signal.lock().await.is_some();
+
+        debug!(
+            "Worker {} idle check: waiting_for_command={waiting_for_command} has_pending_invocations={has_pending_invocations} has_queued_internal_work={has_queued_internal_work} has_resume_replay={has_resume_replay} has_interrupt={has_interrupt}",
+            self.owned_agent_id
+        );
+
+        waiting_for_command
+            && !has_pending_invocations
+            && !has_queued_internal_work
+            && !has_resume_replay
+            && !has_interrupt
     }
 
     /// Gets the timestamp of the last time the execution status changed
@@ -2151,12 +2164,15 @@ impl WaitingWorker {
 
         let handle = tokio::task::spawn(
             async move {
-                let permit = parent.active_workers().acquire(memory_requirement).await;
                 let account_id = parent.initial_worker_metadata.created_by;
                 let concurrent_agent_permit = parent
                     .active_workers()
                     .acquire_concurrent_agent(account_id)
                     .await;
+                // Do not reserve executor memory while waiting for a per-account
+                // concurrency slot. Otherwise one account could fill the memory
+                // pool with workers that are not allowed to run yet.
+                let permit = parent.active_workers().acquire(memory_requirement).await;
                 // Pre-acquire storage permits for this restart.
                 //
                 // We need to acquire `filesystem_storage_requirement + desired_extra` total:
@@ -2247,6 +2263,9 @@ struct RunningWorker {
     filesystem_storage_permit: Option<OwnedSemaphorePermit>,
     waiting_for_command: Arc<AtomicBool>,
     interrupt_signal: Arc<async_lock::Mutex<Option<InterruptKind>>>,
+    /// `ResumeReplay` is signalled directly through the command channel rather
+    /// than the internal queue, so eviction must treat it as pending work.
+    resume_replay_pending: Arc<AtomicBool>,
 }
 
 impl Drop for RunningWorker {
@@ -2280,6 +2299,8 @@ impl RunningWorker {
         let waiting_for_command_clone = waiting_for_command.clone();
         let interrupt_signal = Arc::new(async_lock::Mutex::new(None));
         let interrupt_signal_clone = interrupt_signal.clone();
+        let resume_replay_pending = Arc::new(AtomicBool::new(false));
+        let resume_replay_pending_clone = resume_replay_pending.clone();
 
         let span = span!(
             parent: None,
@@ -2303,6 +2324,7 @@ impl RunningWorker {
                     interrupt_signal_clone,
                     oom_retry_count,
                     concurrent_agent_permit,
+                    resume_replay_pending_clone,
                 )
                 .instrument(span)
                 .await;
@@ -2318,6 +2340,7 @@ impl RunningWorker {
             filesystem_storage_permit: None,
             waiting_for_command,
             interrupt_signal,
+            resume_replay_pending,
         }
     }
 
@@ -2563,6 +2586,7 @@ impl RunningWorker {
         interrupt_signal: Arc<async_lock::Mutex<Option<InterruptKind>>>,
         oom_retry_count: u32,
         concurrent_agent_permit: OwnedSemaphorePermit,
+        resume_replay_pending: Arc<AtomicBool>,
     ) {
         let mut invocation_loop = InvocationLoop {
             receiver,
@@ -2573,6 +2597,7 @@ impl RunningWorker {
             interrupt_signal,
             oom_retry_count,
             concurrent_agent_permit: Some(concurrent_agent_permit),
+            resume_replay_pending,
         };
         invocation_loop.run().await;
     }
@@ -2920,10 +2945,6 @@ fn is_snapshot_capable_oplog_processor(
 enum WorkerCommand {
     Unblock,
     ResumeReplay,
-}
-
-async fn is_running_agent_idle(running: &RunningWorker) -> bool {
-    running.waiting_for_command.load(Ordering::Acquire) && running.queue.read().await.is_empty()
 }
 
 #[derive(Debug)]

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -2245,10 +2245,6 @@ struct RunningWorker {
     /// automatically when `RunningWorker` is dropped, returning storage
     /// permits to the pool.
     filesystem_storage_permit: Option<OwnedSemaphorePermit>,
-    /// Concurrent-agent semaphore permit for this account. Held for the
-    /// lifetime of the `RunningWorker` and returned automatically via `Drop`,
-    /// freeing a slot for the next waiting agent from the same account.
-    _concurrent_agent_permit: OwnedSemaphorePermit,
     waiting_for_command: Arc<AtomicBool>,
     interrupt_signal: Arc<async_lock::Mutex<Option<InterruptKind>>>,
 }
@@ -2306,6 +2302,7 @@ impl RunningWorker {
                     waiting_for_command_clone,
                     interrupt_signal_clone,
                     oom_retry_count,
+                    concurrent_agent_permit,
                 )
                 .instrument(span)
                 .await;
@@ -2319,7 +2316,6 @@ impl RunningWorker {
             queue,
             permit,
             filesystem_storage_permit: None,
-            _concurrent_agent_permit: concurrent_agent_permit,
             waiting_for_command,
             interrupt_signal,
         }
@@ -2566,6 +2562,7 @@ impl RunningWorker {
         waiting_for_command: Arc<AtomicBool>,
         interrupt_signal: Arc<async_lock::Mutex<Option<InterruptKind>>>,
         oom_retry_count: u32,
+        concurrent_agent_permit: OwnedSemaphorePermit,
     ) {
         let mut invocation_loop = InvocationLoop {
             receiver,
@@ -2575,6 +2572,7 @@ impl RunningWorker {
             waiting_for_command,
             interrupt_signal,
             oom_retry_count,
+            concurrent_agent_permit: Some(concurrent_agent_permit),
         };
         invocation_loop.run().await;
     }

--- a/golem-worker-executor/tests/resource_limits.rs
+++ b/golem-worker-executor/tests/resource_limits.rs
@@ -243,17 +243,24 @@ async fn concurrent_agent_limit_waits_for_running_agent_to_finish(
         .store()
         .await?;
 
-    // Spawn a2's start in the background. It will block in WaitingForPermit
-    // because a1 is Running (not evictable) and holds the only permit.
+    // Spawn a2's start in background while a1 still holds only permit.
+    // It must stay pending until gate opens; otherwise test is not exercising
+    // contested path.
     let executor_clone = executor.clone();
     let counters_clone = counters_component.clone();
     let a2 = agent_id!("Counter", "concurrent-wait-http-2");
     let a2_clone = a2.clone();
-    tokio::spawn(async move {
+    let a2_start = tokio::spawn(async move {
         executor_clone
             .start_agent(&counters_clone.id, a2_clone)
             .await
     });
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(
+        !a2_start.is_finished(),
+        "a2 start finished while a1 was still Running; test did not hit permit contention"
+    );
 
     // Release the gate — a1's poll loop returns "done", its invocation
     // completes, and its permit is returned to the semaphore via Drop.
@@ -270,6 +277,13 @@ async fn concurrent_agent_limit_waits_for_running_agent_to_finish(
     // that the waiting-and-unblocking path works correctly.
     executor
         .invoke_and_await_agent(&counters_component, &a2, "increment", data_value!())
+        .await?;
+
+    let a2_id = tokio::time::timeout(Duration::from_secs(10), a2_start)
+        .await
+        .expect("a2 start should unblock after a1 releases permit")??;
+    executor
+        .wait_for_status(&a2_id, AgentStatus::Idle, Duration::from_secs(10))
         .await?;
 
     http_server.abort();
@@ -359,10 +373,9 @@ async fn concurrent_agent_idle_releases_permit(
         .wait_for_status(&a1_id, AgentStatus::Running, Duration::from_secs(10))
         .await?;
 
-    // Spawn a2 in background. It enters WaitingForPermit because a1 is Running.
-    // The try_free_up callback runs NOW and finds a1 Running (not idle) → returns
-    // false. a2 falls through to `acquire_owned().await` — blocking on the
-    // semaphore.
+    // Spawn a2 in background while a1 still holds only permit. Assert start is
+    // still pending before gate opens. That proves later success comes from
+    // permit release on idle transition, not lucky late scheduling.
     let counters_component = executor
         .component_dep(&context.default_environment_id, agent_counters)
         .store()
@@ -371,15 +384,17 @@ async fn concurrent_agent_idle_releases_permit(
     let counters_clone = counters_component.clone();
     let a2 = agent_id!("Counter", "idle-permit-2");
     let a2_clone = a2.clone();
-    tokio::spawn(async move {
+    let a2_start = tokio::spawn(async move {
         executor_clone
             .start_agent(&counters_clone.id, a2_clone)
             .await
     });
 
-    // Small delay to ensure a2's acquire + try_free_up has already executed and
-    // failed (a1 was Running). a2 is now blocked on acquire_owned().await.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(
+        !a2_start.is_finished(),
+        "a2 start finished while a1 was still Running; test did not hit idle-release path"
+    );
 
     // Release the gate. a1's poll returns "done", invocation completes, a1 goes Idle.
     // With the fix: Idle transition drops the permit → semaphore notifies a2 → a2 starts.
@@ -400,6 +415,13 @@ async fn concurrent_agent_idle_releases_permit(
          but it timed out — idle agents are still holding permits"
     );
     a2_result.unwrap()?;
+
+    let a2_id = tokio::time::timeout(Duration::from_secs(10), a2_start)
+        .await
+        .expect("a2 start should unblock after a1 goes idle and releases permit")??;
+    executor
+        .wait_for_status(&a2_id, AgentStatus::Idle, Duration::from_secs(10))
+        .await?;
 
     http_server.abort();
     Ok(())

--- a/golem-worker-executor/tests/resource_limits.rs
+++ b/golem-worker-executor/tests/resource_limits.rs
@@ -167,62 +167,6 @@ async fn concurrent_agent_limit_not_reached_starts_immediately(
     Ok(())
 }
 
-/// When the concurrent agent limit is reached and the running agent becomes
-/// idle, starting a new agent automatically evicts the idle one to free a
-/// slot — no manual deletion required.
-#[test]
-#[tracing::instrument]
-#[timeout("2m")]
-async fn concurrent_agent_limit_idle_agent_is_evicted_to_make_room(
-    last_unique_id: &LastUniqueId,
-    deps: &WorkerExecutorTestDependencies,
-    _tracing: &Tracing,
-    #[tagged_as("agent_counters")] agent_counters: &PrecompiledComponent,
-) -> anyhow::Result<()> {
-    let context = TestContext::new(last_unique_id);
-    // Limit of 1: only one agent may hold a permit at a time.
-    let executor = start_with_concurrent_agent_limit(deps, &context, 1).await?;
-
-    let component = executor
-        .component_dep(&context.default_environment_id, agent_counters)
-        .store()
-        .await?;
-
-    // Start a1 — takes the only permit.
-    let a1 = agent_id!("Counter", "concurrent-evict-1");
-    let a1_id = executor.start_agent(&component.id, a1.clone()).await?;
-
-    // Invoke a1 so it runs and then returns to Idle.
-    executor
-        .invoke_and_await_agent(&component, &a1, "increment", data_value!())
-        .await?;
-
-    // Wait until a1 is Idle — it can now be evicted.
-    executor
-        .wait_for_status(&a1_id, AgentStatus::Idle, Duration::from_secs(10))
-        .await?;
-
-    // Spawn a2's start in the background. The permit acquisition will detect
-    // a1 is idle and evict it automatically, without any manual intervention.
-    let executor_clone = executor.clone();
-    let component_clone = component.clone();
-    let a2 = agent_id!("Counter", "concurrent-evict-2");
-    let a2_clone = a2.clone();
-    tokio::spawn(async move {
-        executor_clone
-            .start_agent(&component_clone.id, a2_clone)
-            .await
-    });
-
-    // a2's invocation will complete once the eviction unblocks it.
-    // No sleep, no manual delete — eviction is the feature under test.
-    executor
-        .invoke_and_await_agent(&component, &a2, "increment", data_value!())
-        .await?;
-
-    Ok(())
-}
-
 /// When the limit is reached with no idle agents, a new agent waits in
 /// WaitingForPermit until the running agent finishes and its permit is returned.
 ///
@@ -327,6 +271,135 @@ async fn concurrent_agent_limit_waits_for_running_agent_to_finish(
     executor
         .invoke_and_await_agent(&counters_component, &a2, "increment", data_value!())
         .await?;
+
+    http_server.abort();
+    Ok(())
+}
+
+/// Idle agents must release their concurrent-agent permit so new agents can
+/// start without evicting the idle ones.
+///
+/// Setup: limit=1, keep a1 actively Running via an HTTP gate. While a1 is
+/// Running (not evictable) and holds the only permit, start a2 in the
+/// background — it blocks in WaitingForPermit. Release the gate so a1's
+/// invocation completes and a1 goes Idle.
+///
+/// With the bug (idle agents hold permits): a1 stays idle but still holds the
+/// permit. a2 remains blocked in WaitingForPermit because there is nothing to
+/// evict (the `try_free_up` callback found a1 was still Running at the time it
+/// was called, and now a1 is idle but the callback already returned false). a2
+/// never starts, and invoking it times out.
+///
+/// With the fix (idle agents release permits): a1 goes Idle and immediately
+/// drops its permit. a2's `acquire_owned().await` unblocks, a2 starts, and its
+/// invocation succeeds within the timeout.
+///
+/// Crucially, this test does NOT rely on eviction. The only way a2 can start
+/// is if a1's permit was returned to the pool by the idle transition, not by
+/// `stop_if_idle` eviction.
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn concurrent_agent_idle_releases_permit(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+    #[tagged_as("agent_counters")] agent_counters: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    // limit=1: exactly one concurrent-agent permit.
+    let executor = start_with_concurrent_agent_limit(deps, &context, 1).await?;
+
+    // --- HTTP gate: keeps a1 provably Running until we release it. ---
+    let gate = std::sync::Arc::new(tokio::sync::Notify::new());
+    let gate_clone = gate.clone();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let port = listener.local_addr()?.port();
+    let http_server = tokio::spawn(async move {
+        let route = Router::new().route(
+            "/poll",
+            get(move || {
+                let gate = gate_clone.clone();
+                async move {
+                    gate.notified().await;
+                    "done".to_string()
+                }
+            }),
+        );
+        axum::serve(listener, route).await.unwrap();
+    });
+
+    let http_component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+
+    // Start a1 using HttpClient2 (polls GET /poll until body equals "done").
+    let a1 = agent_id!("HttpClient2");
+    let mut env = HashMap::new();
+    env.insert("PORT".to_string(), port.to_string());
+    let a1_id = executor
+        .start_agent_with(
+            &http_component.id,
+            a1.clone(),
+            env,
+            HashMap::new(),
+            Vec::new(),
+        )
+        .await?;
+
+    // Fire-and-forget: a1 starts polling the gated server.
+    executor
+        .invoke_agent(&http_component, &a1, "start_polling", data_value!("done"))
+        .await?;
+
+    // Confirm a1 is Running (holds the only permit, is NOT evictable).
+    executor
+        .wait_for_status(&a1_id, AgentStatus::Running, Duration::from_secs(10))
+        .await?;
+
+    // Spawn a2 in background. It enters WaitingForPermit because a1 is Running.
+    // The try_free_up callback runs NOW and finds a1 Running (not idle) → returns
+    // false. a2 falls through to `acquire_owned().await` — blocking on the
+    // semaphore.
+    let counters_component = executor
+        .component_dep(&context.default_environment_id, agent_counters)
+        .store()
+        .await?;
+    let executor_clone = executor.clone();
+    let counters_clone = counters_component.clone();
+    let a2 = agent_id!("Counter", "idle-permit-2");
+    let a2_clone = a2.clone();
+    tokio::spawn(async move {
+        executor_clone
+            .start_agent(&counters_clone.id, a2_clone)
+            .await
+    });
+
+    // Small delay to ensure a2's acquire + try_free_up has already executed and
+    // failed (a1 was Running). a2 is now blocked on acquire_owned().await.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Release the gate. a1's poll returns "done", invocation completes, a1 goes Idle.
+    // With the fix: Idle transition drops the permit → semaphore notifies a2 → a2 starts.
+    // With the bug: a1 stays Idle but holds permit → a2 remains blocked forever.
+    gate.notify_waiters();
+
+    // a2 should now be unblocked (fix) or remain stuck (bug).
+    // Give it 15 seconds — well beyond what starting a counter agent takes.
+    let a2_result = tokio::time::timeout(
+        Duration::from_secs(15),
+        executor.invoke_and_await_agent(&counters_component, &a2, "increment", data_value!()),
+    )
+    .await;
+
+    assert!(
+        a2_result.is_ok(),
+        "a2 should have started after a1 went Idle and released its permit, \
+         but it timed out — idle agents are still holding permits"
+    );
+    a2_result.unwrap()?;
 
     http_server.abort();
     Ok(())


### PR DESCRIPTION
Idle agents should release `ConcurrentAgentSemaphore` permits 