### PR TITLE
Reenable CLI TS REPL tests + fix bridge async constructor methods

### DIFF
--- a/cli/golem-cli/src/bridge_gen/typescript/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/typescript/mod.rs
@@ -581,7 +581,7 @@ impl TypeScriptBridgeGenerator {
         ));
         let mut get = writer.begin_static_async_method("get");
         self.write_parameter_list(&mut get, &self.agent_type.constructor.input_schema)?;
-        get.result(&format!("Promise<{class_name}>"));
+        get.result(class_name);
 
         get.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(
@@ -612,7 +612,7 @@ impl TypeScriptBridgeGenerator {
         let mut get_phantom = writer.begin_static_async_method("getPhantom");
         get_phantom.param("phantomId", "base.PhantomId");
         self.write_parameter_list(&mut get_phantom, &self.agent_type.constructor.input_schema)?;
-        get_phantom.result(&format!("Promise<{class_name}>"));
+        get_phantom.result(class_name);
 
         get_phantom.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(
@@ -641,7 +641,7 @@ impl TypeScriptBridgeGenerator {
         ));
         let mut new_phantom = writer.begin_static_async_method("newPhantom");
         self.write_parameter_list(&mut new_phantom, &self.agent_type.constructor.input_schema)?;
-        new_phantom.result(&format!("Promise<{class_name}>"));
+        new_phantom.result(class_name);
 
         new_phantom.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(
@@ -697,7 +697,7 @@ impl TypeScriptBridgeGenerator {
         let mut method = writer.begin_static_async_method("getWithConfig");
         self.write_parameter_list(&mut method, &self.agent_type.constructor.input_schema)?;
         self.write_config_parameter_list(&mut method, local_configs)?;
-        method.result(&format!("Promise<{class_name}>"));
+        method.result(class_name);
 
         method.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(
@@ -731,7 +731,7 @@ impl TypeScriptBridgeGenerator {
         method.param("phantomId", "base.PhantomId");
         self.write_parameter_list(&mut method, &self.agent_type.constructor.input_schema)?;
         self.write_config_parameter_list(&mut method, local_configs)?;
-        method.result(&format!("Promise<{class_name}>"));
+        method.result(class_name);
 
         method.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(
@@ -763,7 +763,7 @@ impl TypeScriptBridgeGenerator {
         let mut method = writer.begin_static_async_method("newPhantomWithConfig");
         self.write_parameter_list(&mut method, &self.agent_type.constructor.input_schema)?;
         self.write_config_parameter_list(&mut method, local_configs)?;
-        method.result(&format!("Promise<{class_name}>"));
+        method.result(class_name);
 
         method.write_line("const parameters: base.DataValue = ");
         self.write_encode_data_value(

--- a/cli/golem-cli/src/command_handler/repl/mod.rs
+++ b/cli/golem-cli/src/command_handler/repl/mod.rs
@@ -285,6 +285,15 @@ impl ReplHandler {
             }
         }
 
+        if let Ok(test_sync_events_file) = std::env::var("GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE") {
+            if !test_sync_events_file.trim().is_empty() {
+                env_vars.insert(
+                    "GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE".to_string(),
+                    test_sync_events_file,
+                );
+            }
+        }
+
         Ok(env_vars)
     }
 }

--- a/cli/golem-cli/src/command_handler/repl/mod.rs
+++ b/cli/golem-cli/src/command_handler/repl/mod.rs
@@ -285,13 +285,13 @@ impl ReplHandler {
             }
         }
 
-        if let Ok(test_sync_events_file) = std::env::var("GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE") {
-            if !test_sync_events_file.trim().is_empty() {
-                env_vars.insert(
-                    "GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE".to_string(),
-                    test_sync_events_file,
-                );
-            }
+        if let Ok(test_sync_events_file) = std::env::var("GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE")
+            && !test_sync_events_file.trim().is_empty()
+        {
+            env_vars.insert(
+                "GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE".to_string(),
+                test_sync_events_file,
+            );
         }
 
         Ok(env_vars)

--- a/cli/golem-cli/tests/app/app.rs
+++ b/cli/golem-cli/tests/app/app.rs
@@ -1,5 +1,5 @@
 use crate::Tracing;
-use crate::app::{InteractiveSession, TestContext, check_component_metadata, cmd, flag, pattern};
+use crate::app::{TestContext, check_component_metadata, cmd, flag, pattern};
 
 use golem_cli::fs;
 use golem_cli::model::GuestLanguage;
@@ -318,8 +318,6 @@ async fn completion(_tracing: &Tracing) {
     assert!(outputs.success(), "zsh");
 }
 
-// TODO: very flaky currently, should wait properly for async repl prompts
-#[ignore]
 #[test]
 async fn ts_repl_interactive(_tracing: &Tracing) {
     let mut ctx = TestContext::new();
@@ -387,9 +385,17 @@ async fn ts_repl_interactive(_tracing: &Tracing) {
     let outputs = ctx.cli([cmd::DEPLOY, flag::YES]).await;
     assert!(outputs.success_or_dump());
 
-    ctx.cli_interactive([cmd::REPL, flag::LANGUAGE, "ts", flag::YES], move |repl| {
-        let agent_type_info_regex = indoc! {
-            r#"(?sx)
+    ctx.cli_interactive_repl_test(
+        [
+            cmd::REPL,
+            flag::LANGUAGE,
+            "ts",
+            flag::YES,
+            "--disable-stream",
+        ],
+        move |session| {
+            let agent_type_info_regex = indoc! {
+                r#"(?sx)
             Available\s+agent\s+client\s+types:
             .*
             (
@@ -412,10 +418,10 @@ async fn ts_repl_interactive(_tracing: &Tracing) {
                 \)
             )
             .*"#
-        };
+            };
 
-        let methods_regex = indoc! {
-            r#"(?sx)
+            let methods_regex = indoc! {
+                r#"(?sx)
             (
                 sampleMethod:\s*\(\)\s*=>\s*number
                 .*
@@ -425,86 +431,106 @@ async fn ts_repl_interactive(_tracing: &Tracing) {
                 .*
                 sampleMethod:\s*\(\)\s*=>\s*number
             )"#
-        };
+            };
 
-        repl.set_expect_timeout(Some(Duration::from_secs(30)));
-        repl.expect_str("golem-ts-repl[test-app-repl-interactive][local]>")?;
-        repl.send_line_and_expect_regex(".agent-type-info", agent_type_info_regex)?;
-        repl.expect_regex(methods_regex)?;
+            session.set_expect_timeout(Some(Duration::from_secs(300)));
+            session.expect_str("golem-ts-repl[test-app-repl-interactive][local]>")?;
+            session.send_line_and_expect_regex(".agent-type-info", agent_type_info_regex)?;
+            session.expect_regex(methods_regex)?;
 
-        repl.set_expect_timeout(Some(Duration::from_secs(2)));
+            session.set_expect_timeout(Some(Duration::from_secs(10)));
 
-        // Hints on "enter"
-        {
-            repl.send_line_and_expect_str("Counter", "CounterAgent")?;
-            repl.send_line_and_expect_regex("CounterAgent.", "get .* getPhantom ")?;
-            repl.send_line_and_expect_str(
-                "CounterAgent.get",
-                "(method) CounterAgent.get(name: string): Promise<CounterAgent>",
-            )?;
-            repl.send_line_and_expect_str("CounterAgent.get(", "\"?\"")?;
-            repl.send_line_and_expect_str(
-                "CounterAgent.get(\"xyz\")",
-                "awaiting Promise<CounterAgent>",
-            )?;
-            repl.send_line_and_expect_str("(await CounterAgent.get(\"xyz\")).", "increment")?;
-            repl.send_line_and_expect_str("CounterAgent.get(\"xyz\").then(c => c.", "increment")?;
-            repl.send_line_and_expect_str("Sample", "SampleAgent")?;
-            repl.send_line_and_expect_regex(
-                "(await SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" })).",
-                "sampleMethod.*\\[local\\]>",
-            )?;
-            repl.send_line_and_expect_regex(
-                "SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" }).then(c => c.",
-                "sampleMethod.*\\[local\\]>",
-            )?;
-        }
+            // Hints on "enter"
+            {
+                session.send_line_wait_eval_expect_str("Counter", "CounterAgent")?;
+                session.send_line_wait_eval_expect_regex("CounterAgent.", "get .* getPhantom ")?;
+                session.send_line_wait_eval_expect_regex(
+                    "CounterAgent.get",
+                    "\\(method\\) CounterAgent\\.get\\(name: string\\): Promise<.*CounterAgent>",
+                )?;
+                session.send_line_wait_eval_expect_str("CounterAgent.get(", "\"?\"")?;
+                session.send_line_wait_eval_expect_regex(
+                    "CounterAgent.get(\"xyz\")",
+                    "awaiting Promise<.*CounterAgent>",
+                )?;
 
-        // Hints on "tab"
-        {
-            fn kill_line(repl: &mut dyn InteractiveSession) -> anyhow::Result<()> {
-                repl.send("\u{15}")
+                session.send_line_wait_eval_expect_str(
+                    "(await CounterAgent.get(\"xyz\")).",
+                    "increment",
+                )?;
+
+                session.send_line_wait_eval_expect_str(
+                    "CounterAgent.get(\"xyz\").then(c => c.",
+                    "increment",
+                )?;
+
+                session.send_line_wait_eval_expect_str("Sample", "SampleAgent")?;
+
+                session.send_line_wait_eval_expect_regex(
+                    "(await SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" })).",
+                    "sampleMethod",
+                )?;
+
+                session.send_line_wait_eval_expect_regex(
+                    "SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" }).then(c => c.",
+                    "sampleMethod",
+                )?;
             }
 
-            repl.send_tab_complete_expect_str("Counter", "Agent")?;
-            kill_line(repl)?;
+            // Hints on "tab"
+            {
+                session.send_tab_wait_completion_expect_str("Counter", "Agent")?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex("CounterAgent.", "get .* getPhantom ")?;
-            kill_line(repl)?;
+                session.send_tab_list_wait_completion_expect_regex(
+                    "CounterAgent.",
+                    "get .* getPhantom ",
+                )?;
+                session.kill_line()?;
 
-            repl.send_tab_complete_expect_str("CounterAgent.g", "et")?;
-            kill_line(repl)?;
+                session.send_tab_wait_completion_expect_str("CounterAgent.g", "et")?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex("CounterAgent.get", "get .* getPhantom")?;
-            kill_line(repl)?;
+                session.send_tab_list_wait_completion_expect_regex(
+                    "CounterAgent.get",
+                    "get .* getPhantom",
+                )?;
+                session.kill_line()?;
 
-            repl.send_tab_complete_expect_str("CounterAgent.get(", "\"?\"")?;
-            kill_line(repl)?;
+                session.send_tab_wait_completion_expect_str("CounterAgent.get(", "\"?\"")?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex("(await CounterAgent.get(\"xyz\")).", "increment")?;
-            kill_line(repl)?;
+                session.send_tab_list_wait_completion_expect_regex(
+                    "(await CounterAgent.get(\"xyz\")).",
+                    "increment",
+                )?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex("CounterAgent.get(\"xyz\").then(x => x.", "increment")?;
-            kill_line(repl)?;
+                session.send_tab_list_wait_completion_expect_regex(
+                    "CounterAgent.get(\"xyz\").then(x => x.",
+                    "increment",
+                )?;
+                session.kill_line()?;
 
-            repl.send_tab_complete_expect_str("Sample", "Agent")?;
-            kill_line(repl)?;
+                session.send_tab_wait_completion_expect_str("Sample", "Agent")?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex(
-                "(await SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" })).",
-                "sampleMethod",
-            )?;
-            kill_line(repl)?;
+                session.send_tab_list_wait_completion_expect_regex(
+                    "(await SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" })).",
+                    "sampleMethod",
+                )?;
+                session.kill_line()?;
 
-            repl.send_tab_list_expect_regex(
-                "SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" }).then(x => x.",
-                "sampleMethod",
-            )?;
-            kill_line(repl)?;
-        }
+                session.send_tab_list_wait_completion_expect_regex(
+                    "SampleAgent.get(\"xyz\", \"eu\", \"fast\", { a: 1, b: \"x\" }).then(x => x.",
+                    "sampleMethod",
+                )?;
+                session.kill_line()?;
+            }
 
-        Ok(())
-    })
+            Ok(())
+        },
+    )
     .await;
 }
 

--- a/cli/golem-cli/tests/app/mod.rs
+++ b/cli/golem-cli/tests/app/mod.rs
@@ -51,6 +51,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::str::FromStr;
+use std::thread::sleep;
 use std::time::Duration;
 use tempfile::TempDir;
 use test_r::{inherit_test_dep, sequential_suite, tag_suite};
@@ -60,6 +61,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::info;
 use url::Url;
+use uuid::Uuid;
 
 mod cmd {
     pub static NO_ARGS: &[&str] = &[];
@@ -535,6 +537,21 @@ impl TestContext {
         .unwrap()
     }
 
+    async fn cli_interactive_repl_test<I, S, F>(&mut self, args: I, session_fn: F)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+        F: FnOnce(&mut ReplTestSession) -> anyhow::Result<()> + Send + 'static,
+    {
+        let test_sync_events_file = ReplTestSession::init_test_sync_events(self);
+
+        self.cli_interactive(args, move |repl| {
+            let mut session = ReplTestSession::new(repl, test_sync_events_file);
+            session_fn(&mut session)
+        })
+        .await;
+    }
+
     async fn start_server(&mut self) {
         assert!(self.server_process.is_none(), "server is already running");
 
@@ -860,6 +877,161 @@ pub trait InteractiveSession {
         self.expect_regex(expected)
             .with_context(|| format!("after sending line: {line:?}"))?;
         Ok(())
+    }
+}
+
+pub struct ReplTestSyncEventsFile {
+    path: PathBuf,
+    last_seq: u64,
+}
+
+impl ReplTestSyncEventsFile {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path, last_seq: 0 }
+    }
+
+    pub fn wait_for_test_sync_event(
+        &mut self,
+        expected_event: &str,
+        timeout: Duration,
+    ) -> anyhow::Result<()> {
+        let start = std::time::Instant::now();
+        loop {
+            let mut newest_seq = self.last_seq;
+            let content = std::fs::read_to_string(&self.path).unwrap_or_default();
+
+            for line in content.lines() {
+                let value = match serde_json::from_str::<serde_json::Value>(line) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+
+                let seq = match value.get("seq").and_then(|v| v.as_u64()) {
+                    Some(seq) if seq > self.last_seq => seq,
+                    _ => continue,
+                };
+                newest_seq = newest_seq.max(seq);
+
+                if value
+                    .get("event")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|event| is_matching_test_sync_event(expected_event, event))
+                {
+                    self.last_seq = seq;
+                    return Ok(());
+                }
+            }
+
+            self.last_seq = newest_seq;
+
+            if start.elapsed() > timeout {
+                return Err(anyhow::anyhow!(
+                    "Timed out waiting for REPL test sync event {expected_event:?} in {}",
+                    self.path.display()
+                ));
+            }
+
+            sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+fn is_matching_test_sync_event(expected_event: &str, actual_event: &str) -> bool {
+    expected_event == actual_event
+        || (expected_event == "repl_ready" && actual_event == "ready")
+        || (expected_event == "completion_done" && actual_event == "complete_done")
+}
+
+pub struct ReplTestSession<'a> {
+    repl: &'a mut dyn InteractiveSession,
+    test_sync_events: ReplTestSyncEventsFile,
+}
+
+const REPL_TEST_SYNC_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
+
+impl<'a> ReplTestSession<'a> {
+    fn init_test_sync_events(ctx: &mut TestContext) -> PathBuf {
+        let test_sync_events_file = ctx.cwd_path_join(format!(
+            ".golem-ts-repl-test-sync-events-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        std::fs::write(&test_sync_events_file, "").unwrap();
+
+        let path = test_sync_events_file.to_string_lossy().to_string();
+        ctx.add_env_var("GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE", path);
+
+        test_sync_events_file
+    }
+
+    pub fn new(repl: &'a mut dyn InteractiveSession, test_sync_events_file: PathBuf) -> Self {
+        Self {
+            repl,
+            test_sync_events: ReplTestSyncEventsFile::new(test_sync_events_file),
+        }
+    }
+
+    pub fn set_expect_timeout(&mut self, timeout: Option<Duration>) {
+        self.repl.set_expect_timeout(timeout);
+    }
+
+    pub fn expect_str(&mut self, expected: &str) -> anyhow::Result<()> {
+        self.repl.expect_str(expected)
+    }
+
+    pub fn expect_regex(&mut self, expected: &str) -> anyhow::Result<()> {
+        self.repl.expect_regex(expected)
+    }
+
+    pub fn send_line_and_expect_regex(&mut self, line: &str, expected: &str) -> anyhow::Result<()> {
+        self.repl.send_line_and_expect_regex(line, expected)
+    }
+
+    pub fn send_line_wait_eval_expect_str(
+        &mut self,
+        line: &str,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        self.repl.send_line(line)?;
+        self.repl.expect_str(expected)?;
+        self.test_sync_events
+            .wait_for_test_sync_event("eval_done", REPL_TEST_SYNC_EVENT_TIMEOUT)
+    }
+
+    pub fn send_line_wait_eval_expect_regex(
+        &mut self,
+        line: &str,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        self.repl.send_line(line)?;
+        self.repl.expect_regex(expected)?;
+        self.test_sync_events
+            .wait_for_test_sync_event("eval_done", REPL_TEST_SYNC_EVENT_TIMEOUT)
+    }
+
+    pub fn send_tab_wait_completion_expect_str(
+        &mut self,
+        line: &str,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        self.repl.send(&format!("{line}\t"))?;
+        self.repl.expect_str(expected)?;
+        self.test_sync_events
+            .wait_for_test_sync_event("completion_done", REPL_TEST_SYNC_EVENT_TIMEOUT)
+    }
+
+    pub fn send_tab_list_wait_completion_expect_regex(
+        &mut self,
+        line: &str,
+        expected: &str,
+    ) -> anyhow::Result<()> {
+        self.repl.send(&format!("{line}\t\t"))?;
+        self.repl.expect_regex(expected)?;
+        self.test_sync_events
+            .wait_for_test_sync_event("completion_done", REPL_TEST_SYNC_EVENT_TIMEOUT)
+    }
+
+    pub fn kill_line(&mut self) -> anyhow::Result<()> {
+        self.repl.send("\u{15}")
     }
 }
 

--- a/sdks/ts/packages/golem-ts-repl/src/repl.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/repl.ts
@@ -29,10 +29,7 @@ import { AsyncCompleter } from 'readline';
 import { PassThrough } from 'node:stream';
 import { ts } from 'ts-morph';
 import { flushStdIO, setOutput, writeln } from './process';
-import {
-  initTestSyncEventsFromEnv,
-  writeTestSyncEvent,
-} from './test-sync-events';
+import { initTestSyncEventsFromEnv, writeTestSyncEvent } from './test-sync-events';
 import { formatAsTable, formatEvalError, logSnippetInfo } from './format';
 import type * as base from '@golemcloud/golem-ts-bridge';
 import type {
@@ -205,10 +202,7 @@ export class Repl {
     const languageService = this.getLanguageService();
     const cli = this.cli;
     const customCompleter: AsyncCompleter = function (line, callback) {
-      const callbackWithSync = (
-        err?: Error | null,
-        result?: [string[], string],
-      ): void => {
+      const callbackWithSync = (err?: Error | null, result?: [string[], string]): void => {
         writeTestSyncEvent('completion_done');
         callback(err, result);
       };

--- a/sdks/ts/packages/golem-ts-repl/src/repl.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/repl.ts
@@ -29,6 +29,10 @@ import { AsyncCompleter } from 'readline';
 import { PassThrough } from 'node:stream';
 import { ts } from 'ts-morph';
 import { flushStdIO, setOutput, writeln } from './process';
+import {
+  initTestSyncEventsFromEnv,
+  writeTestSyncEvent,
+} from './test-sync-events';
 import { formatAsTable, formatEvalError, logSnippetInfo } from './format';
 import type * as base from '@golemcloud/golem-ts-bridge';
 import type {
@@ -49,6 +53,7 @@ export class Repl {
 
   constructor(config: Config) {
     this.config = config;
+    initTestSyncEventsFromEnv();
     this.replCliFlags = loadReplCliFlags();
     this.overrideSnippetForNextEval = undefined;
 
@@ -145,6 +150,7 @@ export class Repl {
           if (!err) {
             languageService.addSnippetToHistory(code);
           }
+          writeTestSyncEvent('eval_done');
           callback(err, result);
         });
       };
@@ -185,6 +191,7 @@ export class Repl {
 
         writeln(typeCheckResult.formattedErrors);
 
+        writeTestSyncEvent('eval_done');
         callback(null, undefined);
       }
     };
@@ -198,18 +205,26 @@ export class Repl {
     const languageService = this.getLanguageService();
     const cli = this.cli;
     const customCompleter: AsyncCompleter = function (line, callback) {
+      const callbackWithSync = (
+        err?: Error | null,
+        result?: [string[], string],
+      ): void => {
+        writeTestSyncEvent('completion_done');
+        callback(err, result);
+      };
+
       if (line.trimStart().startsWith('.') || line.trimStart().startsWith(':')) {
         cli
           .complete(line)
           .then((result) => {
             if (result) {
-              callback(null, result);
+              callbackWithSync(null, result);
             } else {
-              nodeCompleter(line, callback);
+              nodeCompleter(line, callbackWithSync);
             }
           })
           .catch(() => {
-            nodeCompleter(line, callback);
+            nodeCompleter(line, callbackWithSync);
           });
       } else {
         languageService.setSnippet(line);
@@ -219,9 +234,9 @@ export class Repl {
           const replaceStart = completions.replaceStart ?? 0;
           const replaceEnd = completions.replaceEnd ?? line.length;
           const completeOn = line.slice(replaceStart, replaceEnd);
-          callback(null, [completions.entries, completeOn]);
+          callbackWithSync(null, [completions.entries, completeOn]);
         } else {
-          callback(null, [[], '']);
+          callbackWithSync(null, [[], '']);
         }
       }
     };
@@ -368,14 +383,13 @@ export class Repl {
 
     await this.setupRepl(replServer);
 
-    if (!script) {
-      this.showAgentTypeInfo(replServer, false);
-    }
-
     if (script) {
       await this.runScript(replServer, script);
       await flushStdIO();
       replServer.close();
+    } else {
+      this.showAgentTypeInfo(replServer, false);
+      writeTestSyncEvent('repl_ready');
     }
   }
 

--- a/sdks/ts/packages/golem-ts-repl/src/test-sync-events.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/test-sync-events.ts
@@ -1,0 +1,36 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from 'node:fs';
+
+export type TestSyncEvent = 'repl_ready' | 'eval_done' | 'completion_done';
+
+let nextSeq = 1;
+let writeEvent: (event: TestSyncEvent) => void = () => {};
+
+export function initTestSyncEventsFromEnv(): void {
+  const testSyncEventsFilePath = process.env.GOLEM_TS_REPL_TEST_SYNC_EVENTS_FILE;
+  if (!testSyncEventsFilePath) {
+    return;
+  }
+
+  writeEvent = (event: TestSyncEvent): void => {
+    const line = JSON.stringify({ seq: nextSeq++, event }) + '\n';
+    fs.appendFileSync(testSyncEventsFilePath, line, 'utf8');
+  };
+}
+
+export function writeTestSyncEvent(event: TestSyncEvent): void {
+  writeEvent(event);
+}


### PR DESCRIPTION
- resolves https://github.com/golemcloud/golem/issues/3109
- fixes "double" promise return types for agent constructor methods