### PR TITLE
impersonation api

### DIFF
--- a/golem-api-grpc/proto/golem/auth/auth_ctx.proto
+++ b/golem-api-grpc/proto/golem/auth/auth_ctx.proto
@@ -17,10 +17,18 @@ message ImpersonatedUserAuthCtx {
   golem.common.AccountId account_id = 1;
 }
 
+message AdminImpersonationAuthCtx {
+  golem.common.AccountId admin_account_id = 1;
+  golem.common.AccountId target_account_id = 2;
+  repeated AccountRole target_account_roles = 3;
+  golem.account.PlanId target_account_plan_id = 4;
+}
+
 message AuthCtx {
   oneof value {
     golem.common.Empty system = 1;
     UserAuthCtx user = 2;
     ImpersonatedUserAuthCtx impersonated_user = 3;
+    AdminImpersonationAuthCtx admin_impersonation = 4;
   }
 }

--- a/golem-api-grpc/proto/golem/auth/auth_ctx.proto
+++ b/golem-api-grpc/proto/golem/auth/auth_ctx.proto
@@ -13,7 +13,7 @@ message UserAuthCtx {
   repeated AccountRole account_roles = 3;
 }
 
-message ImpersonatedUserAuthCtx {
+message AgentAuthCtx {
   golem.common.AccountId account_id = 1;
 }
 
@@ -28,7 +28,7 @@ message AuthCtx {
   oneof value {
     golem.common.Empty system = 1;
     UserAuthCtx user = 2;
-    ImpersonatedUserAuthCtx impersonated_user = 3;
+    AgentAuthCtx agent = 3;
     AdminImpersonationAuthCtx admin_impersonation = 4;
   }
 }

--- a/golem-api-grpc/proto/golem/registry/v1/registry_service.proto
+++ b/golem-api-grpc/proto/golem/registry/v1/registry_service.proto
@@ -72,7 +72,7 @@ message AuthenticateTokenResponse {
 }
 
 message AuthenticateTokenSuccessResponse {
-    golem.auth.UserAuthCtx auth_ctx = 1;
+    golem.auth.AuthCtx auth_ctx = 1;
 }
 
 message GetAuthDetailsForEnvironmentRequest {

--- a/golem-registry-service/db/migration/postgres/023_impersonation_token.sql
+++ b/golem-registry-service/db/migration/postgres/023_impersonation_token.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens ADD COLUMN impersonated_by UUID NULL;
+
+CREATE INDEX tokens_impersonated_by_idx ON tokens (impersonated_by);

--- a/golem-registry-service/db/migration/sqlite/023_impersonation_token.sql
+++ b/golem-registry-service/db/migration/sqlite/023_impersonation_token.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens ADD COLUMN impersonated_by UUID NULL;
+
+CREATE INDEX tokens_impersonated_by_idx ON tokens (impersonated_by);

--- a/golem-registry-service/src/api/admin.rs
+++ b/golem-registry-service/src/api/admin.rs
@@ -1,0 +1,92 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source Available License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::api::ApiResult;
+use crate::services::auth::AuthService;
+use crate::services::token::TokenService;
+use golem_common::model::account::AccountId;
+use golem_common::model::auth::{TokenCreation, TokenWithSecret};
+use golem_common::recorded_http_api_request;
+use golem_service_base::api_tags::ApiTags;
+use golem_service_base::model::auth::{AuthCtx, GolemSecurityScheme};
+use poem_openapi::param::Path;
+use poem_openapi::payload::Json;
+use poem_openapi::*;
+use std::sync::Arc;
+use tracing::Instrument;
+
+pub struct AdminApi {
+    token_service: Arc<TokenService>,
+    auth_service: Arc<AuthService>,
+}
+
+#[OpenApi(
+    prefix_path = "/v1/admin",
+    tag = ApiTags::RegistryService,
+    tag = ApiTags::Account
+)]
+impl AdminApi {
+    pub fn new(token_service: Arc<TokenService>, auth_service: Arc<AuthService>) -> Self {
+        Self {
+            token_service,
+            auth_service,
+        }
+    }
+
+    /// Create an impersonation token for a target account
+    ///
+    /// Creates a short-lived token that, when used for authentication, produces an
+    /// `AdminImpersonation` auth context: access and visibility checks run as the
+    /// target account, but audit writes (created_by fields) record the admin's account ID.
+    ///
+    /// Only users with the `Admin` account role may call this endpoint.
+    #[oai(
+        path = "/impersonate/:account_id",
+        method = "post",
+        operation_id = "create_impersonation_token"
+    )]
+    async fn create_impersonation_token(
+        &self,
+        account_id: Path<AccountId>,
+        request: Json<TokenCreation>,
+        token: GolemSecurityScheme,
+    ) -> ApiResult<Json<TokenWithSecret>> {
+        let record = recorded_http_api_request!(
+            "create_impersonation_token",
+            account_id = account_id.0.to_string()
+        );
+
+        let auth = self.auth_service.authenticate_token(token.secret()).await?;
+
+        let response = self
+            .create_impersonation_token_internal(account_id.0, request.0, auth)
+            .instrument(record.span.clone())
+            .await;
+
+        record.result(response)
+    }
+
+    async fn create_impersonation_token_internal(
+        &self,
+        account_id: AccountId,
+        request: TokenCreation,
+        auth: AuthCtx,
+    ) -> ApiResult<Json<TokenWithSecret>> {
+        let result = self
+            .token_service
+            .create_impersonation_token(account_id, request.expires_at, &auth)
+            .await?;
+        Ok(Json(result))
+    }
+}

--- a/golem-registry-service/src/api/mod.rs
+++ b/golem-registry-service/src/api/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod account_tokens;
 pub mod accounts;
+pub mod admin;
 pub mod agent_secrets;
 pub mod applications;
 pub mod components;
@@ -34,6 +35,7 @@ pub mod security_schemes;
 pub mod tokens;
 
 use self::accounts::AccountsApi;
+use self::admin::AdminApi;
 use self::agent_secrets::AgentSecretsApi;
 use self::applications::ApplicationsApi;
 use self::components::ComponentsApi;
@@ -64,6 +66,7 @@ pub type Apis = (
     ComponentsApi,
     DomainRegistrationsApi,
     (
+        AdminApi,
         EnvironmentPluginGrantsApi,
         EnvironmentsApi,
         EnvironmentSharesApi,
@@ -107,6 +110,10 @@ pub fn make_open_api_service(services: &Services) -> OpenApiService<Apis, ()> {
                 services.auth_service.clone(),
             ),
             (
+                AdminApi::new(
+                    services.token_service.clone(),
+                    services.auth_service.clone(),
+                ),
                 EnvironmentPluginGrantsApi::new(
                     services.environment_plugin_grant_service.clone(),
                     services.auth_service.clone(),

--- a/golem-registry-service/src/grpc/api_impl.rs
+++ b/golem-registry-service/src/grpc/api_impl.rs
@@ -131,7 +131,7 @@ impl RegistryServiceGrpcApi {
     ) -> Result<AuthenticateTokenSuccessResponse, GrpcApiError> {
         let auth_ctx = self
             .auth_service
-            .authenticate_user(TokenSecret::trusted(request.secret))
+            .authenticate_token(TokenSecret::trusted(request.secret))
             .await?;
         Ok(AuthenticateTokenSuccessResponse {
             auth_ctx: Some(auth_ctx.into()),

--- a/golem-registry-service/src/repo/account.rs
+++ b/golem-registry-service/src/repo/account.rs
@@ -355,6 +355,7 @@ impl AccountRepo for DbAccountRepo<PostgresPool> {
                     SELECT
                         t.token_id,
                         t.expires_at as token_expires_at,
+                        t.impersonated_by,
                         a.created_at AS entity_created_at,
                         ar.account_id, ar.revision_id, ar.name, ar.email,
                         ar.plan_id, ar.roles, ar.created_at, ar.created_by, ar.deleted

--- a/golem-registry-service/src/repo/model/account.rs
+++ b/golem-registry-service/src/repo/model/account.rs
@@ -121,6 +121,7 @@ impl TryFrom<AccountExtRevisionRecord> for Account {
 pub struct AccountBySecretRecord {
     pub token_id: Uuid,
     pub token_expires_at: SqlDateTime,
+    pub impersonated_by: Option<Uuid>,
 
     #[sqlx(flatten)]
     pub value: AccountExtRevisionRecord,

--- a/golem-registry-service/src/repo/model/token.rs
+++ b/golem-registry-service/src/repo/model/token.rs
@@ -26,6 +26,10 @@ pub struct TokenRecord {
     pub account_id: Uuid,
     pub created_at: SqlDateTime,
     pub expires_at: SqlDateTime,
+    /// When set, this is an admin impersonation token. The admin's account ID is stored
+    /// here and is used as the actor (created_by) in audit trails, while `account_id`
+    /// is the target account used for access checks.
+    pub impersonated_by: Option<Uuid>,
 }
 
 impl Debug for TokenRecord {
@@ -35,6 +39,7 @@ impl Debug for TokenRecord {
             .field("account_id", &self.account_id)
             .field("created_at", &self.created_at)
             .field("expires_at", &self.expires_at)
+            .field("impersonated_by", &self.impersonated_by)
             .finish()
     }
 }

--- a/golem-registry-service/src/repo/token.rs
+++ b/golem-registry-service/src/repo/token.rs
@@ -146,15 +146,16 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
         self.with_rw("create")
             .fetch_one_as(
                 sqlx::query_as(indoc! { r#"
-                    INSERT INTO tokens (token_id, account_id, secret, created_at, expires_at)
-                    VALUES ($1, $2, $3, $4, $5)
-                    RETURNING token_id, account_id, secret, created_at, expires_at
+                    INSERT INTO tokens (token_id, account_id, secret, created_at, expires_at, impersonated_by)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                    RETURNING token_id, account_id, secret, created_at, expires_at, impersonated_by
                 "#})
                 .bind(token.token_id)
                 .bind(token.account_id)
                 .bind(token.secret)
                 .bind(token.created_at)
-                .bind(token.expires_at),
+                .bind(token.expires_at)
+                .bind(token.impersonated_by),
             )
             .await
             .none_on_unique_violation()
@@ -164,7 +165,8 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
         self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
-                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at
+                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
+                           t.impersonated_by
                     FROM accounts a
                     JOIN tokens t
                         ON t.account_id = a.account_id
@@ -181,7 +183,8 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
         self.with_ro("get_by_secret")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
-                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at
+                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
+                           t.impersonated_by
                     FROM accounts a
                     JOIN tokens t
                         ON t.account_id = a.account_id
@@ -198,7 +201,8 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
         self.with_ro("get_by_account")
             .fetch_all_as(
                 sqlx::query_as(indoc! { r#"
-                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at
+                    SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
+                           t.impersonated_by
                     FROM accounts a
                     JOIN tokens t
                         ON t.account_id = a.account_id

--- a/golem-registry-service/src/services/account.rs
+++ b/golem-registry-service/src/services/account.rs
@@ -226,7 +226,7 @@ impl AccountService {
 
         let record = AccountRevisionRecord::from_model(
             account,
-            DeletableRevisionAuditFields::deletion(auth.account_id().0),
+            DeletableRevisionAuditFields::deletion(auth.actor_account_id().0),
         );
 
         match self.account_repo.delete(record).await {
@@ -311,7 +311,7 @@ impl AccountService {
             account.email.into_inner(),
             plan_id,
             roles,
-            auth.account_id(),
+            auth.actor_account_id(),
         );
 
         let result = self.account_repo.create(record).await;
@@ -334,7 +334,7 @@ impl AccountService {
 
         let record = AccountRevisionRecord::from_model(
             account,
-            DeletableRevisionAuditFields::new(auth.account_id().0),
+            DeletableRevisionAuditFields::new(auth.actor_account_id().0),
         );
 
         let result = self.account_repo.update(record).await;

--- a/golem-registry-service/src/services/agent_secret.rs
+++ b/golem-registry-service/src/services/agent_secret.rs
@@ -127,7 +127,7 @@ impl AgentSecretService {
                 agent_secret_path.clone(),
                 data.secret_type,
                 secret_value,
-                auth.account_id(),
+                auth.actor_account_id(),
             ))
             .await
             .map_err(|err| match err {
@@ -181,7 +181,7 @@ impl AgentSecretService {
             }
         }
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
 
         let stored_agent_secret = self
             .agent_secret_repo
@@ -220,7 +220,7 @@ impl AgentSecretService {
 
         agent_secret.revision = current_revision.next()?;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
 
         let stored_agent_secret = self
             .agent_secret_repo

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -127,7 +127,7 @@ impl ApplicationService {
             name: data.name,
         };
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
         let record = ApplicationRevisionRecord::from_model(application, audit);
 
         let result = self
@@ -164,7 +164,7 @@ impl ApplicationService {
             application.name = new_name
         };
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
         let record = ApplicationRevisionRecord::from_model(application, audit);
 
         let result = self
@@ -201,7 +201,7 @@ impl ApplicationService {
 
         application.revision = application.revision.next()?;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
         let record = ApplicationRevisionRecord::from_model(application, audit);
 
         self.application_repo

--- a/golem-registry-service/src/services/auth.rs
+++ b/golem-registry-service/src/services/auth.rs
@@ -15,10 +15,10 @@
 use crate::repo::account::AccountRepo;
 use crate::repo::model::account::{AccountBySecretRecord, AccountRepoError};
 use chrono::Utc;
-use golem_common::model::account::Account;
-use golem_common::model::auth::{AccountRole, TokenSecret};
+use golem_common::model::account::{Account, AccountId};
+use golem_common::model::auth::TokenSecret;
 use golem_common::{SafeDisplay, error_forwarding};
-use golem_service_base::model::auth::{AuthCtx, UserAuthCtx};
+use golem_service_base::model::auth::{AdminImpersonationAuthCtx, AuthCtx, UserAuthCtx};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use tracing::warn;
@@ -51,7 +51,7 @@ impl AuthService {
         Self { account_repo }
     }
 
-    pub async fn authenticate_user(&self, token: TokenSecret) -> Result<UserAuthCtx, AuthError> {
+    pub async fn authenticate_token(&self, token: TokenSecret) -> Result<AuthCtx, AuthError> {
         let record: AccountBySecretRecord = self
             .account_repo
             .get_by_secret(token.secret())
@@ -64,19 +64,26 @@ impl AuthService {
             return Err(AuthError::CouldNotAuthenticate);
         };
 
-        let account: Account = record.value.try_into()?;
+        let target_account: Account = record.value.try_into()?;
 
-        let account_roles: BTreeSet<AccountRole> = BTreeSet::from_iter(account.roles.clone());
-
-        Ok(UserAuthCtx {
-            account_id: account.id,
-            account_roles,
-            account_plan_id: account.plan_id,
-        })
-    }
-
-    pub async fn authenticate_token(&self, token: TokenSecret) -> Result<AuthCtx, AuthError> {
-        let user = self.authenticate_user(token).await?;
-        Ok(AuthCtx::User(user))
+        match record.impersonated_by {
+            None => {
+                let account_roles = BTreeSet::from_iter(target_account.roles.clone());
+                Ok(AuthCtx::User(UserAuthCtx {
+                    account_id: target_account.id,
+                    account_roles,
+                    account_plan_id: target_account.plan_id,
+                }))
+            }
+            Some(admin_uuid) => {
+                let target_account_roles = BTreeSet::from_iter(target_account.roles.clone());
+                Ok(AuthCtx::AdminImpersonation(AdminImpersonationAuthCtx {
+                    admin_account_id: AccountId(admin_uuid),
+                    target_account_id: target_account.id,
+                    target_account_roles,
+                    target_account_plan_id: target_account.plan_id,
+                }))
+            }
+        }
     }
 }

--- a/golem-registry-service/src/services/auth.rs
+++ b/golem-registry-service/src/services/auth.rs
@@ -18,7 +18,9 @@ use chrono::Utc;
 use golem_common::model::account::{Account, AccountId};
 use golem_common::model::auth::TokenSecret;
 use golem_common::{SafeDisplay, error_forwarding};
-use golem_service_base::model::auth::{AdminImpersonationAuthCtx, AuthCtx, UserAuthCtx};
+use golem_service_base::model::auth::{
+    AdminImpersonationAuthCtx, AuthCtx, GlobalAction, UserAuthCtx,
+};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use tracing::warn;
@@ -67,6 +69,7 @@ impl AuthService {
         let target_account: Account = record.value.try_into()?;
 
         match record.impersonated_by {
+            // Normal login flow
             None => {
                 let account_roles = BTreeSet::from_iter(target_account.roles.clone());
                 Ok(AuthCtx::User(UserAuthCtx {
@@ -75,7 +78,35 @@ impl AuthService {
                     account_plan_id: target_account.plan_id,
                 }))
             }
+            // Impersonation flow
             Some(admin_uuid) => {
+                // ensure the admin account is still alive and still has impersonation rights
+                let admin_account: Account = self
+                    .account_repo
+                    .get_by_id(admin_uuid)
+                    .await?
+                    .ok_or(AuthError::CouldNotAuthenticate)?
+                    .try_into()?;
+
+                {
+                    let account_roles = BTreeSet::from_iter(admin_account.roles.clone());
+                    let admin_auth_ctx = AuthCtx::User(UserAuthCtx {
+                        account_id: admin_account.id,
+                        account_roles,
+                        account_plan_id: admin_account.plan_id,
+                    });
+
+                    if admin_auth_ctx
+                        .authorize_global_action(GlobalAction::ImpersonateUser)
+                        .is_err()
+                    {
+                        warn!(
+                            "Admin that minted the token ({admin_uuid}), is no longer allowed to impersonate. Failing auth"
+                        );
+                        return Err(AuthError::CouldNotAuthenticate);
+                    };
+                }
+
                 let target_account_roles = BTreeSet::from_iter(target_account.roles.clone());
                 Ok(AuthCtx::AdminImpersonation(AdminImpersonationAuthCtx {
                     admin_account_id: AccountId(admin_uuid),

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -155,7 +155,7 @@ impl ComponentWriteService {
             .upload_and_hash_component_wasm(environment_id, wasm.clone())
             .await?;
         record_component_uploaded(
-            &auth.account_id().to_string(),
+            &auth.actor_account_id().to_string(),
             &environment_id.to_string(),
             wasm_bytes,
         );
@@ -219,7 +219,7 @@ impl ComponentWriteService {
             component_metadata,
             wasm_hash,
             wasm_object_store_key,
-            auth.account_id(),
+            auth.actor_account_id(),
         );
 
         let stored_component: Component = self
@@ -329,7 +329,7 @@ impl ComponentWriteService {
                 .upload_and_hash_component_wasm(environment_id, new_wasm.clone())
                 .await?;
             record_component_uploaded(
-                &auth.account_id().to_string(),
+                &auth.actor_account_id().to_string(),
                 &environment_id.to_string(),
                 new_wasm_bytes,
             );
@@ -439,7 +439,7 @@ impl ComponentWriteService {
             }
         }
 
-        let record = ComponentRevisionRecord::from_model(component, auth.account_id());
+        let record = ComponentRevisionRecord::from_model(component, auth.actor_account_id());
 
         let stored_component: Component = self
             .component_repo
@@ -506,7 +506,7 @@ impl ComponentWriteService {
 
         self.component_repo
             .delete(
-                auth.account_id().0,
+                auth.actor_account_id().0,
                 component_id.0,
                 current_revision.next()?.into(),
             )

--- a/golem-registry-service/src/services/deployment/read.rs
+++ b/golem-registry-service/src/services/deployment/read.rs
@@ -402,7 +402,7 @@ impl DeploymentService {
         owner_account_email: Option<&str>,
         auth: &AuthCtx,
     ) -> Result<ResolvedAgentType, DeploymentError> {
-        let caller_account_id = auth.account_id();
+        let caller_account_id = auth.access_account_id();
 
         let record = self
             .deployment_repo

--- a/golem-registry-service/src/services/deployment/write.rs
+++ b/golem-registry-service/src/services/deployment/write.rs
@@ -311,7 +311,7 @@ impl DeploymentWriteService {
         let new_retry_policies = deployment_context.deployment_retry_policy_creations(
             retry_policies_in_environment,
             data.retry_policy_defaults,
-            auth.account_id(),
+            auth.actor_account_id(),
             &mut errors,
         )?;
 
@@ -352,7 +352,7 @@ impl DeploymentWriteService {
             replaced_agent_secrets,
             new_resource_definitions,
             new_retry_policies,
-            auth.account_id(),
+            auth.actor_account_id(),
         )?;
 
         let ext_revision = self
@@ -437,7 +437,7 @@ impl DeploymentWriteService {
         let revision_record = self
             .deployment_repo
             .set_current_deployment(
-                auth.account_id().0,
+                auth.actor_account_id().0,
                 environment_id.0,
                 payload.deployment_revision.into(),
             )

--- a/golem-registry-service/src/services/domain_registration/mod.rs
+++ b/golem-registry-service/src/services/domain_registration/mod.rs
@@ -99,7 +99,7 @@ impl DomainRegistrationService {
 
         let record = DomainRegistrationRecord::from_model(
             domain_registration,
-            ImmutableAuditFields::new(auth.account_id().0),
+            ImmutableAuditFields::new(auth.actor_account_id().0),
         );
 
         let created_record = self
@@ -136,7 +136,7 @@ impl DomainRegistrationService {
 
         let deleted_record = self
             .domain_registration_repo
-            .delete(domain_registration_id.0, auth.account_id().0)
+            .delete(domain_registration_id.0, auth.actor_account_id().0)
             .await?
             .ok_or(DomainRegistrationError::DomainRegistrationNotFound(
                 domain_registration_id,

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -139,7 +139,7 @@ impl EnvironmentService {
             .ensure_environment_within_limits(application.account_id)
             .await?;
 
-        let record = EnvironmentRevisionRecord::creation(data, auth.account_id());
+        let record = EnvironmentRevisionRecord::creation(data, auth.actor_account_id());
 
         let builtin_plugins = self
             .plugin_repo
@@ -152,7 +152,7 @@ impl EnvironmentService {
                 EnvironmentPluginGrantRecord::creation(
                     EnvironmentId(record.environment_id),
                     PluginRegistrationId(p.plugin_id),
-                    auth.account_id(),
+                    auth.actor_account_id(),
                 )
             })
             .collect();
@@ -204,7 +204,7 @@ impl EnvironmentService {
             environment.security_overrides = security_overrides;
         }
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
         let record = EnvironmentRevisionRecord::from_model(environment, audit);
 
         let result = self
@@ -245,7 +245,7 @@ impl EnvironmentService {
 
         environment.revision = current_revision.next()?;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
         let record = EnvironmentRevisionRecord::from_model(environment, audit);
 
         self.environment_repo
@@ -272,7 +272,7 @@ impl EnvironmentService {
             .environment_repo
             .get_by_id(
                 environment_id.0,
-                auth.account_id().0,
+                auth.access_account_id().0,
                 include_deleted,
                 auth.should_override_storage_visibility_rules(),
             )
@@ -301,7 +301,7 @@ impl EnvironmentService {
             .get_by_name(
                 application_id.0,
                 &name.0,
-                auth.account_id().0,
+                auth.access_account_id().0,
                 auth.should_override_storage_visibility_rules(),
             )
             .await?
@@ -330,7 +330,7 @@ impl EnvironmentService {
             .environment_repo
             .list_by_app(
                 application_id.0,
-                auth.account_id().0,
+                auth.access_account_id().0,
                 auth.should_override_storage_visibility_rules(),
             )
             .await?
@@ -389,7 +389,7 @@ impl EnvironmentService {
         // When we go for an admin ui / view, this should be extended with an optional, admin-only parameter that allows listing for a different account.
         self.environment_repo
             .list_visible_to_account(
-                auth.account_id().0,
+                auth.access_account_id().0,
                 account_email.map(|ae| ae.as_str()),
                 app_name.map(|an| an.0.as_str()),
                 env_name.map(|en| en.0.as_str()),

--- a/golem-registry-service/src/services/environment_plugin_grant.rs
+++ b/golem-registry-service/src/services/environment_plugin_grant.rs
@@ -129,7 +129,7 @@ impl EnvironmentPluginGrantService {
         let record = EnvironmentPluginGrantRecord::creation(
             environment_id,
             data.plugin_registration_id,
-            auth.account_id(),
+            auth.actor_account_id(),
         );
 
         let created: EnvironmentPluginGrant = self
@@ -169,7 +169,7 @@ impl EnvironmentPluginGrantService {
         }
 
         self.environment_plugin_grant_repo
-            .delete(environment_plugin_grant_id.0, auth.account_id().0)
+            .delete(environment_plugin_grant_id.0, auth.actor_account_id().0)
             .await?;
 
         Ok(())

--- a/golem-registry-service/src/services/environment_share.rs
+++ b/golem-registry-service/src/services/environment_share.rs
@@ -114,7 +114,8 @@ impl EnvironmentShareService {
         )?;
 
         let id = EnvironmentShareId::new();
-        let record = EnvironmentShareRevisionRecord::creation(id, data.roles, auth.account_id());
+        let record =
+            EnvironmentShareRevisionRecord::creation(id, data.roles, auth.actor_account_id());
 
         let result = self
             .environment_share_repo
@@ -158,7 +159,7 @@ impl EnvironmentShareService {
         environment_share.revision = environment_share.revision.next()?;
         environment_share.roles = update.roles;
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
 
         let result = self
             .environment_share_repo
@@ -204,7 +205,7 @@ impl EnvironmentShareService {
 
         environment_share.revision = current_revision.next()?;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
 
         let result = self
             .environment_share_repo

--- a/golem-registry-service/src/services/http_api_deployment.rs
+++ b/golem-registry-service/src/services/http_api_deployment.rs
@@ -156,7 +156,7 @@ impl HttpApiDeploymentService {
                 data.openapi_endpoint_prefix,
             ),
             data.agents,
-            auth.account_id(),
+            auth.actor_account_id(),
         )?;
 
         let stored_http_api_deployment: HttpApiDeployment = self
@@ -235,7 +235,7 @@ impl HttpApiDeploymentService {
 
         let record = HttpApiDeploymentRevisionRecord::from_model(
             http_api_deployment,
-            DeletableRevisionAuditFields::new(auth.account_id().0),
+            DeletableRevisionAuditFields::new(auth.actor_account_id().0),
         )?;
 
         let stored_http_api_deployment: HttpApiDeployment = self
@@ -298,7 +298,7 @@ impl HttpApiDeploymentService {
 
         self.http_api_deployment_repo
             .delete(
-                auth.account_id().0,
+                auth.actor_account_id().0,
                 http_api_deployment_id.0,
                 current_revision.next()?.into(),
             )

--- a/golem-registry-service/src/services/mcp_deployment.rs
+++ b/golem-registry-service/src/services/mcp_deployment.rs
@@ -147,7 +147,8 @@ impl McpDeploymentService {
             })?;
 
         let id = McpDeploymentId::new();
-        let record = McpDeploymentRevisionRecord::creation(id, auth.account_id(), data.agents)?;
+        let record =
+            McpDeploymentRevisionRecord::creation(id, auth.actor_account_id(), data.agents)?;
 
         let stored_mcp_deployment: McpDeployment = self
             .mcp_deployment_repo
@@ -215,7 +216,7 @@ impl McpDeploymentService {
 
         let record = McpDeploymentRevisionRecord::from_model(
             mcp_deployment,
-            DeletableRevisionAuditFields::new(auth.account_id().0),
+            DeletableRevisionAuditFields::new(auth.actor_account_id().0),
         )?;
 
         let stored_mcp_deployment: McpDeployment = self
@@ -276,7 +277,7 @@ impl McpDeploymentService {
 
         self.mcp_deployment_repo
             .delete(
-                auth.account_id().0,
+                auth.actor_account_id().0,
                 mcp_deployment_id.0,
                 current_revision.next()?.into(),
             )

--- a/golem-registry-service/src/services/plugin_registration.rs
+++ b/golem-registry-service/src/services/plugin_registration.rs
@@ -121,7 +121,7 @@ impl PluginRegistrationService {
             spec,
         };
 
-        let audit = ImmutableAuditFields::new(auth.account_id().0);
+        let audit = ImmutableAuditFields::new(auth.actor_account_id().0);
 
         let record = PluginRecord::from_model(registration, audit);
 
@@ -146,7 +146,7 @@ impl PluginRegistrationService {
 
         let plugin = self
             .plugin_repo
-            .delete(plugin_id.0, auth.account_id().0)
+            .delete(plugin_id.0, auth.actor_account_id().0)
             .await?
             .ok_or(PluginRegistrationError::PluginRegistrationNotFound(
                 plugin_id,

--- a/golem-registry-service/src/services/resource_definition.rs
+++ b/golem-registry-service/src/services/resource_definition.rs
@@ -122,7 +122,7 @@ impl ResourceDefinitionService {
             data.enforcement_action,
             data.unit,
             data.units,
-            auth.account_id(),
+            auth.actor_account_id(),
         )?;
 
         let stored_resource_definition: ResourceDefinition = self
@@ -192,7 +192,7 @@ impl ResourceDefinitionService {
 
         let record = ResourceDefinitionRevisionRecord::from_model(
             resource_definition,
-            DeletableRevisionAuditFields::new(auth.account_id().0),
+            DeletableRevisionAuditFields::new(auth.actor_account_id().0),
         )?;
 
         let stored_resource_definition: ResourceDefinition = self
@@ -235,7 +235,7 @@ impl ResourceDefinitionService {
 
         let record = ResourceDefinitionRevisionRecord::from_model(
             resource_definition,
-            DeletableRevisionAuditFields::deletion(auth.account_id().0),
+            DeletableRevisionAuditFields::deletion(auth.actor_account_id().0),
         )?;
 
         self.resource_definition_repo

--- a/golem-registry-service/src/services/retry_policy.rs
+++ b/golem-registry-service/src/services/retry_policy.rs
@@ -118,7 +118,7 @@ impl RetryPolicyService {
             data.priority,
             predicate_json,
             policy_json,
-            auth.account_id(),
+            auth.actor_account_id(),
         );
 
         let result = self.retry_policy_repo.create(create_record).await;
@@ -167,7 +167,7 @@ impl RetryPolicyService {
             retry_policy.policy_json = policy_json(new_policy.0)?;
         }
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
 
         let result = self
             .retry_policy_repo
@@ -206,7 +206,7 @@ impl RetryPolicyService {
 
         retry_policy.revision = current_revision.next()?;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
 
         let result = self
             .retry_policy_repo

--- a/golem-registry-service/src/services/security_scheme.rs
+++ b/golem-registry-service/src/services/security_scheme.rs
@@ -140,7 +140,7 @@ impl SecuritySchemeService {
             data.client_secret,
             &redirect_url,
             &scopes,
-            auth.account_id(),
+            auth.actor_account_id(),
         );
 
         let result = self
@@ -205,7 +205,7 @@ impl SecuritySchemeService {
             security_scheme.scopes = scopes;
         };
 
-        let audit = DeletableRevisionAuditFields::new(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
 
         let environment_id = security_scheme.environment_id;
 
@@ -251,7 +251,7 @@ impl SecuritySchemeService {
 
         let environment_id = security_scheme.environment_id;
 
-        let audit = DeletableRevisionAuditFields::deletion(auth.account_id().0);
+        let audit = DeletableRevisionAuditFields::deletion(auth.actor_account_id().0);
 
         let result = self
             .security_scheme_repo

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -24,7 +24,7 @@ use golem_common::model::auth::TokenId;
 use golem_common::model::auth::{TokenSecret, TokenWithSecret};
 use golem_common::{SafeDisplay, error_forwarding};
 use golem_service_base::model::auth::AccountAction;
-use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
+use golem_service_base::model::auth::{AuthCtx, AuthorizationError, GlobalAction};
 use golem_service_base::repo::RepoError;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -176,7 +176,7 @@ impl TokenService {
         auth.authorize_account_action(account_id, AccountAction::CreateToken)?;
 
         let secret = TokenSecret::new();
-        self.create_known_secret(account_id, secret, expires_at)
+        self.create_known_secret(account_id, secret, expires_at, None)
             .await
     }
 
@@ -185,6 +185,7 @@ impl TokenService {
         account_id: AccountId,
         secret: TokenSecret,
         expires_at: DateTime<Utc>,
+        impersonated_by: Option<AccountId>,
     ) -> Result<TokenWithSecret, TokenError> {
         let created_at = Utc::now();
         let token_id = TokenId::new();
@@ -195,6 +196,7 @@ impl TokenService {
             account_id: account_id.0,
             created_at: created_at.into(),
             expires_at: expires_at.into(),
+            impersonated_by: impersonated_by.map(|id| id.0),
         };
 
         let record = self
@@ -215,11 +217,50 @@ impl TokenService {
                 .get_optional_by_secret(secret, &AuthCtx::System)
                 .await?;
             if existing.is_none() {
-                self.create_known_secret(*account_id, secret.clone(), DateTime::<Utc>::MAX_UTC)
-                    .await?;
+                self.create_known_secret(
+                    *account_id,
+                    secret.clone(),
+                    DateTime::<Utc>::MAX_UTC,
+                    None,
+                )
+                .await?;
             }
         }
         Ok(())
+    }
+
+    /// Create an impersonation token. Only admin users may call this.
+    /// The token's `account_id` is the target account; `impersonated_by` records the admin.
+    /// When this token is used for authentication the resulting `AuthCtx` is
+    /// `AdminImpersonation`, which uses the target account for access checks but the
+    /// admin account for audit writes.
+    pub async fn create_impersonation_token(
+        &self,
+        target_account_id: AccountId,
+        expires_at: DateTime<Utc>,
+        auth: &AuthCtx,
+    ) -> Result<TokenWithSecret, TokenError> {
+        auth.authorize_global_action(GlobalAction::ImpersonateUser)?;
+
+        // Verify the target account exists.
+        self.account_service
+            .get(target_account_id, &AuthCtx::System)
+            .await
+            .map_err(|err| match err {
+                AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
+                    TokenError::ParentAccountNotFound(target_account_id)
+                }
+                other => other.into(),
+            })?;
+
+        let secret = TokenSecret::new();
+        self.create_known_secret(
+            target_account_id,
+            secret,
+            expires_at,
+            Some(auth.actor_account_id()),
+        )
+        .await
     }
 
     pub async fn delete(&self, token_id: TokenId, auth: &AuthCtx) -> Result<(), TokenError> {

--- a/golem-service-base/src/clients/registry.rs
+++ b/golem-service-base/src/clients/registry.rs
@@ -15,7 +15,7 @@
 use crate::custom_api::CompiledRoutes;
 use crate::grpc::client::{GrpcClient, GrpcClientConfig};
 use crate::mcp::CompiledMcp;
-use crate::model::auth::{AuthCtx, AuthDetailsForEnvironment, UserAuthCtx};
+use crate::model::auth::{AuthCtx, AuthDetailsForEnvironment};
 use crate::model::component::Component;
 use crate::model::environment::EnvironmentState;
 use crate::model::{AccountResourceLimits, ResourceLimits};
@@ -454,11 +454,11 @@ impl RegistryService for GrpcRegistryService {
         match response.result {
             None => Err(RegistryServiceError::empty_response()),
             Some(authenticate_token_response::Result::Success(payload)) => {
-                let user_auth_ctx: UserAuthCtx = payload
+                let auth_ctx: AuthCtx = payload
                     .auth_ctx
                     .ok_or("missing authctx field")?
                     .try_into()?;
-                Ok(AuthCtx::User(user_auth_ctx))
+                Ok(auth_ctx)
             }
             Some(authenticate_token_response::Result::Error(error)) => Err(error.into()),
         }

--- a/golem-service-base/src/model/auth/mod.rs
+++ b/golem-service-base/src/model/auth/mod.rs
@@ -275,10 +275,10 @@ pub struct UserAuthCtx {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-/// AuthCtx for systems that do requests on behalf of users.
+/// AuthCtx for systems or agents that do requests on behalf of users.
 /// A bit more limited in what they can execute, but can be constructed
 /// without any data lookups
-pub struct ImpersonatedUserAuthCtx {
+pub struct AgentAuthCtx {
     pub account_id: AccountId,
 }
 
@@ -297,7 +297,7 @@ pub struct AdminImpersonationAuthCtx {
 pub enum AuthCtx {
     System,
     User(UserAuthCtx),
-    ImpersonatedUser(ImpersonatedUserAuthCtx),
+    Agent(AgentAuthCtx),
     AdminImpersonation(AdminImpersonationAuthCtx),
 }
 
@@ -315,8 +315,8 @@ impl AuthCtx {
         AuthCtx::System
     }
 
-    pub fn impersonated_user(account_id: AccountId) -> AuthCtx {
-        AuthCtx::ImpersonatedUser(ImpersonatedUserAuthCtx { account_id })
+    pub fn agent(account_id: AccountId) -> AuthCtx {
+        AuthCtx::Agent(AgentAuthCtx { account_id })
     }
 
     pub fn admin_impersonation(
@@ -333,18 +333,20 @@ impl AuthCtx {
         })
     }
 
-    pub fn impersonated(&self) -> Self {
+    // Downgrade user auth context to agent auth context. This has weaker permissions
+    // than user auth contexts (due to missing account roles and plan information), but can lead to better
+    // cache hit rates if both user and agent auth is stored in the cache.
+    pub fn downgrade_to_agent(&self) -> Self {
         match self {
-            Self::User(inner) => Self::ImpersonatedUser(ImpersonatedUserAuthCtx {
+            Self::User(inner) => Self::Agent(AgentAuthCtx {
                 account_id: inner.account_id,
             }),
-            Self::ImpersonatedUser(inner) => Self::ImpersonatedUser(ImpersonatedUserAuthCtx {
+            Self::Agent(inner) => Self::Agent(AgentAuthCtx {
                 account_id: inner.account_id,
             }),
             Self::System => Self::System,
-            Self::AdminImpersonation(inner) => Self::ImpersonatedUser(ImpersonatedUserAuthCtx {
-                account_id: inner.target_account_id,
-            }),
+            // Down't downgrade impersonation auth contexts for better logging
+            Self::AdminImpersonation(inner) => Self::AdminImpersonation(inner.clone()),
         }
     }
 
@@ -358,7 +360,7 @@ impl AuthCtx {
         match self {
             Self::System => AccountId::SYSTEM,
             Self::User(user) => user.account_id,
-            Self::ImpersonatedUser(user) => user.account_id,
+            Self::Agent(user) => user.account_id,
             Self::AdminImpersonation(ctx) => ctx.admin_account_id,
         }
     }
@@ -370,7 +372,7 @@ impl AuthCtx {
         match self {
             Self::System => AccountId::SYSTEM,
             Self::User(user) => user.account_id,
-            Self::ImpersonatedUser(user) => user.account_id,
+            Self::Agent(user) => user.account_id,
             Self::AdminImpersonation(ctx) => ctx.target_account_id,
         }
     }
@@ -388,7 +390,7 @@ impl AuthCtx {
         match self {
             Self::System => &SYSTEM_ACCOUNT_ROLES,
             Self::User(user) => &user.account_roles,
-            Self::ImpersonatedUser(_) => &IMPERSONATED_USER_ACCOUNT_ROLES,
+            Self::Agent(_) => &IMPERSONATED_USER_ACCOUNT_ROLES,
             Self::AdminImpersonation(ctx) => &ctx.target_account_roles,
         }
     }
@@ -402,7 +404,7 @@ impl AuthCtx {
         match self {
             Self::System => None,
             Self::User(user) => Some(&user.account_plan_id),
-            Self::ImpersonatedUser(_) => None,
+            Self::Agent(_) => None,
             Self::AdminImpersonation(ctx) => Some(&ctx.target_account_plan_id),
         }
     }
@@ -992,8 +994,7 @@ mod test {
 mod protobuf {
     use super::AuthDetailsForEnvironment;
     use super::{
-        AdminImpersonationAuthCtx, AuthCtx, AuthorizationError, ImpersonatedUserAuthCtx,
-        UserAuthCtx,
+        AdminImpersonationAuthCtx, AgentAuthCtx, AuthCtx, AuthorizationError, UserAuthCtx,
     };
     use golem_common::model::auth::{AccountRole, EnvironmentRole};
 
@@ -1066,12 +1067,10 @@ mod protobuf {
         }
     }
 
-    impl TryFrom<golem_api_grpc::proto::golem::auth::ImpersonatedUserAuthCtx>
-        for ImpersonatedUserAuthCtx
-    {
+    impl TryFrom<golem_api_grpc::proto::golem::auth::AgentAuthCtx> for AgentAuthCtx {
         type Error = String;
         fn try_from(
-            value: golem_api_grpc::proto::golem::auth::ImpersonatedUserAuthCtx,
+            value: golem_api_grpc::proto::golem::auth::AgentAuthCtx,
         ) -> Result<Self, Self::Error> {
             Ok(Self {
                 account_id: value.account_id.ok_or("missing account id")?.try_into()?,
@@ -1079,8 +1078,8 @@ mod protobuf {
         }
     }
 
-    impl From<ImpersonatedUserAuthCtx> for golem_api_grpc::proto::golem::auth::ImpersonatedUserAuthCtx {
-        fn from(value: ImpersonatedUserAuthCtx) -> Self {
+    impl From<AgentAuthCtx> for golem_api_grpc::proto::golem::auth::AgentAuthCtx {
+        fn from(value: AgentAuthCtx) -> Self {
             Self {
                 account_id: Some(value.account_id.into()),
             }
@@ -1150,9 +1149,9 @@ mod protobuf {
                 Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::User(user)) => {
                     Ok(AuthCtx::User(user.try_into()?))
                 }
-                Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::ImpersonatedUser(
-                    impersonated_user,
-                )) => Ok(AuthCtx::ImpersonatedUser(impersonated_user.try_into()?)),
+                Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::Agent(agent)) => {
+                    Ok(AuthCtx::Agent(agent.try_into()?))
+                }
                 Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::AdminImpersonation(
                     ctx,
                 )) => Ok(AuthCtx::AdminImpersonation(ctx.try_into()?)),
@@ -1174,12 +1173,10 @@ mod protobuf {
                         user.into(),
                     )),
                 },
-                AuthCtx::ImpersonatedUser(impersonated_user) => Self {
-                    value: Some(
-                        golem_api_grpc::proto::golem::auth::auth_ctx::Value::ImpersonatedUser(
-                            impersonated_user.into(),
-                        ),
-                    ),
+                AuthCtx::Agent(impersonated_user) => Self {
+                    value: Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::Agent(
+                        impersonated_user.into(),
+                    )),
                 },
                 AuthCtx::AdminImpersonation(ctx) => Self {
                     value: Some(

--- a/golem-service-base/src/model/auth/mod.rs
+++ b/golem-service-base/src/model/auth/mod.rs
@@ -155,6 +155,7 @@ pub enum GlobalAction {
     CreateAccount,
     GetDefaultPlan,
     GetReports,
+    ImpersonateUser
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, strum_macros::Display)]
@@ -282,10 +283,22 @@ pub struct ImpersonatedUserAuthCtx {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// AuthCtx for admin users impersonating another account via the /v1/admin/impersonate API.
+/// Access checks (ownership, visibility) run as the target account, including its roles.
+/// Audit writes (created_by) record the admin's account ID.
+pub struct AdminImpersonationAuthCtx {
+    pub admin_account_id: AccountId,
+    pub target_account_id: AccountId,
+    pub target_account_roles: BTreeSet<AccountRole>,
+    pub target_account_plan_id: PlanId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AuthCtx {
     System,
     User(UserAuthCtx),
     ImpersonatedUser(ImpersonatedUserAuthCtx),
+    AdminImpersonation(AdminImpersonationAuthCtx),
 }
 
 // Note: Basic visibility of resources is enforced in the repo. Use this to check permissions to modify resource / access restricted resources.
@@ -306,6 +319,20 @@ impl AuthCtx {
         AuthCtx::ImpersonatedUser(ImpersonatedUserAuthCtx { account_id })
     }
 
+    pub fn admin_impersonation(
+        admin_account_id: AccountId,
+        target_account_id: AccountId,
+        target_account_roles: BTreeSet<AccountRole>,
+        target_account_plan_id: PlanId,
+    ) -> AuthCtx {
+        AuthCtx::AdminImpersonation(AdminImpersonationAuthCtx {
+            admin_account_id,
+            target_account_id,
+            target_account_roles,
+            target_account_plan_id,
+        })
+    }
+
     pub fn impersonated(&self) -> Self {
         match self {
             Self::User(inner) => Self::ImpersonatedUser(ImpersonatedUserAuthCtx {
@@ -315,6 +342,9 @@ impl AuthCtx {
                 account_id: inner.account_id,
             }),
             Self::System => Self::System,
+            Self::AdminImpersonation(inner) => Self::ImpersonatedUser(ImpersonatedUserAuthCtx {
+                account_id: inner.target_account_id,
+            }),
         }
     }
 
@@ -322,12 +352,36 @@ impl AuthCtx {
         matches!(self, AuthCtx::System)
     }
 
-    pub fn account_id(&self) -> AccountId {
+    /// The account ID recorded in audit fields (created_by).
+    /// For admin impersonation this is the admin's account, not the target.
+    pub fn actor_account_id(&self) -> AccountId {
         match self {
             Self::System => AccountId::SYSTEM,
             Self::User(user) => user.account_id,
             Self::ImpersonatedUser(user) => user.account_id,
+            Self::AdminImpersonation(ctx) => ctx.admin_account_id,
         }
+    }
+
+    /// The account ID used for access and visibility checks.
+    /// For admin impersonation this is the target account, giving the admin
+    /// the same view as the impersonated user.
+    pub fn access_account_id(&self) -> AccountId {
+        match self {
+            Self::System => AccountId::SYSTEM,
+            Self::User(user) => user.account_id,
+            Self::ImpersonatedUser(user) => user.account_id,
+            Self::AdminImpersonation(ctx) => ctx.target_account_id,
+        }
+    }
+
+    /// Returns the access account ID.
+    ///
+    /// Prefer calling `actor_account_id()` for audit writes or `access_account_id()` for
+    /// visibility/ownership checks explicitly. This method exists for call sites that have
+    /// not yet been migrated.
+    pub fn account_id(&self) -> AccountId {
+        self.access_account_id()
     }
 
     pub fn account_roles(&self) -> &BTreeSet<AccountRole> {
@@ -335,6 +389,7 @@ impl AuthCtx {
             Self::System => &SYSTEM_ACCOUNT_ROLES,
             Self::User(user) => &user.account_roles,
             Self::ImpersonatedUser(_) => &IMPERSONATED_USER_ACCOUNT_ROLES,
+            Self::AdminImpersonation(ctx) => &ctx.target_account_roles,
         }
     }
 
@@ -348,6 +403,7 @@ impl AuthCtx {
             Self::System => None,
             Self::User(user) => Some(&user.account_plan_id),
             Self::ImpersonatedUser(_) => None,
+            Self::AdminImpersonation(ctx) => Some(&ctx.target_account_plan_id),
         }
     }
 
@@ -364,6 +420,7 @@ impl AuthCtx {
             GlobalAction::GetReports => {
                 self.has_any_account_role(&[AccountRole::Admin, AccountRole::MarketingAdmin])
             }
+            GlobalAction::ImpersonateUser => self.has_any_account_role(&[AccountRole::Admin]),
         };
 
         if !is_allowed {
@@ -415,7 +472,7 @@ impl AuthCtx {
                 self.has_any_account_role(&[AccountRole::Admin])
             }
             _ => {
-                (self.account_id() == target_account_id)
+                (self.access_account_id() == target_account_id)
                     || self.has_any_account_role(&[AccountRole::Admin])
             }
         };
@@ -434,7 +491,7 @@ impl AuthCtx {
         action: EnvironmentAction,
     ) -> Result<(), AuthorizationError> {
         // Environment owners, admins and system users are allowed to do everything with their environments
-        if self.account_id() == account_owning_enviroment
+        if self.access_account_id() == account_owning_enviroment
             || self.has_any_account_role(&[AccountRole::Admin])
         {
             return Ok(());
@@ -932,7 +989,10 @@ mod test {
 
 mod protobuf {
     use super::AuthDetailsForEnvironment;
-    use super::{AuthCtx, AuthorizationError, ImpersonatedUserAuthCtx, UserAuthCtx};
+    use super::{
+        AdminImpersonationAuthCtx, AuthCtx, AuthorizationError, ImpersonatedUserAuthCtx,
+        UserAuthCtx,
+    };
     use golem_common::model::auth::{AccountRole, EnvironmentRole};
 
     impl TryFrom<golem_api_grpc::proto::golem::auth::AuthDetailsForEnvironment>
@@ -998,7 +1058,7 @@ mod protobuf {
                 account_roles: value
                     .account_roles
                     .into_iter()
-                    .map(|ar| golem_api_grpc::proto::golem::auth::AccountRole::from(ar) as i32)
+                    .map(|ar| golem_api_grpc::proto::golem::auth::AccountRole::from(ar).into())
                     .collect(),
             }
         }
@@ -1025,6 +1085,57 @@ mod protobuf {
         }
     }
 
+    impl TryFrom<golem_api_grpc::proto::golem::auth::AdminImpersonationAuthCtx>
+        for AdminImpersonationAuthCtx
+    {
+        type Error = String;
+        fn try_from(
+            value: golem_api_grpc::proto::golem::auth::AdminImpersonationAuthCtx,
+        ) -> Result<Self, Self::Error> {
+            let target_account_roles = value
+                .target_account_roles
+                .into_iter()
+                .map(|r| {
+                    golem_api_grpc::proto::golem::auth::AccountRole::try_from(r)
+                        .map_err(|_| "invalid account role".to_string())
+                        .and_then(AccountRole::try_from)
+                })
+                .collect::<Result<_, _>>()?;
+            Ok(Self {
+                admin_account_id: value
+                    .admin_account_id
+                    .ok_or("missing admin_account_id")?
+                    .try_into()?,
+                target_account_id: value
+                    .target_account_id
+                    .ok_or("missing target_account_id")?
+                    .try_into()?,
+                target_account_roles,
+                target_account_plan_id: value
+                    .target_account_plan_id
+                    .ok_or("missing target_account_plan_id")?
+                    .try_into()?,
+            })
+        }
+    }
+
+    impl From<AdminImpersonationAuthCtx>
+        for golem_api_grpc::proto::golem::auth::AdminImpersonationAuthCtx
+    {
+        fn from(value: AdminImpersonationAuthCtx) -> Self {
+            Self {
+                admin_account_id: Some(value.admin_account_id.into()),
+                target_account_id: Some(value.target_account_id.into()),
+                target_account_roles: value
+                    .target_account_roles
+                    .into_iter()
+                    .map(|r| golem_api_grpc::proto::golem::auth::AccountRole::from(r).into())
+                    .collect(),
+                target_account_plan_id: Some(value.target_account_plan_id.into()),
+            }
+        }
+    }
+
     impl TryFrom<golem_api_grpc::proto::golem::auth::AuthCtx> for AuthCtx {
         type Error = String;
         fn try_from(
@@ -1040,6 +1151,9 @@ mod protobuf {
                 Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::ImpersonatedUser(
                     impersonated_user,
                 )) => Ok(AuthCtx::ImpersonatedUser(impersonated_user.try_into()?)),
+                Some(golem_api_grpc::proto::golem::auth::auth_ctx::Value::AdminImpersonation(
+                    ctx,
+                )) => Ok(AuthCtx::AdminImpersonation(ctx.try_into()?)),
                 None => Err("No auth_ctx value present".to_string()),
             }
         }
@@ -1062,6 +1176,13 @@ mod protobuf {
                     value: Some(
                         golem_api_grpc::proto::golem::auth::auth_ctx::Value::ImpersonatedUser(
                             impersonated_user.into(),
+                        ),
+                    ),
+                },
+                AuthCtx::AdminImpersonation(ctx) => Self {
+                    value: Some(
+                        golem_api_grpc::proto::golem::auth::auth_ctx::Value::AdminImpersonation(
+                            ctx.into(),
                         ),
                     ),
                 },

--- a/golem-service-base/src/model/auth/mod.rs
+++ b/golem-service-base/src/model/auth/mod.rs
@@ -155,7 +155,7 @@ pub enum GlobalAction {
     CreateAccount,
     GetDefaultPlan,
     GetReports,
-    ImpersonateUser
+    ImpersonateUser,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, strum_macros::Display)]
@@ -407,10 +407,12 @@ impl AuthCtx {
         }
     }
 
-    /// Whether storage level visibility rules (e.g. does this account have any shares for this environment / does this user own the environment)
-    /// should be disabled for this user.
+    /// Whether storage-level visibility rules (e.g. environment ownership and share checks)
+    /// should be bypassed. Only `System` (internal service calls) bypasses these rules.
+    /// Human accounts — including admins — are subject to normal ownership and share checks.
+    /// Admins who need to act on another account's resources must use an impersonation token.
     pub fn should_override_storage_visibility_rules(&self) -> bool {
-        self.has_any_account_role(&[AccountRole::Admin])
+        self.is_system()
     }
 
     pub fn authorize_global_action(&self, action: GlobalAction) -> Result<(), AuthorizationError> {

--- a/golem-service-base/src/model/auth/tests.rs
+++ b/golem-service-base/src/model/auth/tests.rs
@@ -25,7 +25,7 @@ fn mk_user_ctx(roles: &[AccountRole], plan_id: PlanId, account_id: AccountId) ->
 }
 
 fn mk_impersonated(id: AccountId) -> AuthCtx {
-    AuthCtx::ImpersonatedUser(ImpersonatedUserAuthCtx { account_id: id })
+    AuthCtx::Agent(AgentAuthCtx { account_id: id })
 }
 
 fn make_env_roles(roles: &[EnvironmentRole]) -> BTreeSet<EnvironmentRole> {

--- a/golem-worker-executor/src/services/direct_invocation_auth.rs
+++ b/golem-worker-executor/src/services/direct_invocation_auth.rs
@@ -112,7 +112,7 @@ impl DefaultDirectInvocationAuthService {
         caller_account_id: AccountId,
     ) -> Result<Option<AuthDetailsForEnvironment>, RpcError> {
         let registry_service = self.registry_service.clone();
-        let auth_ctx = AuthCtx::impersonated_user(caller_account_id);
+        let auth_ctx = AuthCtx::agent(caller_account_id);
 
         self.auth_details_cache
             .get_or_insert_simple(&(environment_id, caller_account_id), move || {
@@ -198,17 +198,12 @@ impl DirectInvocationAuthService for DefaultDirectInvocationAuthService {
                 details: format!("The environment action {action} is not allowed"),
             })?;
 
-        let env_owner = auth_details.account_id_owning_environment;
-        if caller_account_id == env_owner {
-            return Ok(EnvironmentOwnerAccountId(env_owner));
-        }
-
         // Non-owner slow path: check environment shares. Auth details already
         // in hand from the fetch above — no second cache lookup needed.
-        let auth_ctx = AuthCtx::impersonated_user(caller_account_id);
+        let auth_ctx = AuthCtx::agent(caller_account_id);
         auth_ctx
             .authorize_environment_action(
-                env_owner,
+                auth_details.account_id_owning_environment,
                 &auth_details.environment_roles_from_shares,
                 action,
             )

--- a/golem-worker-executor/src/services/worker_proxy.rs
+++ b/golem-worker-executor/src/services/worker_proxy.rs
@@ -258,7 +258,7 @@ impl RemoteWorkerProxy {
     }
 
     fn get_auth_ctx(&self, account_id: AccountId) -> AuthCtx {
-        AuthCtx::impersonated_user(account_id)
+        AuthCtx::agent(account_id)
     }
 }
 

--- a/golem-worker-service/src/custom_api/call_agent/mod.rs
+++ b/golem-worker-service/src/custom_api/call_agent/mod.rs
@@ -90,7 +90,7 @@ impl CallAgentHandler {
                 None,
                 Some(IdempotencyKey::fresh()),
                 invocation_context,
-                AuthCtx::impersonated_user(resolved_route.route.account_id),
+                AuthCtx::agent(resolved_route.route.account_id),
                 proto_principal,
                 Some(resolved_route.route.environment_id),
             )

--- a/golem-worker-service/src/custom_api/webhooks.rs
+++ b/golem-worker-service/src/custom_api/webhooks.rs
@@ -81,7 +81,7 @@ impl WebhookCallbackHandler {
 
         let body_binary = body_data.take().map(|bs| bs.data).unwrap_or_default();
 
-        let auth_ctx = AuthCtx::impersonated_user(resolved_route.route.account_id);
+        let auth_ctx = AuthCtx::agent(resolved_route.route.account_id);
 
         tracing::debug!("Completing promise due to webhook_callback: {promise_id}");
         self.worker_service

--- a/golem-worker-service/src/mcp/invoke/resource.rs
+++ b/golem-worker-service/src/mcp/invoke/resource.rs
@@ -82,8 +82,7 @@ pub async fn invoke_resource(
         agent_id: parsed_agent_id.to_string(),
     };
 
-    let auth_ctx =
-        golem_service_base::model::auth::AuthCtx::impersonated_user(mcp_resource.account_id);
+    let auth_ctx = golem_service_base::model::auth::AuthCtx::agent(mcp_resource.account_id);
 
     let agent_output = worker_service
         .invoke_agent(

--- a/golem-worker-service/src/mcp/invoke/tool.rs
+++ b/golem-worker-service/src/mcp/invoke/tool.rs
@@ -78,7 +78,7 @@ pub async fn invoke_tool(
         agent_id: parsed_agent_id.to_string(),
     };
 
-    let auth_ctx = golem_service_base::model::auth::AuthCtx::impersonated_user(mcp_tool.account_id);
+    let auth_ctx = golem_service_base::model::auth::AuthCtx::agent(mcp_tool.account_id);
 
     let agent_output = worker_service
         .invoke_agent(

--- a/golem-worker-service/src/service/auth.rs
+++ b/golem-worker-service/src/service/auth.rs
@@ -131,16 +131,16 @@ impl RemoteAuthService {
         environment_id: EnvironmentId,
         auth_ctx: &AuthCtx,
     ) -> Result<Option<AuthDetailsForEnvironment>, AuthServiceError> {
-        // environment level auth does not care about impersonation, so downgrade here to avoid cache
+        // worker-service level auth does not care about account roles or plans, so downgrade here to avoid cache
         // misses during rpc
-        let impersonated_auth = auth_ctx.impersonated();
+        let downgraded_auth = auth_ctx.downgrade_to_agent();
         let result = self
             .environment_auth_details_cache
             .get_or_insert_simple(
-                &(environment_id, impersonated_auth.clone()),
+                &(environment_id, downgraded_auth.clone()),
                 async move || {
                     self.client
-                        .get_auth_details_for_environment(environment_id, false, &impersonated_auth)
+                        .get_auth_details_for_environment(environment_id, false, &downgraded_auth)
                         .await
                         .map_err(|e| match e {
                             RegistryServiceError::NotFound(_) => {

--- a/openapi/golem-registry-service.yaml
+++ b/openapi/golem-registry-service.yaml
@@ -2546,6 +2546,86 @@ paths:
       - Cookie: []
       - Token: []
       operationId: delete_domain_registration
+  /v1/admin/impersonate/{account_id}:
+    post:
+      tags:
+      - RegistryService
+      - Account
+      summary: Create an impersonation token for a target account
+      description: |-
+        Creates a short-lived token that, when used for authentication, produces an
+        `AdminImpersonation` auth context: access and visibility checks run as the
+        target account, but audit writes (created_by fields) record the admin's account ID.
+
+        Only users with the `Admin` account role may call this endpoint.
+      parameters:
+      - name: account_id
+        schema:
+          type: string
+          format: uuid
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/TokenCreation'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/TokenWithSecret'
+        '400':
+          description: Invalid request, returning with a list of issues detected in the request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: Unauthorized request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: Forbidden Request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: Entity not found
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Limits of the plan exceeded
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      security:
+      - Cookie: []
+      - Token: []
+      operationId: create_impersonation_token
   /v1/envs/{environment_id}/plugins:
     post:
       tags:

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -4503,6 +4503,87 @@ paths:
       security:
       - Cookie: []
       - Token: []
+  /v1/admin/impersonate/{account_id}:
+    post:
+      tags:
+      - RegistryService
+      - Account
+      summary: Create an impersonation token for a target account
+      description: |-
+        Creates a short-lived token that, when used for authentication, produces an
+        `AdminImpersonation` auth context: access and visibility checks run as the
+        target account, but audit writes (created_by fields) record the admin's account ID.
+
+        Only users with the `Admin` account role may call this endpoint.
+      operationId: create_impersonation_token
+      parameters:
+      - in: path
+        name: account_id
+        required: true
+        deprecated: false
+        schema:
+          type: string
+          format: uuid
+        explode: true
+        style: simple
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/TokenCreation'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/TokenWithSecret'
+        '400':
+          description: Invalid request, returning with a list of issues detected in the request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorsBody'
+        '401':
+          description: Unauthorized request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '403':
+          description: Forbidden Request
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '404':
+          description: Entity not found
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '409':
+          description: ''
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Limits of the plan exceeded
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      security:
+      - Cookie: []
+      - Token: []
   /v1/envs/{environment_id}/plugins:
     get:
       tags:


### PR DESCRIPTION
Adds a new impersonation endpoint that admins can use to impersonate a user. Typical debugging workflow would be to call this endpoint and then configure the cli to use the impersonation token.

Also removes visibility bypass (e.g. seeing environments they have no relationship with) from admin. These usecases should now be handled via impersonation.

cc @kmatasfp 