### PR TITLE
Remove deleted agent provision configs during component updates

### DIFF
--- a/golem-common/src/base_model/api.rs
+++ b/golem-common/src/base_model/api.rs
@@ -92,6 +92,7 @@ pub mod error_code {
     pub const BAD_FILE_TYPE: &str = "BAD_FILE_TYPE";
     pub const COMPONENT_PROCESSING_ERROR: &str = "COMPONENT_PROCESSING_ERROR";
     pub const DEPLOYMENT_HASH_MISMATCH: &str = "DEPLOYMENT_HASH_MISMATCH";
+    pub const DUPLICATE_AGENT_TYPE_NAME: &str = "DUPLICATE_AGENT_TYPE_NAME";
     pub mod deployment_validation {
         // Main code
         pub const FAILED: &str = "DEPLOYMENT_VALIDATION_FAILED";

--- a/golem-registry-service/src/api/error.rs
+++ b/golem-registry-service/src/api/error.rs
@@ -507,6 +507,9 @@ impl From<ComponentError> for ApiError {
             ComponentError::AgentTypeForNameNotFound(_) => {
                 Self::not_found(api::error_code::AGENT_TYPE_NOT_FOUND, error)
             }
+            ComponentError::DuplicateAgentTypeName(_) => {
+                Self::bad_request(api::error_code::DUPLICATE_AGENT_TYPE_NAME, error)
+            }
             ComponentError::DeploymentRevisionNotFound(_) => {
                 Self::not_found(api::error_code::DEPLOYMENT_NOT_FOUND, error)
             }

--- a/golem-registry-service/src/services/component/error.rs
+++ b/golem-registry-service/src/services/component/error.rs
@@ -77,6 +77,8 @@ pub enum ComponentError {
     ConflictingEnvironmentPluginGrantId(EnvironmentPluginGrantId),
     #[error("agent type for name {0} not found in environment")]
     AgentTypeForNameNotFound(String),
+    #[error("Multiple agent types with the same name: {0}")]
+    DuplicateAgentTypeName(AgentTypeName),
     #[error(
         "Agent type '{0}' is referenced in provision config but not declared in the component's agent types"
     )]
@@ -150,6 +152,7 @@ impl SafeDisplay for ComponentError {
             Self::ComponentNotFound(_) => self.to_string(),
             Self::ComponentByNameNotFound(_) => self.to_string(),
             Self::AgentTypeForNameNotFound(_) => self.to_string(),
+            Self::DuplicateAgentTypeName(_) => self.to_string(),
             Self::UndeclaredAgentTypeInProvisionConfig(_) => self.to_string(),
             Self::AgentConfigNotDeclared { .. } => self.to_string(),
             Self::AgentConfigTypeMismatch { .. } => self.to_string(),

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -311,10 +311,79 @@ impl ComponentWriteService {
         info!(environment_id = %environment_id, "Update component");
 
         let agent_types_changed = component_update.agent_types.is_some();
+        let allow_incompatible_config = component_update.allow_incompatible_config;
 
         let agent_types = component_update
             .agent_types
             .unwrap_or(component.metadata.agent_types().to_vec());
+
+        let mut final_provision_configs = component.metadata.agent_type_provision_configs().clone();
+        if agent_types_changed {
+            final_provision_configs =
+                provision_configs_for_agent_types(&agent_types, final_provision_configs);
+        }
+
+        let mut provision_configs_changed = false;
+
+        if let Some(updates) = component_update.agent_type_provision_config_updates {
+            provision_configs_changed = true;
+
+            let referenced_paths: HashSet<ArchiveFilePath> = updates
+                .values()
+                .flat_map(|u| u.files_to_add_or_update.keys().cloned())
+                .collect();
+            let uploaded_files = match new_files_archive {
+                Some(archive) => {
+                    self.upload_agent_files(environment_id, archive, &referenced_paths)
+                        .await?
+                }
+                None => HashMap::new(),
+            };
+
+            for (agent_type_name, update) in updates {
+                let agent_type = agent_types
+                    .iter()
+                    .find(|agent_type| agent_type.type_name == agent_type_name)
+                    .ok_or_else(|| {
+                        ComponentError::UndeclaredAgentTypeInProvisionConfig(
+                            agent_type_name.clone(),
+                        )
+                    })?;
+
+                let existing = final_provision_configs
+                    .get(&agent_type_name)
+                    .cloned()
+                    .unwrap_or_default();
+
+                let updated = self
+                    .apply_provision_config_update(
+                        &agent_type_name,
+                        existing,
+                        update,
+                        &uploaded_files,
+                        agent_type,
+                        &environment,
+                        auth,
+                    )
+                    .await?;
+
+                final_provision_configs.insert(agent_type_name, updated);
+            }
+        }
+
+        if agent_types_changed && !allow_incompatible_config {
+            for (agent_type_name, config) in &final_provision_configs {
+                let agent_type = agent_types
+                    .iter()
+                    .find(|agent_type| &agent_type.type_name == agent_type_name)
+                    .ok_or_else(|| {
+                        ComponentError::UndeclaredAgentTypeInProvisionConfig(
+                            agent_type_name.clone(),
+                        )
+                    })?;
+                check_config_entries_match(agent_type, &config.config)?;
+            }
+        }
 
         if let Some(new_wasm) = new_wasm {
             self.account_usage_service
@@ -337,14 +406,10 @@ impl ComponentWriteService {
 
             component.wasm_hash = wasm_hash;
             component.object_store_key = wasm_object_store_key;
-            let existing_provision_configs =
-                component.metadata.agent_type_provision_configs().clone();
-            let existing_provision_configs =
-                provision_configs_for_agent_types(&agent_types, existing_provision_configs);
             component.metadata = analyze_and_validate_component_wasm(
                 agent_types,
                 new_wasm.clone(),
-                existing_provision_configs,
+                final_provision_configs,
             )
             .await?;
         } else if agent_types_changed {
@@ -354,94 +419,16 @@ impl ComponentWriteService {
                 .get(environment_id, &component.object_store_key)
                 .await?;
 
-            let existing_provision_configs =
-                component.metadata.agent_type_provision_configs().clone();
-            let existing_provision_configs =
-                provision_configs_for_agent_types(&agent_types, existing_provision_configs);
             component.metadata = analyze_and_validate_component_wasm(
                 agent_types,
                 Arc::from(old_data),
-                existing_provision_configs,
+                final_provision_configs,
             )
             .await?;
-        };
-
-        if let Some(updates) = component_update.agent_type_provision_config_updates {
-            let referenced_paths: HashSet<ArchiveFilePath> = updates
-                .values()
-                .flat_map(|u| u.files_to_add_or_update.keys().cloned())
-                .collect();
-            let uploaded_files = match new_files_archive {
-                Some(archive) => {
-                    self.upload_agent_files(environment_id, archive, &referenced_paths)
-                        .await?
-                }
-                None => HashMap::new(),
-            };
-
-            let mut provision_configs = component.metadata.agent_type_provision_configs().clone();
-
-            for (agent_type_name, update) in updates {
-                let agent_type = component
-                    .metadata
-                    .find_agent_type_by_name(&agent_type_name)
-                    .ok_or_else(|| {
-                        ComponentError::UndeclaredAgentTypeInProvisionConfig(
-                            agent_type_name.clone(),
-                        )
-                    })?;
-
-                let existing = provision_configs
-                    .get(&agent_type_name)
-                    .cloned()
-                    .unwrap_or_default();
-
-                let updated = self
-                    .apply_provision_config_update(
-                        &agent_type_name,
-                        existing,
-                        update,
-                        &uploaded_files,
-                        &agent_type,
-                        &environment,
-                        auth,
-                    )
-                    .await?;
-
-                provision_configs.insert(agent_type_name, updated);
-            }
-
-            // If agent types changed without a new wasm, validate existing typed config still matches
-            if agent_types_changed && !component_update.allow_incompatible_config {
-                for (agent_type_name, config) in &provision_configs {
-                    let agent_type = component
-                        .metadata
-                        .find_agent_type_by_name(agent_type_name)
-                        .ok_or_else(|| {
-                            ComponentError::UndeclaredAgentTypeInProvisionConfig(
-                                agent_type_name.clone(),
-                            )
-                        })?;
-                    check_config_entries_match(&agent_type, &config.config)?;
-                }
-            }
-
-            // Preserve agent types from the (possibly updated) metadata, replace provision configs
-            component.metadata = component.metadata.with_provision_configs(provision_configs);
-        } else if agent_types_changed && !component_update.allow_incompatible_config {
-            // No explicit updates but agent types changed: validate existing typed config
-            let provision_configs = component.metadata.agent_type_provision_configs().clone();
-            for (agent_type_name, config) in &provision_configs {
-                let agent_type = component
-                    .metadata
-                    .find_agent_type_by_name(agent_type_name)
-                    .ok_or_else(|| {
-                        ComponentError::UndeclaredAgentTypeInProvisionConfig(
-                            agent_type_name.clone(),
-                        )
-                    })?;
-                check_config_entries_match(&agent_type, &config.config)?;
-            }
+        } else if provision_configs_changed {
+            component.metadata = component
+                .metadata
+                .with_provision_configs(final_provision_configs);
         }
 
         validate_component_metadata_invariants(&component.metadata)?;

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -210,6 +210,7 @@ impl ComponentWriteService {
             provision_configs,
         )
         .await?;
+        validate_component_metadata_invariants(&component_metadata)?;
 
         let component_size = wasm.len() as u64;
 
@@ -442,6 +443,8 @@ impl ComponentWriteService {
                 check_config_entries_match(&agent_type, &config.config)?;
             }
         }
+
+        validate_component_metadata_invariants(&component.metadata)?;
 
         let record = ComponentRevisionRecord::from_model(component, auth.actor_account_id());
 
@@ -961,6 +964,30 @@ fn provision_configs_for_agent_types(
         .into_iter()
         .filter(|(agent_type_name, _)| agent_type_names.contains(agent_type_name))
         .collect()
+}
+
+fn validate_component_metadata_invariants(
+    metadata: &ComponentMetadata,
+) -> Result<(), ComponentError> {
+    let mut agent_type_names = HashSet::new();
+
+    for agent_type in metadata.agent_types() {
+        if !agent_type_names.insert(agent_type.type_name.clone()) {
+            return Err(ComponentError::DuplicateAgentTypeName(
+                agent_type.type_name.clone(),
+            ));
+        }
+    }
+
+    for agent_type_name in metadata.agent_type_provision_configs().keys() {
+        if !agent_type_names.contains(agent_type_name) {
+            return Err(ComponentError::UndeclaredAgentTypeInProvisionConfig(
+                agent_type_name.clone(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_agent_config_declarations(agent_type: &AgentType) -> Result<(), ComponentError> {

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -338,6 +338,8 @@ impl ComponentWriteService {
             component.object_store_key = wasm_object_store_key;
             let existing_provision_configs =
                 component.metadata.agent_type_provision_configs().clone();
+            let existing_provision_configs =
+                provision_configs_for_agent_types(&agent_types, existing_provision_configs);
             component.metadata = analyze_and_validate_component_wasm(
                 agent_types,
                 new_wasm.clone(),
@@ -353,6 +355,8 @@ impl ComponentWriteService {
 
             let existing_provision_configs =
                 component.metadata.agent_type_provision_configs().clone();
+            let existing_provision_configs =
+                provision_configs_for_agent_types(&agent_types, existing_provision_configs);
             component.metadata = analyze_and_validate_component_wasm(
                 agent_types,
                 Arc::from(old_data),
@@ -942,6 +946,21 @@ async fn analyze_and_validate_component_wasm(
     .await?;
 
     Ok(component_metadata)
+}
+
+fn provision_configs_for_agent_types(
+    agent_types: &[AgentType],
+    provision_configs: BTreeMap<AgentTypeName, AgentTypeProvisionConfig>,
+) -> BTreeMap<AgentTypeName, AgentTypeProvisionConfig> {
+    let agent_type_names = agent_types
+        .iter()
+        .map(|agent_type| &agent_type.type_name)
+        .collect::<HashSet<_>>();
+
+    provision_configs
+        .into_iter()
+        .filter(|(agent_type_name, _)| agent_type_names.contains(agent_type_name))
+        .collect()
 }
 
 fn validate_agent_config_declarations(agent_type: &AgentType) -> Result<(), ComponentError> {

--- a/integration-tests/tests/api/component.rs
+++ b/integration-tests/tests/api/component.rs
@@ -202,6 +202,80 @@ async fn update_config_vars(deps: &EnvBasedTestDependencies) -> anyhow::Result<(
 
 #[test]
 #[tracing::instrument]
+async fn component_update_removes_provision_configs_for_removed_agent_types(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?.with_auto_deploy(false);
+    let client = deps.registry_service().client(&user.token).await;
+    let (_, env) = user.app_and_env().await?;
+
+    let component = user
+        .component(&env.id, "it_agent_update_v1_release")
+        .with_agent_config(
+            "CounterAgent",
+            vec![AgentConfigEntryDto {
+                path: vec!["var1".to_string()],
+                value: serde_json::Value::String("value1".to_string()).into(),
+            }],
+        )
+        .store()
+        .await?;
+
+    assert!(
+        component
+            .metadata
+            .agent_type_provision_configs()
+            .contains_key(&AgentTypeName("CounterAgent".to_string()))
+    );
+
+    let mut other_agent = component.metadata.agent_types()[0].clone();
+    other_agent.type_name = AgentTypeName("OtherAgent".to_string());
+    other_agent.description = "Constructs the agent OtherAgent".to_string();
+
+    let updated_component = client
+        .update_component(
+            &component.id.0,
+            &ComponentUpdate {
+                current_revision: component.revision,
+                agent_types: Some(vec![other_agent]),
+                agent_type_provision_config_updates: Some(BTreeMap::from([(
+                    AgentTypeName("OtherAgent".to_string()),
+                    AgentTypeProvisionConfigUpdate::default(),
+                )])),
+                allow_incompatible_config: false,
+            },
+            None::<File>,
+            None::<File>,
+        )
+        .await?;
+
+    assert_eq!(
+        updated_component
+            .metadata
+            .agent_types()
+            .iter()
+            .map(|agent_type| agent_type.type_name.0.as_str())
+            .collect::<Vec<_>>(),
+        vec!["OtherAgent"]
+    );
+    assert!(
+        updated_component
+            .metadata
+            .agent_type_provision_configs()
+            .contains_key(&AgentTypeName("OtherAgent".to_string()))
+    );
+    assert!(
+        !updated_component
+            .metadata
+            .agent_type_provision_configs()
+            .contains_key(&AgentTypeName("CounterAgent".to_string()))
+    );
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
 async fn component_update_with_wrong_revision_is_rejected(
     deps: &EnvBasedTestDependencies,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
Resolves https://github.com/golemcloud/golem/issues/3446 + adds invariant checks before saving metadata