### PR TITLE
add com.apple.security.cs.allow-unsigned-executable-memory for macos cli binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1191,6 +1191,24 @@ jobs:
           # Save keychain path for cleanup
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
+      - name: Create entitlements
+        if: contains(matrix.cfg.rust-target, 'apple-darwin')
+        run: |
+          ENTITLEMENTS_PATH=$RUNNER_TEMP/entitlements.plist
+
+          cat > $ENTITLEMENTS_PATH << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN">
+          <plist version="1.0">
+            <dict>
+              <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+              <true/>
+            </dict>
+          </plist>
+          EOF
+
+          echo "ENTITLEMENTS_PATH=$ENTITLEMENTS_PATH" >> $GITHUB_ENV
+
       - name: Code Sign Binary
         if: contains(matrix.cfg.rust-target, 'apple-darwin')
         env:
@@ -1202,12 +1220,13 @@ jobs:
           codesign --force \
             --options runtime \
             --timestamp \
+            --entitlements "$ENTITLEMENTS_PATH" \
             --sign "$APPLE_SIGNING_IDENTITY" \
             "$BINARY_PATH"
 
           # Verify signature
           codesign --verify --verbose "$BINARY_PATH"
-          codesign --display --verbose=4 "$BINARY_PATH"
+          codesign --display --verbose=4 --entitlements - "$BINARY_PATH"
 
       - name: Create Notarization Archive
         if: contains(matrix.cfg.rust-target, 'apple-darwin')


### PR DESCRIPTION
Tested manually. The weaker com.apple.security.cs.allow-jit is not enough.

Without this executing wizer as part of the build process fails with
```
CODE SIGNING: process 38951[golem-cli-aarch6]: rejecting invalid page at address 0x1073c4000 from offset 0xb00000 in file "<nil>" (cs_mtime:0.0 == mtime:0.0) (signed:0 validated:0 tainted:0 nx:0 wpmapped:1 dirty:0 depth:0)
```