### PR TITLE
TS REPL: more remote method type hints

### DIFF
--- a/sdks/ts/packages/golem-ts-repl/src/format.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/format.ts
@@ -116,8 +116,12 @@ function splitTopLevelParams(text: string): string[] {
   let bracketDepth = 0;
   let parenDepth = 0;
   let angleDepth = 0;
+  let stringState: StringLiteralState = {};
 
   for (const { char, index } of chars) {
+    stringState = updateStringLiteralState(stringState, char);
+    if (stringState.active || stringState.justEnteredOrExited) continue;
+
     if (char === '{') braceDepth++;
     else if (char === '}') braceDepth = Math.max(0, braceDepth - 1);
     else if (char === '[') bracketDepth++;
@@ -170,8 +174,12 @@ function splitTopLevelUnion(text: string): string[] {
   let bracketDepth = 0;
   let parenDepth = 0;
   let angleDepth = 0;
+  let stringState: StringLiteralState = {};
 
   for (const { char, index } of chars) {
+    stringState = updateStringLiteralState(stringState, char);
+    if (stringState.active || stringState.justEnteredOrExited) continue;
+
     if (char === '{') braceDepth++;
     else if (char === '}') braceDepth = Math.max(0, braceDepth - 1);
     else if (char === '[') bracketDepth++;
@@ -198,10 +206,45 @@ function splitTopLevelUnion(text: string): string[] {
 }
 
 function findTopLevelChar(text: string, needle: string): number | undefined {
+  let stringState: StringLiteralState = {};
   for (const { char, index } of visibleChars(text)) {
+    stringState = updateStringLiteralState(stringState, char);
+    if (stringState.active || stringState.justEnteredOrExited) continue;
+
     if (char === needle) return index;
   }
   return undefined;
+}
+
+type StringLiteralState = {
+  quote?: '"' | "'" | '`';
+  escaped?: boolean;
+  active?: boolean;
+  justEnteredOrExited?: boolean;
+};
+
+function updateStringLiteralState(state: StringLiteralState, char: string): StringLiteralState {
+  if (state.quote) {
+    if (state.escaped) {
+      return { ...state, escaped: false, active: true, justEnteredOrExited: false };
+    }
+
+    if (char === '\\') {
+      return { ...state, escaped: true, active: true, justEnteredOrExited: false };
+    }
+
+    if (char === state.quote) {
+      return { justEnteredOrExited: true };
+    }
+
+    return { ...state, active: true, justEnteredOrExited: false };
+  }
+
+  if (char === '"' || char === "'" || char === '`') {
+    return { quote: char, active: true, justEnteredOrExited: true };
+  }
+
+  return {};
 }
 
 function trimVisible(value: string): string {

--- a/sdks/ts/packages/golem-ts-repl/src/format.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/format.ts
@@ -29,7 +29,7 @@ export function logSnippetInfo(message: string | string[]) {
   let maxLineLength = 0;
   lines.forEach((line) => {
     maxLineLength = Math.max(maxLineLength, util.stripVTControlCharacters(line).length);
-    writeln(`${INFO_PREFIX} ${line}`);
+    writeln(pc.reset(`${INFO_PREFIX} ${line}`));
   });
 
   if (maxLineLength > 0) {

--- a/sdks/ts/packages/golem-ts-repl/src/format.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/format.ts
@@ -62,7 +62,9 @@ function visibleLength(value: string): number {
   return util.stripVTControlCharacters(value).length;
 }
 
-function findCallableSignature(line: string): { paramsStart: number; paramsEnd: number } | undefined {
+function findCallableSignature(
+  line: string,
+): { paramsStart: number; paramsEnd: number } | undefined {
   const chars = visibleChars(line);
   const parenStart = chars.findIndex((char) => char.char === '(');
   if (parenStart < 0) return;
@@ -122,9 +124,16 @@ function splitTopLevelParams(text: string): string[] {
     else if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
     else if (char === '(') parenDepth++;
     else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) angleDepth++;
+    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0)
+      angleDepth++;
     else if (char === '>' && angleDepth > 0) angleDepth--;
-    else if (char === ',' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0 && angleDepth === 0) {
+    else if (
+      char === ',' &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      parenDepth === 0 &&
+      angleDepth === 0
+    ) {
       result.push(text.slice(start, index));
       start = index + 1;
     }
@@ -169,9 +178,16 @@ function splitTopLevelUnion(text: string): string[] {
     else if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
     else if (char === '(') parenDepth++;
     else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) angleDepth++;
+    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0)
+      angleDepth++;
     else if (char === '>' && angleDepth > 0) angleDepth--;
-    else if (char === '|' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0 && angleDepth === 0) {
+    else if (
+      char === '|' &&
+      braceDepth === 0 &&
+      bracketDepth === 0 &&
+      parenDepth === 0 &&
+      angleDepth === 0
+    ) {
       result.push(text.slice(start, index));
       start = index + 1;
     }

--- a/sdks/ts/packages/golem-ts-repl/src/format.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/format.ts
@@ -20,7 +20,10 @@ export const INFO_PREFIX = pc.bold(pc.red('>'));
 export const INFO_PREFIX_LENGTH = util.stripVTControlCharacters(INFO_PREFIX).length + 1;
 
 export function logSnippetInfo(message: string | string[]) {
-  const lines = Array.isArray(message) ? message : message.split('\n');
+  const availableLineLength = getTerminalWidth() - INFO_PREFIX_LENGTH;
+  const lines = (Array.isArray(message) ? message : message.split('\n')).flatMap((line) =>
+    wrapSnippetInfoLine(line, availableLineLength),
+  );
   if (lines.length === 0) return;
 
   let maxLineLength = 0;
@@ -32,6 +35,188 @@ export function logSnippetInfo(message: string | string[]) {
   if (maxLineLength > 0) {
     writeFullLineSeparator();
   }
+}
+
+export function wrapSnippetInfoLine(line: string, maxLineLength: number): string[] {
+  if (maxLineLength <= 0 || visibleLength(line) <= maxLineLength) return [line];
+
+  const signature = findCallableSignature(line);
+  if (!signature) return [line];
+
+  const params = splitTopLevelParams(line.slice(signature.paramsStart + 1, signature.paramsEnd));
+  if (params.length <= 1) return [line];
+
+  const baseIndent = line.match(/^\s*/)?.[0] ?? '';
+  const prefix = line.slice(0, signature.paramsStart + 1);
+  const suffix = line.slice(signature.paramsEnd);
+  const firstLine = trimVisibleEnd(prefix);
+  const paramLines = params.flatMap((param, index) => {
+    const comma = index === params.length - 1 ? '' : ',';
+    return wrapParamLine(`${baseIndent}  ${trimVisible(param)}${comma}`, maxLineLength);
+  });
+
+  return [firstLine, ...paramLines, `${baseIndent}${trimVisibleStart(suffix)}`];
+}
+
+function visibleLength(value: string): number {
+  return util.stripVTControlCharacters(value).length;
+}
+
+function findCallableSignature(line: string): { paramsStart: number; paramsEnd: number } | undefined {
+  const chars = visibleChars(line);
+  const parenStart = chars.findIndex((char) => char.char === '(');
+  if (parenStart < 0) return;
+
+  const beforeParen = chars
+    .slice(0, parenStart)
+    .map((char) => char.char)
+    .join('')
+    .trimEnd();
+  if (beforeParen && !beforeParen.endsWith(':')) return;
+
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let angleDepth = 0;
+
+  for (let i = parenStart; i < chars.length; i++) {
+    const char = chars[i].char;
+    if (char === '(') parenDepth++;
+    else if (char === ')') {
+      parenDepth--;
+      if (parenDepth === 0) {
+        const afterParen = chars
+          .slice(i + 1)
+          .map((entry) => entry.char)
+          .join('')
+          .trimStart();
+        if (afterParen.startsWith(':') || afterParen.startsWith('=>')) {
+          return { paramsStart: chars[parenStart].index, paramsEnd: chars[i].index };
+        }
+        return undefined;
+      }
+    } else if (char === '{') braceDepth++;
+    else if (char === '}') braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === '[') bracketDepth++;
+    else if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === '<' && parenDepth > 0 && braceDepth === 0 && bracketDepth === 0) angleDepth++;
+    else if (char === '>' && angleDepth > 0) angleDepth--;
+  }
+
+  return undefined;
+}
+
+function splitTopLevelParams(text: string): string[] {
+  const chars = visibleChars(text);
+  const result: string[] = [];
+  let start = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let angleDepth = 0;
+
+  for (const { char, index } of chars) {
+    if (char === '{') braceDepth++;
+    else if (char === '}') braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === '[') bracketDepth++;
+    else if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === '(') parenDepth++;
+    else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) angleDepth++;
+    else if (char === '>' && angleDepth > 0) angleDepth--;
+    else if (char === ',' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0 && angleDepth === 0) {
+      result.push(text.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  result.push(text.slice(start));
+  return result.map(trimVisible).filter(Boolean);
+}
+
+function wrapParamLine(line: string, maxLineLength: number): string[] {
+  if (visibleLength(line) <= maxLineLength) return [line];
+
+  const colonIndex = findTopLevelChar(line, ':');
+  if (colonIndex === undefined) return [line];
+
+  const trailingComma = trimVisibleEnd(line).endsWith(',') ? ',' : '';
+  const withoutComma = trailingComma ? trimVisibleEnd(line).slice(0, -1) : line;
+  const unionParts = splitTopLevelUnion(withoutComma.slice(colonIndex + 1));
+  if (unionParts.length <= 1) return [line];
+
+  const firstPrefix = trimVisibleEnd(withoutComma.slice(0, colonIndex + 1));
+  const continuationIndent = `${line.match(/^\s*/)?.[0] ?? ''}  `;
+  return unionParts.map((part, index) => {
+    const rendered = index === 0 ? `${firstPrefix} ${part}` : `${continuationIndent}| ${part}`;
+    return index === unionParts.length - 1 ? `${rendered}${trailingComma}` : rendered;
+  });
+}
+
+function splitTopLevelUnion(text: string): string[] {
+  const chars = visibleChars(text);
+  const result: string[] = [];
+  let start = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let angleDepth = 0;
+
+  for (const { char, index } of chars) {
+    if (char === '{') braceDepth++;
+    else if (char === '}') braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === '[') bracketDepth++;
+    else if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === '(') parenDepth++;
+    else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === '<' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) angleDepth++;
+    else if (char === '>' && angleDepth > 0) angleDepth--;
+    else if (char === '|' && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0 && angleDepth === 0) {
+      result.push(text.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  result.push(text.slice(start));
+  return result.map(trimVisible).filter(Boolean);
+}
+
+function findTopLevelChar(text: string, needle: string): number | undefined {
+  for (const { char, index } of visibleChars(text)) {
+    if (char === needle) return index;
+  }
+  return undefined;
+}
+
+function trimVisible(value: string): string {
+  return trimVisibleEnd(trimVisibleStart(value));
+}
+
+function trimVisibleStart(value: string): string {
+  const chars = visibleChars(value);
+  const first = chars.find((entry) => !/\s/.test(entry.char));
+  return first ? value.slice(first.index) : '';
+}
+
+function trimVisibleEnd(value: string): string {
+  const chars = visibleChars(value);
+  const last = [...chars].reverse().find((entry) => !/\s/.test(entry.char));
+  return last ? value.slice(0, last.index + 1) : '';
+}
+
+function visibleChars(text: string): Array<{ char: string; index: number }> {
+  const result: Array<{ char: string; index: number }> = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\u001b') {
+      const match = /^\u001b\[[0-9;]*m/.exec(text.slice(i));
+      if (match) {
+        i += match[0].length - 1;
+        continue;
+      }
+    }
+    result.push({ char: text[i], index: i });
+  }
+  return result;
 }
 
 export function formatAsTable(items: string[]): string {

--- a/sdks/ts/packages/golem-ts-repl/src/language-service.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/language-service.ts
@@ -24,6 +24,7 @@ export type SnippetTypeCheckResult =
   | {
       ok: false;
       formattedErrors: string;
+      formattedHints: string[];
     };
 
 export type SnippetQuickInfo = {
@@ -125,6 +126,7 @@ export class LanguageService {
       return {
         ok: false,
         formattedErrors: this.project.formatDiagnosticsWithColorAndContext(errors),
+        formattedHints: this.getRemoteMethodDiagnosticHints(snippet, errors),
       };
     }
   }
@@ -188,7 +190,7 @@ export class LanguageService {
     };
   }
 
-  getSnippetCompletions(): SnippetCompletion | undefined {
+  getSnippetCompletions(options?: { includePlaceholders?: boolean }): SnippetCompletion | undefined {
     const snippet = this.getSnippet();
     if (!snippet) return;
 
@@ -202,8 +204,9 @@ export class LanguageService {
     const rawStart = this.snippetStartPos;
     const rawEnd = rawStart + this.rawSnippet.length;
 
+    const includePlaceholders = options?.includePlaceholders ?? true;
     const placeholderResult =
-      triggerCharacter === '.'
+      !includePlaceholders || triggerCharacter === '.'
         ? undefined
         : this.getSnippetPlaceholderCompletions(snippet, pos, rawStart);
 
@@ -524,6 +527,157 @@ export class LanguageService {
 
     return { checker, typeInfo, remoteMethodExpansion };
   }
+
+  private getRemoteMethodDiagnosticHints(
+    snippet: tsm.SourceFile,
+    diagnostics: tsm.Diagnostic[],
+  ): string[] {
+    const checker = this.project.getTypeChecker();
+    const hints: string[] = [];
+    const seen = new Set<string>();
+
+    for (const diagnostic of diagnostics) {
+      if (!isDiagnosticFromSnippet(diagnostic, snippet)) continue;
+
+      const span = getDiagnosticSpan(diagnostic);
+      const access = span ? getRemoteMethodAccessForDiagnostic(snippet, span) : undefined;
+      if (!access) continue;
+
+      const parameterNames = this.getRemoteMethodParameterNames(access, checker);
+      const hint = formatRemoteMethodOperationHint(access, checker, parameterNames);
+      if (!hint || seen.has(hint)) continue;
+
+      seen.add(hint);
+      hints.push(formatTypeText(hint));
+    }
+
+    return hints;
+  }
+}
+
+function isDiagnosticFromSnippet(diagnostic: tsm.Diagnostic, snippet: tsm.SourceFile): boolean {
+  const sourceFile = diagnostic.getSourceFile();
+  return !sourceFile || sourceFile.getFilePath() === snippet.getFilePath();
+}
+
+function getDiagnosticSpan(
+  diagnostic: tsm.Diagnostic,
+): { start: number; end: number } | undefined {
+  const start = diagnostic.getStart();
+  if (start === undefined) return;
+  return { start, end: start + (diagnostic.getLength() ?? 0) };
+}
+
+function getRemoteMethodAccessForDiagnostic(
+  snippet: tsm.SourceFile,
+  span: { start: number; end: number },
+): tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined {
+  for (const call of getCallsIntersectingSpan(snippet, span)) {
+    const access = getRemoteMethodAccessFromTarget(call.getExpression());
+    if (access) return access;
+  }
+
+  return getRemoteMethodAccessFromUnclosedCall(snippet, span);
+}
+
+function getCallsIntersectingSpan(
+  snippet: tsm.SourceFile,
+  span: { start: number; end: number },
+): tsm.CallExpression[] {
+  const spanEnd = span.end === span.start ? span.start + 1 : span.end;
+  return snippet
+    .getDescendantsOfKind(tsm.SyntaxKind.CallExpression)
+    .filter((call) => call.getStart() < spanEnd && call.getEnd() >= span.start)
+    .sort((a, b) => a.getWidth() - b.getWidth());
+}
+
+function getRemoteMethodAccessFromUnclosedCall(
+  snippet: tsm.SourceFile,
+  span: { start: number; end: number },
+): tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined {
+  const text = snippet.getText();
+  for (const pos of [span.start, Math.max(0, span.end - 1), snippet.getEnd() - 1]) {
+    const openParenPos = findOpenParenForCall(text, pos);
+    if (openParenPos === undefined) continue;
+
+    const target = getAccessEndingAt(snippet, openParenPos);
+    const access = target ? getRemoteMethodAccessFromTarget(target) : undefined;
+    if (access) return access;
+  }
+  return undefined;
+}
+
+function getAccessEndingAt(
+  snippet: tsm.SourceFile,
+  pos: number,
+): tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined {
+  const node = snippet.getDescendantAtPos(Math.max(0, pos - 1));
+  if (!node) return;
+
+  let best: tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined;
+  let current: tsm.Node | undefined = node;
+  while (current) {
+    if (
+      (tsm.Node.isPropertyAccessExpression(current) || tsm.Node.isElementAccessExpression(current)) &&
+      current.getEnd() >= pos
+    ) {
+      best = current;
+    }
+    current = current.getParent();
+  }
+  return best;
+}
+
+const REMOTE_METHOD_OPERATIONS = new Set([
+  'abortable',
+  'trigger',
+  'schedule',
+  'scheduleCancelable',
+]);
+
+function getRemoteMethodAccessFromTarget(
+  target: tsm.Node,
+): tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined {
+  const access = getAccessExpression(target);
+  if (!access) return;
+
+  if (isRemoteMethodType(access.getType())) return access;
+
+  const operationName = getRemoteMethodName(access);
+  if (!operationName || !REMOTE_METHOD_OPERATIONS.has(operationName)) return;
+
+  const receiver = getAccessExpression(access.getExpression());
+  return receiver && isRemoteMethodType(receiver.getType()) ? receiver : undefined;
+}
+
+function getAccessExpression(
+  node: tsm.Node,
+): tsm.PropertyAccessExpression | tsm.ElementAccessExpression | undefined {
+  if (tsm.Node.isPropertyAccessExpression(node) || tsm.Node.isElementAccessExpression(node)) {
+    return node;
+  }
+  return undefined;
+}
+
+function isRemoteMethodType(type: tsm.Type): boolean {
+  return type.getAliasSymbol()?.getName() === REMOTE_METHOD_ALIAS;
+}
+
+function formatRemoteMethodOperationHint(
+  access: tsm.PropertyAccessExpression | tsm.ElementAccessExpression,
+  checker: tsm.TypeChecker,
+  parameterNames?: string[],
+): string | undefined {
+  const parent = access.getParent();
+  const operation =
+    parent && tsm.Node.isPropertyAccessExpression(parent) ? parent.getName() : undefined;
+  const operationName = operation && REMOTE_METHOD_OPERATIONS.has(operation) ? operation : 'invoke';
+  const expansion = getRemoteMethodExpansion(access.getType(), access, checker, parameterNames);
+  if (!expansion) return;
+
+  return expansion
+    .split('\n')
+    .find((line) => operationName === 'invoke' || line.trimStart().startsWith(`${operationName}:`));
 }
 
 function matchTriggerCharacter(
@@ -1396,24 +1550,42 @@ function getRemoteMethodExpansion(
   checker: tsm.TypeChecker,
   parameterNames?: string[],
 ): string | undefined {
-  const aliasSymbol = type.getAliasSymbol();
-  if (!aliasSymbol || aliasSymbol.getName() !== REMOTE_METHOD_ALIAS) return;
-
-  const aliasArgs = type.getAliasTypeArguments();
-  if (aliasArgs.length < 2) return;
+  const aliasArgs = getRemoteMethodAliasArgs(type);
+  if (!aliasArgs) return;
 
   const argsText = formatRemoteMethodArgs(aliasArgs[0], checker, node, parameterNames);
   const returnText = stripImportTypePrefix(
     checker.getTypeText(aliasArgs[1], node, ts.TypeFormatFlags.NoTruncation),
   );
-
-  const scheduleAtText = getRemoteMethodScheduleParam(type, checker, node);
-  const scheduleArgs = argsText ? `${scheduleAtText}, ${argsText}` : scheduleAtText;
+  const scheduleAtText = getRemoteMethodFunctionParam(
+    type,
+    'schedule',
+    0,
+    'scheduleAt',
+    'string',
+    checker,
+    node,
+  );
+  const abortSignalText = getRemoteMethodFunctionParam(
+    type,
+    'abortable',
+    0,
+    'signal',
+    'AbortSignal',
+    checker,
+    node,
+  );
+  const scheduleArgs = joinParameterTexts(scheduleAtText, argsText);
+  const abortableArgs = joinParameterTexts(abortSignalText, argsText);
+  const cancellationTokenText =
+    getRemoteMethodFunctionReturn(type, 'scheduleCancelable', checker, node) ?? 'CancellationToken';
 
   const lines = [
     `(${argsText}): Promise<${returnText}>;`,
+    `abortable: (${abortableArgs}) => Promise<${returnText}>;`,
     `trigger: (${argsText}) => void;`,
     `schedule: (${scheduleArgs}) => void;`,
+    `scheduleCancelable: (${scheduleArgs}) => ${cancellationTokenText};`,
   ];
 
   return lines.map((line) => line.replace(/\(\)/g, '()')).join('\n');
@@ -1425,11 +1597,8 @@ function getRemoteMethodClientSignature(
   location: tsm.Node,
   parameterNames?: string[],
 ): string | undefined {
-  const aliasSymbol = type.getAliasSymbol();
-  if (!aliasSymbol || aliasSymbol.getName() !== REMOTE_METHOD_ALIAS) return;
-
-  const aliasArgs = type.getAliasTypeArguments();
-  if (aliasArgs.length < 2) return;
+  const aliasArgs = getRemoteMethodAliasArgs(type);
+  if (!aliasArgs) return;
 
   const argsText = formatRemoteMethodArgs(aliasArgs[0], checker, location, parameterNames);
   const returnText = stripImportTypePrefix(
@@ -1437,6 +1606,15 @@ function getRemoteMethodClientSignature(
   );
 
   return `(${argsText}) => ${returnText}`;
+}
+
+function getRemoteMethodAliasArgs(type: tsm.Type): [tsm.Type, tsm.Type] | undefined {
+  const aliasSymbol = type.getAliasSymbol();
+  if (!aliasSymbol || aliasSymbol.getName() !== REMOTE_METHOD_ALIAS) return;
+
+  const aliasArgs = type.getAliasTypeArguments();
+  if (aliasArgs.length < 2) return;
+  return [aliasArgs[0], aliasArgs[1]];
 }
 
 function formatRemoteMethodArgs(
@@ -1485,28 +1663,60 @@ function formatRemoteMethodArgs(
   return `...args: ${fallbackTypeText}`;
 }
 
-function getRemoteMethodScheduleParam(
+function joinParameterTexts(...entries: Array<string | undefined>): string {
+  return entries.filter((entry): entry is string => Boolean(entry)).join(', ');
+}
+
+function getRemoteMethodFunctionParam(
   type: tsm.Type,
+  propertyName: string,
+  parameterIndex: number,
+  parameterName: string,
+  fallbackType: string,
   checker: tsm.TypeChecker,
   location: tsm.Node,
 ): string {
+  const signature = getRemoteMethodFunctionSignature(type, propertyName, checker, location);
+  const param = signature?.getParameters()[parameterIndex];
+  const paramType = param
+    ? stripImportTypePrefix(
+        checker.getTypeText(
+          checker.getTypeOfSymbolAtLocation(param, location),
+          location,
+          ts.TypeFormatFlags.NoTruncation,
+        ),
+      )
+    : fallbackType;
+  return `${parameterName}: ${paramType}`;
+}
+
+function getRemoteMethodFunctionReturn(
+  type: tsm.Type,
+  propertyName: string,
+  checker: tsm.TypeChecker,
+  location: tsm.Node,
+): string | undefined {
+  const signature = getRemoteMethodFunctionSignature(type, propertyName, checker, location);
+  const returnType = signature?.getReturnType();
+  if (!returnType) return;
+
+  return stripImportTypePrefix(
+    checker.getTypeText(returnType, location, ts.TypeFormatFlags.NoTruncation),
+  );
+}
+
+function getRemoteMethodFunctionSignature(
+  type: tsm.Type,
+  propertyName: string,
+  checker: tsm.TypeChecker,
+  location: tsm.Node,
+): tsm.Signature | undefined {
   const apparent = type.getApparentType();
-  const scheduleProp = apparent.getProperty('schedule') ?? type.getProperty('schedule');
-  if (scheduleProp) {
-    const scheduleType = checker.getTypeOfSymbolAtLocation(scheduleProp, location);
-    const signature = scheduleType.getCallSignatures()[0];
-    const param = signature?.getParameters()[0];
-    if (param) {
-      const paramType = checker.getTypeOfSymbolAtLocation(param, location);
-      const paramText = stripImportTypePrefix(
-        checker.getTypeText(paramType, location, ts.TypeFormatFlags.NoTruncation),
-      );
-      if (paramText) {
-        return `scheduleAt: ${paramText}`;
-      }
-    }
-  }
-  return 'scheduleAt: string';
+  const prop = apparent.getProperty(propertyName) ?? type.getProperty(propertyName);
+  if (!prop) return;
+
+  const propType = checker.getTypeOfSymbolAtLocation(prop, location);
+  return propType.getCallSignatures()[0];
 }
 
 function parameterNameForIndex(index: number): string {

--- a/sdks/ts/packages/golem-ts-repl/src/language-service.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/language-service.ts
@@ -190,7 +190,9 @@ export class LanguageService {
     };
   }
 
-  getSnippetCompletions(options?: { includePlaceholders?: boolean }): SnippetCompletion | undefined {
+  getSnippetCompletions(options?: {
+    includePlaceholders?: boolean;
+  }): SnippetCompletion | undefined {
     const snippet = this.getSnippet();
     if (!snippet) return;
 
@@ -560,9 +562,7 @@ function isDiagnosticFromSnippet(diagnostic: tsm.Diagnostic, snippet: tsm.Source
   return !sourceFile || sourceFile.getFilePath() === snippet.getFilePath();
 }
 
-function getDiagnosticSpan(
-  diagnostic: tsm.Diagnostic,
-): { start: number; end: number } | undefined {
+function getDiagnosticSpan(diagnostic: tsm.Diagnostic): { start: number; end: number } | undefined {
   const start = diagnostic.getStart();
   if (start === undefined) return;
   return { start, end: start + (diagnostic.getLength() ?? 0) };
@@ -618,7 +618,8 @@ function getAccessEndingAt(
   let current: tsm.Node | undefined = node;
   while (current) {
     if (
-      (tsm.Node.isPropertyAccessExpression(current) || tsm.Node.isElementAccessExpression(current)) &&
+      (tsm.Node.isPropertyAccessExpression(current) ||
+        tsm.Node.isElementAccessExpression(current)) &&
       current.getEnd() >= pos
     ) {
       best = current;

--- a/sdks/ts/packages/golem-ts-repl/src/repl.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/repl.ts
@@ -187,7 +187,10 @@ export class Repl {
           evalCode(code);
         }
       } else {
-        const completions = languageService.getSnippetCompletions({ includePlaceholders: false });
+        const formattedHints = typeCheckResult.formattedHints;
+        const completions = languageService.getSnippetCompletions({
+          includePlaceholders: formattedHints.length === 0,
+        });
         if (completions && completions.entries.length) {
           let entries = completions.entries;
           if (completions.entries.length > MAX_COMPLETION_ENTRIES) {
@@ -198,8 +201,8 @@ export class Repl {
           logSnippetInfo(formatAsTable(entries));
         }
 
-        if (typeCheckResult.formattedHints.length) {
-          logSnippetInfo(typeCheckResult.formattedHints.map((hint) => pc.bold(hint)));
+        if (formattedHints.length) {
+          logSnippetInfo(formattedHints);
         }
 
         writeln(typeCheckResult.formattedErrors);

--- a/sdks/ts/packages/golem-ts-repl/src/repl.ts
+++ b/sdks/ts/packages/golem-ts-repl/src/repl.ts
@@ -177,7 +177,7 @@ export class Repl {
           evalCode(code);
         }
       } else {
-        const completions = languageService.getSnippetCompletions();
+        const completions = languageService.getSnippetCompletions({ includePlaceholders: false });
         if (completions && completions.entries.length) {
           let entries = completions.entries;
           if (completions.entries.length > MAX_COMPLETION_ENTRIES) {
@@ -186,6 +186,10 @@ export class Repl {
           }
 
           logSnippetInfo(formatAsTable(entries));
+        }
+
+        if (typeCheckResult.formattedHints.length) {
+          logSnippetInfo(typeCheckResult.formattedHints.map((hint) => pc.bold(hint)));
         }
 
         writeln(typeCheckResult.formattedErrors);

--- a/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+import { wrapSnippetInfoLine } from '../src/format';
+
+describe('wrapSnippetInfoLine', () => {
+  it('does not wrap short callable signatures', () => {
+    const line = '(x: number): Promise<number>;';
+
+    expect(wrapSnippetInfoLine(line, 120)).toEqual([line]);
+  });
+
+  it('wraps long callable signatures by top-level parameters', () => {
+    expect(
+      wrapSnippetInfoLine(
+        '(x: number, y: string, z: { tag: "case1"; val: number; } | { tag: "case2"; val: string; }): Promise<number>;',
+        50,
+      ),
+    ).toEqual([
+      '(',
+      '  x: number,',
+      '  y: string,',
+      '  z: { tag: "case1"; val: number; }',
+      '    | { tag: "case2"; val: string; }',
+      '): Promise<number>;',
+    ]);
+  });
+
+  it('wraps long property callable signatures', () => {
+    expect(
+      wrapSnippetInfoLine(
+        'schedule: (scheduleAt: string, x: number, y: string) => void;',
+        40,
+      ),
+    ).toEqual([
+      'schedule: (',
+      '  scheduleAt: string,',
+      '  x: number,',
+      '  y: string',
+      ') => void;',
+    ]);
+  });
+
+  it('does not split generic type arguments', () => {
+    expect(
+      wrapSnippetInfoLine(
+        '(x: Map<string, number>, y: Array<{ a: string, b: number }>): void;',
+        40,
+      ),
+    ).toEqual([
+      '(',
+      '  x: Map<string, number>,',
+      '  y: Array<{ a: string, b: number }>',
+      '): void;',
+    ]);
+  });
+
+  it('preserves base indentation when wrapping', () => {
+    expect(
+      wrapSnippetInfoLine(
+        '  abortable: (signal: AbortSignal, x: number, y: string) => Promise<number>;',
+        48,
+      ),
+    ).toEqual([
+      '  abortable: (',
+      '    signal: AbortSignal,',
+      '    x: number,',
+      '    y: string',
+      '  ) => Promise<number>;',
+    ]);
+  });
+});

--- a/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
@@ -64,6 +64,25 @@ describe('wrapSnippetInfoLine', () => {
     ]);
   });
 
+  it('does not split commas inside string literal types', () => {
+    expect(wrapSnippetInfoLine('(x: "a,b", y: string): void;', 20)).toEqual([
+      '(',
+      '  x: "a,b",',
+      '  y: string',
+      '): void;',
+    ]);
+  });
+
+  it('does not split unions inside string literal types', () => {
+    expect(wrapSnippetInfoLine('(x: "ok|failed" | "unknown", y: string): void;', 24)).toEqual([
+      '(',
+      '  x: "ok|failed"',
+      '    | "unknown",',
+      '  y: string',
+      '): void;',
+    ]);
+  });
+
   it('preserves base indentation when wrapping', () => {
     expect(
       wrapSnippetInfoLine(

--- a/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/format.test.ts
@@ -40,10 +40,7 @@ describe('wrapSnippetInfoLine', () => {
 
   it('wraps long property callable signatures', () => {
     expect(
-      wrapSnippetInfoLine(
-        'schedule: (scheduleAt: string, x: number, y: string) => void;',
-        40,
-      ),
+      wrapSnippetInfoLine('schedule: (scheduleAt: string, x: number, y: string) => void;', 40),
     ).toEqual([
       'schedule: (',
       '  scheduleAt: string,',

--- a/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it } from 'vitest';
 import util from 'node:util';
+import { describe, expect, it } from 'vitest';
 import { LanguageService } from '../src/language-service';
 import type { Config, ReplCliFlags } from '../src/config';
 

--- a/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
@@ -37,6 +37,49 @@ function getSnippetCompletionEntries(history: string, snippet: string): string[]
   return languageService.getSnippetCompletions()?.entries ?? [];
 }
 
+function typeCheckSnippet(history: string, snippet: string, customConfig = config) {
+  const languageService = new LanguageService(customConfig, flags);
+  languageService.addSnippetToHistory(history);
+  languageService.setSnippet(snippet);
+  const result = languageService.typeCheckSnippet();
+  expect(result.ok).toBe(false);
+  return result.ok ? undefined : result;
+}
+
+const remoteMethodHistory = [
+  'type CancellationToken = string;',
+  'type RemoteMethod<Args extends unknown[], R> = {',
+  '  (...args: Args): Promise<R>;',
+  '  abortable: (signal: AbortSignal, ...args: Args) => Promise<R>;',
+  '  trigger: (...args: Args) => void;',
+  '  schedule: (ts: string, ...args: Args) => void;',
+  '  scheduleCancelable: (ts: string, ...args: Args) => CancellationToken;',
+  '};',
+  'declare const MyAgent: { get: RemoteMethod<[string], string> };',
+  'declare function plain(value: string): void;',
+].join('\n');
+
+const remoteMethodConfig: Config = {
+  ...config,
+  agents: {
+    MyAgent: {
+      clientPackageName: '',
+      clientPackageImportedName: '',
+      package: {},
+      mode: 'durable',
+      methodParameterNames: {
+        get: ['authorization'],
+      },
+    },
+  },
+};
+
+function expectRemoteMethodHint(result: { formattedHints: string[] }, expected: string): void {
+  expect(result.formattedHints).toHaveLength(1);
+  expect(result.formattedHints[0]).toContain(expected);
+  expect(result.formattedHints[0]).toContain('authorization');
+}
+
 describe('LanguageService tagged union placeholders', () => {
   it('matches runtime tagged-union semantics for tag-based unions', () => {
     const entries = getSnippetCompletionEntries(
@@ -60,5 +103,98 @@ describe('LanguageService tagged union placeholders', () => {
     );
 
     expect(entries).toEqual(['{ text: "?", kind: "text" }', '{ count: 0, kind: "count" }']);
+  });
+});
+
+describe('LanguageService remote method diagnostic hints', () => {
+  it('enriches missing argument diagnostics for remote method invocation', () => {
+    const result = typeCheckSnippet(remoteMethodHistory, 'MyAgent.get()', remoteMethodConfig);
+
+    expect(result?.formattedErrors).toContain('TS2554');
+    expectRemoteMethodHint(result!, '(authorization: string): Promise<string>;');
+  });
+
+  it('enriches wrong argument diagnostics for remote method invocation', () => {
+    const result = typeCheckSnippet(remoteMethodHistory, 'MyAgent.get(123)', remoteMethodConfig);
+
+    expect(result?.formattedErrors).toContain('TS2345');
+    expectRemoteMethodHint(result!, '(authorization: string): Promise<string>;');
+  });
+
+  it('enriches operation diagnostics with the relevant operation signature', () => {
+    const cases = [
+      ['MyAgent.get.trigger()', 'trigger: (authorization: string) => void;'],
+      [
+        'MyAgent.get.schedule("2026-01-01T00:00:00Z")',
+        'schedule: (scheduleAt: string, authorization: string) => void;',
+      ],
+      [
+        'MyAgent.get.scheduleCancelable("2026-01-01T00:00:00Z")',
+        'scheduleCancelable: (scheduleAt: string, authorization: string) => string;',
+      ],
+      [
+        'MyAgent.get.abortable(new AbortController().signal)',
+        'abortable: (signal: AbortSignal, authorization: string) => Promise<string>;',
+      ],
+    ];
+
+    for (const [snippet, expected] of cases) {
+      const result = typeCheckSnippet(remoteMethodHistory, snippet, remoteMethodConfig);
+
+      expect(result?.formattedErrors).toContain('TS2554');
+      expectRemoteMethodHint(result!, expected);
+    }
+  });
+
+  it('enriches element-access remote method diagnostics', () => {
+    const result = typeCheckSnippet(remoteMethodHistory, 'MyAgent["get"]()', remoteMethodConfig);
+
+    expect(result?.formattedErrors).toContain('TS2554');
+    expectRemoteMethodHint(result!, '(authorization: string): Promise<string>;');
+  });
+
+  it('enriches unfinished remote invocation diagnostics', () => {
+    for (const snippet of ['MyAgent.get(', 'MyAgent.get(1,', 'MyAgent.get(1, 2,']) {
+      const result = typeCheckSnippet(remoteMethodHistory, snippet, remoteMethodConfig);
+
+      expect(result?.formattedErrors).toContain('TS1005');
+      expectRemoteMethodHint(result!, '(authorization: string): Promise<string>;');
+    }
+  });
+
+  it('enriches unfinished remote operation diagnostics', () => {
+    const cases = [
+      ['MyAgent.get.trigger(', 'trigger: (authorization: string) => void;'],
+      [
+        'MyAgent.get.schedule(',
+        'schedule: (scheduleAt: string, authorization: string) => void;',
+      ],
+      [
+        'MyAgent.get.schedule("2026-01-01T00:00:00Z",',
+        'schedule: (scheduleAt: string, authorization: string) => void;',
+      ],
+      [
+        'MyAgent.get.scheduleCancelable(',
+        'scheduleCancelable: (scheduleAt: string, authorization: string) => string;',
+      ],
+      [
+        'MyAgent.get.abortable(',
+        'abortable: (signal: AbortSignal, authorization: string) => Promise<string>;',
+      ],
+    ];
+
+    for (const [snippet, expected] of cases) {
+      const result = typeCheckSnippet(remoteMethodHistory, snippet, remoteMethodConfig);
+
+      expect(result?.formattedErrors).toContain('TS1005');
+      expectRemoteMethodHint(result!, expected);
+    }
+  });
+
+  it('does not enrich normal function diagnostics', () => {
+    const result = typeCheckSnippet(remoteMethodHistory, 'plain()', remoteMethodConfig);
+
+    expect(result?.formattedErrors).toContain('TS2554');
+    expect(result?.formattedHints).toEqual([]);
   });
 });

--- a/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, it } from 'vitest';
+import util from 'node:util';
 import { LanguageService } from '../src/language-service';
 import type { Config, ReplCliFlags } from '../src/config';
 
@@ -76,8 +77,9 @@ const remoteMethodConfig: Config = {
 
 function expectRemoteMethodHint(result: { formattedHints: string[] }, expected: string): void {
   expect(result.formattedHints).toHaveLength(1);
-  expect(result.formattedHints[0]).toContain(expected);
-  expect(result.formattedHints[0]).toContain('authorization');
+  const hint = util.stripVTControlCharacters(result.formattedHints[0]);
+  expect(hint).toContain(expected);
+  expect(hint).toContain('authorization');
 }
 
 describe('LanguageService tagged union placeholders', () => {

--- a/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
+++ b/sdks/ts/packages/golem-ts-repl/tests/languageService.test.ts
@@ -165,10 +165,7 @@ describe('LanguageService remote method diagnostic hints', () => {
   it('enriches unfinished remote operation diagnostics', () => {
     const cases = [
       ['MyAgent.get.trigger(', 'trigger: (authorization: string) => void;'],
-      [
-        'MyAgent.get.schedule(',
-        'schedule: (scheduleAt: string, authorization: string) => void;',
-      ],
+      ['MyAgent.get.schedule(', 'schedule: (scheduleAt: string, authorization: string) => void;'],
       [
         'MyAgent.get.schedule("2026-01-01T00:00:00Z",',
         'schedule: (scheduleAt: string, authorization: string) => void;',


### PR DESCRIPTION
- resolves: https://github.com/golemcloud/golem/issues/3277
- also adds naive multi line formatting for info snippets, making type hints more usable or narrower terminal hints

<img width="1020" height="943" alt="image" src="https://github.com/user-attachments/assets/6ca102b7-71b5-44fd-8ec1-7e76f95c93d2" />

---

<img width="1019" height="272" alt="image" src="https://github.com/user-attachments/assets/63fb51b4-daf0-4a07-b280-4f947305a460" />

---

<img width="764" height="381" alt="image" src="https://github.com/user-attachments/assets/dba2b4ca-c541-4440-91c1-16e2e09ef017" />

---

<img width="545" height="395" alt="image" src="https://github.com/user-attachments/assets/b556d286-c5d3-441f-b678-f8264572ed35" />

---

<img width="760" height="390" alt="image" src="https://github.com/user-attachments/assets/772e538c-38f1-4088-bea2-c61b86c75194" />
