### PR TITLE
always consult active workers before fetching metadata

### DIFF
--- a/golem-common/src/model/oplog/payload/mod.rs
+++ b/golem-common/src/model/oplog/payload/mod.rs
@@ -19,7 +19,6 @@ mod tests;
 
 use crate::model::agent::{AgentTypeName, DataValue, RegisteredAgentType, UntypedDataValue};
 use crate::model::component::ComponentRevision;
-use crate::model::environment::EnvironmentId;
 use crate::model::oplog::PayloadId;
 use crate::model::oplog::payload::types::{
     FileSystemError, ObjectMetadata, SerializableDateTime, SerializableFileTimes,
@@ -34,9 +33,7 @@ use crate::model::oplog::types::{
 };
 use crate::model::retry_policy::{NamedRetryPolicy, PredicateValue, RetryPolicy};
 use crate::model::worker::RevertWorkerTarget;
-use crate::model::{
-    AgentFingerprint, AgentId, ComponentId, ForkResult, IdempotencyKey, OplogIndex, PromiseId,
-};
+use crate::model::{AgentId, ComponentId, ForkResult, IdempotencyKey, OplogIndex, PromiseId};
 use crate::oplog_payload;
 use crate::serialization::serialize;
 use desert_rust::{
@@ -220,9 +217,6 @@ oplog_payload! {
             verb: String,
             noun_uri: String,
             properties: Vec<(String, PredicateValue)>
-        },
-        GolemRpcCreate {
-            remote_agent_id: AgentId
         },
     }
 }
@@ -433,10 +427,6 @@ oplog_payload! {
         GolemRetryResolvedPolicy {
             policy: Option<RetryPolicy>
         },
-        GolemRpcCreate {
-            target_fingerprint: AgentFingerprint,
-            target_environment_id: EnvironmentId
-        }
     }
 }
 
@@ -561,8 +551,7 @@ pub mod host_functions {
         (GolemQuotaReservationCommit => "golem::quota::reservation", "commit", QuotaCommitRequest, QuotaCommitResult),
         (GolemApiRetryGetRetryPolicies => "golem::api::retry", "get_retry_policies", NoInput, GolemRetryPolicies),
         (GolemApiRetryGetRetryPolicyByName => "golem::api::retry", "get_retry_policy_by_name", GolemRetryPolicyByName, GolemRetryNamedPolicy),
-        (GolemApiRetryResolveRetryPolicy => "golem::api::retry", "resolve_retry_policy", GolemRetryResolvePolicy, GolemRetryResolvedPolicy),
-        (GolemRpcWasmRpcNew => "golem::rpc::wasm-rpc", "new", GolemRpcCreate, GolemRpcCreate)
+        (GolemApiRetryResolveRetryPolicy => "golem::api::retry", "resolve_retry_policy", GolemRetryResolvePolicy, GolemRetryResolvedPolicy)
     }
 }
 

--- a/golem-common/src/model/oplog/payload/mod.rs
+++ b/golem-common/src/model/oplog/payload/mod.rs
@@ -19,6 +19,7 @@ mod tests;
 
 use crate::model::agent::{AgentTypeName, DataValue, RegisteredAgentType, UntypedDataValue};
 use crate::model::component::ComponentRevision;
+use crate::model::environment::EnvironmentId;
 use crate::model::oplog::PayloadId;
 use crate::model::oplog::payload::types::{
     FileSystemError, ObjectMetadata, SerializableDateTime, SerializableFileTimes,
@@ -33,7 +34,9 @@ use crate::model::oplog::types::{
 };
 use crate::model::retry_policy::{NamedRetryPolicy, PredicateValue, RetryPolicy};
 use crate::model::worker::RevertWorkerTarget;
-use crate::model::{AgentId, ComponentId, ForkResult, IdempotencyKey, OplogIndex, PromiseId};
+use crate::model::{
+    AgentFingerprint, AgentId, ComponentId, ForkResult, IdempotencyKey, OplogIndex, PromiseId,
+};
 use crate::oplog_payload;
 use crate::serialization::serialize;
 use desert_rust::{
@@ -217,6 +220,9 @@ oplog_payload! {
             verb: String,
             noun_uri: String,
             properties: Vec<(String, PredicateValue)>
+        },
+        GolemRpcCreate {
+            remote_agent_id: AgentId
         },
     }
 }
@@ -426,6 +432,10 @@ oplog_payload! {
         },
         GolemRetryResolvedPolicy {
             policy: Option<RetryPolicy>
+        },
+        GolemRpcCreate {
+            target_fingerprint: AgentFingerprint,
+            target_environment_id: EnvironmentId
         }
     }
 }
@@ -551,7 +561,8 @@ pub mod host_functions {
         (GolemQuotaReservationCommit => "golem::quota::reservation", "commit", QuotaCommitRequest, QuotaCommitResult),
         (GolemApiRetryGetRetryPolicies => "golem::api::retry", "get_retry_policies", NoInput, GolemRetryPolicies),
         (GolemApiRetryGetRetryPolicyByName => "golem::api::retry", "get_retry_policy_by_name", GolemRetryPolicyByName, GolemRetryNamedPolicy),
-        (GolemApiRetryResolveRetryPolicy => "golem::api::retry", "resolve_retry_policy", GolemRetryResolvePolicy, GolemRetryResolvedPolicy)
+        (GolemApiRetryResolveRetryPolicy => "golem::api::retry", "resolve_retry_policy", GolemRetryResolvePolicy, GolemRetryResolvedPolicy),
+        (GolemRpcWasmRpcNew => "golem::rpc::wasm-rpc", "new", GolemRpcCreate, GolemRpcCreate)
     }
 }
 

--- a/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
+++ b/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
@@ -37,15 +37,15 @@ use golem_common::model::invocation_context::{AttributeValue, InvocationContextS
 use golem_common::model::oplog::host_functions::{
     GolemRpcCancellationTokenCancel, GolemRpcFutureInvokeResultCancel,
     GolemRpcFutureInvokeResultGet, GolemRpcWasmRpcInvoke, GolemRpcWasmRpcInvokeAndAwaitResult,
-    GolemRpcWasmRpcNew, GolemRpcWasmRpcScheduleInvocation,
+    GolemRpcWasmRpcScheduleInvocation,
 };
 use golem_common::model::oplog::types::{SerializableInvokeResult, SerializableScheduleId};
 use golem_common::model::oplog::{
     DurableFunctionType, HostPayloadPair, HostRequest, HostRequestGolemRpcInvoke,
     HostRequestGolemRpcScheduledInvocation, HostRequestGolemRpcScheduledInvocationCancellation,
-    HostResponse, HostResponseGolemRpcCreate, HostResponseGolemRpcInvokeAndAwait,
-    HostResponseGolemRpcInvokeGet, HostResponseGolemRpcScheduledInvocation,
-    HostResponseGolemRpcUnit, HostResponseGolemRpcUnitOrFailure, OplogEntry, PersistenceLevel,
+    HostResponse, HostResponseGolemRpcInvokeAndAwait, HostResponseGolemRpcInvokeGet,
+    HostResponseGolemRpcScheduledInvocation, HostResponseGolemRpcUnit,
+    HostResponseGolemRpcUnitOrFailure, OplogEntry, PersistenceLevel,
 };
 use golem_common::model::{
     AgentFingerprint, AgentId, AgentInvocation, IdempotencyKey, NamedRetryPolicy, OplogIndex,
@@ -64,7 +64,6 @@ use tracing::{Instrument, error};
 use wasmtime::component::{Resource, ResourceTableError};
 use wasmtime_wasi::runtime::AbortOnDropJoinHandle;
 
-use golem_common::model::oplog::payload::HostRequestGolemRpcCreate;
 use golem_common::model::worker::AgentConfigEntryDto;
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use golem_wasm::json::ValueAndTypeJsonExtensions;
@@ -88,6 +87,8 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             golem_common::model::agent::bindings::golem::agent::common::TypedAgentConfigValue,
         >,
     ) -> anyhow::Result<Resource<WasmRpcEntry>> {
+        self.observe_function_call("golem::rpc::wasm-rpc", "new");
+
         let mut env =
             wasmtime_wasi::p2::bindings::cli::environment::Host::get_environment(self).await?;
         crate::model::AgentConfig::remove_dynamic_vars(&mut env);
@@ -132,21 +133,7 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let durability =
-            Durability::<GolemRpcWasmRpcNew>::new(self, DurableFunctionType::WriteRemote).await?;
-
-        if durability.is_live() {
-            construct_wasm_rpc_resource(self, remote_agent_id, &env, config, &durability).await
-        } else {
-            let response = durability.replay(self).await?;
-            reconstruct_wasm_rpc_resource(
-                self,
-                remote_agent_id,
-                response.target_environment_id,
-                response.target_fingerprint,
-            )
-            .await
-        }
+        construct_wasm_rpc_resource(self, remote_agent_id, &env, config).await
     }
 
     async fn invoke_and_await(
@@ -1167,7 +1154,6 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
     remote_agent_id: AgentId,
     env: &[(String, String)],
     config: Vec<AgentConfigEntryDto>,
-    durability: &Durability<GolemRpcWasmRpcNew>,
 ) -> anyhow::Result<Resource<WasmRpcEntry>> {
     let span = create_rpc_connection_span(ctx, &remote_agent_id).await?;
 
@@ -1177,8 +1163,7 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
         .component_service()
         .get_metadata(remote_agent_id.component_id, None)
         .await?;
-    let target_environment_id = target_component.environment_id;
-    let remote_agent_id = OwnedAgentId::new(target_environment_id, &remote_agent_id);
+    let remote_agent_id = OwnedAgentId::new(target_component.environment_id, &remote_agent_id);
     let demand = ctx
         .rpc()
         .create_demand(
@@ -1192,43 +1177,9 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
         .await?;
     let target_fingerprint = demand.fingerprint();
 
-    durability
-        .persist(
-            ctx,
-            HostRequestGolemRpcCreate {
-                remote_agent_id: remote_agent_id.agent_id(),
-            },
-            HostResponseGolemRpcCreate {
-                target_fingerprint,
-                target_environment_id,
-            },
-        )
-        .await?;
-
     let entry = ctx.table().push(WasmRpcEntry {
         payload: Box::new(WasmRpcEntryPayload {
             demand,
-            remote_agent_id,
-            span_id: span.span_id().clone(),
-            target_fingerprint,
-        }),
-    })?;
-    Ok(entry)
-}
-
-async fn reconstruct_wasm_rpc_resource<Ctx: WorkerCtx>(
-    ctx: &mut DurableWorkerCtx<Ctx>,
-    remote_agent_id: AgentId,
-    target_environment_id: EnvironmentId,
-    target_fingerprint: AgentFingerprint,
-) -> anyhow::Result<Resource<WasmRpcEntry>> {
-    let span = create_rpc_connection_span(ctx, &remote_agent_id).await?;
-    let remote_agent_id = OwnedAgentId::new(target_environment_id, &remote_agent_id);
-    let entry = ctx.table().push(WasmRpcEntry {
-        payload: Box::new(WasmRpcEntryPayload {
-            demand: Box::new(crate::services::rpc::ReplayedDemand::new(
-                target_fingerprint,
-            )),
             remote_agent_id,
             span_id: span.span_id().clone(),
             target_fingerprint,

--- a/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
+++ b/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
@@ -37,15 +37,15 @@ use golem_common::model::invocation_context::{AttributeValue, InvocationContextS
 use golem_common::model::oplog::host_functions::{
     GolemRpcCancellationTokenCancel, GolemRpcFutureInvokeResultCancel,
     GolemRpcFutureInvokeResultGet, GolemRpcWasmRpcInvoke, GolemRpcWasmRpcInvokeAndAwaitResult,
-    GolemRpcWasmRpcScheduleInvocation,
+    GolemRpcWasmRpcNew, GolemRpcWasmRpcScheduleInvocation,
 };
 use golem_common::model::oplog::types::{SerializableInvokeResult, SerializableScheduleId};
 use golem_common::model::oplog::{
     DurableFunctionType, HostPayloadPair, HostRequest, HostRequestGolemRpcInvoke,
     HostRequestGolemRpcScheduledInvocation, HostRequestGolemRpcScheduledInvocationCancellation,
-    HostResponse, HostResponseGolemRpcInvokeAndAwait, HostResponseGolemRpcInvokeGet,
-    HostResponseGolemRpcScheduledInvocation, HostResponseGolemRpcUnit,
-    HostResponseGolemRpcUnitOrFailure, OplogEntry, PersistenceLevel,
+    HostResponse, HostResponseGolemRpcCreate, HostResponseGolemRpcInvokeAndAwait,
+    HostResponseGolemRpcInvokeGet, HostResponseGolemRpcScheduledInvocation,
+    HostResponseGolemRpcUnit, HostResponseGolemRpcUnitOrFailure, OplogEntry, PersistenceLevel,
 };
 use golem_common::model::{
     AgentFingerprint, AgentId, AgentInvocation, IdempotencyKey, NamedRetryPolicy, OplogIndex,
@@ -64,6 +64,7 @@ use tracing::{Instrument, error};
 use wasmtime::component::{Resource, ResourceTableError};
 use wasmtime_wasi::runtime::AbortOnDropJoinHandle;
 
+use golem_common::model::oplog::payload::HostRequestGolemRpcCreate;
 use golem_common::model::worker::AgentConfigEntryDto;
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use golem_wasm::json::ValueAndTypeJsonExtensions;
@@ -87,8 +88,6 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             golem_common::model::agent::bindings::golem::agent::common::TypedAgentConfigValue,
         >,
     ) -> anyhow::Result<Resource<WasmRpcEntry>> {
-        self.observe_function_call("golem::rpc::wasm-rpc", "new");
-
         let mut env =
             wasmtime_wasi::p2::bindings::cli::environment::Host::get_environment(self).await?;
         crate::model::AgentConfig::remove_dynamic_vars(&mut env);
@@ -133,7 +132,21 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        construct_wasm_rpc_resource(self, remote_agent_id, &env, config).await
+        let durability =
+            Durability::<GolemRpcWasmRpcNew>::new(self, DurableFunctionType::WriteRemote).await?;
+
+        if durability.is_live() {
+            construct_wasm_rpc_resource(self, remote_agent_id, &env, config, &durability).await
+        } else {
+            let response = durability.replay(self).await?;
+            reconstruct_wasm_rpc_resource(
+                self,
+                remote_agent_id,
+                response.target_environment_id,
+                response.target_fingerprint,
+            )
+            .await
+        }
     }
 
     async fn invoke_and_await(
@@ -1154,6 +1167,7 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
     remote_agent_id: AgentId,
     env: &[(String, String)],
     config: Vec<AgentConfigEntryDto>,
+    durability: &Durability<GolemRpcWasmRpcNew>,
 ) -> anyhow::Result<Resource<WasmRpcEntry>> {
     let span = create_rpc_connection_span(ctx, &remote_agent_id).await?;
 
@@ -1163,7 +1177,8 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
         .component_service()
         .get_metadata(remote_agent_id.component_id, None)
         .await?;
-    let remote_agent_id = OwnedAgentId::new(target_component.environment_id, &remote_agent_id);
+    let target_environment_id = target_component.environment_id;
+    let remote_agent_id = OwnedAgentId::new(target_environment_id, &remote_agent_id);
     let demand = ctx
         .rpc()
         .create_demand(
@@ -1176,9 +1191,44 @@ pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
         )
         .await?;
     let target_fingerprint = demand.fingerprint();
+
+    durability
+        .persist(
+            ctx,
+            HostRequestGolemRpcCreate {
+                remote_agent_id: remote_agent_id.agent_id(),
+            },
+            HostResponseGolemRpcCreate {
+                target_fingerprint,
+                target_environment_id,
+            },
+        )
+        .await?;
+
     let entry = ctx.table().push(WasmRpcEntry {
         payload: Box::new(WasmRpcEntryPayload {
             demand,
+            remote_agent_id,
+            span_id: span.span_id().clone(),
+            target_fingerprint,
+        }),
+    })?;
+    Ok(entry)
+}
+
+async fn reconstruct_wasm_rpc_resource<Ctx: WorkerCtx>(
+    ctx: &mut DurableWorkerCtx<Ctx>,
+    remote_agent_id: AgentId,
+    target_environment_id: EnvironmentId,
+    target_fingerprint: AgentFingerprint,
+) -> anyhow::Result<Resource<WasmRpcEntry>> {
+    let span = create_rpc_connection_span(ctx, &remote_agent_id).await?;
+    let remote_agent_id = OwnedAgentId::new(target_environment_id, &remote_agent_id);
+    let entry = ctx.table().push(WasmRpcEntry {
+        payload: Box::new(WasmRpcEntryPayload {
+            demand: Box::new(crate::services::rpc::ReplayedDemand::new(
+                target_fingerprint,
+            )),
             remote_agent_id,
             span_id: span.span_id().clone(),
             target_fingerprint,

--- a/golem-worker-executor/src/grpc/mod.rs
+++ b/golem-worker-executor/src/grpc/mod.rs
@@ -337,20 +337,31 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 ))
             })?;
 
-        // NOTE: to return creation (limit) errors, we still "get_or_create",
-        //       even if the worker already exists with ignore_already_existing requested
-        let existing_worker = self.worker_service().get(&owned_agent_id).await;
-        if let Some(existing) = existing_worker
-            && !request.ignore_already_existing
-            && !Self::is_same_worker_creation_request(
-                &existing.initial_worker_metadata,
-                &env,
-                &config,
-            )
-        {
-            return Err(WorkerExecutorError::worker_already_exists(
-                owned_agent_id.agent_id(),
-            ));
+        if !request.ignore_already_existing {
+            if let Some(existing) = self.active_workers().try_get(&owned_agent_id).await {
+                if !Self::is_same_worker_creation_request(
+                    &existing.get_initial_worker_metadata(),
+                    &env,
+                    &config,
+                ) {
+                    return Err(WorkerExecutorError::worker_already_exists(
+                        owned_agent_id.agent_id(),
+                    ));
+                }
+            } else {
+                let existing_worker = self.worker_service().get(&owned_agent_id).await;
+                if let Some(existing) = existing_worker
+                    && !Self::is_same_worker_creation_request(
+                        &existing.initial_worker_metadata,
+                        &env,
+                        &config,
+                    )
+                {
+                    return Err(WorkerExecutorError::worker_already_exists(
+                        owned_agent_id.agent_id(),
+                    ));
+                }
+            }
         }
 
         let invocation_context = self.limit_invocation_context_stack_depth(

--- a/golem-worker-executor/src/services/rpc.rs
+++ b/golem-worker-executor/src/services/rpc.rs
@@ -246,22 +246,6 @@ struct LoggingDemand {
     fingerprint: AgentFingerprint,
 }
 
-pub struct ReplayedDemand {
-    fingerprint: AgentFingerprint,
-}
-
-impl ReplayedDemand {
-    pub fn new(fingerprint: AgentFingerprint) -> Self {
-        Self { fingerprint }
-    }
-}
-
-impl RpcDemand for ReplayedDemand {
-    fn fingerprint(&self) -> AgentFingerprint {
-        self.fingerprint
-    }
-}
-
 impl LoggingDemand {
     pub fn new(agent_id: AgentId, fingerprint: AgentFingerprint) -> Self {
         log::debug!("Initializing RPC connection for worker {agent_id}");

--- a/golem-worker-executor/src/services/rpc.rs
+++ b/golem-worker-executor/src/services/rpc.rs
@@ -246,6 +246,22 @@ struct LoggingDemand {
     fingerprint: AgentFingerprint,
 }
 
+pub struct ReplayedDemand {
+    fingerprint: AgentFingerprint,
+}
+
+impl ReplayedDemand {
+    pub fn new(fingerprint: AgentFingerprint) -> Self {
+        Self { fingerprint }
+    }
+}
+
+impl RpcDemand for ReplayedDemand {
+    fn fingerprint(&self) -> AgentFingerprint {
+        self.fingerprint
+    }
+}
+
 impl LoggingDemand {
     pub fn new(agent_id: AgentId, fingerprint: AgentFingerprint) -> Self {
         log::debug!("Initializing RPC connection for worker {agent_id}");

--- a/golem-worker-executor/src/services/scheduler.rs
+++ b/golem-worker-executor/src/services/scheduler.rs
@@ -27,7 +27,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use golem_common::model::agent::Principal;
 use golem_common::model::invocation_context::InvocationContextStack;
-use golem_common::model::{AgentInvocation, OwnedAgentId, ScheduleId, ScheduledAction, ShardId};
+use golem_common::model::{
+    AgentFingerprint, AgentInvocation, OwnedAgentId, ScheduleId, ScheduledAction, ShardId,
+};
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use std::future::Future;
 use std::ops::{Add, Deref};
@@ -56,6 +58,11 @@ pub trait SchedulerService: Send + Sync {
 /// for `SchedulerServiceDefault`, making it easier to test (by being independent of `WorkerCtx`).
 #[async_trait]
 pub trait SchedulerWorkerAccess {
+    async fn active_worker_fingerprint(
+        &self,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Option<AgentFingerprint>;
+
     async fn activate_worker(&self, owned_agent_id: &OwnedAgentId);
     async fn open_oplog(
         &self,
@@ -72,6 +79,13 @@ pub trait SchedulerWorkerAccess {
 
 #[async_trait]
 impl<Ctx: WorkerCtx> SchedulerWorkerAccess for Arc<dyn WorkerActivator<Ctx>> {
+    async fn active_worker_fingerprint(
+        &self,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Option<AgentFingerprint> {
+        self.deref().active_worker_fingerprint(owned_agent_id).await
+    }
+
     async fn activate_worker(&self, owned_agent_id: &OwnedAgentId) {
         self.deref().activate_worker(owned_agent_id).await;
     }
@@ -413,11 +427,18 @@ impl SchedulerServiceDefault {
             } => {
                 // A mismatch means the original worker was deleted and recreated — drop the stale
                 // invocation silently.
-                let stale = match self.worker_service.get(&owned_agent_id).await {
-                    Some(meta) => {
-                        meta.initial_worker_metadata.fingerprint != target_worker_fingerprint
-                    }
-                    None => true,
+                let stale = match self
+                    .worker_access
+                    .active_worker_fingerprint(&owned_agent_id)
+                    .await
+                {
+                    Some(fingerprint) => fingerprint != target_worker_fingerprint,
+                    None => match self.worker_service.get(&owned_agent_id).await {
+                        Some(meta) => {
+                            meta.initial_worker_metadata.fingerprint != target_worker_fingerprint
+                        }
+                        None => true,
+                    },
                 };
 
                 if stale {
@@ -516,19 +537,21 @@ mod tests {
     use chrono::DateTime;
     use golem_common::model::AgentStatusRecord;
     use golem_common::model::account::AccountId;
-    use golem_common::model::agent::AgentMode;
+    use golem_common::model::agent::{AgentMode, Principal, UntypedDataValue};
     use golem_common::model::component::ComponentId;
     use golem_common::model::environment::EnvironmentId;
+    use golem_common::model::invocation_context::InvocationContextStack;
     use golem_common::model::oplog::OplogIndex;
     use golem_common::model::{
-        AgentId, AgentInvocation, IdempotencyKey, OwnedAgentId, PromiseId, ScheduleId,
-        ScheduledAction, ShardAssignment, ShardId,
+        AgentFingerprint, AgentId, AgentInvocation, IdempotencyKey, OwnedAgentId, PromiseId,
+        ScheduleId, ScheduledAction, ShardAssignment, ShardId,
     };
     use golem_service_base::error::worker_executor::WorkerExecutorError;
     use golem_service_base::storage::blob::memory::InMemoryBlobStorage;
     use std::collections::HashSet;
     use std::str::FromStr;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use test_r::test;
     use tokio_util::sync::CancellationToken;
@@ -538,6 +561,13 @@ mod tests {
 
     #[async_trait]
     impl SchedulerWorkerAccess for SchedulerWorkerAccessMock {
+        async fn active_worker_fingerprint(
+            &self,
+            _owned_agent_id: &OwnedAgentId,
+        ) -> Option<AgentFingerprint> {
+            None
+        }
+
         async fn activate_worker(&self, _owned_agent_id: &OwnedAgentId) {}
 
         async fn open_oplog(
@@ -553,6 +583,39 @@ mod tests {
             _invocation: AgentInvocation,
         ) -> Result<(), WorkerExecutorError> {
             unimplemented!()
+        }
+    }
+
+    struct ActiveWorkerAccessMock {
+        fingerprint: AgentFingerprint,
+        enqueue_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SchedulerWorkerAccess for ActiveWorkerAccessMock {
+        async fn active_worker_fingerprint(
+            &self,
+            _owned_agent_id: &OwnedAgentId,
+        ) -> Option<AgentFingerprint> {
+            Some(self.fingerprint)
+        }
+
+        async fn activate_worker(&self, _owned_agent_id: &OwnedAgentId) {}
+
+        async fn open_oplog(
+            &self,
+            _owned_agent_id: &OwnedAgentId,
+        ) -> Result<Arc<dyn Oplog>, WorkerExecutorError> {
+            unimplemented!()
+        }
+
+        async fn enqueue_invocation(
+            &self,
+            _owned_agent_id: &OwnedAgentId,
+            _invocation: AgentInvocation,
+        ) -> Result<(), WorkerExecutorError> {
+            self.enqueue_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -654,6 +717,16 @@ mod tests {
             account_id: AccountId::new(),
             environment_id: EnvironmentId::new(),
             promise_id,
+        }
+    }
+
+    fn agent_method_invocation() -> AgentInvocation {
+        AgentInvocation::AgentMethod {
+            idempotency_key: IdempotencyKey::fresh(),
+            method_name: "run".to_string(),
+            input: UntypedDataValue::Tuple(vec![]),
+            invocation_context: InvocationContextStack::fresh(),
+            principal: Principal::anonymous(),
         }
     }
 
@@ -767,6 +840,50 @@ mod tests {
 
         let completed_promises = promise_service.all_completed().await;
         assert!(completed_promises.contains(&promise_id));
+    }
+
+    #[test]
+    async fn scheduled_invoke_uses_active_worker_fingerprint_before_worker_service_lookup() {
+        let storage = Arc::new(InMemorySchedulerStorage::new());
+        let promise_service = create_promise_service_mock();
+        let fingerprint = AgentFingerprint::new();
+        let enqueue_count = Arc::new(AtomicUsize::new(0));
+        let worker_access: Arc<dyn SchedulerWorkerAccess + Send + Sync> =
+            Arc::new(ActiveWorkerAccessMock {
+                fingerprint,
+                enqueue_count: enqueue_count.clone(),
+            });
+        let svc = SchedulerServiceDefault::new(
+            storage,
+            create_shard_service_mock(),
+            promise_service,
+            worker_access,
+            create_oplog_service_mock().await,
+            create_worker_service_mock(),
+            Duration::from_secs(1000),
+            100,
+            Duration::from_secs(30),
+            10,
+            CancellationToken::new(),
+        );
+
+        let owned_agent_id = OwnedAgentId::new(EnvironmentId::new(), &agent("inst1"));
+        svc.schedule(
+            DateTime::from_str("2023-07-17T07:05:00Z").unwrap(),
+            ScheduledAction::Invoke {
+                account_id: AccountId::new(),
+                owned_agent_id,
+                invocation: Box::new(agent_method_invocation()),
+                target_worker_fingerprint: fingerprint,
+            },
+        )
+        .await;
+
+        svc.process(DateTime::from_str("2023-07-17T10:15:00Z").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(enqueue_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/golem-worker-executor/src/services/worker_activator.rs
+++ b/golem-worker-executor/src/services/worker_activator.rs
@@ -20,7 +20,7 @@ use golem_common::base_model::agent::Principal;
 use golem_common::model::component::ComponentRevision;
 use golem_common::model::invocation_context::InvocationContextStack;
 use golem_common::model::worker::AgentConfigEntryDto;
-use golem_common::model::{AgentId, OwnedAgentId};
+use golem_common::model::{AgentFingerprint, AgentId, OwnedAgentId};
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, Weak};
@@ -29,6 +29,12 @@ use tracing::{error, warn};
 /// Service for activating workers in the background
 #[async_trait]
 pub trait WorkerActivator<Ctx: WorkerCtx>: Send + Sync {
+    /// Returns the fingerprint of an active in-memory worker without touching persistent storage.
+    async fn active_worker_fingerprint(
+        &self,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Option<AgentFingerprint>;
+
     /// Makes sure an already existing worker is active in a background task. Returns immediately
     async fn activate_worker(&self, owned_agent_id: &OwnedAgentId);
 
@@ -81,6 +87,26 @@ impl<Ctx: WorkerCtx> Default for LazyWorkerActivator<Ctx> {
 
 #[async_trait]
 impl<Ctx: WorkerCtx> WorkerActivator<Ctx> for LazyWorkerActivator<Ctx> {
+    async fn active_worker_fingerprint(
+        &self,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Option<AgentFingerprint> {
+        let maybe_worker_activator = self
+            .worker_activator
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|w| w.upgrade());
+        match maybe_worker_activator {
+            Some(worker_activator) => {
+                worker_activator
+                    .active_worker_fingerprint(owned_agent_id)
+                    .await
+            }
+            None => None,
+        }
+    }
+
     async fn activate_worker(&self, owned_agent_id: &OwnedAgentId) {
         let maybe_worker_activator = self
             .worker_activator
@@ -186,7 +212,26 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx>> DefaultWorkerActivator<Ctx, Svcs> {
 impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + Send + Sync + 'static> WorkerActivator<Ctx>
     for DefaultWorkerActivator<Ctx, Svcs>
 {
+    async fn active_worker_fingerprint(
+        &self,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Option<AgentFingerprint> {
+        self.all
+            .active_workers()
+            .try_get(owned_agent_id)
+            .await
+            .map(|worker| worker.get_initial_worker_metadata().fingerprint)
+    }
+
     async fn activate_worker(&self, owned_agent_id: &OwnedAgentId) {
+        if self
+            .active_worker_fingerprint(owned_agent_id)
+            .await
+            .is_some()
+        {
+            return;
+        }
+
         let metadata = self.all.worker_service().get(owned_agent_id).await;
         match metadata {
             Some(_) => {


### PR DESCRIPTION
partially resolves #3563 

Always consult active workers before fetching metadata, which mitigates impact of large metadata.