### PR TITLE
ts-sdk: apply retry policy to language level errors

### DIFF
--- a/golem-worker-executor/tests/agent_sdk_ts.rs
+++ b/golem-worker-executor/tests/agent_sdk_ts.rs
@@ -1,0 +1,139 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Tracing;
+use axum::Router;
+use axum::extract::State;
+use axum::routing::get;
+use golem_common::model::RetryConfig;
+use golem_common::{agent_id, data_value};
+use golem_test_framework::dsl::TestDsl;
+use golem_wasm::Value;
+use golem_worker_executor_test_utils::{
+    LastUniqueId, PrecompiledComponent, TestContext, TestExecutorOverrides,
+    WorkerExecutorTestDependencies, start_with_overrides,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use test_r::{inherit_test_dep, test, timeout};
+use tokio::net::TcpListener;
+use tracing::Instrument;
+
+inherit_test_dep!(WorkerExecutorTestDependencies);
+inherit_test_dep!(LastUniqueId);
+inherit_test_dep!(Tracing);
+inherit_test_dep!(
+    #[tagged_as("agent_sdk_ts")]
+    PrecompiledComponent
+);
+
+#[derive(Clone)]
+struct AttemptCounterState {
+    counter: Arc<AtomicUsize>,
+    fail_count: usize,
+}
+
+async fn attempt_handler(State(state): State<AttemptCounterState>) -> axum::response::Response {
+    let attempt = state.counter.fetch_add(1, Ordering::SeqCst) + 1;
+    if attempt <= state.fail_count {
+        axum::response::Response::builder()
+            .status(500)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    } else {
+        axum::response::Response::builder()
+            .status(200)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    }
+}
+
+async fn start_attempt_counter_server(fail_count: usize) -> (u16, Arc<AtomicUsize>) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let state = AttemptCounterState {
+        counter: counter.clone(),
+        fail_count,
+    };
+    let app = Router::new()
+        .route("/attempt", get(attempt_handler))
+        .with_state(state);
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(
+        async move {
+            axum::serve(listener, app).await.unwrap();
+        }
+        .in_current_span(),
+    );
+    (port, counter)
+}
+
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn ts_with_retry_policy_retries_on_user_land_error(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("agent_sdk_ts")] agent_sdk_ts: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+
+    let overrides = TestExecutorOverrides {
+        configure: Some(Arc::new(|config| {
+            config.retry = RetryConfig {
+                max_attempts: 10,
+                min_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(10),
+                multiplier: 1.0,
+                max_jitter_factor: None,
+            };
+        })),
+        ..Default::default()
+    };
+    let executor = start_with_overrides(deps, &context, overrides).await?;
+
+    // Server fails the first 3 requests with HTTP 500, succeeds on the 4th.
+    let (port, counter) = start_attempt_counter_server(3).await;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, agent_sdk_ts)
+        .store()
+        .await?;
+
+    let agent_id = agent_id!("RetryTest", "retry-test");
+    executor
+        .start_agent_with(&component.id, agent_id.clone(), HashMap::new(), Vec::new())
+        .await?;
+
+    let result = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "withRetryPolicyTest",
+            data_value!("localhost", port as f64),
+        )
+        .await?
+        .into_return_value()
+        .ok_or_else(|| anyhow::anyhow!("expected return value"))?;
+
+    assert_eq!(result, Value::Bool(true));
+    // The server was called at least fail_count+1 times: once per failure plus the final success.
+    // With oplog-replay retries the exact count may be higher, but it must be > 3.
+    assert!(counter.load(Ordering::SeqCst) > 3);
+
+    Ok(())
+}

--- a/golem-worker-executor/tests/lib.rs
+++ b/golem-worker-executor/tests/lib.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::AtomicU16;
 use test_r::{sequential_suite, tag_suite, test_dep, timeout_suite};
 
 pub mod agent;
+pub mod agent_sdk_ts;
 pub mod api;
 pub mod blobstore;
 pub mod compatibility;
@@ -60,6 +61,7 @@ tag_suite!(http, group1);
 tag_suite!(websocket, group1);
 tag_suite!(rdbms, group1);
 tag_suite!(agent, group1);
+tag_suite!(agent_sdk_ts, group1);
 
 tag_suite!(hot_update, group2);
 tag_suite!(transactions, group2);

--- a/sdks/ts/packages/golem-ts-sdk/src/host/guard.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/host/guard.ts
@@ -47,6 +47,9 @@ export function usePersistenceLevel(level: PersistenceLevel) {
   return new PersistenceLevelGuard(originalLevel);
 }
 
+export function withPersistenceLevel<R>(level: PersistenceLevel, f: () => Promise<R>): Promise<R>;
+export function withPersistenceLevel<R>(level: PersistenceLevel, f: () => R): R;
+
 /**
  * Executes a function with a specific persistence level for the oplog.
  * Supports both sync and async callbacks.
@@ -54,7 +57,10 @@ export function usePersistenceLevel(level: PersistenceLevel) {
  * @param f - The function to execute (sync or async).
  * @returns The result of the executed function, or a Promise if an async function was passed.
  */
-export function withPersistenceLevel<R>(level: PersistenceLevel, f: () => R): R {
+export function withPersistenceLevel<R>(
+  level: PersistenceLevel,
+  f: () => R | Promise<R>,
+): R | Promise<R> {
   const guard = usePersistenceLevel(level);
   return executeWithDrop([guard], f);
 }
@@ -82,6 +88,9 @@ export function useIdempotenceMode(mode: boolean): IdempotenceModeGuard {
   return new IdempotenceModeGuard(original);
 }
 
+export function withIdempotenceMode<R>(mode: boolean, f: () => Promise<R>): Promise<R>;
+export function withIdempotenceMode<R>(mode: boolean, f: () => R): R;
+
 /**
  * Executes a function with a specific idempotence mode.
  * Supports both sync and async callbacks.
@@ -89,7 +98,7 @@ export function useIdempotenceMode(mode: boolean): IdempotenceModeGuard {
  * @param f - The function to execute (sync or async).
  * @returns The result of the executed function, or a Promise if an async function was passed.
  */
-export function withIdempotenceMode<R>(mode: boolean, f: () => R): R {
+export function withIdempotenceMode<R>(mode: boolean, f: () => R | Promise<R>): R | Promise<R> {
   const guard = useIdempotenceMode(mode);
   return executeWithDrop([guard], f);
 }
@@ -115,24 +124,22 @@ export function markAtomicOperation(): AtomicOperationGuard {
   return new AtomicOperationGuard(begin);
 }
 
+export function atomically<T>(f: () => Promise<T>): Promise<T>;
+export function atomically<T>(f: () => T): T;
+
 /**
  * Executes a function atomically.
  * Supports both sync and async callbacks.
  *
- * On success the atomic region is committed via `mark_end_operation`.
- * On failure the SDK calls the host `trap` function to terminate the worker
- * invocation with an uncatchable wasm trap. This guarantees that the failure
- * cannot be observed by user code: trying to `try/catch` around `atomically`
- * is a no-op because the worker is recovered by the executor.
- *
- * The atomic region is intentionally left open at trap time so the existing
- * replay-time fallback in `mark_begin_operation` deletes the partial inner
- * side effects via a `Jump` and re-executes the block from the begin marker.
+ * On success the atomic region is committed.
+ * On failure the worker is immediately terminated so the failed partial
+ * execution is rolled back and the block is retried from the beginning on
+ * recovery.
  *
  * @param f - The function to execute atomically (sync or async).
  * @returns The result of the executed function, or a Promise if an async function was passed.
  */
-export function atomically<T>(f: () => T): T {
+export function atomically<T>(f: () => T | Promise<T>): T | Promise<T> {
   const guard = markAtomicOperation();
   try {
     const result = f();
@@ -176,6 +183,15 @@ export function isPromiseLike(value: unknown): value is Promise<unknown> {
   return value !== null && value !== undefined && typeof (value as any).then === 'function';
 }
 
+export function executeWithDrop<Resource extends { drop: () => void }, R>(
+  resources: [Resource],
+  fn: () => Promise<R>,
+): Promise<R>;
+export function executeWithDrop<Resource extends { drop: () => void }, R>(
+  resources: [Resource],
+  fn: () => R,
+): R;
+
 /**
  * Executes a function and automatically drops the provided resources after execution.
  * Supports both sync and async callbacks — if the callback returns a Promise,
@@ -184,12 +200,10 @@ export function isPromiseLike(value: unknown): value is Promise<unknown> {
  * @param fn - The function to execute (sync or async).
  * @returns The result of the executed function, or a Promise if an async function was passed.
  */
-export function executeWithDrop<
-  Resource extends {
-    drop: () => void;
-  },
-  R,
->(resources: [Resource], fn: () => R): R {
+export function executeWithDrop<Resource extends { drop: () => void }, R>(
+  resources: [Resource],
+  fn: () => R | Promise<R>,
+): R | Promise<R> {
   try {
     const result = fn();
     if (isPromiseLike(result)) {

--- a/sdks/ts/packages/golem-ts-sdk/src/host/quota.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/host/quota.ts
@@ -128,26 +128,22 @@ export function acquireQuotaToken(resourceName: string, expectedUse: bigint): Qu
   return new QuotaToken(new RawQuotaToken(resourceName, expectedUse));
 }
 
-/**
- * Reserve `amount` units, run `fn`, then commit the actual usage returned
- * by `fn`.  Commits zero if `fn` throws or the returned Promise rejects.
- *
- * Returns `Result.ok(value)` on success, or `Result.err(failedReservation)`
- * if the reservation could not be granted.
- *
- * @param token  - The token to reserve against.
- * @param amount - Units to reserve.
- * @param fn     - Async work to perform; must resolve with the actual units consumed.
- */
 export function withReservation<R>(
   token: QuotaToken,
   amount: bigint,
   fn: (reservation: Reservation) => Promise<{ used: bigint; value: R }>,
 ): Promise<Result<R, FailedReservation>>;
 
+export function withReservation<R>(
+  token: QuotaToken,
+  amount: bigint,
+  fn: (reservation: Reservation) => { used: bigint; value: R },
+): Result<R, FailedReservation>;
+
 /**
  * Reserve `amount` units, run `fn`, then commit the actual usage returned
- * by `fn`.  Commits zero if `fn` throws.
+ * by `fn`. Commits zero if `fn` throws or the returned Promise rejects.
+ * Supports both sync and async callbacks.
  *
  * Returns `Result.ok(value)` on success, or `Result.err(failedReservation)`
  * if the reservation could not be granted.
@@ -155,14 +151,7 @@ export function withReservation<R>(
  * @param token  - The token to reserve against.
  * @param amount - Units to reserve.
  * @param fn     - Work to perform; must return the actual units consumed.
- */
-export function withReservation<R>(
-  token: QuotaToken,
-  amount: bigint,
-  fn: (reservation: Reservation) => { used: bigint; value: R },
-): Result<R, FailedReservation>;
-
-export function withReservation<R>(
+ */ export function withReservation<R>(
   token: QuotaToken,
   amount: bigint,
   fn: (

--- a/sdks/ts/packages/golem-ts-sdk/src/host/retry.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/host/retry.ts
@@ -29,8 +29,7 @@ import {
   setRetryPolicy as rawSetRetryPolicy,
   removeRetryPolicy as rawRemoveRetryPolicy,
 } from 'golem:api/retry@1.5.0';
-import { isPromiseLike } from './guard';
-import { trap } from './hostapi';
+import { executeWithDrop } from './guard';
 import {
   Duration,
   NamedPolicy,
@@ -108,14 +107,12 @@ export function withRetryPolicy<R>(policy: NamedPolicyInput, f: () => R): R;
  * Executes a function with a named retry policy temporarily set.
  * Supports both sync and async callbacks.
  *
- * On failure the worker is immediately terminated and retried by the executor
- * according to the active retry policy. This has two practical consequences:
+ * On success the named policy is restored to its previous value (or removed if
+ * it did not exist before). On failure the policy is also restored and the error
+ * propagates normally.
  *
- * - Errors thrown inside `f` always trigger the retry policy — this is the
- *   recommended way to make user-land exceptions subject to executor-level
- *   retries.
- * - The callback cannot be wrapped in a `try/catch` to suppress the retry:
- *   any thrown error unconditionally causes the worker to be retried.
+ * To make errors inside `f` subject to executor-level retries, wrap the
+ * body with {@link atomically}.
  *
  * @param policy - The named retry policy to set.
  * @param f - The function to execute (sync or async).
@@ -126,37 +123,5 @@ export function withRetryPolicy<R>(
   f: () => R | Promise<R>,
 ): R | Promise<R> {
   const guard = useRetryPolicy(policy);
-  try {
-    const result = f();
-    if (isPromiseLike(result)) {
-      return result.then(
-        (val) => {
-          guard.drop();
-          return val;
-        },
-        (err) => {
-          // Leave the retry policy active and terminate the worker so the
-          // executor retries the invocation with the policy applied.
-          trap(`withRetryPolicy: ${formatErrorForTrap(err)}`);
-          throw err;
-        },
-      ) as R;
-    }
-    guard.drop();
-    return result;
-  } catch (e) {
-    trap(`withRetryPolicy: ${formatErrorForTrap(e)}`);
-    throw e;
-  }
-}
-
-function formatErrorForTrap(err: unknown): string {
-  if (err instanceof Error) {
-    return err.stack ?? `${err.name}: ${err.message}`;
-  }
-  try {
-    return String(err);
-  } catch {
-    return '<unprintable error>';
-  }
+  return executeWithDrop([guard], f);
 }

--- a/sdks/ts/packages/golem-ts-sdk/src/host/retry.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/host/retry.ts
@@ -29,7 +29,8 @@ import {
   setRetryPolicy as rawSetRetryPolicy,
   removeRetryPolicy as rawRemoveRetryPolicy,
 } from 'golem:api/retry@1.5.0';
-import { executeWithDrop } from './guard';
+import { isPromiseLike } from './guard';
+import { trap } from './hostapi';
 import {
   Duration,
   NamedPolicy,
@@ -100,15 +101,62 @@ export function useRetryPolicy(policy: NamedPolicyInput): RetryPolicyGuard {
   return new RetryPolicyGuard(previous, name);
 }
 
+export function withRetryPolicy<R>(policy: NamedPolicyInput, f: () => Promise<R>): Promise<R>;
+export function withRetryPolicy<R>(policy: NamedPolicyInput, f: () => R): R;
+
 /**
  * Executes a function with a named retry policy temporarily set.
  * Supports both sync and async callbacks.
- * The policy is restored (or removed) after the function completes.
- * @param policy - The named retry policy to set, either as a raw WIT shape or a high-level NamedPolicy.
+ *
+ * On failure the worker is immediately terminated and retried by the executor
+ * according to the active retry policy. This has two practical consequences:
+ *
+ * - Errors thrown inside `f` always trigger the retry policy — this is the
+ *   recommended way to make user-land exceptions subject to executor-level
+ *   retries.
+ * - The callback cannot be wrapped in a `try/catch` to suppress the retry:
+ *   any thrown error unconditionally causes the worker to be retried.
+ *
+ * @param policy - The named retry policy to set.
  * @param f - The function to execute (sync or async).
  * @returns The result of the executed function, or a Promise if an async function was passed.
  */
-export function withRetryPolicy<R>(policy: NamedPolicyInput, f: () => R): R {
+export function withRetryPolicy<R>(
+  policy: NamedPolicyInput,
+  f: () => R | Promise<R>,
+): R | Promise<R> {
   const guard = useRetryPolicy(policy);
-  return executeWithDrop([guard], f);
+  try {
+    const result = f();
+    if (isPromiseLike(result)) {
+      return result.then(
+        (val) => {
+          guard.drop();
+          return val;
+        },
+        (err) => {
+          // Leave the retry policy active and terminate the worker so the
+          // executor retries the invocation with the policy applied.
+          trap(`withRetryPolicy: ${formatErrorForTrap(err)}`);
+          throw err;
+        },
+      ) as R;
+    }
+    guard.drop();
+    return result;
+  } catch (e) {
+    trap(`withRetryPolicy: ${formatErrorForTrap(e)}`);
+    throw e;
+  }
+}
+
+function formatErrorForTrap(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  try {
+    return String(err);
+  } catch {
+    return '<unprintable error>';
+  }
 }

--- a/sdks/ts/packages/golem-ts-sdk/tests/retry.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/retry.test.ts
@@ -247,7 +247,7 @@ describe('retry host helpers', () => {
     expect(trapMock).not.toHaveBeenCalled();
   });
 
-  it('withRetryPolicy calls trap on sync throw and does NOT restore the policy', async () => {
+  it('withRetryPolicy restores the policy on sync throw', async () => {
     getRetryPolicyByNameMock.mockReturnValue(undefined);
     const error = new Error('boom');
 
@@ -259,16 +259,12 @@ describe('retry host helpers', () => {
       }),
     ).toThrow(error);
 
-    // trap must have been called so the executor can retry with the policy active
-    expect(trapMock).toHaveBeenCalledOnce();
-    expect(trapMock.mock.calls[0][0]).toContain('withRetryPolicy');
-
-    // the policy must NOT have been removed — it stays active for the executor's retry
-    expect(removeRetryPolicyMock).not.toHaveBeenCalled();
-    expect(setRetryPolicyMock).toHaveBeenCalledTimes(1); // only the initial set, no restore
+    // policy is cleaned up (removed) on error — the old behaviour
+    expect(removeRetryPolicyMock).toHaveBeenCalledWith('temporary');
+    expect(trapMock).not.toHaveBeenCalled();
   });
 
-  it('withRetryPolicy calls trap on async rejection and does NOT restore the policy', async () => {
+  it('withRetryPolicy restores the policy on async rejection', async () => {
     getRetryPolicyByNameMock.mockReturnValue(undefined);
     const error = new Error('async-boom');
 
@@ -280,9 +276,7 @@ describe('retry host helpers', () => {
       }),
     ).rejects.toThrow(error);
 
-    expect(trapMock).toHaveBeenCalledOnce();
-    expect(trapMock.mock.calls[0][0]).toContain('withRetryPolicy');
-    expect(removeRetryPolicyMock).not.toHaveBeenCalled();
-    expect(setRetryPolicyMock).toHaveBeenCalledTimes(1);
+    expect(removeRetryPolicyMock).toHaveBeenCalledWith('temporary');
+    expect(trapMock).not.toHaveBeenCalled();
   });
 });

--- a/sdks/ts/packages/golem-ts-sdk/tests/retry.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/retry.test.ts
@@ -157,15 +157,18 @@ describe('retry host helpers', () => {
   let getRetryPolicyByNameMock: ReturnType<typeof vi.fn>;
   let setRetryPolicyMock: ReturnType<typeof vi.fn>;
   let removeRetryPolicyMock: ReturnType<typeof vi.fn>;
+  let trapMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     getRetryPolicyByNameMock = vi.fn();
     setRetryPolicyMock = vi.fn();
     removeRetryPolicyMock = vi.fn();
+    trapMock = vi.fn();
   });
 
   afterEach(() => {
     vi.doUnmock('golem:api/retry@1.5.0');
+    vi.doUnmock('golem:api/host@1.5.0');
     vi.resetModules();
   });
 
@@ -177,6 +180,15 @@ describe('retry host helpers', () => {
       resolveRetryPolicy: vi.fn(),
       setRetryPolicy: setRetryPolicyMock,
       removeRetryPolicy: removeRetryPolicyMock,
+    }));
+    vi.doMock('golem:api/host@1.5.0', () => ({
+      trap: trapMock,
+      getOplogPersistenceLevel: vi.fn(),
+      setOplogPersistenceLevel: vi.fn(),
+      getIdempotenceMode: vi.fn(),
+      setIdempotenceMode: vi.fn(),
+      markBeginOperation: vi.fn(),
+      markEndOperation: vi.fn(),
     }));
 
     return import('../src/host/retry');
@@ -232,5 +244,45 @@ describe('retry host helpers', () => {
 
     expect(result).toBe('ok');
     expect(removeRetryPolicyMock).toHaveBeenCalledWith('temporary');
+    expect(trapMock).not.toHaveBeenCalled();
+  });
+
+  it('withRetryPolicy calls trap on sync throw and does NOT restore the policy', async () => {
+    getRetryPolicyByNameMock.mockReturnValue(undefined);
+    const error = new Error('boom');
+
+    const retry = await loadRetryModule();
+
+    expect(() =>
+      retry.withRetryPolicy(NamedPolicy.named('temporary', Policy.immediate()), () => {
+        throw error;
+      }),
+    ).toThrow(error);
+
+    // trap must have been called so the executor can retry with the policy active
+    expect(trapMock).toHaveBeenCalledOnce();
+    expect(trapMock.mock.calls[0][0]).toContain('withRetryPolicy');
+
+    // the policy must NOT have been removed — it stays active for the executor's retry
+    expect(removeRetryPolicyMock).not.toHaveBeenCalled();
+    expect(setRetryPolicyMock).toHaveBeenCalledTimes(1); // only the initial set, no restore
+  });
+
+  it('withRetryPolicy calls trap on async rejection and does NOT restore the policy', async () => {
+    getRetryPolicyByNameMock.mockReturnValue(undefined);
+    const error = new Error('async-boom');
+
+    const retry = await loadRetryModule();
+
+    await expect(
+      retry.withRetryPolicy(NamedPolicy.named('temporary', Policy.immediate()), async () => {
+        throw error;
+      }),
+    ).rejects.toThrow(error);
+
+    expect(trapMock).toHaveBeenCalledOnce();
+    expect(trapMock.mock.calls[0][0]).toContain('withRetryPolicy');
+    expect(removeRetryPolicyMock).not.toHaveBeenCalled();
+    expect(setRetryPolicyMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/test-components/agent-sdk-ts/AGENTS.md
+++ b/test-components/agent-sdk-ts/AGENTS.md
@@ -7,16 +7,37 @@ This project includes coding-agent skills in `.agents/skills/`. Load a skill whe
 
 | Skill | Description |
 |-------|-------------|
+| `golem-cloud-account-setup` | Setting up a Golem Cloud account — authentication, cloud profiles, API tokens, and first cloud deployment |
 | `golem-new-project` | Creating a new Golem application project with `golem new` |
+| `golem-add-component` | Adding a new component or agent templates to an existing application |
+| `golem-edit-manifest` | Editing the Golem Application Manifest (golem.yaml) — components, agents, templates, environments, httpApi, mcp, bridge SDKs, plugins, and more |
 | `golem-build` | Building a Golem application with `golem build` |
+| `golem-troubleshoot-build` | Troubleshooting Golem build failures and debugging manifest file (golem.yaml) configuration — diagnosing tool, dependency, env var, config, and manifest layer issues with `golem component manifest-trace` |
 | `golem-deploy` | Deploying a Golem application with `golem deploy` |
+| `golem-local-dev-server` | Starting and managing the local Golem development server with `golem server` |
+| `golem-rollback` | Rolling back a Golem deployment to a previous revision or version |
+| `golem-redeploy-agents` | Redeploying existing agents by deleting and recreating them |
+| `golem-create-agent-instance-ts` | Creating a new agent instance with `golem agent new` |
+| `golem-invoke-agent-ts` | Invoking a Golem agent method from the CLI |
+| `golem-trigger-agent-ts` | Triggering a fire-and-forget invocation on a Golem agent |
+| `golem-schedule-agent-ts` | Scheduling a future invocation on a Golem agent |
 | `golem-add-npm-package` | Adding an npm package dependency to the project |
+| `golem-add-postgres-ts` | Connecting to PostgreSQL with `golem:rdbms/postgres` from TypeScript agents |
+| `golem-add-mysql-ts` | Connecting to MySQL with `golem:rdbms/mysql` from TypeScript agents |
+| `golem-add-ignite-ts` | Connecting to Apache Ignite 2 with `golem:rdbms/ignite2` from TypeScript agents |
 | `golem-add-agent-ts` | Adding a new agent type to a TypeScript Golem component |
 | `golem-configure-durability-ts` | Choosing between durable and ephemeral agents |
+| `golem-stateless-agent-ts` | Creating ephemeral (stateless) agents with a fresh instance per invocation |
 | `golem-annotate-agent-ts` | Adding prompt and description annotations to agent methods |
 | `golem-call-another-agent-ts` | Calling another agent and awaiting the result (RPC) |
+| `golem-call-from-external-ts` | Calling agents from external TypeScript/Node.js applications using generated bridge SDKs |
 | `golem-fire-and-forget-ts` | Triggering an agent invocation without waiting for the result |
+| `golem-parallel-workers-ts` | Fan out work to multiple parallel agents and collect results |
 | `golem-schedule-future-call-ts` | Scheduling a future agent invocation |
+| `golem-recurring-task-ts` | Implementing recurring (cron-like) tasks via self-scheduling — periodic polling, cleanup, heartbeats, backoff, and cancellation |
+| `golem-wait-for-external-input-ts` | Waiting for external input using Golem promises (human-in-the-loop, webhooks, external events) |
+| `golem-add-webhook-ts` | Creating and awaiting webhooks for integrating with webhook-driven external APIs |
+| `golem-multi-instance-agent-ts` | Creating multiple agent instances with the same constructor parameters using phantom agents |
 | `golem-atomic-block-ts` | Atomic blocks, persistence control, and idempotency |
 | `golem-add-transactions-ts` | Saga-pattern transactions with compensation |
 | `golem-add-http-endpoint-ts` | Exposing an agent over HTTP with mount paths and endpoint decorators |
@@ -24,7 +45,32 @@ This project includes coding-agent skills in `.agents/skills/`. Load a skill whe
 | `golem-add-http-auth-ts` | Enabling authentication and receiving Principal on HTTP endpoints |
 | `golem-add-cors-ts` | Configuring CORS allowed origins for HTTP endpoints |
 | `golem-configure-api-domain` | Configuring HTTP API domain deployments and security schemes in golem.yaml |
+| `golem-configure-mcp-server` | Configuring MCP (Model Context Protocol) server deployments in golem.yaml |
+| `golem-manage-plugins` | Managing Golem plugins — listing available plugins, installing and configuring plugins via golem.yaml or CLI, and understanding built-in plugins like the OTLP exporter |
+| `golem-add-config-ts` | Adding typed configuration to a TypeScript Golem agent |
+| `golem-add-secret-ts` | Adding secrets to TypeScript Golem agents |
+| `golem-quota-ts` | Adding resource quotas (rate limiting, capacity, concurrency) to TypeScript Golem agents using QuotaToken and reservations |
+| `golem-retry-policies-ts` | Configuring semantic retry policies — composable exponential/periodic/fibonacci backoff, predicates on error properties, scoped overrides with `withRetryPolicy`, and live CLI management |
+| `golem-profiles-and-environments` | Understanding CLI profiles, app environments, and component presets — switching between local/cloud, managing deployment targets, and activating per-environment configuration |
+| `golem-add-env-vars` | Defining environment variables for agents in golem.yaml and via CLI |
+| `golem-add-initial-files` | Adding initial files to agent filesystems via golem.yaml |
+| `golem-file-io-ts` | Reading and writing files from agent code |
+| `golem-js-runtime` | JavaScript runtime environment: available Web APIs, Node.js modules, and npm compatibility |
+| `golem-add-llm-ts` | Adding LLM and AI capabilities using third-party npm libraries |
 | `golem-make-http-request-ts` | Making outgoing HTTP requests from agent code using fetch |
+| `golem-logging-ts` | Adding logging to a TypeScript Golem agent using `console` methods |
+| `golem-enable-otlp-ts` | Enabling the OpenTelemetry (OTLP) plugin for a TypeScript agent — exporting traces, logs, and metrics to an OTLP collector, adding custom spans with the invocation context API or `node:diagnostics_channel` |
+| `golem-view-agent-logs` | Viewing agent logs and output via streaming |
+| `golem-view-agent-files` | Listing files in an agent's virtual filesystem |
+| `golem-list-and-filter-agents` | Listing and querying agents with filters |
+| `golem-get-agent-metadata` | Checking agent metadata and status |
+| `golem-debug-agent-history` | Querying the operation log |
+| `golem-undo-agent-state` | Reverting agent state by undoing operations |
+| `golem-interrupt-resume-agent` | Interrupting and resuming a Golem agent |
+| `golem-test-crash-recovery` | Simulating a crash on an agent for testing crash recovery |
+| `golem-cancel-queued-invocation` | Canceling a pending (queued) invocation on an agent |
+| `golem-delete-agent` | Deleting an agent instance |
+| `golem-interactive-repl-ts` | Using the Golem REPL for interactive testing and scripting of agents |
 
 # Golem Application Development Guide (TypeScript)
 
@@ -84,167 +130,6 @@ golem-temp/                           # Build artifacts (gitignored)
 - Node.js (with npm)
 - Golem CLI (`golem`): download from https://github.com/golemcloud/golem/releases
 
-## Building
-
-```shell
-npm install                      # Install dependencies (run once, or after adding packages)
-golem build                      # Build all components
-golem component build my:comp    # Build a specific component
-```
-
-The build runs TypeScript type-checking, type metadata generation via `golem-typegen`, Rollup bundling, QuickJS WASM injection, agent wrapper generation, and WASM composition. Output goes to `golem-temp/`.
-
-Do NOT run `npx rollup` or `npx tsc` directly — always use `golem build` which orchestrates the full pipeline including type metadata generation and WASM component linking.
-
-## Deploying and Running
-
-```shell
-golem server run                 # Start local Golem server
-golem deploy                     # Deploy all components to the configured server
-golem deploy --try-update-agents # Deploy and update running agents
-golem deploy --reset             # Deploy and delete all previously created agents
-```
-
-**WARNING**: `golem server run --clean` deletes all existing state (agents, data, deployed components). Never run it without explicitly asking the user for confirmation first.
-
-After starting the server, components must be deployed with `golem deploy` before agents can be invoked. When iterating on code changes, use `golem deploy --reset` to delete all previously created agents — without this, existing agent instances continue running with the old component version. This is by design: Golem updates do not break existing running instances.
-
-To try out agents after deploying, use `golem agent invoke` for individual method calls, or write a Rib script and run it with `golem repl` for interactive testing. The Golem server must be running in a separate process before invoking or testing agents.
-
-## Name Mapping (Kebab-Case Convention)
-
-All TypeScript identifiers are converted to **kebab-case** when used externally (in CLI commands, Rib scripts, REPL, agent IDs, and WAVE values). This applies to:
-
-- **Agent type names**: `CounterAgent` → `counter-agent`
-- **Method names**: `getCount` → `get-count`, `increment` → `increment`
-- **Record/object field names**: `fieldName` → `field-name`
-- **Variant/union tag names**: `myCase` → `my-case`
-
-This conversion is automatic and consistent across all external interfaces.
-
-## Testing Agents
-
-### Using the REPL
-
-```shell
-golem repl                       # Interactive Rib scripting REPL
-```
-
-In the REPL, use kebab-case names and WAVE-encoded values:
-```rib
-let agent = counter-agent("my-counter")
-agent.increment()
-agent.increment()
-```
-
-### Using `golem agent invoke`
-
-Invoke agent methods directly from the CLI. The method name must be fully qualified:
-
-```shell
-# Method name format: <component-name>/<agent-type>.{method-name}
-# All names in kebab-case
-
-golem agent invoke 'counter-agent("my-counter")' \
-  'my:example/counter-agent.{increment}'
-
-# With arguments (WAVE-encoded)
-golem agent invoke 'my-agent("id")' \
-  'my:example/my-agent.{set-value}' '"hello world"'
-
-# With a record argument
-golem agent invoke 'my-agent("id")' \
-  'my:example/my-agent.{update}' '{field-name: "value", count: 42.0}'
-
-# Fire-and-forget (enqueue without waiting for result)
-golem agent invoke --enqueue 'counter-agent("c1")' \
-  'my:example/counter-agent.{increment}'
-
-# With idempotency key
-golem agent invoke --idempotency-key 'unique-key-123' \
-  'counter-agent("c1")' 'my:example/counter-agent.{increment}'
-```
-
-## WAVE Value Encoding
-
-All argument values passed to `golem agent invoke` and used in Rib scripts follow the [WAVE (WebAssembly Value Encoding)](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-wave) format. See the full [type mapping reference](https://learn.golem.cloud/type-mapping).
-
-### TypeScript Type to WAVE Mapping
-
-| TypeScript Type | WIT Type | WAVE Example |
-|-----------------|----------|--------------|
-| `string` | `string` | `"hello world"` |
-| `boolean` | `bool` | `true`, `false` |
-| `number` | `f64` | `1234.0` |
-| `Array<T>` | `list<T>` | `[1.0, 2.0, 3.0]` |
-| `Map<K, V>` | `list<tuple<K, V>>` | `[("key1", 100.0), ("key2", 200.0)]` |
-| `T \| undefined` or `T \| null` | `option<T>` | `some("value")`, `none` |
-| `object` / interface | `record { ... }` | `{field-name: "value", count: 42.0}` |
-| `{ tag: "x", val: T }` union | `variant { ... }` | `my-case("data")` |
-| `"x" \| "y"` string literal union | `enum { ... }` | `my-variant` |
-| tuple | `tuple<...>` | `("hello", 1234.0, true)` |
-| `Uint8Array` | `list<u8>` | `[104, 101, 108]` |
-
-### WAVE Encoding Rules
-
-**Strings**: double-quoted with escape sequences (`\"`, `\\`, `\n`, `\t`, `\r`, `\u{...}`)
-```
-"hello \"world\""
-```
-
-**Records**: field names in kebab-case, optional fields (`T | undefined`) can be omitted (defaults to `none`)
-```
-{required-field: "value", optional-field: some(42.0)}
-{required-field: "value"}
-```
-
-**Variants**: case name in kebab-case, with optional payload in parentheses
-```
-my-case
-my-case("payload")
-```
-
-**Options**: can use shorthand (bare value = `some`)
-```
-some(42.0)    // explicit
-42.0          // shorthand for some(42.0), only for non-option/non-result inner types
-none
-```
-
-**Results**: can use shorthand (bare value = `ok`)
-```
-ok("value")   // explicit ok
-err("oops")   // explicit err
-"value"       // shorthand for ok("value")
-```
-
-**Flags**: set of labels in curly braces
-```
-{read, write}
-{}
-```
-
-**Keywords as identifiers**: prefix with `%` if a name conflicts with `true`, `false`, `some`, `none`, `ok`, `err`, `inf`, `nan`
-```
-%true
-%none
-```
-
-## Defining Agents
-
-Load the `golem-add-agent-ts` skill for defining agents and custom types. See also the skill table above for durability configuration, annotations, RPC, atomic blocks, and transactions.
-
-## Application Manifest (golem.yaml)
-
-- Root `golem.yaml`: app name, includes, environments, and `components` entries
-- `golem-temp/common/ts/golem.yaml`: generated on-demand build templates (TypeScript compilation, Rollup bundling, WASM composition) shared by all TS components
-
-Key fields in each `components.<name>` entry:
-- `dir`: component directory (`"."` for single-component apps)
-- `templates`: references a template from common golem.yaml (e.g., `ts`)
-- `env`: environment variables passed to agents at runtime
-- `dependencies`: WASM dependencies (e.g., LLM providers from golem-ai)
-
 ## Available Libraries
 
 From root `package.json`:
@@ -254,16 +139,6 @@ From root `package.json`:
 - `typescript` (dev) — TypeScript compiler
 
 To enable AI features, uncomment the relevant provider dependency in the component's `golem.yaml` and set the corresponding environment variables.
-
-## Debugging
-
-```shell
-golem agent get '<agent-id>'                    # Check agent state
-golem agent stream '<agent-id>'                 # Stream live logs
-golem agent oplog '<agent-id>'                  # View operation log
-golem agent revert '<agent-id>' --number-of-invocations 1  # Revert last invocation
-golem agent invoke '<agent-id>' 'method' args   # Invoke method directly
-```
 
 ## Key Constraints
 

--- a/test-components/agent-sdk-ts/src/main.ts
+++ b/test-components/agent-sdk-ts/src/main.ts
@@ -1,4 +1,5 @@
 import './config.js'
 import './http.js'
 import './quota_rpc.js'
+import './retry.js'
 import './websocket.js'

--- a/test-components/agent-sdk-ts/src/retry.ts
+++ b/test-components/agent-sdk-ts/src/retry.ts
@@ -1,0 +1,42 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  BaseAgent,
+  agent,
+  NamedPolicy,
+  Policy,
+  atomically,
+  withRetryPolicy,
+} from '@golemcloud/golem-ts-sdk';
+
+@agent()
+class RetryTest extends BaseAgent {
+  constructor(private readonly _name: string) {
+    super();
+  }
+
+  async withRetryPolicyTest(host: string, port: number): Promise<boolean> {
+    const policy = NamedPolicy.named('retry-test', Policy.immediate().maxRetries(10));
+    return withRetryPolicy(policy, () =>
+      atomically(async () => {
+        const response = await fetch(`http://${host}:${port}/attempt`);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return true;
+      }),
+    );
+  }
+}


### PR DESCRIPTION
resolves #3287
resolves #3288

~Uses the same approach as #3309 to automatically trap if an error bubbles up. This still requires users to use atomically in most (all?) cases for language level errors, but I think that makes the behavior more intuitive.~

After the changes in #3309 changing the behaviour here is not really needed. Atomically already automatically traps on bubbling errors, which will fire the current retry policy. Using withRetryPolicy without atomcially does not really work as the cause of the error is already persisted in the oplog and the code until the error is transformed to a trap is deterministic.

Also improves the typing for some functions in the ts sdk a bit using overloads