### PR TITLE
Automatically use phantom agents when an agent type is ephemeral

### DIFF
--- a/cli/golem-cli/src/bridge_gen/rust/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/rust/mod.rs
@@ -20,8 +20,8 @@ use crate::sdk_overrides::{sdk_overrides, workspace_root};
 use anyhow::anyhow;
 use camino::{Utf8Path, Utf8PathBuf};
 use golem_common::model::agent::{
-    AgentConfigDeclaration, AgentConfigSource, AgentMethod, AgentType, BinaryType, DataSchema,
-    ElementSchema, NamedElementSchemas, TextType,
+    AgentConfigDeclaration, AgentConfigSource, AgentMethod, AgentMode, AgentType, BinaryType,
+    DataSchema, ElementSchema, NamedElementSchemas, TextType,
 };
 use golem_wasm::analysis::AnalysedType;
 use heck::{ToSnakeCase, ToUpperCamelCase};
@@ -204,7 +204,7 @@ impl RustBridgeGenerator {
             });
         }
 
-        let with_config_methods = if !local_configs.is_empty() {
+        let get_with_config_method = if self.agent_type.mode == AgentMode::Durable {
             quote! {
                 pub async fn get_with_config(#(#constructor_params,)* #(#config_param_defs,)*) -> Result<Self, golem_client::bridge::ClientError> {
                     #constructor_params_to_data_value
@@ -214,6 +214,14 @@ impl RustBridgeGenerator {
                     #(#config_encode_stmts)*
                     Self::__create(constructor_parameters, None, agent_config).await
                 }
+            }
+        } else {
+            quote! {}
+        };
+
+        let with_config_methods = if !local_configs.is_empty() {
+            quote! {
+                #get_with_config_method
 
                 pub async fn get_phantom_with_config(uuid: uuid::Uuid, #(#constructor_params,)* #(#config_param_defs,)*) -> Result<Self, golem_client::bridge::ClientError> {
                     #constructor_params_to_data_value
@@ -250,6 +258,19 @@ impl RustBridgeGenerator {
             quote! { use crate::multimodal::MultimodalEnum; }
         };
 
+        let get_method = if self.agent_type.mode == AgentMode::Durable {
+            quote! {
+                pub async fn get(#(#constructor_params),*) -> Result<Self, golem_client::bridge::ClientError> {
+                    #constructor_params_to_data_value
+                    let constructor_parameters: golem_common::model::agent::UntypedJsonDataValue =
+                        typed_constructor_parameters.into();
+                    Self::__create(constructor_parameters, None, vec![]).await
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         let tokens = quote! {
             #![allow(unused)]
 
@@ -274,12 +295,7 @@ impl RustBridgeGenerator {
             }
 
             impl #client_struct_name {
-                pub async fn get(#(#constructor_params),*) -> Result<Self, golem_client::bridge::ClientError> {
-                    #constructor_params_to_data_value
-                    let constructor_parameters: golem_common::model::agent::UntypedJsonDataValue =
-                        typed_constructor_parameters.into();
-                    Self::__create(constructor_parameters, None, vec![]).await
-                }
+                #get_method
 
                 pub async fn get_phantom(uuid: uuid::Uuid, #(#constructor_params),*) -> Result<Self, golem_client::bridge::ClientError> {
                     #constructor_params_to_data_value

--- a/cli/golem-cli/src/command_handler/worker/mod.rs
+++ b/cli/golem-cli/src/command_handler/worker/mod.rs
@@ -263,7 +263,13 @@ impl WorkerCommandHandler {
 
         let agent_name =
             self.try_recanonicalize_agent_name(&agent_name_match.agent_name, &component);
-        self.validate_worker_and_function_names(&component, &agent_name, None)?;
+        let agent_name =
+            match self.validate_worker_and_function_names(&component, &agent_name, None)? {
+                Some((agent_id, agent_type)) => {
+                    RawAgentId(normalize_public_agent_id(&agent_id, &agent_type)?.to_string())
+                }
+                None => agent_name,
+            };
 
         log_action(
             "Creating",
@@ -353,6 +359,7 @@ impl WorkerCommandHandler {
 
         let (agent_id, agent_type) =
             agent_id_and_type.ok_or_else(|| anyhow!("Agent invoke requires an agent component"))?;
+        let agent_id = normalize_public_agent_id(&agent_id, &agent_type)?;
 
         // If the function name is fully qualified (e.g., "rust:agent/foo-agent.{fun-string}"),
         // extract the simple method name for fuzzy matching.
@@ -583,16 +590,14 @@ impl WorkerCommandHandler {
             bail!("Agent type not found: {}", agent_type_name);
         };
 
-        let agent_type_name = agent_type.agent_type.type_name;
         let typed_parameters = DataValue::try_from_untyped_json(
             parameters,
-            agent_type.agent_type.constructor.input_schema,
+            agent_type.agent_type.constructor.input_schema.clone(),
         )
         .map_err(|err| {
             anyhow!("Failed to match agent type parameters to the latest metadata: {err}")
         })?;
-        let agent_id = ParsedAgentId::new(agent_type_name, typed_parameters, phantom_id)
-            .map_err(|e| anyhow!("Failed to format agent ID: {e}"))?;
+        let agent_id = build_repl_agent_id(&agent_type.agent_type, typed_parameters, phantom_id)?;
         let agent_name = RawAgentId(agent_id.to_string());
 
         let connection = WorkerConnection::new(
@@ -2422,11 +2427,72 @@ fn split_agent_name(agent_name: &str) -> Vec<&str> {
     }
 }
 
+fn build_repl_agent_id(
+    agent_type: &AgentType,
+    typed_parameters: DataValue,
+    phantom_id: Option<Uuid>,
+) -> anyhow::Result<ParsedAgentId> {
+    ParsedAgentId::new_auto_phantom(
+        agent_type.type_name.clone(),
+        typed_parameters,
+        phantom_id,
+        agent_type.mode,
+    )
+    .map_err(|e| anyhow!("Failed to format agent ID: {e}"))
+}
+
+fn normalize_public_agent_id(
+    agent_id: &ParsedAgentId,
+    agent_type: &AgentType,
+) -> anyhow::Result<ParsedAgentId> {
+    build_repl_agent_id(agent_type, agent_id.parameters.clone(), agent_id.phantom_id)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::command_handler::worker::split_agent_name;
+    use super::{
+        build_repl_agent_id, extract_simple_method_name, normalize_public_agent_id,
+        split_agent_name,
+    };
+    use golem_common::model::Empty;
+    use golem_common::model::agent::{
+        AgentConstructor, AgentMethod, AgentMode, AgentType, AgentTypeName, DataSchema,
+        ElementValues, NamedElementSchemas, ParsedAgentId, Snapshotting,
+    };
     use pretty_assertions::assert_eq;
     use test_r::test;
+    use uuid::Uuid;
+
+    fn test_agent_type(mode: AgentMode) -> AgentType {
+        AgentType {
+            type_name: AgentTypeName("repl-agent".to_string()),
+            description: String::new(),
+            source_language: String::new(),
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            methods: vec![AgentMethod {
+                name: "run".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![],
+            }],
+            dependencies: vec![],
+            mode,
+            http_mount: None,
+            snapshotting: Snapshotting::Disabled(Empty {}),
+            config: vec![],
+        }
+    }
+
+    fn empty_tuple() -> golem_common::model::agent::DataValue {
+        golem_common::model::agent::DataValue::Tuple(ElementValues { elements: vec![] })
+    }
 
     #[test]
     fn test_split_agent_name() {
@@ -2445,15 +2511,11 @@ mod tests {
 
     #[test]
     fn test_extract_simple_method_name_simple() {
-        use super::extract_simple_method_name;
-
         assert_eq!(extract_simple_method_name("fun_string"), "fun_string");
     }
 
     #[test]
     fn test_extract_simple_method_name_qualified_kebab() {
-        use super::extract_simple_method_name;
-
         assert_eq!(
             extract_simple_method_name("rust:agent/FooAgent.{fun-string}"),
             "fun-string"
@@ -2462,11 +2524,50 @@ mod tests {
 
     #[test]
     fn test_extract_simple_method_name_qualified_underscore() {
-        use super::extract_simple_method_name;
-
         assert_eq!(
             extract_simple_method_name("rust:agent/FooAgent.{fun_string}"),
             "fun_string"
         );
+    }
+
+    #[test]
+    fn repl_agent_id_auto_generates_phantom_for_ephemeral_agents() {
+        let agent_id =
+            build_repl_agent_id(&test_agent_type(AgentMode::Ephemeral), empty_tuple(), None)
+                .unwrap();
+
+        assert!(agent_id.phantom_id.is_some());
+    }
+
+    #[test]
+    fn repl_agent_id_keeps_durable_agents_non_phantom() {
+        let agent_id =
+            build_repl_agent_id(&test_agent_type(AgentMode::Durable), empty_tuple(), None).unwrap();
+
+        assert!(agent_id.phantom_id.is_none());
+    }
+
+    #[test]
+    fn repl_agent_id_preserves_explicit_phantom_id() {
+        let explicit_phantom_id = Uuid::new_v4();
+        let agent_id = build_repl_agent_id(
+            &test_agent_type(AgentMode::Ephemeral),
+            empty_tuple(),
+            Some(explicit_phantom_id),
+        )
+        .unwrap();
+
+        assert_eq!(agent_id.phantom_id, Some(explicit_phantom_id));
+    }
+
+    #[test]
+    fn normalize_public_agent_id_auto_generates_phantom_for_ephemeral_agents() {
+        let agent_id =
+            ParsedAgentId::new(AgentTypeName("repl-agent".to_string()), empty_tuple(), None)
+                .unwrap();
+        let normalized =
+            normalize_public_agent_id(&agent_id, &test_agent_type(AgentMode::Ephemeral)).unwrap();
+
+        assert!(normalized.phantom_id.is_some());
     }
 }

--- a/cli/golem-cli/tests/bridge_gen/rust.rs
+++ b/cli/golem-cli/tests/bridge_gen/rust.rs
@@ -22,8 +22,8 @@ use golem_cli::bridge_gen::rust::{RustBridgeGenerator, RustTypeName};
 use golem_cli::model::GuestLanguage;
 use golem_common::model::Empty;
 use golem_common::model::agent::{
-    AgentConstructor, AgentMethod, AgentMode, AgentType, AgentTypeName,
-    ComponentModelElementSchema, DataSchema, ElementSchema, NamedElementSchema,
+    AgentConfigDeclaration, AgentConfigSource, AgentConstructor, AgentMethod, AgentMode, AgentType,
+    AgentTypeName, ComponentModelElementSchema, DataSchema, ElementSchema, NamedElementSchema,
     NamedElementSchemas, Snapshotting,
 };
 use golem_wasm::analysis::analysed_type::{f64, str};
@@ -188,6 +188,72 @@ fn bridge_rust_compiles_rust_code_first_snippets_bar_agent(
     #[tagged_as("rust_code_first_snippets_bar_agent")] _pkg: &GeneratedPackage,
 ) {
     // The test_dep ensures it was compiled successfully in generate_and_compile
+}
+
+#[test]
+fn bridge_rust_ephemeral_agent_skips_non_phantom_constructors() {
+    let dir = TempDir::new().unwrap();
+    let target_dir = Utf8Path::from_path(dir.path()).unwrap();
+
+    let mut generator =
+        RustBridgeGenerator::new(ephemeral_config_agent(), target_dir, true).unwrap();
+    generator
+        .generate()
+        .expect("Failed to generate Rust bridge");
+
+    let lib_rs = std::fs::read_to_string(target_dir.join("src/lib.rs")).unwrap();
+
+    assert!(!lib_rs.contains("pub async fn get("));
+    assert!(!lib_rs.contains("pub async fn get_with_config("));
+    assert!(lib_rs.contains("pub async fn new_phantom("));
+    assert!(lib_rs.contains("pub async fn get_phantom("));
+    assert!(lib_rs.contains("pub async fn new_phantom_with_config("));
+    assert!(lib_rs.contains("pub async fn get_phantom_with_config("));
+}
+
+fn ephemeral_config_agent() -> AgentType {
+    AgentType {
+        type_name: AgentTypeName("EphemeralBridgeAgent".to_string()),
+        description: "Constructs an ephemeral bridge agent".to_string(),
+        source_language: "rust".to_string(),
+        constructor: AgentConstructor {
+            name: Some("EphemeralBridgeAgent".to_string()),
+            description: "Constructs an ephemeral bridge agent".to_string(),
+            prompt_hint: None,
+            input_schema: DataSchema::Tuple(NamedElementSchemas {
+                elements: vec![NamedElementSchema {
+                    name: "name".to_string(),
+                    schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                        element_type: str(),
+                    }),
+                }],
+            }),
+        },
+        methods: vec![AgentMethod {
+            name: "ping".to_string(),
+            description: "Returns the name".to_string(),
+            prompt_hint: None,
+            input_schema: DataSchema::Tuple(NamedElementSchemas { elements: vec![] }),
+            output_schema: DataSchema::Tuple(NamedElementSchemas {
+                elements: vec![NamedElementSchema {
+                    name: "return_value".to_string(),
+                    schema: ElementSchema::ComponentModel(ComponentModelElementSchema {
+                        element_type: str(),
+                    }),
+                }],
+            }),
+            http_endpoint: vec![],
+        }],
+        dependencies: vec![],
+        mode: AgentMode::Ephemeral,
+        http_mount: None,
+        snapshotting: Snapshotting::Disabled(Empty {}),
+        config: vec![AgentConfigDeclaration {
+            source: AgentConfigSource::Local,
+            path: vec!["timeout".to_string()],
+            value_type: str(),
+        }],
+    }
 }
 
 fn generate_and_compile(agent_type: AgentType, target_dir: &Utf8Path) {

--- a/golem-common/src/model/agent/mod.rs
+++ b/golem-common/src/model/agent/mod.rs
@@ -343,6 +343,21 @@ impl ParsedAgentId {
         })
     }
 
+    pub fn new_auto_phantom(
+        agent_type: AgentTypeName,
+        parameters: DataValue,
+        phantom_id: Option<Uuid>,
+        mode: AgentMode,
+    ) -> Result<Self, String> {
+        let phantom_id = match (mode, phantom_id) {
+            (_, Some(id)) => Some(id),
+            (AgentMode::Ephemeral, None) => Some(Uuid::new_v4()),
+            (AgentMode::Durable, None) => None,
+        };
+
+        Self::new(agent_type, parameters, phantom_id)
+    }
+
     pub fn parse(s: impl AsRef<str>, resolver: impl AgentTypeResolver) -> Result<Self, String> {
         Self::parse_and_resolve_type(s, resolver).map(|(agent_id, _)| agent_id)
     }

--- a/golem-common/src/model/agent/tests.rs
+++ b/golem-common/src/model/agent/tests.rs
@@ -1433,3 +1433,62 @@ fn source_language_protobuf_roundtrip() {
         );
     }
 }
+
+#[test]
+fn new_auto_phantom_durable_none() {
+    let agent_type = AgentTypeName("test-agent".to_string());
+    let params = DataValue::Tuple(ElementValues { elements: vec![] });
+    let id = ParsedAgentId::new_auto_phantom(agent_type, params, None, AgentMode::Durable).unwrap();
+    assert_eq!(
+        id.phantom_id, None,
+        "Durable agent with no phantom_id should remain None"
+    );
+}
+
+#[test]
+fn new_auto_phantom_durable_some() {
+    let supplied = Uuid::new_v4();
+    let agent_type = AgentTypeName("test-agent".to_string());
+    let params = DataValue::Tuple(ElementValues { elements: vec![] });
+    let id =
+        ParsedAgentId::new_auto_phantom(agent_type, params, Some(supplied), AgentMode::Durable)
+            .unwrap();
+    assert_eq!(
+        id.phantom_id,
+        Some(supplied),
+        "Durable agent should preserve supplied phantom_id"
+    );
+}
+
+#[test]
+fn new_auto_phantom_ephemeral_none() {
+    let agent_type = AgentTypeName("test-agent".to_string());
+    let params = DataValue::Tuple(ElementValues { elements: vec![] });
+    let id =
+        ParsedAgentId::new_auto_phantom(agent_type, params, None, AgentMode::Ephemeral).unwrap();
+    assert!(
+        id.phantom_id.is_some(),
+        "Ephemeral agent with no phantom_id should auto-generate one"
+    );
+    // Verify it appears in the string representation
+    let s = id.to_string();
+    assert!(
+        s.contains('['),
+        "Ephemeral auto-phantom ID should appear in string: {s}"
+    );
+}
+
+#[test]
+fn new_auto_phantom_ephemeral_some() {
+    let supplied = Uuid::new_v4();
+    let agent_type = AgentTypeName("test-agent".to_string());
+    let params = DataValue::Tuple(ElementValues { elements: vec![] });
+    let id =
+        ParsedAgentId::new_auto_phantom(agent_type, params, Some(supplied), AgentMode::Ephemeral)
+            .unwrap();
+    assert_eq!(
+        id.phantom_id,
+        Some(supplied),
+        "Ephemeral agent should preserve supplied phantom_id"
+    );
+}

--- a/golem-registry-service/src/services/deployment/route_compilation.rs
+++ b/golem-registry-service/src/services/deployment/route_compilation.rs
@@ -21,9 +21,9 @@ use crate::model::api_definition::{
 };
 use golem_common::model::Empty;
 use golem_common::model::agent::{
-    AgentMethod, AgentType, AgentTypeName, DataSchema, ElementSchema, HttpEndpointDetails,
-    HttpMethod, HttpMountDetails, NamedElementSchemas, RegisteredAgentTypeImplementer,
-    SystemVariable,
+    AgentMethod, AgentMode, AgentType, AgentTypeName, DataSchema, ElementSchema,
+    HttpEndpointDetails, HttpMethod, HttpMountDetails, NamedElementSchemas,
+    RegisteredAgentTypeImplementer, SystemVariable,
 };
 use golem_common::model::domain_registration::Domain;
 use golem_common::model::environment::Environment;
@@ -140,7 +140,7 @@ pub fn add_agent_method_http_routes(
                     component_revision: implementer.component_revision,
                     agent_type: agent.type_name.clone(),
                     method_name: agent_method.name.clone(),
-                    phantom: http_mount.phantom_agent,
+                    phantom: http_mount.phantom_agent || agent.mode == AgentMode::Ephemeral,
                     constructor_parameters: constructor_parameters.clone(),
                     method_parameters,
                     expected_agent_response: agent_method.output_schema.clone(),
@@ -629,12 +629,142 @@ mod tests {
     use crate::model::api_definition::UnboundRouteSecurity;
     use chrono::Utc;
     use golem_common::model::Empty;
+    use golem_common::model::account::AccountId;
+    use golem_common::model::agent::{
+        AgentConstructor, AgentMethod, AgentMode, AgentType, CorsOptions as AgentCorsOptions,
+        HttpMountDetails, LiteralSegment, Snapshotting,
+    };
+    use golem_common::model::application::ApplicationId;
+    use golem_common::model::auth::EnvironmentRole;
+    use golem_common::model::component::{ComponentId, ComponentRevision};
     use golem_common::model::diff::Hash;
     use golem_common::model::domain_registration::Domain;
-    use golem_common::model::environment::EnvironmentId;
-    use golem_common::model::http_api_deployment::{HttpApiDeployment, HttpApiDeploymentId};
-    use std::collections::BTreeMap;
+    use golem_common::model::environment::{
+        Environment, EnvironmentId, EnvironmentName, EnvironmentRevision,
+    };
+    use golem_common::model::http_api_deployment::{
+        HttpApiDeployment, HttpApiDeploymentAgentOptions, HttpApiDeploymentId,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
     use test_r::test;
+    use uuid::Uuid;
+
+    fn test_environment(environment_id: EnvironmentId) -> Environment {
+        Environment {
+            id: environment_id,
+            revision: EnvironmentRevision::INITIAL,
+            application_id: ApplicationId(Uuid::new_v4()),
+            name: EnvironmentName::try_from("prod").unwrap(),
+            diff_model_version: 0,
+            compatibility_check: false,
+            version_check: false,
+            security_overrides: false,
+            owner_account_id: AccountId(Uuid::new_v4()),
+            roles_from_active_shares: BTreeSet::<EnvironmentRole>::new(),
+            current_deployment: None,
+        }
+    }
+
+    fn test_agent(mode: AgentMode, phantom_agent: bool) -> AgentType {
+        AgentType {
+            type_name: AgentTypeName("note-agent".to_string()),
+            description: String::new(),
+            source_language: String::new(),
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            methods: vec![AgentMethod {
+                name: "fetch".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![HttpEndpointDetails {
+                    http_method: HttpMethod::Get(Empty {}),
+                    path_suffix: vec![],
+                    header_vars: vec![],
+                    query_vars: vec![],
+                    auth_details: None,
+                    cors_options: AgentCorsOptions {
+                        allowed_patterns: vec![],
+                    },
+                }],
+            }],
+            dependencies: vec![],
+            mode,
+            http_mount: Some(HttpMountDetails {
+                path_prefix: vec![golem_common::model::agent::PathSegment::Literal(
+                    LiteralSegment {
+                        value: "notes".to_string(),
+                    },
+                )],
+                auth_details: None,
+                phantom_agent,
+                cors_options: AgentCorsOptions {
+                    allowed_patterns: vec![],
+                },
+                webhook_suffix: vec![],
+            }),
+            snapshotting: Snapshotting::Disabled(Empty {}),
+            config: vec![],
+        }
+    }
+
+    fn test_deployment(environment_id: EnvironmentId) -> HttpApiDeployment {
+        HttpApiDeployment {
+            id: HttpApiDeploymentId::new(),
+            revision:
+                golem_common::model::http_api_deployment::HttpApiDeploymentRevision::try_from(0u64)
+                    .unwrap(),
+            environment_id,
+            domain: Domain("example.com".to_string()),
+            hash: Hash::empty(),
+            agents: BTreeMap::new(),
+            webhooks_url: "/webhooks".to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    fn compiled_phantom_flag(mode: AgentMode, phantom_agent: bool) -> bool {
+        let environment_id = EnvironmentId(Uuid::new_v4());
+        let environment = test_environment(environment_id);
+        let deployment = test_deployment(environment_id);
+        let agent = test_agent(mode, phantom_agent);
+        let http_mount = agent.http_mount.clone().unwrap();
+        let implementer = RegisteredAgentTypeImplementer {
+            component_id: ComponentId(Uuid::new_v4()),
+            component_revision: ComponentRevision::INITIAL,
+        };
+        let mut current_route_id = 0;
+        let mut compiled_routes = Vec::new();
+        let mut errors = Vec::new();
+
+        add_agent_method_http_routes(
+            &environment,
+            &deployment,
+            &agent,
+            &implementer,
+            &http_mount,
+            &agent.methods,
+            vec![],
+            &HttpApiDeploymentAgentOptions::default(),
+            &mut current_route_id,
+            &mut compiled_routes,
+            &mut errors,
+        );
+
+        assert!(errors.is_empty());
+
+        let compiled_route = compiled_routes.into_iter().next().unwrap();
+        let RouteBehaviour::CallAgent(call_agent) = compiled_route.behaviour else {
+            panic!("expected call-agent route");
+        };
+
+        call_agent.phantom
+    }
 
     #[test]
     fn parses_mixed_segments_as_literals() {
@@ -808,5 +938,15 @@ mod tests {
             post_policy.allowed_headers,
             BTreeSet::from(["content-type".to_string(), "x-session".to_string(),])
         );
+    }
+
+    #[test]
+    fn ephemeral_agents_force_http_routes_to_be_phantom() {
+        assert!(compiled_phantom_flag(AgentMode::Ephemeral, false));
+    }
+
+    #[test]
+    fn durable_agents_keep_explicit_http_phantom_flag() {
+        assert!(compiled_phantom_flag(AgentMode::Durable, true));
     }
 }

--- a/golem-worker-service/src/api/agents.rs
+++ b/golem-worker-service/src/api/agents.rs
@@ -135,6 +135,7 @@ pub struct AgentInvocationRequest {
 #[oai(rename_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub struct AgentInvocationResult {
+    pub agent_id: AgentId,
     pub result: Option<UntypedJsonDataValue>,
     pub component_revision: Option<ComponentRevision>,
 }

--- a/golem-worker-service/src/api/worker.rs
+++ b/golem-worker-service/src/api/worker.rs
@@ -1181,6 +1181,7 @@ fn make_component_file_path(name: String) -> Result<CanonicalFilePath> {
 mod tests {
     use super::normalize_agent_name_with_latest_component;
     use chrono::Utc;
+    use golem_common::model::AgentId;
     use golem_common::model::Empty;
     use golem_common::model::account::AccountId;
     use golem_common::model::agent::{
@@ -1192,7 +1193,6 @@ mod tests {
     use golem_common::model::component_metadata::ComponentMetadata;
     use golem_common::model::diff::Hash;
     use golem_common::model::environment::EnvironmentId;
-    use golem_common::model::AgentId;
     use golem_service_base::model::component::Component;
     use test_r::test;
     use uuid::Uuid;

--- a/golem-worker-service/src/api/worker.rs
+++ b/golem-worker-service/src/api/worker.rs
@@ -21,6 +21,7 @@ use crate::service::worker::{WorkerService, proxy_worker_connection};
 use futures::StreamExt;
 use futures::TryStreamExt;
 use golem_common::base_model::api;
+use golem_common::model::agent::ParsedAgentId;
 use golem_common::model::auth::TokenSecret;
 use golem_common::model::component::{CanonicalFilePath, ComponentId, PluginPriority};
 use golem_common::model::oplog::OplogCursor;
@@ -1113,12 +1114,7 @@ impl WorkerApi {
             })?;
 
         let agent_id =
-            AgentId::from_agent_name_string(component_id, agent_id).map_err(|error| {
-                ApiEndpointError::bad_request(
-                    api::error_code::INVALID_WORKER_ID,
-                    golem_common::safe(format!("Invalid worker id: {error}")),
-                )
-            })?;
+            normalize_agent_name_with_latest_component(component_id, agent_id, &latest_component)?;
         Ok((agent_id, latest_component))
     }
 
@@ -1136,6 +1132,42 @@ impl WorkerApi {
     }
 }
 
+fn normalize_agent_name_with_latest_component(
+    component_id: ComponentId,
+    agent_id: &str,
+    latest_component: &Component,
+) -> Result<AgentId> {
+    if latest_component.metadata.is_agent()
+        && let Ok((parsed_agent_id, agent_type)) =
+            ParsedAgentId::parse_and_resolve_type(agent_id, &latest_component.metadata)
+    {
+        let normalized_agent_id = ParsedAgentId::new_auto_phantom(
+            parsed_agent_id.agent_type,
+            parsed_agent_id.parameters,
+            parsed_agent_id.phantom_id,
+            agent_type.mode,
+        )
+        .map_err(|error| {
+            ApiEndpointError::bad_request(
+                api::error_code::INVALID_WORKER_ID,
+                golem_common::safe(format!("Invalid worker id: {error}")),
+            )
+        })?;
+
+        return Ok(AgentId {
+            component_id,
+            agent_id: normalized_agent_id.to_string(),
+        });
+    }
+
+    AgentId::from_agent_name_string(component_id, agent_id).map_err(|error| {
+        ApiEndpointError::bad_request(
+            api::error_code::INVALID_WORKER_ID,
+            golem_common::safe(format!("Invalid worker id: {error}")),
+        )
+    })
+}
+
 fn make_component_file_path(name: String) -> Result<CanonicalFilePath> {
     CanonicalFilePath::from_rel_str(&name).map_err(|error| {
         ApiEndpointError::bad_request(
@@ -1143,4 +1175,117 @@ fn make_component_file_path(name: String) -> Result<CanonicalFilePath> {
             golem_common::safe(format!("Invalid file name: {error}")),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_agent_name_with_latest_component;
+    use chrono::Utc;
+    use golem_common::model::Empty;
+    use golem_common::model::account::AccountId;
+    use golem_common::model::agent::{
+        AgentConstructor, AgentMethod, AgentMode, AgentType, AgentTypeName, DataSchema,
+        NamedElementSchemas, Snapshotting,
+    };
+    use golem_common::model::application::ApplicationId;
+    use golem_common::model::component::{ComponentId, ComponentName, ComponentRevision};
+    use golem_common::model::component_metadata::ComponentMetadata;
+    use golem_common::model::diff::Hash;
+    use golem_common::model::environment::EnvironmentId;
+    use golem_common::model::AgentId;
+    use golem_service_base::model::component::Component;
+    use test_r::test;
+    use uuid::Uuid;
+
+    fn test_agent_type(mode: AgentMode) -> AgentType {
+        AgentType {
+            type_name: AgentTypeName("weather-agent".to_string()),
+            description: String::new(),
+            source_language: String::new(),
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            methods: vec![AgentMethod {
+                name: "run".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![],
+            }],
+            dependencies: vec![],
+            mode,
+            http_mount: None,
+            snapshotting: Snapshotting::Disabled(Empty {}),
+            config: vec![],
+        }
+    }
+
+    fn test_component(mode: AgentMode) -> Component {
+        Component {
+            id: ComponentId(Uuid::new_v4()),
+            revision: ComponentRevision::INITIAL,
+            environment_id: EnvironmentId(Uuid::new_v4()),
+            component_name: ComponentName("weather-component".to_string()),
+            hash: Hash::empty(),
+            application_id: ApplicationId(Uuid::new_v4()),
+            account_id: AccountId(Uuid::new_v4()),
+            component_size: 0,
+            metadata: ComponentMetadata::from_parts(
+                vec![],
+                vec![],
+                None,
+                None,
+                vec![test_agent_type(mode)],
+                std::collections::BTreeMap::new(),
+            ),
+            created_at: Utc::now(),
+            wasm_hash: Hash::empty(),
+            object_store_key: String::new(),
+        }
+    }
+
+    fn phantom_id(agent_id: &AgentId) -> Option<Uuid> {
+        agent_id
+            .agent_id
+            .rsplit_once('[')
+            .and_then(|(_, phantom_id)| phantom_id.strip_suffix(']'))
+            .and_then(|phantom_id| Uuid::parse_str(phantom_id).ok())
+    }
+
+    #[test]
+    fn latest_component_normalization_auto_generates_phantom_for_ephemeral_agents() {
+        let component = test_component(AgentMode::Ephemeral);
+
+        let agent_id =
+            normalize_agent_name_with_latest_component(component.id, "weather-agent()", &component)
+                .unwrap();
+
+        assert!(phantom_id(&agent_id).is_some());
+    }
+
+    #[test]
+    fn latest_component_normalization_keeps_durable_agents_non_phantom() {
+        let component = test_component(AgentMode::Durable);
+
+        let agent_id =
+            normalize_agent_name_with_latest_component(component.id, "weather-agent()", &component)
+                .unwrap();
+
+        assert!(phantom_id(&agent_id).is_none());
+    }
+
+    #[test]
+    fn latest_component_normalization_preserves_non_agent_worker_names() {
+        let component = test_component(AgentMode::Ephemeral);
+
+        let agent_id =
+            normalize_agent_name_with_latest_component(component.id, "custom-worker", &component)
+                .unwrap();
+
+        assert_eq!(agent_id.agent_id, "custom-worker");
+    }
 }

--- a/golem-worker-service/src/mcp/agent_mcp_capability.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_capability.rs
@@ -17,7 +17,7 @@ use crate::mcp::agent_mcp_tool::AgentMcpTool;
 use crate::mcp::schema::{McpToolSchema, get_input_mcp_schema, get_mcp_tool_schema};
 use golem_common::base_model::account::AccountId;
 use golem_common::base_model::agent::{
-    AgentMethod, AgentTypeName, DataSchema, ElementSchema, NamedElementSchemas,
+    AgentMethod, AgentMode, AgentTypeName, DataSchema, ElementSchema, NamedElementSchemas,
 };
 use golem_common::base_model::component::ComponentId;
 use golem_common::base_model::environment::EnvironmentId;
@@ -37,6 +37,7 @@ impl McpAgentCapability {
         account_id: &AccountId,
         environment_id: &EnvironmentId,
         agent_type_name: &AgentTypeName,
+        agent_mode: AgentMode,
         method: &AgentMethod,
         constructor: &AgentConstructor,
         component_id: ComponentId,
@@ -82,6 +83,7 @@ impl McpAgentCapability {
                 tool,
                 component_id,
                 agent_type_name: agent_type_name.clone(),
+                agent_mode,
             }))
         } else {
             tracing::debug!(
@@ -140,6 +142,7 @@ impl McpAgentCapability {
                 raw_method: method.clone(),
                 component_id,
                 agent_type_name: agent_type_name.clone(),
+                agent_mode,
             }))
         }
     }

--- a/golem-worker-service/src/mcp/agent_mcp_resource.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_resource.rs
@@ -14,7 +14,7 @@
 
 use golem_common::base_model::account::AccountId;
 use golem_common::base_model::agent::{
-    AgentMethod, AgentTypeName, DataSchema, NamedElementSchemas,
+    AgentMethod, AgentMode, AgentTypeName, DataSchema, NamedElementSchemas,
 };
 use golem_common::base_model::component::ComponentId;
 use golem_common::base_model::environment::EnvironmentId;
@@ -31,6 +31,7 @@ pub struct AgentMcpResource {
     pub raw_method: AgentMethod,
     pub component_id: ComponentId,
     pub agent_type_name: AgentTypeName,
+    pub agent_mode: AgentMode,
 }
 
 #[derive(Clone)]

--- a/golem-worker-service/src/mcp/agent_mcp_server.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_server.rs
@@ -164,6 +164,7 @@ pub async fn get_agent_capabilities(
                 &account_id,
                 &environment_id,
                 &agent_type.type_name,
+                agent_type.mode,
                 method,
                 &agent_type.constructor,
                 component_id,

--- a/golem-worker-service/src/mcp/agent_mcp_tool.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_tool.rs
@@ -16,7 +16,7 @@ use crate::mcp::GolemAgentMcpServer;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use golem_common::base_model::account::AccountId;
-use golem_common::base_model::agent::{AgentConstructor, AgentMethod, AgentTypeName};
+use golem_common::base_model::agent::{AgentConstructor, AgentMethod, AgentMode, AgentTypeName};
 use golem_common::base_model::component::ComponentId;
 use golem_common::base_model::environment::EnvironmentId;
 use rmcp::ErrorData;
@@ -33,6 +33,7 @@ pub struct AgentMcpTool {
     pub raw_method: AgentMethod,
     pub component_id: ComponentId,
     pub agent_type_name: AgentTypeName,
+    pub agent_mode: AgentMode,
 }
 
 impl CallToolHandler<GolemAgentMcpServer, ()> for AgentMcpTool {

--- a/golem-worker-service/src/mcp/invoke/mod.rs
+++ b/golem-worker-service/src/mcp/invoke/mod.rs
@@ -16,4 +16,6 @@ mod agent_method_input;
 mod constructor_param_extraction;
 mod multimodal_params_extraction;
 pub mod resource;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod tool;

--- a/golem-worker-service/src/mcp/invoke/resource.rs
+++ b/golem-worker-service/src/mcp/invoke/resource.rs
@@ -53,7 +53,7 @@ pub async fn invoke_resource(
         }
     };
 
-    let parsed_agent_id = ParsedAgentId::new(
+    let parsed_agent_id = ParsedAgentId::new_auto_phantom(
         mcp_resource.agent_type_name.clone(),
         DataValue::Tuple(ElementValues {
             elements: constructor_params
@@ -62,6 +62,7 @@ pub async fn invoke_resource(
                 .collect(),
         }),
         None,
+        mcp_resource.agent_mode,
     )
     .map_err(|e| {
         tracing::error!("Failed to parse agent id: {}", e);
@@ -231,12 +232,17 @@ fn convert_to_resource_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::agent_mcp_resource::{AgentMcpResource, AgentMcpResourceKind};
+    use crate::mcp::invoke::test_support::{InvocationHarness, phantom_id};
     use golem_common::base_model::agent::{
-        BinaryDescriptor, ComponentModelElementSchema, ElementSchema, NamedElementSchema,
+        AgentConstructor, AgentMethod, AgentMode, AgentTypeName, BinaryDescriptor,
+        ComponentModelElementSchema, DataSchema, ElementSchema, NamedElementSchema,
         NamedElementSchemas, TextDescriptor, UntypedNamedElementValue, Url as AgentUrl,
     };
+    use golem_common::model::AgentInvocationOutput;
     use golem_wasm::Value;
     use golem_wasm::analysis::analysed_type::str;
+    use rmcp::model::{Annotated, RawResource};
     use serde_json::json;
     use test_r::test;
 
@@ -415,5 +421,56 @@ mod tests {
         });
         let err = convert_to_resource_content(elem, TEST_URI).unwrap_err();
         assert!(err.message.contains("URL"), "got: {}", err.message);
+    }
+
+    #[test]
+    async fn invoke_resource_auto_generates_phantom_for_ephemeral_agents() {
+        let harness = InvocationHarness::new(AgentInvocationOutput {
+            result: golem_common::model::AgentInvocationResult::AgentInitialization,
+            consumed_fuel: None,
+            invocation_status: None,
+            component_revision: None,
+        });
+        let resource = AgentMcpResource {
+            kind: AgentMcpResourceKind::Static(Annotated::new(
+                RawResource {
+                    uri: TEST_URI.to_string(),
+                    name: "mcp-agent-read".to_string(),
+                    title: None,
+                    description: None,
+                    mime_type: None,
+                    size: None,
+                    icons: None,
+                    meta: None,
+                },
+                None,
+            )),
+            environment_id: harness.environment_id,
+            account_id: harness.account_id,
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            raw_method: AgentMethod {
+                name: "read".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![],
+            },
+            component_id: harness.component_id,
+            agent_type_name: AgentTypeName("mcp-agent".to_string()),
+            agent_mode: AgentMode::Ephemeral,
+        };
+
+        let result = invoke_resource(&harness.worker_service, &resource, TEST_URI, None).await;
+
+        assert!(result.is_ok());
+        let agent_id = harness.recorded_agent_id();
+        assert_eq!(agent_id.component_id, harness.component_id);
+        assert!(phantom_id(&agent_id).is_some());
     }
 }

--- a/golem-worker-service/src/mcp/invoke/test_support.rs
+++ b/golem-worker-service/src/mcp/invoke/test_support.rs
@@ -1,0 +1,634 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::service::agent_resolution_cache::AgentResolutionCache;
+use crate::service::auth::{AuthService, AuthServiceError};
+use crate::service::component::{ComponentService, ComponentServiceError};
+use crate::service::limit::{LimitService, LimitServiceError};
+use crate::service::worker::{WorkerClient, WorkerResult, WorkerService, WorkerStream};
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::Utc;
+use futures::Stream;
+use golem_api_grpc::proto::golem::worker::{InvocationContext, LogEvent};
+use golem_common::model::AgentInvocationOutput;
+use golem_common::model::account::AccountId;
+use golem_common::model::agent::{AgentMode, AgentType, AgentTypeName};
+use golem_common::model::agent::{NamedElementSchemas, Snapshotting};
+use golem_common::model::application::ApplicationId;
+use golem_common::model::auth::EnvironmentRole;
+use golem_common::model::component::{
+    CanonicalFilePath, ComponentId, ComponentName, ComponentRevision, PluginPriority,
+};
+use golem_common::model::component_metadata::ComponentMetadata;
+use golem_common::model::diff::Hash;
+use golem_common::model::environment::EnvironmentId;
+use golem_common::model::oplog::{OplogCursor, OplogIndex};
+use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto, RevertWorkerTarget};
+use golem_common::model::{AgentFilter, AgentId, IdempotencyKey, ScanCursor};
+use golem_service_base::clients::registry::{RegistryService, RegistryServiceError};
+use golem_service_base::model::auth::{AuthCtx, AuthDetailsForEnvironment, EnvironmentAction};
+use golem_service_base::model::component::Component;
+use golem_service_base::model::{ComponentFileSystemNode, GetOplogResponse};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+struct NoopRegistryService;
+
+#[async_trait]
+impl RegistryService for NoopRegistryService {
+    async fn authenticate_token(
+        &self,
+        _: &golem_common::model::auth::TokenSecret,
+    ) -> Result<AuthCtx, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_auth_details_for_environment(
+        &self,
+        _: EnvironmentId,
+        _: bool,
+        _: &AuthCtx,
+    ) -> Result<AuthDetailsForEnvironment, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_resource_limits(
+        &self,
+        _: AccountId,
+    ) -> Result<golem_service_base::model::ResourceLimits, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn update_worker_connection_limit(
+        &self,
+        _: AccountId,
+        _: &golem_common::base_model::AgentId,
+        _: bool,
+    ) -> Result<(), RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn batch_update_resource_usage(
+        &self,
+        _: HashMap<AccountId, golem_service_base::clients::registry::ResourceUsageUpdate>,
+    ) -> Result<golem_service_base::model::AccountResourceLimits, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn download_component(
+        &self,
+        _: ComponentId,
+        _: ComponentRevision,
+    ) -> Result<Vec<u8>, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_component_metadata(
+        &self,
+        _: ComponentId,
+        _: ComponentRevision,
+    ) -> Result<Component, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_deployed_component_metadata(
+        &self,
+        _: ComponentId,
+    ) -> Result<Component, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_all_deployed_component_revisions(
+        &self,
+        _: ComponentId,
+    ) -> Result<Vec<Component>, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn resolve_component(
+        &self,
+        _: AccountId,
+        _: ApplicationId,
+        _: EnvironmentId,
+        _: &str,
+    ) -> Result<Component, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_all_agent_types(
+        &self,
+        _: EnvironmentId,
+        _: ComponentId,
+        _: ComponentRevision,
+    ) -> Result<Vec<golem_common::model::agent::RegisteredAgentType>, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_agent_type(
+        &self,
+        _: EnvironmentId,
+        _: ComponentId,
+        _: ComponentRevision,
+        _: &AgentTypeName,
+    ) -> Result<golem_common::model::agent::RegisteredAgentType, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn resolve_agent_type_by_names(
+        &self,
+        _: &golem_common::model::application::ApplicationName,
+        _: &golem_common::model::environment::EnvironmentName,
+        _: &AgentTypeName,
+        _: Option<golem_common::model::deployment::DeploymentRevision>,
+        _: Option<&str>,
+        _: &AuthCtx,
+    ) -> Result<golem_common::model::agent::ResolvedAgentType, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_active_routes_for_domain(
+        &self,
+        _: &golem_common::model::domain_registration::Domain,
+    ) -> Result<golem_service_base::custom_api::CompiledRoutes, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_active_compiled_mcps_for_domain(
+        &self,
+        _: &golem_common::model::domain_registration::Domain,
+    ) -> Result<golem_service_base::mcp::CompiledMcp, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_current_environment_state(
+        &self,
+        _: EnvironmentId,
+    ) -> Result<golem_service_base::model::environment::EnvironmentState, RegistryServiceError>
+    {
+        unimplemented!()
+    }
+
+    async fn get_resource_definition_by_id(
+        &self,
+        _: golem_common::model::quota::ResourceDefinitionId,
+    ) -> Result<golem_common::model::quota::ResourceDefinition, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_resource_definition_by_name(
+        &self,
+        _: EnvironmentId,
+        _: golem_common::model::quota::ResourceName,
+    ) -> Result<golem_common::model::quota::ResourceDefinition, RegistryServiceError> {
+        unimplemented!()
+    }
+
+    async fn subscribe_registry_invalidations(
+        &self,
+        _: Option<u64>,
+    ) -> Result<
+        Pin<
+            Box<
+                dyn futures::Stream<
+                        Item = Result<
+                            golem_common::model::agent::RegistryInvalidationEvent,
+                            RegistryServiceError,
+                        >,
+                    > + Send,
+            >,
+        >,
+        RegistryServiceError,
+    > {
+        unimplemented!()
+    }
+
+    async fn run_registry_invalidation_event_subscriber(
+        &self,
+        _: &'static str,
+        _: Option<tokio_util::sync::CancellationToken>,
+        _: Arc<dyn golem_service_base::clients::registry::RegistryInvalidationHandler>,
+    ) {
+        unimplemented!()
+    }
+}
+
+struct StaticComponentService {
+    component: Component,
+}
+
+#[async_trait]
+impl ComponentService for StaticComponentService {
+    async fn get_latest_by_id_in_cache(&self, component_id: ComponentId) -> Option<Component> {
+        (self.component.id == component_id).then(|| self.component.clone())
+    }
+
+    async fn get_latest_by_id_uncached(
+        &self,
+        component_id: ComponentId,
+    ) -> Result<Component, ComponentServiceError> {
+        if self.component.id == component_id {
+            Ok(self.component.clone())
+        } else {
+            Err(ComponentServiceError::ComponentNotFound)
+        }
+    }
+
+    async fn get_revision(
+        &self,
+        component_id: ComponentId,
+        component_revision: ComponentRevision,
+    ) -> Result<Component, ComponentServiceError> {
+        if self.component.id == component_id && self.component.revision == component_revision {
+            Ok(self.component.clone())
+        } else {
+            Err(ComponentServiceError::ComponentNotFound)
+        }
+    }
+
+    async fn get_all_revisions(
+        &self,
+        component_id: ComponentId,
+    ) -> Result<Vec<Component>, ComponentServiceError> {
+        if self.component.id == component_id {
+            Ok(vec![self.component.clone()])
+        } else {
+            Err(ComponentServiceError::ComponentNotFound)
+        }
+    }
+}
+
+struct AllowAllAuthService {
+    account_id: AccountId,
+}
+
+#[async_trait]
+impl AuthService for AllowAllAuthService {
+    async fn authenticate_token(
+        &self,
+        _: golem_common::model::auth::TokenSecret,
+    ) -> Result<AuthCtx, AuthServiceError> {
+        unimplemented!()
+    }
+
+    async fn authorize_environment_actions(
+        &self,
+        _: EnvironmentId,
+        _: EnvironmentAction,
+        _: &AuthCtx,
+    ) -> Result<AuthDetailsForEnvironment, AuthServiceError> {
+        Ok(AuthDetailsForEnvironment {
+            account_id_owning_environment: self.account_id,
+            environment_roles_from_shares: BTreeSet::<EnvironmentRole>::new(),
+        })
+    }
+}
+
+struct NoopLimitService;
+
+#[async_trait]
+impl LimitService for NoopLimitService {
+    async fn update_worker_connection_limit(
+        &self,
+        _: AccountId,
+        _: &AgentId,
+        _: bool,
+    ) -> Result<(), LimitServiceError> {
+        Ok(())
+    }
+}
+
+struct RecordingWorkerClient {
+    agent_ids: Arc<Mutex<Vec<AgentId>>>,
+    invocation_output: AgentInvocationOutput,
+}
+
+#[async_trait]
+impl WorkerClient for RecordingWorkerClient {
+    async fn create(
+        &self,
+        _: &AgentId,
+        _: HashMap<String, String>,
+        _: BTreeMap<String, String>,
+        _: Vec<AgentConfigEntryDto>,
+        _: bool,
+        _: AccountId,
+        _: EnvironmentId,
+        _: AuthCtx,
+        _: Option<InvocationContext>,
+        _: Option<golem_api_grpc::proto::golem::component::Principal>,
+    ) -> WorkerResult<AgentId> {
+        unimplemented!()
+    }
+
+    async fn connect(
+        &self,
+        _: &AgentId,
+        _: EnvironmentId,
+        _: AccountId,
+        _: AuthCtx,
+    ) -> WorkerResult<WorkerStream<LogEvent>> {
+        unimplemented!()
+    }
+
+    async fn delete(&self, _: &AgentId, _: EnvironmentId, _: AuthCtx) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn complete_promise(
+        &self,
+        _: &AgentId,
+        _: u64,
+        _: Vec<u8>,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<bool> {
+        unimplemented!()
+    }
+
+    async fn interrupt(
+        &self,
+        _: &AgentId,
+        _: bool,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn get_metadata(
+        &self,
+        _: &AgentId,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<AgentMetadataDto> {
+        unimplemented!()
+    }
+
+    async fn find_metadata(
+        &self,
+        _: ComponentId,
+        _: Option<AgentFilter>,
+        _: ScanCursor,
+        _: u64,
+        _: bool,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<(Option<ScanCursor>, Vec<AgentMetadataDto>)> {
+        unimplemented!()
+    }
+
+    async fn resume(&self, _: &AgentId, _: bool, _: EnvironmentId, _: AuthCtx) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn update(
+        &self,
+        _: &AgentId,
+        _: golem_common::model::worker::AgentUpdateMode,
+        _: ComponentRevision,
+        _: bool,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn get_oplog(
+        &self,
+        _: &AgentId,
+        _: OplogIndex,
+        _: Option<OplogCursor>,
+        _: u64,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> Result<GetOplogResponse, crate::service::worker::WorkerServiceError> {
+        unimplemented!()
+    }
+
+    async fn search_oplog(
+        &self,
+        _: &AgentId,
+        _: Option<OplogCursor>,
+        _: u64,
+        _: String,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> Result<GetOplogResponse, crate::service::worker::WorkerServiceError> {
+        unimplemented!()
+    }
+
+    async fn get_file_system_node(
+        &self,
+        _: &AgentId,
+        _: CanonicalFilePath,
+        _: EnvironmentId,
+        _: AccountId,
+        _: AuthCtx,
+    ) -> WorkerResult<Vec<ComponentFileSystemNode>> {
+        unimplemented!()
+    }
+
+    async fn get_file_contents(
+        &self,
+        _: &AgentId,
+        _: CanonicalFilePath,
+        _: EnvironmentId,
+        _: AccountId,
+        _: AuthCtx,
+    ) -> WorkerResult<Pin<Box<dyn Stream<Item = WorkerResult<Bytes>> + Send + 'static>>> {
+        unimplemented!()
+    }
+
+    async fn activate_plugin(
+        &self,
+        _: &AgentId,
+        _: PluginPriority,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn deactivate_plugin(
+        &self,
+        _: &AgentId,
+        _: PluginPriority,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn fork_worker(
+        &self,
+        _: &AgentId,
+        _: &AgentId,
+        _: OplogIndex,
+        _: EnvironmentId,
+        _: AccountId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn revert_worker(
+        &self,
+        _: &AgentId,
+        _: RevertWorkerTarget,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+
+    async fn cancel_invocation(
+        &self,
+        _: &AgentId,
+        _: &IdempotencyKey,
+        _: EnvironmentId,
+        _: AuthCtx,
+    ) -> WorkerResult<bool> {
+        unimplemented!()
+    }
+
+    async fn invoke_agent(
+        &self,
+        agent_id: &AgentId,
+        _: Option<String>,
+        _: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
+        _: i32,
+        _: Option<::prost_types::Timestamp>,
+        _: Option<IdempotencyKey>,
+        _: Option<InvocationContext>,
+        _: EnvironmentId,
+        _: AccountId,
+        _: AuthCtx,
+        _: golem_api_grpc::proto::golem::component::Principal,
+    ) -> WorkerResult<AgentInvocationOutput> {
+        self.agent_ids.lock().unwrap().push(agent_id.clone());
+        Ok(self.invocation_output.clone())
+    }
+
+    async fn process_oplog_entries(
+        &self,
+        _: &AgentId,
+        _: EnvironmentId,
+        _: ComponentRevision,
+        _: IdempotencyKey,
+        _: AccountId,
+        _: HashMap<String, String>,
+        _: golem_api_grpc::proto::golem::worker::AgentMetadata,
+        _: OplogIndex,
+        _: Vec<golem_api_grpc::proto::golem::worker::RawOplogEntry>,
+        _: AuthCtx,
+    ) -> WorkerResult<()> {
+        unimplemented!()
+    }
+}
+
+pub(crate) struct InvocationHarness {
+    pub(crate) worker_service: Arc<WorkerService>,
+    pub(crate) component_id: ComponentId,
+    pub(crate) environment_id: EnvironmentId,
+    pub(crate) account_id: AccountId,
+    agent_ids: Arc<Mutex<Vec<AgentId>>>,
+}
+
+impl InvocationHarness {
+    pub(crate) fn new(invocation_output: AgentInvocationOutput) -> Self {
+        let component_id = ComponentId(Uuid::new_v4());
+        let environment_id = EnvironmentId(Uuid::new_v4());
+        let account_id = AccountId(Uuid::new_v4());
+        let component = Component {
+            id: component_id,
+            revision: ComponentRevision::INITIAL,
+            environment_id,
+            component_name: ComponentName("mcp-component".to_string()),
+            hash: Hash::empty(),
+            application_id: ApplicationId(Uuid::new_v4()),
+            account_id,
+            component_size: 0,
+            metadata: ComponentMetadata::from_parts(
+                vec![],
+                vec![],
+                None,
+                None,
+                vec![AgentType {
+                    type_name: AgentTypeName("mcp-agent".to_string()),
+                    description: String::new(),
+                    source_language: String::new(),
+                    constructor: golem_common::model::agent::AgentConstructor {
+                        name: None,
+                        description: String::new(),
+                        prompt_hint: None,
+                        input_schema: golem_common::model::agent::DataSchema::Tuple(
+                            NamedElementSchemas::empty(),
+                        ),
+                    },
+                    methods: vec![],
+                    dependencies: vec![],
+                    mode: AgentMode::Durable,
+                    http_mount: None,
+                    snapshotting: Snapshotting::Disabled(golem_common::model::Empty {}),
+                    config: vec![],
+                }],
+                BTreeMap::new(),
+            ),
+            created_at: Utc::now(),
+            wasm_hash: Hash::empty(),
+            object_store_key: String::new(),
+        };
+        let agent_ids = Arc::new(Mutex::new(Vec::new()));
+        let worker_client = Arc::new(RecordingWorkerClient {
+            agent_ids: agent_ids.clone(),
+            invocation_output,
+        });
+
+        Self {
+            worker_service: Arc::new(WorkerService::new(
+                Arc::new(StaticComponentService { component }),
+                Arc::new(AllowAllAuthService { account_id }),
+                Arc::new(NoopLimitService),
+                worker_client,
+                Arc::new(AgentResolutionCache::new(
+                    Arc::new(NoopRegistryService),
+                    1,
+                    Duration::from_secs(60),
+                    Duration::from_secs(60),
+                )),
+            )),
+            component_id,
+            environment_id,
+            account_id,
+            agent_ids,
+        }
+    }
+
+    pub(crate) fn recorded_agent_id(&self) -> AgentId {
+        self.agent_ids.lock().unwrap()[0].clone()
+    }
+}
+
+pub(crate) fn phantom_id(agent_id: &AgentId) -> Option<Uuid> {
+    agent_id
+        .agent_id
+        .rsplit_once('[')
+        .and_then(|(_, phantom_id)| phantom_id.strip_suffix(']'))
+        .and_then(|phantom_id| Uuid::parse_str(phantom_id).ok())
+}

--- a/golem-worker-service/src/mcp/invoke/tool.rs
+++ b/golem-worker-service/src/mcp/invoke/tool.rs
@@ -45,7 +45,7 @@ pub async fn invoke_tool(
             },
         )?;
 
-    let parsed_agent_id = ParsedAgentId::new(
+    let parsed_agent_id = ParsedAgentId::new_auto_phantom(
         mcp_tool.agent_type_name.clone(),
         DataValue::Tuple(ElementValues {
             elements: constructor_params
@@ -54,6 +54,7 @@ pub async fn invoke_tool(
                 .collect(),
         }),
         None,
+        mcp_tool.agent_mode,
     )
     .map_err(|e| {
         tracing::error!("Failed to parse agent id: {}", e);
@@ -309,13 +310,20 @@ fn convert_elem_value_to_mcp_tool_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::agent_mcp_tool::AgentMcpTool;
+    use crate::mcp::invoke::test_support::{InvocationHarness, phantom_id};
     use golem_common::base_model::agent::{
-        BinaryDescriptor, ComponentModelElementSchema, ElementSchema, NamedElementSchema,
+        AgentConstructor, AgentMethod, AgentMode, AgentTypeName, BinaryDescriptor,
+        ComponentModelElementSchema, DataSchema, ElementSchema, NamedElementSchema,
         NamedElementSchemas, TextDescriptor, TextType, UntypedNamedElementValue, Url,
     };
+    use golem_common::model::AgentInvocationOutput;
     use golem_wasm::Value;
     use golem_wasm::analysis::{AnalysedType, TypeStr};
+    use rmcp::model::Tool;
     use serde_json::json;
+    use std::borrow::Cow;
+    use std::sync::Arc;
     use test_r::test;
 
     fn str_output_schema() -> DataSchema {
@@ -474,5 +482,54 @@ mod tests {
         });
         let err = convert_elem_value_to_mcp_tool_response(&elem).unwrap_err();
         assert!(err.message.contains("URL"), "got: {}", err.message);
+    }
+
+    #[test]
+    async fn invoke_tool_auto_generates_phantom_for_ephemeral_agents() {
+        let harness = InvocationHarness::new(AgentInvocationOutput {
+            result: golem_common::model::AgentInvocationResult::AgentInitialization,
+            consumed_fuel: None,
+            invocation_status: None,
+            component_revision: None,
+        });
+        let tool = AgentMcpTool {
+            tool: Tool {
+                name: Cow::Borrowed("mcp-agent-run"),
+                title: None,
+                description: None,
+                input_schema: Arc::new(JsonObject::default()),
+                output_schema: None,
+                annotations: None,
+                execution: None,
+                icons: None,
+                meta: None,
+            },
+            environment_id: harness.environment_id,
+            account_id: harness.account_id,
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            raw_method: AgentMethod {
+                name: "run".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![],
+            },
+            component_id: harness.component_id,
+            agent_type_name: AgentTypeName("mcp-agent".to_string()),
+            agent_mode: AgentMode::Ephemeral,
+        };
+
+        let result = invoke_tool(JsonObject::default(), &tool, &harness.worker_service).await;
+
+        assert!(result.is_ok());
+        let agent_id = harness.recorded_agent_id();
+        assert_eq!(agent_id.component_id, harness.component_id);
+        assert!(phantom_id(&agent_id).is_some());
     }
 }

--- a/golem-worker-service/src/service/worker/service.rs
+++ b/golem-worker-service/src/service/worker/service.rs
@@ -28,7 +28,8 @@ use golem_api_grpc::proto::golem::worker::InvocationContext;
 use golem_common::model::AgentInvocationOutput;
 use golem_common::model::account::AccountId;
 use golem_common::model::agent::{
-    DataValue, GolemUserPrincipal, ParsedAgentId, Principal, UntypedDataValue,
+    AgentMode, AgentTypeName, DataValue, GolemUserPrincipal, ParsedAgentId, Principal,
+    UntypedDataValue,
 };
 use golem_common::model::component::{
     CanonicalFilePath, ComponentId, ComponentRevision, PluginPriority,
@@ -47,6 +48,27 @@ use golem_service_base::model::{ComponentFileSystemNode, GetOplogResponse};
 use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::{collections::HashMap, sync::Arc};
+
+fn build_public_agent_id(
+    component_id: ComponentId,
+    agent_type_name: AgentTypeName,
+    constructor_parameters: DataValue,
+    phantom_id: Option<uuid::Uuid>,
+    agent_mode: AgentMode,
+) -> WorkerResult<AgentId> {
+    let agent_id = ParsedAgentId::new_auto_phantom(
+        agent_type_name,
+        constructor_parameters,
+        phantom_id,
+        agent_mode,
+    )
+    .map_err(|err| WorkerServiceError::TypeChecker(format!("Agent ID formatting error: {err}")))?;
+
+    Ok(AgentId {
+        component_id,
+        agent_id: agent_id.to_string(),
+    })
+}
 
 fn required_environment_action_for_invocation_mode(mode: i32) -> EnvironmentAction {
     if mode == golem_api_grpc::proto::golem::worker::AgentInvocationMode::Lookup as i32 {
@@ -817,19 +839,13 @@ impl WorkerService {
             ))
         })?;
 
-        let agent_id = ParsedAgentId::new(
+        let agent_id = build_public_agent_id(
+            component_id,
             request.agent_type_name.clone(),
             constructor_parameters,
             request.phantom_id,
-        )
-        .map_err(|err| {
-            WorkerServiceError::TypeChecker(format!("Agent ID formatting error: {err}"))
-        })?;
-
-        let agent_id = AgentId {
-            component_id,
-            agent_id: agent_id.to_string(),
-        };
+            agent_type.mode,
+        )?;
 
         let component = self
             .component_service
@@ -920,19 +936,13 @@ impl WorkerService {
             ))
         })?;
 
-        let agent_id = ParsedAgentId::new(
+        let agent_id = build_public_agent_id(
+            component_id,
             request.agent_type_name.clone(),
             constructor_parameters,
             request.phantom_id,
-        )
-        .map_err(|err| {
-            WorkerServiceError::TypeChecker(format!("Agent ID formatting error: {err}"))
-        })?;
-
-        let agent_id = AgentId {
-            component_id,
-            agent_id: agent_id.to_string(),
-        };
+            agent_type.mode,
+        )?;
 
         let method = agent_type
             .methods
@@ -1030,11 +1040,13 @@ impl WorkerService {
                     WorkerServiceError::TypeChecker(format!("DataValue conversion error: {err}"))
                 })?;
                 Ok(AgentInvocationResult {
+                    agent_id: agent_id.clone(),
                     result: Some(typed_data_value.into()),
                     component_revision: Some(decode_revision),
                 })
             }
             _ => Ok(AgentInvocationResult {
+                agent_id,
                 result: None,
                 component_revision: output.component_revision,
             }),
@@ -1044,9 +1056,753 @@ impl WorkerService {
 
 #[cfg(test)]
 mod tests {
-    use super::required_environment_action_for_invocation_mode;
-    use golem_service_base::model::auth::EnvironmentAction;
+    use super::{WorkerService, required_environment_action_for_invocation_mode};
+    use crate::api::agents::{AgentInvocationMode, AgentInvocationRequest, CreateAgentRequest};
+    use crate::service::agent_resolution_cache::AgentResolutionCache;
+    use crate::service::auth::{AuthService, AuthServiceError};
+    use crate::service::component::{ComponentService, ComponentServiceError};
+    use crate::service::limit::{LimitService, LimitServiceError};
+    use crate::service::worker::{WorkerClient, WorkerResult, WorkerStream};
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use futures::Stream;
+    use golem_api_grpc::proto::golem::worker::{InvocationContext, LogEvent};
+    use golem_common::model::AgentInvocationOutput;
+    use golem_common::model::Empty;
+    use golem_common::model::account::AccountId;
+    use golem_common::model::agent::{
+        AgentConstructor, AgentMethod, AgentMode, AgentType, AgentTypeName, DataSchema,
+        HttpEndpointDetails, NamedElementSchemas, RegisteredAgentType,
+        RegisteredAgentTypeImplementer, ResolvedAgentType, Snapshotting, UntypedJsonDataValue,
+    };
+    use golem_common::model::application::{ApplicationId, ApplicationName};
+    use golem_common::model::auth::EnvironmentRole;
+    use golem_common::model::component::{
+        CanonicalFilePath, ComponentId, ComponentName, ComponentRevision, PluginPriority,
+    };
+    use golem_common::model::component_metadata::ComponentMetadata;
+    use golem_common::model::deployment::{CurrentDeploymentRevision, DeploymentRevision};
+    use golem_common::model::diff::Hash;
+    use golem_common::model::environment::{EnvironmentId, EnvironmentName};
+    use golem_common::model::oplog::{OplogCursor, OplogIndex};
+    use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto, RevertWorkerTarget};
+    use golem_common::model::{AgentFilter, AgentId, IdempotencyKey, ScanCursor};
+    use golem_service_base::clients::registry::{RegistryService, RegistryServiceError};
+    use golem_service_base::model::auth::{AuthCtx, AuthDetailsForEnvironment, EnvironmentAction};
+    use golem_service_base::model::component::Component;
+    use golem_service_base::model::{ComponentFileSystemNode, GetOplogResponse};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
     use test_r::test;
+    use uuid::Uuid;
+
+    #[derive(Clone)]
+    struct TestRegistryService {
+        resolved: ResolvedAgentType,
+    }
+
+    #[async_trait]
+    impl RegistryService for TestRegistryService {
+        async fn authenticate_token(
+            &self,
+            _: &golem_common::model::auth::TokenSecret,
+        ) -> Result<AuthCtx, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_auth_details_for_environment(
+            &self,
+            _: EnvironmentId,
+            _: bool,
+            _: &AuthCtx,
+        ) -> Result<AuthDetailsForEnvironment, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_resource_limits(
+            &self,
+            _: AccountId,
+        ) -> Result<golem_service_base::model::ResourceLimits, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn update_worker_connection_limit(
+            &self,
+            _: AccountId,
+            _: &golem_common::base_model::AgentId,
+            _: bool,
+        ) -> Result<(), RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn batch_update_resource_usage(
+            &self,
+            _: HashMap<AccountId, golem_service_base::clients::registry::ResourceUsageUpdate>,
+        ) -> Result<golem_service_base::model::AccountResourceLimits, RegistryServiceError>
+        {
+            unimplemented!()
+        }
+
+        async fn download_component(
+            &self,
+            _: ComponentId,
+            _: ComponentRevision,
+        ) -> Result<Vec<u8>, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_component_metadata(
+            &self,
+            _: ComponentId,
+            _: ComponentRevision,
+        ) -> Result<Component, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_deployed_component_metadata(
+            &self,
+            _: ComponentId,
+        ) -> Result<Component, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_all_deployed_component_revisions(
+            &self,
+            _: ComponentId,
+        ) -> Result<Vec<Component>, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn resolve_component(
+            &self,
+            _: AccountId,
+            _: ApplicationId,
+            _: EnvironmentId,
+            _: &str,
+        ) -> Result<Component, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_all_agent_types(
+            &self,
+            _: EnvironmentId,
+            _: ComponentId,
+            _: ComponentRevision,
+        ) -> Result<Vec<RegisteredAgentType>, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_agent_type(
+            &self,
+            _: EnvironmentId,
+            _: ComponentId,
+            _: ComponentRevision,
+            _: &AgentTypeName,
+        ) -> Result<RegisteredAgentType, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn resolve_agent_type_by_names(
+            &self,
+            _: &ApplicationName,
+            _: &EnvironmentName,
+            _: &AgentTypeName,
+            _: Option<DeploymentRevision>,
+            _: Option<&str>,
+            _: &AuthCtx,
+        ) -> Result<ResolvedAgentType, RegistryServiceError> {
+            Ok(self.resolved.clone())
+        }
+
+        async fn get_active_routes_for_domain(
+            &self,
+            _: &golem_common::model::domain_registration::Domain,
+        ) -> Result<golem_service_base::custom_api::CompiledRoutes, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_active_compiled_mcps_for_domain(
+            &self,
+            _: &golem_common::model::domain_registration::Domain,
+        ) -> Result<golem_service_base::mcp::CompiledMcp, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_current_environment_state(
+            &self,
+            _: EnvironmentId,
+        ) -> Result<golem_service_base::model::environment::EnvironmentState, RegistryServiceError>
+        {
+            unimplemented!()
+        }
+
+        async fn get_resource_definition_by_id(
+            &self,
+            _: golem_common::model::quota::ResourceDefinitionId,
+        ) -> Result<golem_common::model::quota::ResourceDefinition, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_resource_definition_by_name(
+            &self,
+            _: EnvironmentId,
+            _: golem_common::model::quota::ResourceName,
+        ) -> Result<golem_common::model::quota::ResourceDefinition, RegistryServiceError> {
+            unimplemented!()
+        }
+
+        async fn subscribe_registry_invalidations(
+            &self,
+            _: Option<u64>,
+        ) -> Result<
+            Pin<
+                Box<
+                    dyn futures::Stream<
+                            Item = Result<
+                                golem_common::model::agent::RegistryInvalidationEvent,
+                                RegistryServiceError,
+                            >,
+                        > + Send,
+                >,
+            >,
+            RegistryServiceError,
+        > {
+            unimplemented!()
+        }
+
+        async fn run_registry_invalidation_event_subscriber(
+            &self,
+            _: &'static str,
+            _: Option<tokio_util::sync::CancellationToken>,
+            _: Arc<dyn golem_service_base::clients::registry::RegistryInvalidationHandler>,
+        ) {
+            unimplemented!()
+        }
+    }
+
+    struct StaticComponentService {
+        component: Component,
+    }
+
+    #[async_trait]
+    impl ComponentService for StaticComponentService {
+        async fn get_latest_by_id_in_cache(&self, component_id: ComponentId) -> Option<Component> {
+            (self.component.id == component_id).then(|| self.component.clone())
+        }
+
+        async fn get_latest_by_id_uncached(
+            &self,
+            component_id: ComponentId,
+        ) -> Result<Component, ComponentServiceError> {
+            if self.component.id == component_id {
+                Ok(self.component.clone())
+            } else {
+                Err(ComponentServiceError::ComponentNotFound)
+            }
+        }
+
+        async fn get_revision(
+            &self,
+            component_id: ComponentId,
+            component_revision: ComponentRevision,
+        ) -> Result<Component, ComponentServiceError> {
+            if self.component.id == component_id && self.component.revision == component_revision {
+                Ok(self.component.clone())
+            } else {
+                Err(ComponentServiceError::ComponentNotFound)
+            }
+        }
+
+        async fn get_all_revisions(
+            &self,
+            component_id: ComponentId,
+        ) -> Result<Vec<Component>, ComponentServiceError> {
+            if self.component.id == component_id {
+                Ok(vec![self.component.clone()])
+            } else {
+                Err(ComponentServiceError::ComponentNotFound)
+            }
+        }
+    }
+
+    struct AllowAllAuthService {
+        account_id: AccountId,
+    }
+
+    #[async_trait]
+    impl AuthService for AllowAllAuthService {
+        async fn authenticate_token(
+            &self,
+            _: golem_common::model::auth::TokenSecret,
+        ) -> Result<AuthCtx, AuthServiceError> {
+            unimplemented!()
+        }
+
+        async fn authorize_environment_actions(
+            &self,
+            _: EnvironmentId,
+            _: EnvironmentAction,
+            _: &AuthCtx,
+        ) -> Result<AuthDetailsForEnvironment, AuthServiceError> {
+            Ok(AuthDetailsForEnvironment {
+                account_id_owning_environment: self.account_id,
+                environment_roles_from_shares: BTreeSet::<EnvironmentRole>::new(),
+            })
+        }
+    }
+
+    struct NoopLimitService;
+
+    #[async_trait]
+    impl LimitService for NoopLimitService {
+        async fn update_worker_connection_limit(
+            &self,
+            _: AccountId,
+            _: &AgentId,
+            _: bool,
+        ) -> Result<(), LimitServiceError> {
+            Ok(())
+        }
+    }
+
+    struct RecordingWorkerClient {
+        created_agent_ids: Mutex<Vec<AgentId>>,
+        invoked_agent_ids: Mutex<Vec<AgentId>>,
+        invocation_output: AgentInvocationOutput,
+    }
+
+    impl RecordingWorkerClient {
+        fn new(invocation_output: AgentInvocationOutput) -> Self {
+            Self {
+                created_agent_ids: Mutex::new(Vec::new()),
+                invoked_agent_ids: Mutex::new(Vec::new()),
+                invocation_output,
+            }
+        }
+
+        fn created_agent_id(&self) -> AgentId {
+            self.created_agent_ids.lock().unwrap()[0].clone()
+        }
+
+        fn invoked_agent_id(&self) -> AgentId {
+            self.invoked_agent_ids.lock().unwrap()[0].clone()
+        }
+    }
+
+    #[async_trait]
+    impl WorkerClient for RecordingWorkerClient {
+        async fn create(
+            &self,
+            agent_id: &AgentId,
+            _: HashMap<String, String>,
+            _: BTreeMap<String, String>,
+            _: Vec<AgentConfigEntryDto>,
+            _: bool,
+            _: AccountId,
+            _: EnvironmentId,
+            _: AuthCtx,
+            _: Option<InvocationContext>,
+            _: Option<golem_api_grpc::proto::golem::component::Principal>,
+        ) -> WorkerResult<AgentId> {
+            self.created_agent_ids
+                .lock()
+                .unwrap()
+                .push(agent_id.clone());
+            Ok(agent_id.clone())
+        }
+
+        async fn connect(
+            &self,
+            _: &AgentId,
+            _: EnvironmentId,
+            _: AccountId,
+            _: AuthCtx,
+        ) -> WorkerResult<WorkerStream<LogEvent>> {
+            unimplemented!()
+        }
+
+        async fn delete(&self, _: &AgentId, _: EnvironmentId, _: AuthCtx) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn complete_promise(
+            &self,
+            _: &AgentId,
+            _: u64,
+            _: Vec<u8>,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<bool> {
+            unimplemented!()
+        }
+
+        async fn interrupt(
+            &self,
+            _: &AgentId,
+            _: bool,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn get_metadata(
+            &self,
+            _: &AgentId,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<AgentMetadataDto> {
+            unimplemented!()
+        }
+
+        async fn find_metadata(
+            &self,
+            _: ComponentId,
+            _: Option<AgentFilter>,
+            _: ScanCursor,
+            _: u64,
+            _: bool,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<(Option<ScanCursor>, Vec<AgentMetadataDto>)> {
+            unimplemented!()
+        }
+
+        async fn resume(
+            &self,
+            _: &AgentId,
+            _: bool,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn update(
+            &self,
+            _: &AgentId,
+            _: golem_common::model::worker::AgentUpdateMode,
+            _: ComponentRevision,
+            _: bool,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn get_oplog(
+            &self,
+            _: &AgentId,
+            _: OplogIndex,
+            _: Option<OplogCursor>,
+            _: u64,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> Result<GetOplogResponse, super::WorkerServiceError> {
+            unimplemented!()
+        }
+
+        async fn search_oplog(
+            &self,
+            _: &AgentId,
+            _: Option<OplogCursor>,
+            _: u64,
+            _: String,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> Result<GetOplogResponse, super::WorkerServiceError> {
+            unimplemented!()
+        }
+
+        async fn get_file_system_node(
+            &self,
+            _: &AgentId,
+            _: CanonicalFilePath,
+            _: EnvironmentId,
+            _: AccountId,
+            _: AuthCtx,
+        ) -> WorkerResult<Vec<ComponentFileSystemNode>> {
+            unimplemented!()
+        }
+
+        async fn get_file_contents(
+            &self,
+            _: &AgentId,
+            _: CanonicalFilePath,
+            _: EnvironmentId,
+            _: AccountId,
+            _: AuthCtx,
+        ) -> WorkerResult<Pin<Box<dyn Stream<Item = WorkerResult<Bytes>> + Send + 'static>>>
+        {
+            unimplemented!()
+        }
+
+        async fn activate_plugin(
+            &self,
+            _: &AgentId,
+            _: PluginPriority,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn deactivate_plugin(
+            &self,
+            _: &AgentId,
+            _: PluginPriority,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn fork_worker(
+            &self,
+            _: &AgentId,
+            _: &AgentId,
+            _: OplogIndex,
+            _: EnvironmentId,
+            _: AccountId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn revert_worker(
+            &self,
+            _: &AgentId,
+            _: RevertWorkerTarget,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+
+        async fn cancel_invocation(
+            &self,
+            _: &AgentId,
+            _: &IdempotencyKey,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<bool> {
+            unimplemented!()
+        }
+
+        async fn invoke_agent(
+            &self,
+            agent_id: &AgentId,
+            _: Option<String>,
+            _: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
+            _: i32,
+            _: Option<::prost_types::Timestamp>,
+            _: Option<IdempotencyKey>,
+            _: Option<InvocationContext>,
+            _: EnvironmentId,
+            _: AccountId,
+            _: AuthCtx,
+            _: golem_api_grpc::proto::golem::component::Principal,
+        ) -> WorkerResult<AgentInvocationOutput> {
+            self.invoked_agent_ids
+                .lock()
+                .unwrap()
+                .push(agent_id.clone());
+            Ok(self.invocation_output.clone())
+        }
+
+        async fn process_oplog_entries(
+            &self,
+            _: &AgentId,
+            _: EnvironmentId,
+            _: ComponentRevision,
+            _: IdempotencyKey,
+            _: AccountId,
+            _: HashMap<String, String>,
+            _: golem_api_grpc::proto::golem::worker::AgentMetadata,
+            _: OplogIndex,
+            _: Vec<golem_api_grpc::proto::golem::worker::RawOplogEntry>,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            unimplemented!()
+        }
+    }
+
+    struct RestHarness {
+        worker_service: WorkerService,
+        worker_client: Arc<RecordingWorkerClient>,
+        agent_type_name: AgentTypeName,
+        component_id: ComponentId,
+        component_revision: ComponentRevision,
+    }
+
+    impl RestHarness {
+        fn new(mode: AgentMode) -> Self {
+            let component_id = ComponentId(Uuid::new_v4());
+            let environment_id = EnvironmentId(Uuid::new_v4());
+            let account_id = AccountId(Uuid::new_v4());
+            let component_revision = ComponentRevision::INITIAL;
+            let agent_type_name = AgentTypeName("weather-agent".to_string());
+            let agent_type = test_agent_type(agent_type_name.clone(), mode);
+            let component = test_component(
+                component_id,
+                environment_id,
+                account_id,
+                component_revision,
+                agent_type.clone(),
+            );
+            let worker_client = Arc::new(RecordingWorkerClient::new(AgentInvocationOutput {
+                result: golem_common::model::AgentInvocationResult::AgentInitialization,
+                consumed_fuel: None,
+                invocation_status: None,
+                component_revision: Some(component_revision),
+            }));
+            let registry = Arc::new(TestRegistryService {
+                resolved: ResolvedAgentType {
+                    registered_agent_type: RegisteredAgentType {
+                        agent_type,
+                        implemented_by: RegisteredAgentTypeImplementer {
+                            component_id,
+                            component_revision,
+                        },
+                    },
+                    environment_id,
+                    deployment_revision: DeploymentRevision::INITIAL,
+                    current_deployment_revision: Some(CurrentDeploymentRevision::INITIAL),
+                },
+            });
+            let agent_resolution_cache = Arc::new(AgentResolutionCache::new(
+                registry,
+                1,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+            ));
+
+            Self {
+                worker_service: WorkerService::new(
+                    Arc::new(StaticComponentService { component }),
+                    Arc::new(AllowAllAuthService { account_id }),
+                    Arc::new(NoopLimitService),
+                    worker_client.clone(),
+                    agent_resolution_cache,
+                ),
+                worker_client,
+                agent_type_name,
+                component_id,
+                component_revision,
+            }
+        }
+
+        fn create_request(&self) -> CreateAgentRequest {
+            CreateAgentRequest {
+                app_name: ApplicationName::try_from("weather-app".to_string()).unwrap(),
+                env_name: EnvironmentName::try_from("prod").unwrap(),
+                agent_type_name: self.agent_type_name.clone(),
+                parameters: empty_json_tuple(),
+                phantom_id: None,
+                config: vec![],
+            }
+        }
+
+        fn invoke_request(&self) -> AgentInvocationRequest {
+            AgentInvocationRequest {
+                app_name: ApplicationName::try_from("weather-app".to_string()).unwrap(),
+                env_name: EnvironmentName::try_from("prod").unwrap(),
+                agent_type_name: self.agent_type_name.clone(),
+                parameters: empty_json_tuple(),
+                phantom_id: None,
+                method_name: "run".to_string(),
+                method_parameters: empty_json_tuple(),
+                mode: AgentInvocationMode::Await,
+                schedule_at: None,
+                idempotency_key: None,
+                deployment_revision: None,
+                owner_account_email: None,
+            }
+        }
+    }
+
+    fn test_agent_type(agent_type_name: AgentTypeName, mode: AgentMode) -> AgentType {
+        AgentType {
+            type_name: agent_type_name,
+            description: String::new(),
+            source_language: String::new(),
+            constructor: AgentConstructor {
+                name: None,
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+            },
+            methods: vec![AgentMethod {
+                name: "run".to_string(),
+                description: String::new(),
+                prompt_hint: None,
+                input_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                output_schema: DataSchema::Tuple(NamedElementSchemas::empty()),
+                http_endpoint: vec![HttpEndpointDetails {
+                    http_method: golem_common::model::agent::HttpMethod::Get(Empty {}),
+                    path_suffix: vec![],
+                    header_vars: vec![],
+                    query_vars: vec![],
+                    auth_details: None,
+                    cors_options: golem_common::model::agent::CorsOptions {
+                        allowed_patterns: vec![],
+                    },
+                }],
+            }],
+            dependencies: vec![],
+            mode,
+            http_mount: None,
+            snapshotting: Snapshotting::Disabled(Empty {}),
+            config: vec![],
+        }
+    }
+
+    fn test_component(
+        component_id: ComponentId,
+        environment_id: EnvironmentId,
+        account_id: AccountId,
+        component_revision: ComponentRevision,
+        agent_type: AgentType,
+    ) -> Component {
+        Component {
+            id: component_id,
+            revision: component_revision,
+            environment_id,
+            component_name: ComponentName("weather-component".to_string()),
+            hash: Hash::empty(),
+            application_id: ApplicationId(Uuid::new_v4()),
+            account_id,
+            component_size: 0,
+            metadata: ComponentMetadata::from_parts(
+                vec![],
+                vec![],
+                None,
+                None,
+                vec![agent_type],
+                BTreeMap::new(),
+            ),
+            created_at: Utc::now(),
+            wasm_hash: Hash::empty(),
+            object_store_key: String::new(),
+        }
+    }
+
+    fn empty_json_tuple() -> UntypedJsonDataValue {
+        UntypedJsonDataValue::Tuple(golem_common::model::agent::UntypedJsonElementValues {
+            elements: vec![],
+        })
+    }
+
+    fn phantom_id(agent_id: &AgentId) -> Option<Uuid> {
+        agent_id
+            .agent_id
+            .rsplit_once('[')
+            .and_then(|(_, phantom_id)| phantom_id.strip_suffix(']'))
+            .and_then(|phantom_id| Uuid::parse_str(phantom_id).ok())
+    }
 
     #[test]
     fn lookup_invocation_requires_view_worker_permission() {
@@ -1066,5 +1822,67 @@ mod tests {
             ),
             EnvironmentAction::UpdateWorker,
         );
+    }
+
+    #[test]
+    async fn create_agent_rest_auto_generates_phantom_for_ephemeral_agents() {
+        let harness = RestHarness::new(AgentMode::Ephemeral);
+
+        let response = harness
+            .worker_service
+            .create_agent_rest(harness.create_request(), AuthCtx::system())
+            .await
+            .unwrap();
+
+        assert_eq!(response.agent_id.component_id, harness.component_id);
+        assert_eq!(response.component_revision, harness.component_revision);
+        assert_eq!(response.agent_id, harness.worker_client.created_agent_id());
+        assert!(phantom_id(&response.agent_id).is_some());
+    }
+
+    #[test]
+    async fn invoke_agent_rest_auto_generates_phantom_for_ephemeral_agents() {
+        let harness = RestHarness::new(AgentMode::Ephemeral);
+
+        let response = harness
+            .worker_service
+            .invoke_agent_rest(harness.invoke_request(), AuthCtx::system())
+            .await
+            .unwrap();
+
+        assert_eq!(response.agent_id.component_id, harness.component_id);
+        assert_eq!(
+            response.component_revision,
+            Some(harness.component_revision)
+        );
+        assert_eq!(response.agent_id, harness.worker_client.invoked_agent_id());
+        assert!(phantom_id(&response.agent_id).is_some());
+    }
+
+    #[test]
+    async fn durable_rest_paths_keep_non_phantom_agent_ids() {
+        let harness = RestHarness::new(AgentMode::Durable);
+
+        let create_response = harness
+            .worker_service
+            .create_agent_rest(harness.create_request(), AuthCtx::system())
+            .await
+            .unwrap();
+        let invoke_response = harness
+            .worker_service
+            .invoke_agent_rest(harness.invoke_request(), AuthCtx::system())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            create_response.agent_id,
+            harness.worker_client.created_agent_id()
+        );
+        assert_eq!(
+            invoke_response.agent_id,
+            harness.worker_client.invoked_agent_id()
+        );
+        assert!(phantom_id(&create_response.agent_id).is_none());
+        assert!(phantom_id(&invoke_response.agent_id).is_none());
     }
 }

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -9992,11 +9992,15 @@ components:
       title: AgentInvocationResult
       type: object
       properties:
+        agentId:
+          $ref: '#/components/schemas/AgentId'
         result:
           $ref: '#/components/schemas/UntypedJsonDataValue'
         componentRevision:
           type: integer
           format: uint64
+      required:
+      - agentId
     AgentMetadataDto:
       title: AgentMetadataDto
       type: object

--- a/openapi/golem-worker-service.yaml
+++ b/openapi/golem-worker-service.yaml
@@ -2073,7 +2073,11 @@ components:
     AgentInvocationResult:
       type: object
       title: AgentInvocationResult
+      required:
+      - agentId
       properties:
+        agentId:
+          $ref: '#/components/schemas/AgentId'
         result:
           $ref: '#/components/schemas/UntypedJsonDataValue'
         componentRevision:

--- a/sdks/moonbit/golem_sdk_tools/lib/clients_emit.mbt
+++ b/sdks/moonbit/golem_sdk_tools/lib/clients_emit.mbt
@@ -37,13 +37,19 @@ pub fn generate_client_code(
     }
     let client_name = agent.name + "Client"
     impls.push(build_client_struct(client_name))
-    impls.push(build_client_get(agent, client_name))
+    match agent.mode {
+      Durable => impls.push(build_client_get(agent, client_name))
+      Ephemeral => ()
+    }
     impls.push(build_client_new_phantom(agent, client_name))
     impls.push(build_client_get_phantom(agent, client_name))
     impls.push(build_client_get_agent_id(client_name))
     impls.push(build_client_phantom_id(client_name))
     impls.push(build_client_drop(client_name))
-    impls.push(build_client_scoped(agent, client_name))
+    match agent.mode {
+      Durable => impls.push(build_client_scoped(agent, client_name))
+      Ephemeral => ()
+    }
     impls.push(build_client_scoped_new_phantom(agent, client_name))
     impls.push(build_client_scoped_get_phantom(agent, client_name))
     for meth in agent.methods {
@@ -62,11 +68,15 @@ pub fn generate_client_code(
         if has_non_secret_config_fields(ct) {
           let override_name = ct.name + "Override"
           let walker_name = "collect_" + pascal_to_snake(ct.name) + "_overrides"
-          impls.push(
-            build_client_get_with_config(
-              agent, client_name, override_name, walker_name,
-            ),
-          )
+          match agent.mode {
+            Durable =>
+              impls.push(
+                build_client_get_with_config(
+                  agent, client_name, override_name, walker_name,
+                ),
+              )
+            Ephemeral => ()
+          }
           impls.push(
             build_client_new_phantom_with_config(
               agent, client_name, override_name, walker_name,
@@ -77,9 +87,13 @@ pub fn generate_client_code(
               agent, client_name, override_name, walker_name,
             ),
           )
-          impls.push(
-            build_client_scoped_with_config(agent, client_name, override_name),
-          )
+          match agent.mode {
+            Durable =>
+              impls.push(
+                build_client_scoped_with_config(agent, client_name, override_name),
+              )
+            Ephemeral => ()
+          }
           impls.push(
             build_client_scoped_new_phantom_with_config(
               agent, client_name, override_name,

--- a/sdks/moonbit/golem_sdk_tools/lib/clients_emit_test.mbt
+++ b/sdks/moonbit/golem_sdk_tools/lib/clients_emit_test.mbt
@@ -595,6 +595,56 @@ test "generate_client_code - mixed config generates with_config methods" {
 }
 
 ///|
+test "generate_client_code - ephemeral agent skips non-phantom constructors" {
+  let agent : @lib.AgentInfo = {
+    name: "EphemeralWorker",
+    description: "An ephemeral worker",
+    mode: @lib.AgentMode::Ephemeral,
+    constructor_params: [("name", @lib.ParamType::Simple("String"))],
+    constructor_description: "Creates an ephemeral worker",
+    constructor_prompt_hint: None,
+    methods: [],
+    has_init: false,
+    constructor_schema_options: {},
+    has_snapshottable: false,
+    has_json_derives: false,
+    snapshotting: Disabled,
+    fields: [],
+    http_mount: None,
+    config_type: Some("MixedConfig"),
+  }
+  let config_types : Array[@lib.ConfigTypeInfo] = [
+    {
+      name: "MixedConfig",
+      package: "",
+      fields: [
+        (
+          "api_key",
+          @lib.ParamType::Parameterized("Secret", [
+            @lib.ParamType::Simple("String"),
+          ]),
+        ),
+        ("timeout", @lib.ParamType::Simple("UInt64")),
+      ],
+    },
+  ]
+  let impls = @lib.generate_client_code(
+    [agent],
+    config_types~,
+    agent_package="",
+  )
+  let output = @formatter.impls_to_string(impls)
+
+  assert_false(output.contains("pub fn EphemeralWorkerClient::get("))
+  assert_false(output.contains("get_with_config"))
+  assert_false(output.contains("scoped_with_config"))
+  assert_true(output.contains("new_phantom_with_config"))
+  assert_true(output.contains("get_phantom_with_config"))
+  assert_true(output.contains("scoped_new_phantom_with_config"))
+  assert_true(output.contains("scoped_get_phantom_with_config"))
+}
+
+///|
 test "generate_config_override_types - flat config" {
   let config_types : Array[@lib.ConfigTypeInfo] = [
     {

--- a/sdks/rust/golem-rust-macro/src/agentic/agent_definition_attributes.rs
+++ b/sdks/rust/golem-rust-macro/src/agentic/agent_definition_attributes.rs
@@ -20,6 +20,7 @@ use syn::{Error, Expr, ExprArray, ExprLit, Lit, Token};
 
 pub struct AgentDefinitionAttributes {
     pub agent_mode: TokenStream,
+    pub agent_is_durable: bool,
     pub http_mount: Option<TokenStream>,
     pub snapshotting: TokenStream,
 }
@@ -30,6 +31,7 @@ pub fn parse_agent_definition_attributes(
     let mut mode = quote! {
         golem_rust::golem_agentic::golem::agent::common::AgentMode::Durable
     };
+    let mut agent_is_durable = true;
     let mut snapshotting = quote! {
         golem_rust::golem_agentic::golem::agent::common::Snapshotting::Disabled
     };
@@ -44,6 +46,7 @@ pub fn parse_agent_definition_attributes(
     if attrs.is_empty() {
         return Ok(AgentDefinitionAttributes {
             agent_mode: mode,
+            agent_is_durable,
             http_mount: None,
             snapshotting,
         });
@@ -56,10 +59,12 @@ pub fn parse_agent_definition_attributes(
         if let Expr::Path(p) = expr {
             if p.path.is_ident("ephemeral") {
                 mode = quote! { golem_rust::golem_agentic::golem::agent::common::AgentMode::Ephemeral };
+                agent_is_durable = false;
                 continue;
             } else if p.path.is_ident("durable") {
                 mode =
                     quote! { golem_rust::golem_agentic::golem::agent::common::AgentMode::Durable };
+                agent_is_durable = true;
                 continue;
             }
         }
@@ -74,9 +79,11 @@ pub fn parse_agent_definition_attributes(
                 {
                     mode = match lit.value().as_str() {
                         "ephemeral" => {
+                            agent_is_durable = false;
                             quote! { golem_rust::golem_agentic::golem::agent::common::AgentMode::Ephemeral }
                         }
                         "durable" => {
+                            agent_is_durable = true;
                             quote! { golem_rust::golem_agentic::golem::agent::common::AgentMode::Durable }
                         }
                         other => {
@@ -138,6 +145,7 @@ pub fn parse_agent_definition_attributes(
 
     Ok(AgentDefinitionAttributes {
         agent_mode: mode,
+        agent_is_durable,
         http_mount: http_tokens,
         snapshotting,
     })

--- a/sdks/rust/golem-rust-macro/src/agentic/agent_definition_impl.rs
+++ b/sdks/rust/golem-rust-macro/src/agentic/agent_definition_impl.rs
@@ -40,6 +40,7 @@ pub fn agent_definition_impl(attrs: TokenStream, item: TokenStream) -> TokenStre
 
     let AgentDefinitionAttributes {
         agent_mode,
+        agent_is_durable,
         http_mount,
         snapshotting,
     } = match parse_agent_definition_attributes(attrs) {
@@ -62,6 +63,7 @@ pub fn agent_definition_impl(attrs: TokenStream, item: TokenStream) -> TokenStre
     match get_agent_type_with_remote_client(
         &agent_definition_trait,
         agent_mode,
+        agent_is_durable,
         http_mount,
         snapshotting,
         &type_parameters,
@@ -147,6 +149,7 @@ struct AgentTypeWithRemoteClient {
 fn get_agent_type_with_remote_client(
     agent_definition_trait: &ItemTrait,
     mode_value: proc_macro2::TokenStream,
+    agent_is_durable: bool,
     http_options: Option<proc_macro2::TokenStream>,
     snapshotting_value: proc_macro2::TokenStream,
     type_parameters: &[String],
@@ -506,6 +509,7 @@ fn get_agent_type_with_remote_client(
         &client_agent_config_param_defs,
         &client_agent_config_param_idents,
         type_parameters,
+        agent_is_durable,
     );
 
     let constructor_prompt_hint = if constructor_prompt.is_empty() {

--- a/sdks/rust/golem-rust-macro/src/agentic/client_generation.rs
+++ b/sdks/rust/golem-rust-macro/src/agentic/client_generation.rs
@@ -25,6 +25,7 @@ pub fn get_remote_client(
     constructor_agent_config_param_defs: &[proc_macro2::TokenStream],
     constructor_agent_config_param_idents: &[proc_macro2::Ident],
     agent_type_parameter_names: &[String],
+    agent_is_durable: bool,
 ) -> proc_macro2::TokenStream {
     let remote_client_type_name = format_ident!("{}Client", item_trait.ident);
 
@@ -60,7 +61,9 @@ pub fn get_remote_client(
         }
     };
 
-    let optional_get_with_config_impl = if !constructor_agent_config_param_defs.is_empty() {
+    let optional_get_with_config_impl = if agent_is_durable
+        && !constructor_agent_config_param_defs.is_empty()
+    {
         quote! {
             pub fn get_with_config(#(#constructor_data_value_param_defs,)* #(#constructor_agent_config_param_defs,)*) -> #remote_client_type_name {
                 let agent_type =
@@ -131,16 +134,8 @@ pub fn get_remote_client(
         quote! {}
     };
 
-    quote! {
-        pub struct #remote_client_type_name {
-            agent_type_name: String,
-            constructor_data: golem_rust::golem_agentic::golem::agent::common::DataValue,
-            phantom_id: Option<golem_rust::Uuid>,
-            component_id: golem_rust::golem_wasm::ComponentId,
-            wasm_rpc: golem_rust::golem_agentic::golem::agent::host::WasmRpc,
-        }
-
-        impl #remote_client_type_name {
+    let get_impl = if agent_is_durable {
+        quote! {
             pub fn #get_method_ident(#(#constructor_data_value_param_defs,)*) -> #remote_client_type_name {
                 let agent_type =
                    golem_rust::golem_agentic::golem::agent::host::get_agent_type(#type_name).expect("Internal Error: Agent type not registered");
@@ -157,6 +152,22 @@ pub fn get_remote_client(
                      wasm_rpc,
                  }
             }
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        pub struct #remote_client_type_name {
+            agent_type_name: String,
+            constructor_data: golem_rust::golem_agentic::golem::agent::common::DataValue,
+            phantom_id: Option<golem_rust::Uuid>,
+            component_id: golem_rust::golem_wasm::ComponentId,
+            wasm_rpc: golem_rust::golem_agentic::golem::agent::host::WasmRpc,
+        }
+
+        impl #remote_client_type_name {
+            #get_impl
 
             #optional_get_with_config_impl
 
@@ -214,6 +225,52 @@ pub fn get_remote_client(
 
             #methods_impl
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_remote_client;
+    use quote::{format_ident, quote};
+    use syn::parse_quote;
+
+    fn render_client(agent_is_durable: bool) -> String {
+        let item_trait = parse_quote! {
+            trait ExampleAgent {
+                fn new(name: String, enabled: bool, cfg: Config) -> Self;
+                fn ping(&self);
+            }
+        };
+
+        get_remote_client(
+            &item_trait,
+            &[quote! { name: String }, quote! { enabled: bool }],
+            &[format_ident!("name"), format_ident!("enabled")],
+            &[quote! { cfg: Config }],
+            &[format_ident!("cfg")],
+            &[],
+            agent_is_durable,
+        )
+        .to_string()
+    }
+
+    #[test]
+    fn durable_agents_generate_getters() {
+        let rendered = render_client(true);
+
+        assert!(rendered.contains("pub fn get ("));
+        assert!(rendered.contains("get_with_config"));
+    }
+
+    #[test]
+    fn ephemeral_agents_skip_non_phantom_getters() {
+        let rendered = render_client(false);
+
+        assert!(!rendered.contains("pub fn get ("));
+        assert!(!rendered.contains("get_with_config"));
+        assert!(rendered.contains("new_phantom"));
+        assert!(rendered.contains("get_phantom"));
+        assert!(rendered.contains("get_phantom_with_config"));
     }
 }
 

--- a/sdks/ts/packages/golem-ts-sdk/src/decorators/agent.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/decorators/agent.ts
@@ -349,8 +349,10 @@ export function agent(options?: AgentDecoratorOptions) {
       );
     }
 
-    (ctor as any).get = getRemoteClient(agentClassName, agentType, ctor, false);
-    (ctor as any).getWithConfig = getRemoteClient(agentClassName, agentType, ctor, true);
+    if (agentType.mode === 'durable') {
+      (ctor as any).get = getRemoteClient(agentClassName, agentType, ctor, false);
+      (ctor as any).getWithConfig = getRemoteClient(agentClassName, agentType, ctor, true);
+    }
     (ctor as any).newPhantom = getNewPhantomRemoteClient(agentClassName, agentType, ctor, false);
     (ctor as any).newPhantomWithConfig = getNewPhantomRemoteClient(
       agentClassName,

--- a/sdks/ts/packages/golem-ts-sdk/tests/decorator.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/decorator.test.ts
@@ -26,12 +26,12 @@ import {
 } from './testUtils';
 import { DataSchema, DataValue, ElementSchema } from 'golem:agent/common@1.5.0';
 import * as util from 'node:util';
-import { FooAgent } from './validAgents';
+import { EphemeralAgent, FooAgent } from './validAgents';
 import { AgentInitiatorRegistry } from '../src/internal/registry/agentInitiatorRegistry';
 import { WitNodeBuilder } from '../src/internal/mapping/values/WitNodeBuilder';
 import { ResolvedAgent } from '../src/internal/resolvedAgent';
 import { Uuid } from '../src/uuid';
-import { AgentClassName } from '../src';
+import { AgentClassName, BaseAgent } from '../src';
 
 // Test setup ensures loading agents prior to every test
 // If the sample agents in the set-up changes, this test should fail
@@ -979,6 +979,20 @@ describe('Annotated FooAgent class', () => {
     );
     expect(await client.phantomId()).toBeUndefined();
     expect(await client.getAgentType()).toEqual(agentType);
+  });
+});
+
+describe('Annotated EphemeralAgent class', () => {
+  it('does not override non-phantom constructors', () => {
+    expect(EphemeralAgent.get).toBe(BaseAgent.get);
+    expect(EphemeralAgent.getWithConfig).toBe(BaseAgent.getWithConfig);
+  });
+
+  it('still exposes phantom constructors', () => {
+    expect(EphemeralAgent.getPhantom).toBeDefined();
+    expect(EphemeralAgent.getPhantom).toBeTypeOf('function');
+    expect(EphemeralAgent.newPhantom).toBeDefined();
+    expect(EphemeralAgent.newPhantom).toBeTypeOf('function');
   });
 });
 

--- a/sdks/ts/packages/golem-ts-sdk/tests/validAgents.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/validAgents.ts
@@ -528,7 +528,7 @@ export type TextOrImage =
   | { tag: 'un-binary'; val: UnstructuredBinary<['application/json']> };
 
 @agent({ mode: 'ephemeral' })
-class EphemeralAgent extends BaseAgent {
+export class EphemeralAgent extends BaseAgent {
   constructor(readonly input: string) {
     super();
     this.input = input;

--- a/test-components/agent-counters/src/lib.rs
+++ b/test-components/agent-counters/src/lib.rs
@@ -34,7 +34,7 @@ impl Counter for CounterImpl {
     }
 
     async fn increment_through_rpc_to_ephemeral(&mut self) -> u32 {
-        let mut client = EphemeralCounterClient::get(format!("{}-ephemeral", self.id));
+        let mut client = EphemeralCounterClient::new_phantom(format!("{}-ephemeral", self.id));
         client.increment().await
     }
 


### PR DESCRIPTION
Resolves #3225 

Ephemeral agents were always meant to be phantom as well. In Golem 1.4.2 this was enforced in the rib-based api gateway, the REPL and the generated wit-based RPC. 

This PR fixes this in Golem 1.5 by making it enforced in various levels:

- Ephemeral RPC clients only have `getPhantom/newPhantom` variants (Scala already had this)
- Ephemeral bridge clients only have `getPhantom/newPhantom` variants (TS bridge already had this)
- MCP server uses phantom agents for ephemeral agent types
- HTTP server uses phantom agents for ephemeral agent types, the custom `phantomAgent` property on the mount is left to enforce phantom agent behavior on _durable agents_
- The HTTP agent create/invoke APIs enforce this behavior as well
- The gRPC APIs are not touched, as it is expected that internal calls are always passing the right agent-id 
