### PR TITLE
Span and snapshot failure fix

### DIFF
--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -1550,6 +1550,28 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
                             }
                         };
 
+                        let invocation_context = InvocationContextStack::fresh();
+                        let (local_span_ids, inherited_span_ids) = invocation_context.span_ids();
+                        if let Err(err) = store
+                            .as_context_mut()
+                            .data_mut()
+                            .durable_ctx_mut()
+                            .set_current_invocation_context(invocation_context)
+                            .await
+                        {
+                            store
+                                .as_context_mut()
+                                .data_mut()
+                                .on_worker_update_failed(
+                                    target_revision,
+                                    Some(format!(
+                                        "Manual update failed to install invocation context: {err}"
+                                    )),
+                                )
+                                .await;
+                            return Some(RetryDecision::Immediate);
+                        }
+
                         store
                             .as_context_mut()
                             .data_mut()
@@ -1567,6 +1589,21 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
                             .as_context_mut()
                             .data_mut()
                             .end_call_snapshotting_function();
+
+                        for span_id in local_span_ids {
+                            let _ = store
+                                .as_context_mut()
+                                .data_mut()
+                                .durable_ctx_mut()
+                                .remove_span(&span_id);
+                        }
+                        for span_id in inherited_span_ids {
+                            let _ = store
+                                .as_context_mut()
+                                .data_mut()
+                                .durable_ctx_mut()
+                                .remove_span(&span_id);
+                        }
 
                         let failed = match load_result {
                             Err(error) => {
@@ -1767,6 +1804,19 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
             }
         };
 
+        let invocation_context = InvocationContextStack::fresh();
+        let (local_span_ids, inherited_span_ids) = invocation_context.span_ids();
+        if let Err(err) = store
+            .as_context_mut()
+            .data_mut()
+            .durable_ctx_mut()
+            .set_current_invocation_context(invocation_context)
+            .await
+        {
+            warn!("Snapshot recovery failed to install invocation context: {err}");
+            return SnapshotRecoveryResult::Failed;
+        }
+
         store
             .as_context_mut()
             .data_mut()
@@ -1779,6 +1829,21 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
             .as_context_mut()
             .data_mut()
             .end_call_snapshotting_function();
+
+        for span_id in local_span_ids {
+            let _ = store
+                .as_context_mut()
+                .data_mut()
+                .durable_ctx_mut()
+                .remove_span(&span_id);
+        }
+        for span_id in inherited_span_ids {
+            let _ = store
+                .as_context_mut()
+                .data_mut()
+                .durable_ctx_mut()
+                .remove_span(&span_id);
+        }
 
         let failed = match load_result {
             Err(error) => Some(format!(
@@ -2497,30 +2562,25 @@ impl<Ctx: WorkerCtx> InvocationContextManagement for DurableWorkerCtx<Ctx> {
     }
 
     fn remove_span(&mut self, span_id: &SpanId) -> Result<(), WorkerExecutorError> {
-        let parent_id = if &self.state.current_span_id == span_id {
-            self.state
+        if &self.state.current_span_id == span_id {
+            // Walk up to the parent if it still exists in the invocation context;
+            // otherwise fall back to the root.
+            let parent_id = self
+                .state
                 .invocation_context
                 .get(span_id)
-                .unwrap()
-                .parent()
-                .map(|p| p.span_id().clone())
-        } else {
-            None
-        };
+                .ok()
+                .and_then(|span| span.parent().map(|p| p.span_id().clone()));
 
-        if let Some(parent_id) = parent_id
-            && self.state.invocation_context.get(&parent_id).is_ok()
-        {
-            self.state.current_span_id = parent_id;
+            self.state.current_span_id = parent_id
+                .filter(|id| self.state.invocation_context.get(id).is_ok())
+                .unwrap_or_else(|| self.state.invocation_context.root.span_id().clone());
         }
         let _ = self
             .state
             .invocation_context
             .finish_span(span_id)
             .map_err(WorkerExecutorError::runtime);
-        self.state
-            .invocation_context
-            .repair_current_and_root(&mut self.state.current_span_id);
         Ok(())
     }
 

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -2497,21 +2497,30 @@ impl<Ctx: WorkerCtx> InvocationContextManagement for DurableWorkerCtx<Ctx> {
     }
 
     fn remove_span(&mut self, span_id: &SpanId) -> Result<(), WorkerExecutorError> {
-        if &self.state.current_span_id == span_id {
-            self.state.current_span_id = self
-                .state
+        let parent_id = if &self.state.current_span_id == span_id {
+            self.state
                 .invocation_context
                 .get(span_id)
                 .unwrap()
                 .parent()
                 .map(|p| p.span_id().clone())
-                .unwrap_or_else(|| self.state.invocation_context.root.span_id().clone());
+        } else {
+            None
+        };
+
+        if let Some(parent_id) = parent_id
+            && self.state.invocation_context.get(&parent_id).is_ok()
+        {
+            self.state.current_span_id = parent_id;
         }
         let _ = self
             .state
             .invocation_context
             .finish_span(span_id)
             .map_err(WorkerExecutorError::runtime);
+        self.state
+            .invocation_context
+            .repair_current_and_root(&mut self.state.current_span_id);
         Ok(())
     }
 

--- a/golem-worker-executor/src/model/mod.rs
+++ b/golem-worker-executor/src/model/mod.rs
@@ -726,6 +726,33 @@ impl InvocationContext {
         }
     }
 
+    pub fn repair_current_and_root(&mut self, current_span_id: &mut SpanId) {
+        if self.spans.is_empty() {
+            let root = InvocationContextSpan::local().build();
+            *current_span_id = root.span_id().clone();
+            self.root = root.clone();
+            self.spans.insert(root.span_id().clone(), root);
+            return;
+        }
+
+        if !self.spans.contains_key(self.root.span_id()) {
+            self.root = self
+                .spans
+                .values()
+                .find(|span| {
+                    span.parent()
+                        .map(|parent| !self.spans.contains_key(parent.span_id()))
+                        .unwrap_or(true)
+                })
+                .cloned()
+                .unwrap_or_else(|| self.spans.values().next().unwrap().clone());
+        }
+
+        if !self.spans.contains_key(current_span_id) {
+            *current_span_id = self.root.span_id().clone();
+        }
+    }
+
     fn span(&self, span_id: &SpanId) -> Result<&Arc<InvocationContextSpan>, String> {
         self.spans
             .get(span_id)
@@ -1060,5 +1087,27 @@ mod tests {
         assert_eq!(z, Some(vec![s("33"), s("3")]));
         assert_eq!(w, None);
         assert_eq!(a, Some(vec![s("00"), s("0")]));
+    }
+
+    #[test]
+    fn repair_current_and_root_after_removing_switched_stack() {
+        let mut ctx = InvocationContext::new(Some(example_trace_id_1()));
+        let base_root_id = ctx.root.span_id().clone();
+
+        let stack = example_stack_1();
+        let (switched_ctx, _current_id) = InvocationContext::from_stack(stack).unwrap();
+        ctx.switch_to(switched_ctx);
+
+        ctx.finish_span(&example_span_id_6()).unwrap();
+        ctx.finish_span(&example_span_id_5()).unwrap();
+        ctx.finish_span(&example_span_id_2()).unwrap();
+        ctx.finish_span(&example_span_id_1()).unwrap();
+
+        let mut current_span_id = example_span_id_1();
+        ctx.repair_current_and_root(&mut current_span_id);
+
+        assert_eq!(ctx.root.span_id(), &base_root_id);
+        assert_eq!(current_span_id, base_root_id);
+        assert!(ctx.get(&current_span_id).is_ok());
     }
 }

--- a/golem-worker-executor/src/model/mod.rs
+++ b/golem-worker-executor/src/model/mod.rs
@@ -726,33 +726,6 @@ impl InvocationContext {
         }
     }
 
-    pub fn repair_current_and_root(&mut self, current_span_id: &mut SpanId) {
-        if self.spans.is_empty() {
-            let root = InvocationContextSpan::local().build();
-            *current_span_id = root.span_id().clone();
-            self.root = root.clone();
-            self.spans.insert(root.span_id().clone(), root);
-            return;
-        }
-
-        if !self.spans.contains_key(self.root.span_id()) {
-            self.root = self
-                .spans
-                .values()
-                .find(|span| {
-                    span.parent()
-                        .map(|parent| !self.spans.contains_key(parent.span_id()))
-                        .unwrap_or(true)
-                })
-                .cloned()
-                .unwrap_or_else(|| self.spans.values().next().unwrap().clone());
-        }
-
-        if !self.spans.contains_key(current_span_id) {
-            *current_span_id = self.root.span_id().clone();
-        }
-    }
-
     fn span(&self, span_id: &SpanId) -> Result<&Arc<InvocationContextSpan>, String> {
         self.spans
             .get(span_id)
@@ -1087,27 +1060,5 @@ mod tests {
         assert_eq!(z, Some(vec![s("33"), s("3")]));
         assert_eq!(w, None);
         assert_eq!(a, Some(vec![s("00"), s("0")]));
-    }
-
-    #[test]
-    fn repair_current_and_root_after_removing_switched_stack() {
-        let mut ctx = InvocationContext::new(Some(example_trace_id_1()));
-        let base_root_id = ctx.root.span_id().clone();
-
-        let stack = example_stack_1();
-        let (switched_ctx, _current_id) = InvocationContext::from_stack(stack).unwrap();
-        ctx.switch_to(switched_ctx);
-
-        ctx.finish_span(&example_span_id_6()).unwrap();
-        ctx.finish_span(&example_span_id_5()).unwrap();
-        ctx.finish_span(&example_span_id_2()).unwrap();
-        ctx.finish_span(&example_span_id_1()).unwrap();
-
-        let mut current_span_id = example_span_id_1();
-        ctx.repair_current_and_root(&mut current_span_id);
-
-        assert_eq!(ctx.root.span_id(), &base_root_id);
-        assert_eq!(current_span_id, base_root_id);
-        assert!(ctx.get(&current_span_id).is_ok());
     }
 }

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -969,12 +969,36 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
             }
         };
 
+        let invocation_context = InvocationContextStack::fresh();
+        let (local_span_ids, inherited_span_ids) = invocation_context.span_ids();
+        if let Err(err) = self
+            .store
+            .data_mut()
+            .set_current_invocation_context(invocation_context)
+            .await
+        {
+            warn!("Failed to install invocation context for manual update save-snapshot: {err}");
+            return self
+                .fail_update(
+                    target_revision,
+                    format!("failed to install invocation context for save-snapshot: {err}"),
+                )
+                .await;
+        }
+
         self.store.data_mut().begin_call_snapshotting_function();
 
         let result =
             invoke_observed_and_traced(lowered, self.store, self.instance, InvocationMode::Replay)
                 .await;
         self.store.data_mut().end_call_snapshotting_function();
+
+        for span_id in local_span_ids {
+            let _ = self.store.data_mut().remove_span(&span_id);
+        }
+        for span_id in inherited_span_ids {
+            let _ = self.store.data_mut().remove_span(&span_id);
+        }
 
         match result {
             Ok(InvokeResult::Succeeded {
@@ -1174,12 +1198,31 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
             }
         };
 
+        let invocation_context = InvocationContextStack::fresh();
+        let (local_span_ids, inherited_span_ids) = invocation_context.span_ids();
+        if let Err(err) = self
+            .store
+            .data_mut()
+            .set_current_invocation_context(invocation_context)
+            .await
+        {
+            warn!("Failed to install invocation context for periodic save-snapshot: {err}");
+            return CommandOutcome::Continue;
+        }
+
         self.store.data_mut().begin_call_snapshotting_function();
 
         let result =
             invoke_observed_and_traced(lowered, self.store, self.instance, InvocationMode::Replay)
                 .await;
         self.store.data_mut().end_call_snapshotting_function();
+
+        for span_id in local_span_ids {
+            let _ = self.store.data_mut().remove_span(&span_id);
+        }
+        for span_id in inherited_span_ids {
+            let _ = self.store.data_mut().remove_span(&span_id);
+        }
 
         if let Some(outcome) = periodic_snapshot_failure_outcome(&result) {
             match &result {

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -1181,6 +1181,24 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
                 .await;
         self.store.data_mut().end_call_snapshotting_function();
 
+        if let Some(outcome) = periodic_snapshot_failure_outcome(&result) {
+            match &result {
+                Ok(InvokeResult::Failed { .. }) => {
+                    warn!(
+                        "Periodic snapshot save function failed; restarting worker to recover the store"
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        "Periodic snapshot save invocation error: {err}; restarting worker to recover the store"
+                    );
+                }
+                _ => unreachable!(),
+            }
+
+            return outcome;
+        }
+
         match result {
             Ok(InvokeResult::Succeeded {
                 result: AgentInvocationResult::SaveSnapshot { snapshot },
@@ -1219,10 +1237,6 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
                 warn!("Periodic snapshot returned unexpected result format");
                 CommandOutcome::Continue
             }
-            Ok(InvokeResult::Failed { .. }) => {
-                warn!("Periodic snapshot save function failed");
-                CommandOutcome::Continue
-            }
             Ok(InvokeResult::Exited { .. }) => {
                 warn!("Worker exited during periodic snapshot save");
                 CommandOutcome::BreakInnerLoop(RetryDecision::None)
@@ -1231,16 +1245,13 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
                 warn!("Worker interrupted during periodic snapshot save");
                 CommandOutcome::BreakInnerLoop(RetryDecision::None)
             }
-            Err(err) => {
-                warn!("Periodic snapshot save invocation error: {err}");
-                CommandOutcome::Continue
-            }
+            Ok(InvokeResult::Failed { .. }) | Err(_) => unreachable!(),
         }
     }
 }
 
 /// Outcome of processing a single command within the inner invocation loop
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum CommandOutcome {
     /// Break from both the inner and outer loops, there is no way to retry anything
     BreakOuterLoop,
@@ -1257,6 +1268,17 @@ enum PeriodicSnapshotAction {
     NotNeeded,
     DueNow,
     Wait(Duration),
+}
+
+fn periodic_snapshot_failure_outcome(
+    result: &Result<InvokeResult, WorkerExecutorError>,
+) -> Option<CommandOutcome> {
+    match result {
+        Ok(InvokeResult::Failed { .. }) | Err(_) => {
+            Some(CommandOutcome::BreakInnerLoop(RetryDecision::Immediate))
+        }
+        _ => None,
+    }
 }
 
 fn snapshot_baseline_timestamp(
@@ -1288,8 +1310,15 @@ fn snapshot_action_at(
 
 #[cfg(test)]
 mod tests {
-    use super::{PeriodicSnapshotAction, snapshot_action_at, snapshot_baseline_timestamp};
-    use golem_common::model::Timestamp;
+    use super::{
+        CommandOutcome, PeriodicSnapshotAction, periodic_snapshot_failure_outcome,
+        snapshot_action_at, snapshot_baseline_timestamp,
+    };
+    use crate::worker::RetryDecision;
+    use crate::worker::invocation::InvokeResult;
+    use golem_common::model::oplog::AgentError;
+    use golem_common::model::{OplogIndex, Timestamp};
+    use golem_service_base::error::worker_executor::WorkerExecutorError;
     use std::time::Duration;
     use test_r::test;
 
@@ -1322,6 +1351,30 @@ mod tests {
         assert_eq!(
             action,
             PeriodicSnapshotAction::Wait(Duration::from_millis(1_750))
+        );
+    }
+
+    #[test]
+    fn periodic_snapshot_failed_invocation_triggers_immediate_recovery() {
+        let result = Ok(InvokeResult::Failed {
+            consumed_fuel: 0,
+            error: AgentError::InternalError("boom".to_string()),
+            retry_from: OplogIndex::INITIAL,
+        });
+
+        assert_eq!(
+            periodic_snapshot_failure_outcome(&result),
+            Some(CommandOutcome::BreakInnerLoop(RetryDecision::Immediate))
+        );
+    }
+
+    #[test]
+    fn periodic_snapshot_invocation_error_triggers_immediate_recovery() {
+        let result = Err(WorkerExecutorError::runtime("boom"));
+
+        assert_eq!(
+            periodic_snapshot_failure_outcome(&result),
+            Some(CommandOutcome::BreakInnerLoop(RetryDecision::Immediate))
         );
     }
 }


### PR DESCRIPTION
Fixes a "span not found" fatal error
Also when this happened during save-snapshot, it made the component instance poisoned but did not trigger a recovery