### PR TITLE
ts-repl: better rendering of types

### DIFF
--- a/cli/golem-cli/tests/app/agents.rs
+++ b/cli/golem-cli/tests/app/agents.rs
@@ -1176,9 +1176,18 @@ async fn test_invoke_and_repl_agent_id_casing_and_normalizing() {
         ])
         .await;
     assert!(outputs.success_or_dump());
-    assert!(outputs.stdout_contains(
-        r#"[{"oneField":"1212","anotherField":100},{"oneField":"1","anotherField":2}]"#
-    ));
+    assert!(outputs.stdout_contains_ordered(vec![
+        "[",
+        "  {",
+        r#"    "oneField": "1212","#,
+        r#"    "anotherField": 100"#,
+        "  },",
+        "  {",
+        r#"    "oneField": "1","#,
+        r#"    "anotherField": 2"#,
+        "  }",
+        "]"
+    ]));
 }
 
 #[test]

--- a/sdks/ts/packages/golem-ts-repl/src/repl.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/repl.ts
@@ -25,6 +25,7 @@ import { LanguageService } from './language-service';
 import pc from 'picocolors';
 import repl, { type REPLEval } from 'node:repl';
 import process from 'node:process';
+import util from 'node:util';
 import { AsyncCompleter } from 'readline';
 import { PassThrough } from 'node:stream';
 import { ts } from 'ts-morph';
@@ -108,6 +109,7 @@ export class Repl {
       ignoreUndefined: true,
       prompt,
       breakEvalOnSigint: true,
+      writer: (value) => util.inspect(value, { depth: null, colors: pc.isColorSupported }),
     });
   }
 
@@ -461,7 +463,7 @@ function tryHandleColonCommand(
 
 function tryJsonStringify(value: unknown): string | undefined {
   try {
-    const json = JSON.stringify(value);
+    const json = JSON.stringify(value, null, 2);
     return json === undefined ? undefined : json;
   } catch {
     return undefined;


### PR DESCRIPTION
resolves #3279


```ts
golem-ts-repl[js-printing-test][local]> a.getDeeplyNested()
> awaiting Promise<printingAgentClient.GetDeeplyNestedOutReturnValue>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
{
  level1a: { level2a: { x: 1, y: 2, z: 3 }, level2b: { x: 4, y: 5, z: 6 } },
  level1b: { level2c: { x: 7, y: 8, z: 9 } }
}
```