### PR TITLE
ts-repl: do not bundle repl

### DIFF
--- a/sdks/ts/packages/golem-ts-bridge/package.json
+++ b/sdks/ts/packages/golem-ts-bridge/package.json
@@ -28,12 +28,9 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-node-resolve": "^16.0.1",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
     "rollup": "^4.46.2",
     "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-typescript2": "^0.36.0",

--- a/sdks/ts/packages/golem-ts-bridge/rollup.config.mjs
+++ b/sdks/ts/packages/golem-ts-bridge/rollup.config.mjs
@@ -1,5 +1,3 @@
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import dts from 'rollup-plugin-dts';
 import { defineConfig } from 'rollup';
@@ -13,10 +11,6 @@ export default defineConfig([
       sourcemap: true,
     },
     plugins: [
-      resolve({
-        extensions: ['.js', '.ts'],
-      }),
-      commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
         useTsconfigDeclarationDir: true,

--- a/sdks/ts/packages/golem-ts-repl/package.json
+++ b/sdks/ts/packages/golem-ts-repl/package.json
@@ -6,7 +6,6 @@
     "access": "public"
   },
   "files": [
-    "types",
     "dist"
   ],
   "main": "dist/index.mjs",
@@ -19,8 +18,6 @@
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
-    "format": "prettier --write \"src/**/*\"",
-    "format:check": "prettier --check \"src/**/*\"",
     "build": "rollup --failAfterWarnings -c",
     "prepare": "pnpm build",
     "test": "vitest run",
@@ -38,15 +35,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-node-resolve": "^16.0.1",
     "@types/node": "^24.1.0",
     "@types/shell-quote": "^1.7.5",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "eslint": "^9.33.0",
     "fast-check": "^4.2.0",
-    "prettier": "^3.6.2",
     "reflect-metadata": "^0.1.14",
     "rollup": "^4.46.2",
     "rollup-plugin-dts": "^6.2.1",

--- a/sdks/ts/packages/golem-ts-repl/rollup.config.js
+++ b/sdks/ts/packages/golem-ts-repl/rollup.config.js
@@ -1,11 +1,7 @@
 // rollup.config.mjs
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import dts from 'rollup-plugin-dts';
 import { defineConfig } from 'rollup';
-
-const external = ['ts-morph'];
 
 export default defineConfig([
   {
@@ -15,12 +11,18 @@ export default defineConfig([
       format: 'esm',
       sourcemap: true,
     },
-    external,
+    external: [
+      'node:child_process',
+      'node:fs',
+      'node:process',
+      'node:repl',
+      'node:stream',
+      'node:util',
+      'picocolors',
+      'ts-morph',
+      'uuid',
+    ],
     plugins: [
-      resolve({
-        extensions: ['.js', '.ts'],
-      }),
-      commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
         useTsconfigDeclarationDir: true,
@@ -37,7 +39,6 @@ export default defineConfig([
       file: 'dist/index.d.mts',
       format: 'esm',
     },
-    external,
     plugins: [dts()],
   },
 ]);

--- a/sdks/ts/packages/golem-ts-typegen/package.json
+++ b/sdks/ts/packages/golem-ts-typegen/package.json
@@ -38,7 +38,6 @@
     "fast-check": "^4.2.0",
     "log-symbols": "^7.0.1",
     "picocolors": "^1.1.1",
-    "prettier": "^3.6.2",
     "reflect-metadata": "^0.1.14",
     "rollup": "^4.46.2",
     "rollup-plugin-dts": "^6.2.1",

--- a/sdks/ts/packages/golem-ts-types-core/package.json
+++ b/sdks/ts/packages/golem-ts-types-core/package.json
@@ -28,13 +28,10 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-node-resolve": "^16.0.1",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "eslint": "^9.33.0",
     "fast-check": "^4.2.0",
-    "prettier": "^3.6.2",
     "reflect-metadata": "^0.1.14",
     "rollup": "^4.46.2",
     "rollup-plugin-dts": "^6.2.1",

--- a/sdks/ts/packages/golem-ts-types-core/rollup.config.js
+++ b/sdks/ts/packages/golem-ts-types-core/rollup.config.js
@@ -1,6 +1,4 @@
 // rollup.config.mjs
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import dts from 'rollup-plugin-dts';
 import { defineConfig } from 'rollup';

--- a/sdks/ts/pnpm-lock.yaml
+++ b/sdks/ts/pnpm-lock.yaml
@@ -44,12 +44,6 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.35.0
-      '@rollup/plugin-commonjs':
-        specifier: ^28.0.6
-        version: 28.0.6(rollup@4.50.0)
-      '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.1(rollup@4.50.0)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.39.0
         version: 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
@@ -59,9 +53,6 @@ importers:
       eslint:
         specifier: ^9.33.0
         version: 9.35.0
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       rollup:
         specifier: ^4.46.2
         version: 4.50.0
@@ -96,12 +87,6 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.35.0
-      '@rollup/plugin-commonjs':
-        specifier: ^28.0.6
-        version: 28.0.6(rollup@4.50.0)
-      '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.1(rollup@4.50.0)
       '@types/node':
         specifier: ^24.1.0
         version: 24.3.1
@@ -120,9 +105,6 @@ importers:
       fast-check:
         specifier: ^4.2.0
         version: 4.3.0
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       reflect-metadata:
         specifier: ^0.1.14
         version: 0.1.14
@@ -255,9 +237,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       reflect-metadata:
         specifier: ^0.1.14
         version: 0.1.14
@@ -288,12 +267,6 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.35.0
-      '@rollup/plugin-commonjs':
-        specifier: ^28.0.6
-        version: 28.0.6(rollup@4.50.0)
-      '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.1(rollup@4.50.0)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.39.0
         version: 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
@@ -306,9 +279,6 @@ importers:
       fast-check:
         specifier: ^4.2.0
         version: 4.3.0
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       reflect-metadata:
         specifier: ^0.1.14
         version: 0.1.14


### PR DESCRIPTION
We are using the repl as a normal dependency in the packages the cli is generating. Therefore, there is no point in bundling our transitive dependencies, as they will be installed by npm anyway.

(If we do bundle, the dependencies should be declared as devDependencies, not dependencies)