### PR TITLE
Add serialized-size metrics to Postgres and SQLite storage backends

### DIFF
--- a/golem-worker-executor/src/storage/indexed/postgres.rs
+++ b/golem-worker-executor/src/storage/indexed/postgres.rs
@@ -20,6 +20,7 @@ use crate::services::golem_config::IndexedStoragePostgresConfig;
 use async_trait::async_trait;
 use futures::FutureExt;
 use golem_common::SafeDisplay;
+use golem_common::metrics::db::record_db_serialized_size;
 use golem_service_base::db::postgres::PostgresPool;
 use golem_service_base::db::{Pool, PoolApi};
 use golem_service_base::migration::{IncludedMigrationsDir, Migrations};
@@ -31,6 +32,8 @@ use tokio::sync::Semaphore;
 
 static DB_MIGRATIONS: include_dir::Dir =
     include_dir!("$CARGO_MANIFEST_DIR/db/migration/postgres/indexed");
+
+const DB_TYPE: &str = "postgres";
 
 #[derive(Debug, Clone)]
 pub struct PostgresIndexedStorage {
@@ -256,13 +259,14 @@ impl IndexedStorage for PostgresIndexedStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: IndexedStorageNamespace,
         key: &str,
         id: u64,
         value: Vec<u8>,
     ) -> Result<(), IndexedStorageError> {
         let _permit = self.acquire_permit().await;
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let id = Self::to_i64(id, "id")?;
         let query = sqlx::query(
             "INSERT INTO index_storage (namespace, key, id, value) VALUES ($1, $2, $3, $4);",
@@ -284,7 +288,7 @@ impl IndexedStorage for PostgresIndexedStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: IndexedStorageNamespace,
         key: &str,
         pairs: Vec<(u64, Vec<u8>)>,
@@ -298,6 +302,7 @@ impl IndexedStorage for PostgresIndexedStorage {
         let key = key.to_string();
         let mut converted_pairs = Vec::with_capacity(pairs.len());
         for (id, value) in pairs {
+            record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
             converted_pairs.push((Self::to_i64(id, "id")?, value));
         }
 

--- a/golem-worker-executor/src/storage/indexed/sqlite.rs
+++ b/golem-worker-executor/src/storage/indexed/sqlite.rs
@@ -18,9 +18,12 @@ use super::{
 };
 use async_trait::async_trait;
 use golem_common::SafeDisplay;
+use golem_common::metrics::db::record_db_serialized_size;
 use golem_service_base::db::sqlite::SqlitePool;
 use golem_service_base::repo::RepoError;
 use std::time::Duration;
+
+const DB_TYPE: &str = "sqlite";
 
 #[derive(Debug, Clone)]
 pub struct SqliteIndexedStorage {
@@ -206,12 +209,13 @@ impl IndexedStorage for SqliteIndexedStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: IndexedStorageNamespace,
         key: &str,
         id: u64,
         value: Vec<u8>,
     ) -> Result<(), IndexedStorageError> {
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let query = sqlx::query(
             r#"
                     INSERT INTO index_storage (namespace, key, id, value) VALUES (?,?,?,?);

--- a/golem-worker-executor/src/storage/keyvalue/postgres.rs
+++ b/golem-worker-executor/src/storage/keyvalue/postgres.rs
@@ -18,11 +18,14 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::FutureExt;
 use golem_common::SafeDisplay;
+use golem_common::metrics::db::record_db_serialized_size;
 use golem_service_base::db::postgres::PostgresPool;
 use golem_service_base::db::{Pool, PoolApi};
 use golem_service_base::migration::{IncludedMigrationsDir, Migrations};
 use include_dir::include_dir;
 use sqlx::{Postgres, QueryBuilder};
+
+const DB_TYPE: &str = "postgres";
 
 static DB_MIGRATIONS: include_dir::Dir =
     include_dir!("$CARGO_MANIFEST_DIR/db/migration/postgres/keyvalue");
@@ -83,11 +86,12 @@ impl KeyValueStorage for PostgresKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         key: &str,
         value: &[u8],
     ) -> Result<(), String> {
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let query =
             sqlx::query("INSERT INTO kv_storage (namespace, key, value) VALUES ($1, $2, $3) ON CONFLICT (namespace, key) DO UPDATE SET value = EXCLUDED.value;")
                 .bind(Self::namespace(namespace))
@@ -106,7 +110,7 @@ impl KeyValueStorage for PostgresKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         pairs: &[(&str, &[u8])],
     ) -> Result<(), String> {
@@ -117,7 +121,10 @@ impl KeyValueStorage for PostgresKeyValueStorage {
         let namespace = Self::namespace(namespace);
         let pairs: Vec<(String, Vec<u8>)> = pairs
             .iter()
-            .map(|(key, value)| ((*key).to_string(), (*value).to_vec()))
+            .map(|(key, value)| {
+                record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
+                ((*key).to_string(), (*value).to_vec())
+            })
             .collect();
 
         self.pool
@@ -151,11 +158,12 @@ impl KeyValueStorage for PostgresKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         key: &str,
         value: &[u8],
     ) -> Result<bool, String> {
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let query = sqlx::query(
             "INSERT INTO kv_storage (namespace, key, value) VALUES ($1, $2, $3) ON CONFLICT (namespace, key) DO NOTHING;",
         )

--- a/golem-worker-executor/src/storage/keyvalue/sqlite.rs
+++ b/golem-worker-executor/src/storage/keyvalue/sqlite.rs
@@ -16,9 +16,12 @@ use crate::storage::keyvalue::{KeyValueStorage, KeyValueStorageNamespace};
 use async_trait::async_trait;
 use bytes::Bytes;
 use golem_common::SafeDisplay;
+use golem_common::metrics::db::record_db_serialized_size;
 use golem_service_base::db::DBValue;
 use golem_service_base::db::sqlite::SqlitePool;
 use std::collections::HashMap;
+
+const DB_TYPE: &str = "sqlite";
 
 #[derive(Debug, Clone)]
 pub struct SqliteKeyValueStorage {
@@ -113,11 +116,12 @@ impl KeyValueStorage for SqliteKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         key: &str,
         value: &[u8],
     ) -> Result<(), String> {
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let query = sqlx::query(
             "INSERT OR REPLACE INTO kv_storage (key, value, namespace) VALUES (?, ?, ?);",
         )
@@ -137,7 +141,7 @@ impl KeyValueStorage for SqliteKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         pairs: &[(&str, &[u8])],
     ) -> Result<(), String> {
@@ -145,6 +149,7 @@ impl KeyValueStorage for SqliteKeyValueStorage {
         let mut tx = api.begin().await.map_err(|err| err.to_safe_string())?;
 
         for (field_key, field_value) in pairs {
+            record_db_serialized_size(DB_TYPE, svc_name, entity_name, field_value.len());
             tx.execute(
                 sqlx::query(
                     "INSERT OR REPLACE INTO kv_storage (key, value, namespace) VALUES (?, ?, ?);",
@@ -163,7 +168,7 @@ impl KeyValueStorage for SqliteKeyValueStorage {
         &self,
         svc_name: &'static str,
         api_name: &'static str,
-        _entity_name: &'static str,
+        entity_name: &'static str,
         namespace: KeyValueStorageNamespace,
         key: &str,
         value: &[u8],
@@ -180,6 +185,7 @@ impl KeyValueStorage for SqliteKeyValueStorage {
             .await
             .map_err(|err| err.to_safe_string())?;
 
+        record_db_serialized_size(DB_TYPE, svc_name, entity_name, value.len());
         let query = sqlx::query(
             "INSERT OR IGNORE INTO kv_storage (key, value, namespace) VALUES (?, ?, ?);",
         )


### PR DESCRIPTION
This is to fix Grafana dashboard panels (oplog, promise, scheduler, worker entry sizes) that broke after we moved to Postgres based backends for indexed_storage and kv_storage etc. Redis used to report this