### PR TITLE
Better handling of failed shard assignments

### DIFF
--- a/golem-shard-manager/src/sharding/rebalancing.rs
+++ b/golem-shard-manager/src/sharding/rebalancing.rs
@@ -220,12 +220,27 @@ impl Rebalance {
     }
 
     pub fn remove_shards(&mut self, shard_ids: &HashSet<ShardId>) {
-        for assigned_shard_ids in &mut self.assignments.assignments.values_mut() {
+        for assigned_shard_ids in self.assignments.assignments.values_mut() {
             assigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
         }
-        for unassigned_shard_ids in &mut self.unassignments.unassignments.values_mut() {
+        self.assignments
+            .assignments
+            .retain(|_, shards| !shards.is_empty());
+        for unassigned_shard_ids in self.unassignments.unassignments.values_mut() {
             unassigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
         }
+        self.unassignments
+            .unassignments
+            .retain(|_, shards| !shards.is_empty());
+    }
+
+    pub fn remove_assignment_shards(&mut self, shard_ids: &HashSet<ShardId>) {
+        for assigned_shard_ids in self.assignments.assignments.values_mut() {
+            assigned_shard_ids.retain(|shard_id| !shard_ids.contains(shard_id));
+        }
+        self.assignments
+            .assignments
+            .retain(|_, shards| !shards.is_empty());
     }
 
     pub fn add_assignments(&mut self, pod: &Pod, mut shard_ids: BTreeSet<ShardId>) {

--- a/golem-shard-manager/src/sharding/shard_management.rs
+++ b/golem-shard-manager/src/sharding/shard_management.rs
@@ -19,9 +19,9 @@ use super::persistence::RoutingTablePersistence;
 use super::rebalancing::Rebalance;
 use super::worker_executor::{WorkerExecutorService, assign_shards, revoke_shards};
 use async_rwlock::RwLock;
-use golem_common::model::Pod;
+use golem_common::model::{Pod, ShardId};
 use itertools::Itertools;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinSet;
@@ -129,10 +129,11 @@ impl ShardManagement {
             debug!("Shard management loop awaiting changes");
             change.notified().await;
 
-            let (new_pods, removed_pods) = updates.lock().await.reset();
+            let (new_pods, removed_pods, retry_full_assignment_pods) = updates.lock().await.reset();
             debug!(
                 new_pods = new_pods.keys().join(", "),
                 removed_pods = removed_pods.iter().join(", "),
+                retry_pods = retry_full_assignment_pods.iter().join(", "),
                 "Shard management loop woken up",
             );
 
@@ -140,7 +141,7 @@ impl ShardManagement {
             //   - the rebalance plan is calculated,
             //   - new and removed pods are added to the routing table and got persisted,
             // but the rebalance plan is NOT applied yet. The lock is then release for apply.
-            let mut rebalance = {
+            let (mut rebalance, full_assignment_pods) = {
                 let mut current_routing_table = routing_table.write().await;
 
                 for pod in removed_pods {
@@ -163,9 +164,20 @@ impl ShardManagement {
                 let mut rebalance =
                     Rebalance::from_routing_table(&current_routing_table, threshold);
 
+                let mut full_assignment_pods: HashSet<Pod> = HashSet::new();
+
                 for pod in send_full_assignment {
                     let assignments = current_routing_table.get_shards(pod).unwrap_or_default();
                     rebalance.add_assignments(&pod, assignments);
+                    full_assignment_pods.insert(pod);
+                }
+
+                for pod in retry_full_assignment_pods {
+                    if current_routing_table.has_pod(pod) {
+                        let assignments = current_routing_table.get_shards(pod).unwrap_or_default();
+                        rebalance.add_assignments(&pod, assignments);
+                        full_assignment_pods.insert(pod);
+                    }
                 }
 
                 persistence_service
@@ -173,24 +185,53 @@ impl ShardManagement {
                     .await
                     .expect("Failed to persist routing table after pod changes");
 
-                rebalance
+                (rebalance, full_assignment_pods)
             };
 
             debug!(rebalance=%rebalance, "Applying rebalance plan");
-            Self::execute_rebalance(worker_executors.clone(), &mut rebalance).await;
+            let failed_assignments =
+                Self::execute_rebalance(worker_executors.clone(), &mut rebalance).await;
+
+            let mut needs_retry = false;
+            if !failed_assignments.is_empty() {
+                let failed_shards: HashSet<ShardId> = failed_assignments
+                    .iter()
+                    .flat_map(|(_, shard_ids)| shard_ids.clone())
+                    .collect();
+                rebalance.remove_assignment_shards(&failed_shards);
+
+                warn!(
+                    failed_shards = failed_shards.iter().join(", "),
+                    "Some shards could not be assigned and will be left unassigned for retry"
+                );
+
+                {
+                    let mut updates_guard = updates.lock().await;
+                    for (pod, _) in &failed_assignments {
+                        if full_assignment_pods.contains(pod) {
+                            updates_guard.retry_full_assignment(*pod);
+                        }
+                    }
+                }
+                needs_retry = true;
+            }
 
             routing_table.write().await.rebalance(rebalance);
             persistence_service
                 .write(&routing_table.read().await.clone())
                 .await
                 .expect("Failed to persist routing table after rebalance");
+
+            if needs_retry {
+                change.notify_one();
+            }
         }
     }
 
     async fn execute_rebalance(
         worker_executors: Arc<dyn WorkerExecutorService + Send + Sync>,
         rebalance: &mut Rebalance,
-    ) {
+    ) -> Vec<(Pod, BTreeSet<ShardId>)> {
         info!("Beginning rebalance...");
 
         if !rebalance.get_unassignments().is_empty() {
@@ -219,7 +260,8 @@ impl ShardManagement {
                 "Executing shard assignments",
             );
         }
-        assign_shards(worker_executors.clone(), rebalance.get_assignments()).await;
+
+        assign_shards(worker_executors.clone(), rebalance.get_assignments()).await
     }
 }
 
@@ -227,6 +269,7 @@ impl ShardManagement {
 struct ShardManagementChanges {
     new_pods: HashMap<Pod, Option<String>>,
     removed_pods: HashSet<Pod>,
+    retry_full_assignment_pods: HashSet<Pod>,
 }
 
 impl ShardManagementChanges {
@@ -234,24 +277,35 @@ impl ShardManagementChanges {
         ShardManagementChanges {
             new_pods,
             removed_pods,
+            retry_full_assignment_pods: HashSet::new(),
         }
     }
 
     pub fn add_new_pod(&mut self, pod: Pod, pod_name: Option<String>) {
         self.removed_pods.remove(&pod);
+        self.retry_full_assignment_pods.remove(&pod);
         self.new_pods.insert(pod, pod_name);
     }
 
     pub fn remove_pod(&mut self, pod: Pod) {
         self.new_pods.remove(&pod);
+        self.retry_full_assignment_pods.remove(&pod);
         self.removed_pods.insert(pod);
     }
 
-    pub fn reset(&mut self) -> (HashMap<Pod, Option<String>>, HashSet<Pod>) {
+    pub fn retry_full_assignment(&mut self, pod: Pod) {
+        if !self.removed_pods.contains(&pod) {
+            self.retry_full_assignment_pods.insert(pod);
+        }
+    }
+
+    pub fn reset(&mut self) -> (HashMap<Pod, Option<String>>, HashSet<Pod>, HashSet<Pod>) {
         let new = self.new_pods.clone();
         let removed = self.removed_pods.clone();
+        let retry = self.retry_full_assignment_pods.clone();
         self.new_pods.clear();
         self.removed_pods.clear();
-        (new, removed)
+        self.retry_full_assignment_pods.clear();
+        (new, removed, retry)
     }
 }

--- a/golem-worker-service/src/service/worker/routing_logic.rs
+++ b/golem-worker-service/src/service/worker/routing_logic.rs
@@ -463,7 +463,9 @@ impl IsRetriableError for CallWorkerExecutorError {
     fn is_retriable(&self) -> bool {
         match self {
             CallWorkerExecutorError::FailedToGetRoutingTable(error) => error.is_retriable(),
-            CallWorkerExecutorError::FailedToConnectToPod(status) => status.is_retriable(),
+            CallWorkerExecutorError::FailedToConnectToPod(status) => {
+                status.is_retriable() || status.code() == tonic::Code::Cancelled
+            }
         }
     }
 

--- a/integration-tests/tests/sharding.rs
+++ b/integration-tests/tests/sharding.rs
@@ -458,7 +458,7 @@ mod tests {
             let mut pending_count = agent_ids.len();
             let mut completed_agents: Vec<String> = Vec::new();
             loop {
-                match tokio::time::timeout(Duration::from_secs(60), tasks.join_next()).await {
+                match tokio::time::timeout(Duration::from_secs(180), tasks.join_next()).await {
                     Ok(Some(result)) => {
                         let (_component_id, agent_id, result) = result.unwrap();
                         match result {

--- a/integration-tests/tests/sharding.rs
+++ b/integration-tests/tests/sharding.rs
@@ -1214,6 +1214,8 @@ mod tests {
             .unwrap();
         }
 
+        wait_for_oplog_completions(&user, &worker_id, 3, Duration::from_secs(120), &received).await;
+
         // Stop all executors immediately — before flush timer fires
         deps.stop_all_worker_executors().await;
         deps.start_all_worker_executors().await;
@@ -1238,7 +1240,8 @@ mod tests {
             .unwrap();
         }
 
-        let batches = wait_for_invocations(&received, 5, Duration::from_secs(60)).await;
+        wait_for_oplog_completions(&user, &worker_id, 5, Duration::from_secs(120), &received).await;
+        let batches = wait_for_invocations(&received, 5, Duration::from_secs(120)).await;
         let fn_names = extract_function_names(&batches);
         // Exactly-once: exactly 1 init + 4 adds, no duplicates across shard move.
         // Current bug: no checkpoint, in-flight batch may be re-delivered.

--- a/integration-tests/tests/sharding.rs
+++ b/integration-tests/tests/sharding.rs
@@ -456,16 +456,42 @@ mod tests {
 
             info!("Workers invoked");
             let mut pending_count = agent_ids.len();
-            while let Some(result) = tasks.join_next().await {
-                let (_component_id, agent_id, result) = result.unwrap();
-                match result {
-                    Ok(_) => {
-                        pending_count -= 1;
-                        info!("Worker invoke success: {agent_id}, pending: {pending_count}",);
+            let mut completed_agents: Vec<String> = Vec::new();
+            loop {
+                match tokio::time::timeout(Duration::from_secs(60), tasks.join_next()).await {
+                    Ok(Some(result)) => {
+                        let (_component_id, agent_id, result) = result.unwrap();
+                        match result {
+                            Ok(_) => {
+                                pending_count -= 1;
+                                completed_agents.push(agent_id.to_string());
+                                info!(
+                                    "Worker invoke success: {agent_id}, pending: {pending_count}",
+                                );
+                            }
+                            Err(err) => {
+                                error!("Worker invoke error: {agent_id}, {err:?}");
+                                panic!("Worker invoke error: {agent_id}, {err:?}");
+                            }
+                        }
                     }
-                    Err(err) => {
-                        error!("Worker invoke error: {agent_id}, {err:?}");
-                        panic!("Worker invoke error: {agent_id}, {err:?}");
+                    Ok(None) => break,
+                    Err(_) => {
+                        let all_agents: Vec<String> =
+                            agent_ids.iter().map(|a| a.to_string()).collect();
+                        let pending: Vec<&String> = all_agents
+                            .iter()
+                            .filter(|a| !completed_agents.contains(a))
+                            .collect();
+                        tasks.abort_all();
+                        panic!(
+                            "Timed out waiting for worker invocations. Still pending ({pending_count}): {}",
+                            pending
+                                .iter()
+                                .map(|a| a.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Fix designed based on some failing sharding test logs coming from CI.

Failed assignments are detected during rebalance, and a next rebalance is scheduled to retry assigning them.
