### PR TITLE
agent-permissions: use cards for existing permission checks (1)

### DIFF
--- a/docs/src/content/next/rest-api/account.mdx
+++ b/docs/src/content/next/rest-api/account.mdx
@@ -13,7 +13,10 @@ Path|Method|Protected
 ```json copy
 {
   "name": "string",
-  "email": "string"
+  "email": "string",
+  "roles": [
+    "admin"
+  ]
 }
 ```
 
@@ -29,6 +32,7 @@ Path|Method|Protected
   "roles": [
     "admin"
   ],
+  "accountRootCardId": "dc9e74a3-7f70-412c-9cf0-c0704225960b",
   "tokenRootCardId": "a8e18d8d-94ae-4ca6-9f9a-b3e564c451f4",
   "tokenRootCardEpoch": 0
 }
@@ -57,6 +61,7 @@ Path|Method|Protected
   "roles": [
     "admin"
   ],
+  "accountRootCardId": "dc9e74a3-7f70-412c-9cf0-c0704225960b",
   "tokenRootCardId": "a8e18d8d-94ae-4ca6-9f9a-b3e564c451f4",
   "tokenRootCardEpoch": 0
 }
@@ -117,6 +122,7 @@ The response is the updated account data.
   "roles": [
     "admin"
   ],
+  "accountRootCardId": "dc9e74a3-7f70-412c-9cf0-c0704225960b",
   "tokenRootCardId": "a8e18d8d-94ae-4ca6-9f9a-b3e564c451f4",
   "tokenRootCardEpoch": 0
 }
@@ -187,42 +193,7 @@ Path|Method|Protected
   "roles": [
     "admin"
   ],
-  "tokenRootCardId": "a8e18d8d-94ae-4ca6-9f9a-b3e564c451f4",
-  "tokenRootCardEpoch": 0
-}
-```
-
-## Set the roles of an account
-Path|Method|Protected
----|---|---
-`/v1/accounts/{account_id}/roles`|PUT|Yes
-
-
-
-
-
-**Example Request JSON**
-```json copy
-{
-  "currentRevision": 0,
-  "roles": [
-    "admin"
-  ]
-}
-```
-
-**Example Response JSON**
-
-```json copy
-{
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "revision": 0,
-  "name": "string",
-  "email": "string",
-  "planId": "b3f60ba2-c1fd-4b3a-a23d-8e876e0ef75d",
-  "roles": [
-    "admin"
-  ],
+  "accountRootCardId": "dc9e74a3-7f70-412c-9cf0-c0704225960b",
   "tokenRootCardId": "a8e18d8d-94ae-4ca6-9f9a-b3e564c451f4",
   "tokenRootCardEpoch": 0
 }

--- a/golem-api-grpc/proto/golem/auth/auth_ctx.proto
+++ b/golem-api-grpc/proto/golem/auth/auth_ctx.proto
@@ -6,11 +6,22 @@ import "golem/common/account_id.proto";
 import "golem/account/plan_id.proto";
 import "golem/auth/account_role.proto";
 import "golem/common/empty.proto";
+import "golem/common/uuid.proto";
+
+message AuthCard {
+  golem.common.UUID card_id = 1;
+  repeated bytes lower_positive = 2;
+  repeated bytes lower_negative = 3;
+  repeated bytes upper_positive = 4;
+  repeated bytes upper_negative = 5;
+}
 
 message UserAuthCtx {
   golem.common.AccountId account_id = 1;
   golem.account.PlanId plan_id = 2;
   repeated AccountRole account_roles = 3;
+  string account_holder = 4;
+  AuthCard auth_card = 5;
 }
 
 message AgentAuthCtx {
@@ -22,6 +33,8 @@ message AdminImpersonationAuthCtx {
   golem.common.AccountId target_account_id = 2;
   repeated AccountRole target_account_roles = 3;
   golem.account.PlanId target_account_plan_id = 4;
+  string target_account_holder = 5;
+  AuthCard auth_card = 6;
 }
 
 message AuthCtx {

--- a/golem-common/src/base_model/card/algebra.rs
+++ b/golem-common/src/base_model/card/algebra.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::base_model::card::recipient::RecipientPattern;
-use crate::base_model::card::{Card, PermissionPattern};
+use crate::base_model::card::{Card, PermissionPattern, PermissionTarget};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -31,7 +31,40 @@ pub struct GrantSurface {
 }
 
 impl GrantSurface {
-    pub fn allows(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+    pub fn allows(&self, request: &PermissionTarget) -> Result<bool, CardAlgebraError> {
+        let granted = self
+            .positive
+            .iter()
+            .any(|grant| grant.subsumes_target(request));
+        if !granted {
+            return Ok(false);
+        }
+
+        let denied = self
+            .negative
+            .iter()
+            .any(|grant| grant.subsumes_target(request));
+        Ok(!denied)
+    }
+
+    pub fn allows_ceiling(&self, request: &PermissionTarget) -> Result<bool, CardAlgebraError> {
+        let granted = self.positive.is_empty()
+            || self
+                .positive
+                .iter()
+                .any(|grant| grant.subsumes_target(request));
+        if !granted {
+            return Ok(false);
+        }
+
+        let denied = self
+            .negative
+            .iter()
+            .any(|grant| grant.subsumes_target(request));
+        Ok(!denied)
+    }
+
+    pub fn allows_grant(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
         let granted = self.positive.iter().any(|grant| grant.subsumes(request));
         if !granted {
             return Ok(false);
@@ -41,7 +74,10 @@ impl GrantSurface {
         Ok(!denied)
     }
 
-    pub fn allows_ceiling(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+    pub fn allows_grant_ceiling(
+        &self,
+        request: &PermissionPattern,
+    ) -> Result<bool, CardAlgebraError> {
         let granted =
             self.positive.is_empty() || self.positive.iter().any(|grant| grant.subsumes(request));
         if !granted {
@@ -117,7 +153,7 @@ impl EffectiveSurface {
         Ok(Self { lower, upper })
     }
 
-    pub fn authorize(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+    pub fn authorize(&self, request: &PermissionTarget) -> Result<bool, CardAlgebraError> {
         if !self.allows_lower(request)? {
             return Ok(false);
         }
@@ -131,7 +167,7 @@ impl EffectiveSurface {
         child_upper_positive: &[PermissionPattern],
     ) -> Result<(), CardAlgebraError> {
         for grant in child_lower_positive {
-            if !self.allows_lower(grant)? {
+            if !self.allows_lower_grant(grant)? {
                 return Err(CardAlgebraError::DerivationNotSubsumed {
                     grant: Box::new(grant.clone()),
                 });
@@ -139,7 +175,7 @@ impl EffectiveSurface {
         }
 
         for grant in child_upper_positive {
-            if !self.allows_upper(grant)? {
+            if !self.allows_upper_grant(grant)? {
                 return Err(CardAlgebraError::DerivationNotSubsumed {
                     grant: Box::new(grant.clone()),
                 });
@@ -149,7 +185,7 @@ impl EffectiveSurface {
         Ok(())
     }
 
-    fn allows_lower(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+    fn allows_lower(&self, request: &PermissionTarget) -> Result<bool, CardAlgebraError> {
         for surface in &self.lower {
             if surface.allows(request)? {
                 return Ok(true);
@@ -159,9 +195,29 @@ impl EffectiveSurface {
         Ok(false)
     }
 
-    fn allows_upper(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+    fn allows_upper(&self, request: &PermissionTarget) -> Result<bool, CardAlgebraError> {
         for surface in &self.upper {
             if !surface.allows_ceiling(request)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn allows_lower_grant(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+        for surface in &self.lower {
+            if surface.allows_grant(request)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn allows_upper_grant(&self, request: &PermissionPattern) -> Result<bool, CardAlgebraError> {
+        for surface in &self.upper {
+            if !surface.allows_grant_ceiling(request)? {
                 return Ok(false);
             }
         }

--- a/golem-common/src/base_model/card/algebra.rs
+++ b/golem-common/src/base_model/card/algebra.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::base_model::card::recipient::RecipientPattern;
 use crate::base_model::card::{Card, PermissionPattern};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum CardAlgebraError {
     InvalidOwnerPath(String),
@@ -23,7 +24,7 @@ pub enum CardAlgebraError {
     DerivationNotSubsumed { grant: Box<PermissionPattern> },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GrantSurface {
     pub positive: Vec<PermissionPattern>,
     pub negative: Vec<PermissionPattern>,
@@ -52,14 +53,14 @@ impl GrantSurface {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EffectiveSurface {
     lower: Vec<GrantSurface>,
     upper: Vec<GrantSurface>,
 }
 
 impl EffectiveSurface {
-    pub fn from_cards(cards: &[Card], holder: &str) -> Result<Self, CardAlgebraError> {
+    pub fn from_cards(cards: &[Card], holder: &RecipientPattern) -> Result<Self, CardAlgebraError> {
         let mut lower = Vec::new();
         let mut upper = Vec::new();
 
@@ -81,6 +82,36 @@ impl EffectiveSurface {
                     negative: upper_negative,
                 });
             }
+        }
+
+        Ok(Self { lower, upper })
+    }
+
+    pub fn from_grants(
+        lower_positive: &[PermissionPattern],
+        lower_negative: &[PermissionPattern],
+        upper_positive: &[PermissionPattern],
+        upper_negative: &[PermissionPattern],
+        holder: &RecipientPattern,
+    ) -> Result<Self, CardAlgebraError> {
+        let mut lower = Vec::new();
+        let lower_positive = filter_by_recipient(lower_positive, holder)?;
+        let lower_negative = filter_by_recipient(lower_negative, holder)?;
+        if !lower_positive.is_empty() {
+            lower.push(GrantSurface {
+                positive: lower_positive,
+                negative: lower_negative,
+            });
+        }
+
+        let mut upper = Vec::new();
+        let upper_positive = filter_by_recipient(upper_positive, holder)?;
+        let upper_negative = filter_by_recipient(upper_negative, holder)?;
+        if !upper_positive.is_empty() || !upper_negative.is_empty() {
+            upper.push(GrantSurface {
+                positive: upper_positive,
+                negative: upper_negative,
+            });
         }
 
         Ok(Self { lower, upper })
@@ -141,11 +172,11 @@ impl EffectiveSurface {
 
 fn filter_by_recipient(
     grants: &[PermissionPattern],
-    holder: &str,
+    holder: &RecipientPattern,
 ) -> Result<Vec<PermissionPattern>, CardAlgebraError> {
     Ok(grants
         .iter()
-        .filter(|grant| grant.matches_recipient(holder))
+        .filter(|grant| grant.recipient().subsumes(holder))
         .cloned()
         .collect())
 }

--- a/golem-common/src/base_model/card/class/account.rs
+++ b/golem-common/src/base_model/card/class/account.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountResourcePattern;
 
@@ -41,7 +41,7 @@ impl ResourcePattern for AccountResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountVerb {
     View,
@@ -61,7 +61,7 @@ impl VerbPattern for AccountVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountClass;
 

--- a/golem-common/src/base_model/card/class/account_oauth2_identity.rs
+++ b/golem-common/src/base_model/card/class/account_oauth2_identity.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountOauth2IdentityResourcePattern {
     Any,
@@ -77,7 +77,7 @@ impl ResourcePattern for AccountOauth2IdentityResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountOauth2IdentityVerb {
     View,
@@ -95,7 +95,7 @@ impl VerbPattern for AccountOauth2IdentityVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountOauth2IdentityClass;
 

--- a/golem-common/src/base_model/card/class/account_plugin.rs
+++ b/golem-common/src/base_model/card/class/account_plugin.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountPluginResourcePattern {
     Any,
     Name(AccountPluginName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct AccountPluginName(pub String);
@@ -66,7 +66,7 @@ impl ResourcePattern for AccountPluginResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountPluginVerb {
     View,
@@ -86,7 +86,7 @@ impl VerbPattern for AccountPluginVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountPluginClass;
 

--- a/golem-common/src/base_model/card/class/account_token.rs
+++ b/golem-common/src/base_model/card/class/account_token.rs
@@ -21,7 +21,7 @@ use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountTokenResourcePattern {
     Any,
@@ -60,7 +60,7 @@ impl ResourcePattern for AccountTokenResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountTokenVerb {
     View,
@@ -78,7 +78,7 @@ impl VerbPattern for AccountTokenVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountTokenClass;
 

--- a/golem-common/src/base_model/card/class/account_token.rs
+++ b/golem-common/src/base_model/card/class/account_token.rs
@@ -17,15 +17,15 @@ use super::{
     PolymorphicPermissionPattern, ResourcePattern, VerbPattern,
 };
 use crate::base_model::card::parsing::CardParseError;
+use crate::model::auth::TokenId;
 use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountTokenResourcePattern {
     Any,
-    Token(Uuid),
+    Token(TokenId),
 }
 
 impl AccountTokenResourcePattern {
@@ -33,7 +33,7 @@ impl AccountTokenResourcePattern {
         Self::Any
     }
 
-    pub fn token(value: Uuid) -> Self {
+    pub fn token(value: TokenId) -> Self {
         Self::Token(value)
     }
 }
@@ -43,7 +43,7 @@ impl ResourcePattern for AccountTokenResourcePattern {
         if resource == "*" {
             Ok(AccountTokenResourcePattern::Any)
         } else {
-            Uuid::parse_str(resource)
+            TokenId::try_from(resource)
                 .map(AccountTokenResourcePattern::Token)
                 .map_err(|_| CardParseError::InvalidResource {
                     class: AccountTokenClass::NAME.to_string(),

--- a/golem-common/src/base_model/card/class/account_usage.rs
+++ b/golem-common/src/base_model/card/class/account_usage.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AccountOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountUsageResourcePattern;
 
@@ -40,7 +40,7 @@ impl ResourcePattern for AccountUsageResourcePattern {
         true
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountUsageVerb {
     View,
@@ -54,7 +54,7 @@ impl VerbPattern for AccountUsageVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AccountUsageClass;
 

--- a/golem-common/src/base_model/card/class/agent.rs
+++ b/golem-common/src/base_model/card/class/agent.rs
@@ -21,7 +21,7 @@ use crate::model::card::owner::AgentOwnerPattern;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AgentResourcePattern {
     Any,
@@ -31,12 +31,12 @@ pub enum AgentResourcePattern {
     PluginName(AgentPluginName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct AgentMethodName(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct AgentPluginName(pub String);
@@ -47,14 +47,14 @@ impl AgentMethodName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AgentInvocationIdPattern {
     Uuid(Uuid),
     Identifier(AgentInvocationIdentifier),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct AgentInvocationIdentifier(pub String);
@@ -96,7 +96,7 @@ impl ResourcePattern for AgentResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AgentVerb {
     Invoke,
@@ -130,7 +130,7 @@ impl VerbPattern for AgentVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct AgentClass;
 

--- a/golem-common/src/base_model/card/class/application.rs
+++ b/golem-common/src/base_model/card/class/application.rs
@@ -21,14 +21,14 @@ use crate::model::card::owner::AccountOwnerPattern;
 use combine::{EasyParser, Parser, eof, many1, satisfy};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ApplicationResourcePattern {
     Any,
     Application(ApplicationName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct ApplicationName(pub String);
@@ -53,7 +53,7 @@ impl ResourcePattern for ApplicationResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ApplicationVerb {
     View,
@@ -75,7 +75,7 @@ impl VerbPattern for ApplicationVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ApplicationClass;
 

--- a/golem-common/src/base_model/card/class/blob.rs
+++ b/golem-common/src/base_model/card/class/blob.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum BlobResourcePattern {
     BucketKey { bucket: String, key_pattern: String },
@@ -71,7 +71,7 @@ impl ResourcePattern for BlobResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum BlobVerb {
     Read,
@@ -91,7 +91,7 @@ impl VerbPattern for BlobVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct BlobClass;
 

--- a/golem-common/src/base_model/card/class/card.rs
+++ b/golem-common/src/base_model/card/class/card.rs
@@ -21,7 +21,7 @@ use crate::model::card::owner::AccountOwnerPattern;
 use crate::model::card::recipient::RecipientPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum CardResourcePattern {
     Any,
@@ -62,7 +62,7 @@ impl ResourcePattern for CardResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum CardVerb {
     Derive,
@@ -82,7 +82,7 @@ impl VerbPattern for CardVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct CardClass;
 

--- a/golem-common/src/base_model/card/class/component.rs
+++ b/golem-common/src/base_model/card/class/component.rs
@@ -22,7 +22,7 @@ use combine::parser::char::string;
 use combine::{EasyParser, Parser, eof, many1, optional, satisfy};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ComponentResourcePattern {
     Any,
@@ -33,7 +33,7 @@ pub enum ComponentResourcePattern {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct ComponentName(pub String);
@@ -70,7 +70,7 @@ impl ResourcePattern for ComponentResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ComponentVerb {
     View,
@@ -90,7 +90,7 @@ impl VerbPattern for ComponentVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ComponentClass;
 

--- a/golem-common/src/base_model/card/class/config.rs
+++ b/golem-common/src/base_model/card/class/config.rs
@@ -20,20 +20,20 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AgentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ConfigResourcePattern {
     Any,
     Key(ConfigKeyPathPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ConfigKeyPathPattern {
     pub segments: Vec<ConfigKeySegmentPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ConfigKeySegmentPattern {
     Literal(String),
@@ -87,7 +87,7 @@ impl ResourcePattern for ConfigResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ConfigVerb {
     Read,
@@ -101,7 +101,7 @@ impl VerbPattern for ConfigVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ConfigClass;
 

--- a/golem-common/src/base_model/card/class/env.rs
+++ b/golem-common/src/base_model/card/class/env.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AgentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvResourcePattern {
     Any,
     VarName(EnvVarName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvVarName(pub String);
@@ -75,7 +75,7 @@ impl ResourcePattern for EnvResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvVerb {
     Read,
@@ -89,7 +89,7 @@ impl VerbPattern for EnvVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvClass;
 

--- a/golem-common/src/base_model/card/class/environment.rs
+++ b/golem-common/src/base_model/card/class/environment.rs
@@ -22,7 +22,7 @@ use combine::parser::char::string;
 use combine::{EasyParser, Parser, eof, many1, optional, satisfy};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentResourcePattern {
     Any,
@@ -33,7 +33,7 @@ pub enum EnvironmentResourcePattern {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentName(pub String);
@@ -70,7 +70,7 @@ impl ResourcePattern for EnvironmentResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentVerb {
     View,
@@ -102,7 +102,7 @@ impl VerbPattern for EnvironmentVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentClass;
 

--- a/golem-common/src/base_model/card/class/environment_agent_secret.rs
+++ b/golem-common/src/base_model/card/class/environment_agent_secret.rs
@@ -20,20 +20,20 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentAgentSecretResourcePattern {
     Any,
     Key(EnvironmentAgentSecretKeyPathPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentAgentSecretKeyPathPattern {
     pub segments: Vec<EnvironmentAgentSecretKeySegmentPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentAgentSecretKeySegmentPattern {
     Literal(String),
@@ -87,7 +87,7 @@ impl ResourcePattern for EnvironmentAgentSecretResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentAgentSecretVerb {
     View,
@@ -109,7 +109,7 @@ impl VerbPattern for EnvironmentAgentSecretVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentAgentSecretClass;
 

--- a/golem-common/src/base_model/card/class/environment_blob_bucket.rs
+++ b/golem-common/src/base_model/card/class/environment_blob_bucket.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentBlobBucketResourcePattern {
     Any,
     Name(EnvironmentBlobBucketName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentBlobBucketName(pub String);
@@ -66,7 +66,7 @@ impl ResourcePattern for EnvironmentBlobBucketResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentBlobBucketVerb {
     View,
@@ -86,7 +86,7 @@ impl VerbPattern for EnvironmentBlobBucketVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentBlobBucketClass;
 

--- a/golem-common/src/base_model/card/class/environment_domain_registration.rs
+++ b/golem-common/src/base_model/card/class/environment_domain_registration.rs
@@ -20,20 +20,20 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentDomainRegistrationResourcePattern {
     Any,
     Domain(DomainNamePattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct DomainNamePattern {
     pub labels: Vec<DomainLabel>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct DomainLabel(pub String);
@@ -94,7 +94,7 @@ impl ResourcePattern for EnvironmentDomainRegistrationResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentDomainRegistrationVerb {
     View,
@@ -112,7 +112,7 @@ impl VerbPattern for EnvironmentDomainRegistrationVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentDomainRegistrationClass;
 

--- a/golem-common/src/base_model/card/class/environment_http_api_deployment.rs
+++ b/golem-common/src/base_model/card/class/environment_http_api_deployment.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentHttpApiDeploymentResourcePattern {
     Any,
@@ -78,7 +78,7 @@ impl ResourcePattern for EnvironmentHttpApiDeploymentResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentHttpApiDeploymentVerb {
     View,
@@ -100,7 +100,7 @@ impl VerbPattern for EnvironmentHttpApiDeploymentVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentHttpApiDeploymentClass;
 

--- a/golem-common/src/base_model/card/class/environment_initial_files.rs
+++ b/golem-common/src/base_model/card/class/environment_initial_files.rs
@@ -20,19 +20,19 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::ComponentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentInitialFilesResourcePattern {
     Path(EnvironmentInitialFilesPathPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentInitialFilesPathPattern {
     pub segments: Vec<EnvironmentInitialFilesPathSegmentPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentInitialFilesPathSegmentPattern {
     Literal(String),
@@ -84,7 +84,7 @@ impl ResourcePattern for EnvironmentInitialFilesResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentInitialFilesVerb {
     View,
@@ -104,7 +104,7 @@ impl VerbPattern for EnvironmentInitialFilesVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentInitialFilesClass;
 

--- a/golem-common/src/base_model/card/class/environment_kv_bucket.rs
+++ b/golem-common/src/base_model/card/class/environment_kv_bucket.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentKvBucketResourcePattern {
     Any,
     Name(EnvironmentKvBucketName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentKvBucketName(pub String);
@@ -66,7 +66,7 @@ impl ResourcePattern for EnvironmentKvBucketResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentKvBucketVerb {
     View,
@@ -86,7 +86,7 @@ impl VerbPattern for EnvironmentKvBucketVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentKvBucketClass;
 

--- a/golem-common/src/base_model/card/class/environment_mcp_deployment.rs
+++ b/golem-common/src/base_model/card/class/environment_mcp_deployment.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentMcpDeploymentResourcePattern {
     Any,
     Name(EnvironmentMcpDeploymentName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentMcpDeploymentName(pub String);
@@ -67,7 +67,7 @@ impl ResourcePattern for EnvironmentMcpDeploymentResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentMcpDeploymentVerb {
     View,
@@ -89,7 +89,7 @@ impl VerbPattern for EnvironmentMcpDeploymentVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentMcpDeploymentClass;
 

--- a/golem-common/src/base_model/card/class/environment_plugin_grant.rs
+++ b/golem-common/src/base_model/card/class/environment_plugin_grant.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentPluginGrantResourcePattern {
     Any,
     Name(EnvironmentPluginGrantName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentPluginGrantName(pub String);
@@ -66,7 +66,7 @@ impl ResourcePattern for EnvironmentPluginGrantResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentPluginGrantVerb {
     View,
@@ -84,7 +84,7 @@ impl VerbPattern for EnvironmentPluginGrantVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentPluginGrantClass;
 

--- a/golem-common/src/base_model/card/class/environment_resource_definition.rs
+++ b/golem-common/src/base_model/card/class/environment_resource_definition.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentResourceDefinitionResourcePattern {
     Any,
     Name(EnvironmentResourceDefinitionName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentResourceDefinitionName(pub String);
@@ -67,7 +67,7 @@ impl ResourcePattern for EnvironmentResourceDefinitionResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentResourceDefinitionVerb {
     View,
@@ -89,7 +89,7 @@ impl VerbPattern for EnvironmentResourceDefinitionVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentResourceDefinitionClass;
 

--- a/golem-common/src/base_model/card/class/environment_retry_policy.rs
+++ b/golem-common/src/base_model/card/class/environment_retry_policy.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentRetryPolicyResourcePattern {
     Any,
     Name(EnvironmentRetryPolicyName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentRetryPolicyName(pub String);
@@ -66,7 +66,7 @@ impl ResourcePattern for EnvironmentRetryPolicyResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentRetryPolicyVerb {
     View,
@@ -88,7 +88,7 @@ impl VerbPattern for EnvironmentRetryPolicyVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentRetryPolicyClass;
 

--- a/golem-common/src/base_model/card/class/environment_security_scheme.rs
+++ b/golem-common/src/base_model/card/class/environment_security_scheme.rs
@@ -20,14 +20,14 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentSecuritySchemeResourcePattern {
     Any,
     Name(EnvironmentSecuritySchemeName),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct EnvironmentSecuritySchemeName(pub String);
@@ -67,7 +67,7 @@ impl ResourcePattern for EnvironmentSecuritySchemeResourcePattern {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentSecuritySchemeVerb {
     View,
@@ -89,7 +89,7 @@ impl VerbPattern for EnvironmentSecuritySchemeVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentSecuritySchemeClass;
 

--- a/golem-common/src/base_model/card/class/environment_share.rs
+++ b/golem-common/src/base_model/card/class/environment_share.rs
@@ -21,7 +21,7 @@ use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentShareResourcePattern {
     Any,
@@ -56,7 +56,7 @@ impl ResourcePattern for EnvironmentShareResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentShareVerb {
     View,
@@ -78,7 +78,7 @@ impl VerbPattern for EnvironmentShareVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EnvironmentShareClass;
 

--- a/golem-common/src/base_model/card/class/environment_share.rs
+++ b/golem-common/src/base_model/card/class/environment_share.rs
@@ -18,14 +18,14 @@ use super::{
 };
 use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
+use crate::model::environment_share::EnvironmentShareId;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentShareResourcePattern {
     Any,
-    Share(Uuid),
+    Share(EnvironmentShareId),
 }
 
 impl EnvironmentShareResourcePattern {
@@ -39,7 +39,7 @@ impl ResourcePattern for EnvironmentShareResourcePattern {
         if resource == "*" {
             Ok(EnvironmentShareResourcePattern::Any)
         } else {
-            Uuid::parse_str(resource)
+            EnvironmentShareId::try_from(resource)
                 .map(EnvironmentShareResourcePattern::Share)
                 .map_err(|_| CardParseError::InvalidResource {
                     class: EnvironmentShareClass::NAME.to_string(),

--- a/golem-common/src/base_model/card/class/filesystem.rs
+++ b/golem-common/src/base_model/card/class/filesystem.rs
@@ -20,19 +20,19 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AgentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum FilesystemResourcePattern {
     Path(FilesystemPathPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct FilesystemPathPattern {
     pub segments: Vec<FilesystemPathSegmentPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum FilesystemPathSegmentPattern {
     Literal(String),
@@ -84,7 +84,7 @@ impl ResourcePattern for FilesystemResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum FilesystemVerb {
     Read,
@@ -106,7 +106,7 @@ impl VerbPattern for FilesystemVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct FilesystemClass;
 

--- a/golem-common/src/base_model/card/class/kv.rs
+++ b/golem-common/src/base_model/card/class/kv.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum KvResourcePattern {
     StoreKey { store: String, key_pattern: String },
@@ -71,7 +71,7 @@ impl ResourcePattern for KvResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum KvVerb {
     Read,
@@ -91,7 +91,7 @@ impl VerbPattern for KvVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct KvClass;
 

--- a/golem-common/src/base_model/card/class/mod.rs
+++ b/golem-common/src/base_model/card/class/mod.rs
@@ -207,6 +207,14 @@ pub trait PermissionClass {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
+pub struct ClassPermissionTarget<C: PermissionClass> {
+    pub verb: Option<C::Verb>,
+    pub owner: C::Owner,
+    pub resource: C::Resource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ClassPermissionPattern<C: PermissionClass> {
     pub verb: Option<C::Verb>,
     pub owner: C::Owner,
@@ -218,6 +226,12 @@ impl<C: PermissionClass> ClassPermissionPattern<C> {
     pub fn subsumes(&self, other: &Self) -> bool {
         self.owner.subsumes(&other.owner)
             && self.recipient.subsumes(&other.recipient)
+            && (self.verb.is_none() || self.verb == other.verb)
+            && self.resource.subsumes(&other.resource)
+    }
+
+    pub fn subsumes_target(&self, other: &ClassPermissionTarget<C>) -> bool {
+        self.owner.subsumes(&other.owner)
             && (self.verb.is_none() || self.verb == other.verb)
             && self.resource.subsumes(&other.resource)
     }

--- a/golem-common/src/base_model/card/class/mod.rs
+++ b/golem-common/src/base_model/card/class/mod.rs
@@ -138,6 +138,7 @@ pub trait VerbPattern:
     + Clone
     + PartialEq
     + Eq
+    + std::hash::Hash
     + Serialize
     + for<'de> Deserialize<'de>
     + desert_rust::BinarySerializer
@@ -150,7 +151,7 @@ pub trait VerbPattern:
 
 #[cfg(not(feature = "full"))]
 pub trait VerbPattern:
-    Debug + Copy + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de>
+    Debug + Copy + Clone + PartialEq + Eq + std::hash::Hash + Serialize + for<'de> Deserialize<'de>
 {
     fn parse_verb(verb: &str) -> Option<Self>
     where
@@ -163,6 +164,7 @@ pub trait ResourcePattern:
     + Clone
     + PartialEq
     + Eq
+    + std::hash::Hash
     + Serialize
     + for<'de> Deserialize<'de>
     + desert_rust::BinarySerializer
@@ -177,7 +179,7 @@ pub trait ResourcePattern:
 
 #[cfg(not(feature = "full"))]
 pub trait ResourcePattern:
-    Debug + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de>
+    Debug + Clone + PartialEq + Eq + std::hash::Hash + Serialize + for<'de> Deserialize<'de>
 {
     fn parse_resource(resource: &str) -> Result<Self, CardParseError>
     where
@@ -203,7 +205,7 @@ pub trait PermissionClass {
         Self: Sized;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ClassPermissionPattern<C: PermissionClass> {
     pub verb: Option<C::Verb>,
@@ -225,7 +227,7 @@ impl<C: PermissionClass> ClassPermissionPattern<C> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct PolymorphicClassPermissionPattern<C: PermissionClass> {
     pub verb: Option<C::Verb>,
@@ -234,7 +236,7 @@ pub struct PolymorphicClassPermissionPattern<C: PermissionClass> {
     pub resource: C::Resource,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct PolymorphicManifestClassPermissionPattern<C: PermissionClass> {
     pub verb: Option<C::Verb>,

--- a/golem-common/src/base_model/card/class/mod.rs
+++ b/golem-common/src/base_model/card/class/mod.rs
@@ -221,10 +221,6 @@ impl<C: PermissionClass> ClassPermissionPattern<C> {
             && (self.verb.is_none() || self.verb == other.verb)
             && self.resource.subsumes(&other.resource)
     }
-
-    pub fn matches_holder(&self, holder: &str) -> bool {
-        self.recipient.matches_holder(holder)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/golem-common/src/base_model/card/class/network.rs
+++ b/golem-common/src/base_model/card/class/network.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EmptyOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PortPattern {
     Any,
@@ -65,7 +65,7 @@ impl PortPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum NetworkResourcePattern {
     Any,
@@ -126,7 +126,7 @@ impl ResourcePattern for NetworkResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum NetworkVerb {
     Connect,
@@ -140,7 +140,7 @@ impl VerbPattern for NetworkVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct NetworkClass;
 

--- a/golem-common/src/base_model/card/class/oplog.rs
+++ b/golem-common/src/base_model/card/class/oplog.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::AgentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum OplogResourcePattern {
     Any,
@@ -82,7 +82,7 @@ impl ResourcePattern for OplogResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum OplogVerb {
     Read,
@@ -96,7 +96,7 @@ impl VerbPattern for OplogVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct OplogClass;
 

--- a/golem-common/src/base_model/card/class/plan.rs
+++ b/golem-common/src/base_model/card/class/plan.rs
@@ -21,21 +21,21 @@ use crate::model::card::owner::EmptyOwnerPattern;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PlanResourcePattern {
     Any,
     Plan(PlanIdPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PlanIdPattern {
     Identifier(PlanIdentifier),
     Uuid(Uuid),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct PlanIdentifier(pub String);
@@ -83,7 +83,7 @@ impl ResourcePattern for PlanResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PlanVerb {
     View,
@@ -101,7 +101,7 @@ impl VerbPattern for PlanVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct PlanClass;
 

--- a/golem-common/src/base_model/card/class/plan.rs
+++ b/golem-common/src/base_model/card/class/plan.rs
@@ -18,8 +18,8 @@ use super::{
 };
 use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EmptyOwnerPattern;
+use crate::model::plan::PlanId;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
@@ -32,7 +32,7 @@ pub enum PlanResourcePattern {
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PlanIdPattern {
     Identifier(PlanIdentifier),
-    Uuid(Uuid),
+    PlanId(PlanId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -123,8 +123,8 @@ impl PermissionClass for PlanClass {
 }
 
 fn parse_plan_id(value: &str) -> Result<PlanIdPattern, String> {
-    if let Ok(uuid) = Uuid::parse_str(value) {
-        Ok(PlanIdPattern::Uuid(uuid))
+    if let Ok(plan_id) = PlanId::try_from(value) {
+        Ok(PlanIdPattern::PlanId(plan_id))
     } else {
         PlanIdentifier::parse(value).map(PlanIdPattern::Identifier)
     }

--- a/golem-common/src/base_model/card/class/rdbms.rs
+++ b/golem-common/src/base_model/card/class/rdbms.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum RdbmsResourcePattern {
     Table {
@@ -81,7 +81,7 @@ impl ResourcePattern for RdbmsResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum RdbmsVerb {
     Query,
@@ -97,7 +97,7 @@ impl VerbPattern for RdbmsVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct RdbmsClass;
 

--- a/golem-common/src/base_model/card/class/secret.rs
+++ b/golem-common/src/base_model/card/class/secret.rs
@@ -20,20 +20,20 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EnvironmentOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum SecretResourcePattern {
     Any,
     Key(SecretKeyPathPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct SecretKeyPathPattern {
     pub segments: Vec<SecretKeySegmentPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum SecretKeySegmentPattern {
     Literal(String),
@@ -87,7 +87,7 @@ impl ResourcePattern for SecretResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum SecretVerb {
     Hold,
@@ -105,7 +105,7 @@ impl VerbPattern for SecretVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct SecretClass;
 

--- a/golem-common/src/base_model/card/class/system.rs
+++ b/golem-common/src/base_model/card/class/system.rs
@@ -20,7 +20,7 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::EmptyOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct SystemResourcePattern;
 
@@ -40,7 +40,7 @@ impl ResourcePattern for SystemResourcePattern {
         true
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum SystemVerb {
     CreateAccount,
@@ -60,7 +60,7 @@ impl VerbPattern for SystemVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct SystemClass;
 

--- a/golem-common/src/base_model/card/class/tool.rs
+++ b/golem-common/src/base_model/card/class/tool.rs
@@ -20,21 +20,21 @@ use crate::base_model::card::parsing::CardParseError;
 use crate::model::card::owner::ToolOwnerPattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ToolResourcePattern {
     AnyInvocation,
     Invocation(ToolInvocationPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ToolInvocationPattern {
     pub command_path: Option<Vec<ToolIdentifier>>,
     pub args: Vec<ToolArgPattern>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct ToolIdentifier(pub String);
@@ -54,7 +54,7 @@ impl ToolIdentifier {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ToolArgPattern {
     ShortFlags {
@@ -68,7 +68,7 @@ pub enum ToolArgPattern {
     Positional(ToolValuePattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ToolValuePattern {
     Literal(ToolValueLiteral),
@@ -76,7 +76,7 @@ pub enum ToolValuePattern {
     GlobStar,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 #[cfg_attr(feature = "full", desert(transparent))]
 pub struct ToolValueLiteral(pub String);
@@ -114,7 +114,7 @@ impl ResourcePattern for ToolResourcePattern {
         }
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ToolVerb {
     Invoke,
@@ -128,7 +128,7 @@ impl VerbPattern for ToolVerb {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct ToolClass;
 

--- a/golem-common/src/base_model/card/owner/account.rs
+++ b/golem-common/src/base_model/card/owner/account.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AccountOwnerPattern {
     Any,
@@ -33,7 +33,7 @@ impl AccountOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicAccountOwnerPattern {
     Concrete(AccountOwnerPattern),

--- a/golem-common/src/base_model/card/owner/agent.rs
+++ b/golem-common/src/base_model/card/owner/agent.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AgentOwnerLeafPattern {
     Agent(String),
@@ -44,7 +44,7 @@ impl AgentOwnerLeafPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum AgentOwnerPattern {
     AnyAgents,
@@ -190,7 +190,7 @@ impl AgentOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicAgentOwnerPattern {
     Concrete(AgentOwnerPattern),

--- a/golem-common/src/base_model/card/owner/application.rs
+++ b/golem-common/src/base_model/card/owner/application.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ApplicationOwnerPattern {
     AnyApplications,
@@ -52,7 +52,7 @@ impl ApplicationOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicApplicationOwnerPattern {
     Concrete(ApplicationOwnerPattern),

--- a/golem-common/src/base_model/card/owner/component.rs
+++ b/golem-common/src/base_model/card/owner/component.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ComponentOwnerPattern {
     AnyComponents,
@@ -114,7 +114,7 @@ impl ComponentOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicComponentOwnerPattern {
     Concrete(ComponentOwnerPattern),

--- a/golem-common/src/base_model/card/owner/empty.rs
+++ b/golem-common/src/base_model/card/owner/empty.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub struct EmptyOwnerPattern;
 
@@ -28,7 +28,7 @@ impl EmptyOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicEmptyOwnerPattern {
     Concrete(EmptyOwnerPattern),

--- a/golem-common/src/base_model/card/owner/environment.rs
+++ b/golem-common/src/base_model/card/owner/environment.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum EnvironmentOwnerPattern {
     AnyEnvironments,
@@ -77,7 +77,7 @@ impl EnvironmentOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicEnvironmentOwnerPattern {
     Concrete(EnvironmentOwnerPattern),

--- a/golem-common/src/base_model/card/owner/mod.rs
+++ b/golem-common/src/base_model/card/owner/mod.rs
@@ -37,6 +37,7 @@ pub trait OwnerPattern:
     + Clone
     + PartialEq
     + Eq
+    + std::hash::Hash
     + Serialize
     + for<'de> Deserialize<'de>
     + desert_rust::BinarySerializer
@@ -46,6 +47,7 @@ pub trait OwnerPattern:
         + Clone
         + PartialEq
         + Eq
+        + std::hash::Hash
         + Serialize
         + for<'de> Deserialize<'de>
         + desert_rust::BinarySerializer
@@ -63,9 +65,15 @@ pub trait OwnerPattern:
 
 #[cfg(not(feature = "full"))]
 pub trait OwnerPattern:
-    Debug + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de>
+    Debug + Clone + PartialEq + Eq + std::hash::Hash + Serialize + for<'de> Deserialize<'de>
 {
-    type Polymorphic: Debug + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de>;
+    type Polymorphic: Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + std::hash::Hash
+        + Serialize
+        + for<'de> Deserialize<'de>;
 
     fn parse(value: &str) -> Result<Self, String>
     where

--- a/golem-common/src/base_model/card/owner/tool.rs
+++ b/golem-common/src/base_model/card/owner/tool.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum ToolOwnerPattern {
     AnyTools,
@@ -160,7 +160,7 @@ impl ToolOwnerPattern {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicToolOwnerPattern {
     Concrete(ToolOwnerPattern),

--- a/golem-common/src/base_model/card/parsing.rs
+++ b/golem-common/src/base_model/card/parsing.rs
@@ -21,7 +21,7 @@ use combine::{EasyParser, Parser, any, eof, many, none_of};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum CardParseError {
     InvalidRecipientPath(String),

--- a/golem-common/src/base_model/card/parsing_tests.rs
+++ b/golem-common/src/base_model/card/parsing_tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::model::auth::TokenId;
 use crate::model::card::owner::{
     AccountOwnerPattern, AgentOwnerLeafPattern, AgentOwnerPattern, ApplicationOwnerPattern,
     ComponentOwnerPattern, EmptyOwnerPattern, EnvironmentOwnerPattern,
@@ -24,6 +25,7 @@ use crate::model::card::recipient::{
     PolymorphicAgentRecipientPattern, PolymorphicEnvironmentRecipientPattern,
     PolymorphicRecipientPattern, RecipientPattern,
 };
+use crate::model::environment_share::EnvironmentShareId;
 use RecipientPattern as AccountRecipientPattern;
 use RecipientPattern as AgentRecipientPattern;
 use RecipientPattern as EnvironmentRecipientPattern;
@@ -129,8 +131,16 @@ fn environment_agent_secret_key(
     EnvironmentAgentSecretResourcePattern::Key(EnvironmentAgentSecretKeyPathPattern { segments })
 }
 
-fn token_id() -> uuid::Uuid {
+fn fixed_uuid() -> uuid::Uuid {
     uuid::Uuid::from_u128(0x550e8400e29b41d4a716446655440000)
+}
+
+fn token_id() -> TokenId {
+    TokenId(fixed_uuid())
+}
+
+fn environment_share_id() -> EnvironmentShareId {
+    EnvironmentShareId(fixed_uuid())
 }
 
 #[test_gen]
@@ -457,7 +467,7 @@ fn parses_runtime_class_examples_from_spec(r: &mut DynamicTestRegistration) {
                 ),
                 recipient: agent_recipient("acme", "shop", "prod", "cart-svc", "ShoppingCart(*)"),
                 resource: AgentResourcePattern::InvocationId(AgentInvocationIdPattern::Uuid(
-                    token_id(),
+                    fixed_uuid(),
                 )),
             }),
         ),
@@ -770,7 +780,7 @@ fn parses_runtime_class_examples_from_spec(r: &mut DynamicTestRegistration) {
                 verb: Some(EnvironmentShareVerb::View),
                 owner: environment_owner("acme", "shop", "prod"),
                 recipient: environment_recipient("acme", "shop", "prod"),
-                resource: EnvironmentShareResourcePattern::Share(token_id()),
+                resource: EnvironmentShareResourcePattern::Share(environment_share_id()),
             }),
         ),
         (

--- a/golem-common/src/base_model/card/pattern.rs
+++ b/golem-common/src/base_model/card/pattern.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 macro_rules! define_permission_pattern {
     ($($variant:ident: $class:ty,)+) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
         pub enum PermissionPattern {
             $($variant(ClassPermissionPattern<$class>),)+
@@ -28,7 +28,7 @@ macro_rules! define_permission_pattern {
 
 macro_rules! define_polymorphic_permission_pattern {
     ($($variant:ident: $class:ty,)+) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
         pub enum PolymorphicPermissionPattern {
             $($variant(PolymorphicClassPermissionPattern<$class>),)+
@@ -38,7 +38,7 @@ macro_rules! define_polymorphic_permission_pattern {
 
 macro_rules! define_polymorphic_manifest_permission_pattern {
     ($($variant:ident: $class:ty,)+) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
         pub enum PolymorphicManifestPermissionPattern {
             $($variant(PolymorphicManifestClassPermissionPattern<$class>),)+

--- a/golem-common/src/base_model/card/pattern.rs
+++ b/golem-common/src/base_model/card/pattern.rs
@@ -26,6 +26,16 @@ macro_rules! define_permission_pattern {
     };
 }
 
+macro_rules! define_permission_target {
+    ($($variant:ident: $class:ty,)+) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
+        pub enum PermissionTarget {
+            $($variant(ClassPermissionTarget<$class>),)+
+        }
+    };
+}
+
 macro_rules! define_polymorphic_permission_pattern {
     ($($variant:ident: $class:ty,)+) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -47,6 +57,7 @@ macro_rules! define_polymorphic_manifest_permission_pattern {
 }
 
 card_permission_classes!(define_permission_pattern);
+card_permission_classes!(define_permission_target);
 card_permission_classes!(define_polymorphic_permission_pattern);
 card_permission_classes!(define_polymorphic_manifest_permission_pattern);
 
@@ -81,6 +92,23 @@ macro_rules! define_same_variant_subsumes_match {
 
 card_permission_classes!(define_same_variant_subsumes_match);
 
+macro_rules! define_same_variant_subsumes_target_match {
+    ($($variant:ident: $class:ty,)+) => {
+        macro_rules! same_variant_subsumes_target_match {
+            ($left:expr, $right:expr) => {
+                match ($left, $right) {
+                    $(
+                        (PermissionPattern::$variant(a), PermissionTarget::$variant(b)) => a.subsumes_target(b),
+                    )+
+                    _ => false,
+                }
+            };
+        }
+    };
+}
+
+card_permission_classes!(define_same_variant_subsumes_target_match);
+
 macro_rules! define_recipient_match {
     ($($variant:ident: $class:ty,)+) => {
         macro_rules! recipient_match {
@@ -106,8 +134,18 @@ impl PermissionPattern {
         same_variant_subsumes_match!(self, other)
     }
 
+    pub fn subsumes_target(&self, other: &PermissionTarget) -> bool {
+        same_variant_subsumes_target_match!(self, other)
+    }
+
     pub fn recipient(&self) -> &crate::model::card::recipient::RecipientPattern {
         recipient_match!(self)
+    }
+}
+
+impl PermissionTarget {
+    pub fn class_name(&self) -> &'static str {
+        class_name_match!(self)
     }
 }
 

--- a/golem-common/src/base_model/card/pattern.rs
+++ b/golem-common/src/base_model/card/pattern.rs
@@ -81,22 +81,6 @@ macro_rules! define_same_variant_subsumes_match {
 
 card_permission_classes!(define_same_variant_subsumes_match);
 
-macro_rules! define_matches_recipient_match {
-    ($($variant:ident: $class:ty,)+) => {
-        macro_rules! matches_recipient_match {
-            ($self:expr, $holder:expr) => {
-                match $self {
-                    $(
-                        Self::$variant(pattern) => pattern.matches_holder($holder),
-                    )+
-                }
-            };
-        }
-    };
-}
-
-card_permission_classes!(define_matches_recipient_match);
-
 macro_rules! define_recipient_match {
     ($($variant:ident: $class:ty,)+) => {
         macro_rules! recipient_match {
@@ -120,10 +104,6 @@ impl PermissionPattern {
 
     pub fn subsumes(&self, other: &Self) -> bool {
         same_variant_subsumes_match!(self, other)
-    }
-
-    pub fn matches_recipient(&self, holder: &str) -> bool {
-        matches_recipient_match!(self, holder)
     }
 
     pub fn recipient(&self) -> &crate::model::card::recipient::RecipientPattern {

--- a/golem-common/src/base_model/card/recipient.rs
+++ b/golem-common/src/base_model/card/recipient.rs
@@ -90,13 +90,6 @@ impl RecipientPattern {
         }
     }
 
-    pub fn matches_holder(&self, holder: &str) -> bool {
-        let Ok(holder) = Self::parse_holder(holder) else {
-            return false;
-        };
-        self.subsumes(&holder)
-    }
-
     pub fn subsumes(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Any, _) => true,
@@ -137,14 +130,6 @@ impl RecipientPattern {
             }
             (Self::Agent { .. }, _) => false,
         }
-    }
-
-    fn parse_holder(value: &str) -> Result<Self, String> {
-        let segments = parse_holder_segments(value)?;
-        if segments.contains(&"*") {
-            return Err(value.to_string());
-        }
-        Self::parse(value)
     }
 
     fn account_part(&self) -> Option<&str> {
@@ -238,14 +223,6 @@ fn parse_anchored_segments(value: &str) -> Result<Vec<&str>, String> {
         Err(value.to_string())
     } else {
         Ok(segments)
-    }
-}
-
-fn parse_holder_segments(value: &str) -> Result<Vec<&str>, String> {
-    let segments = parse_anchored_segments(value)?;
-    match segments.len() {
-        1 | 3 | 5 => Ok(segments),
-        _ => Err(value.to_string()),
     }
 }
 

--- a/golem-common/src/base_model/card/recipient.rs
+++ b/golem-common/src/base_model/card/recipient.rs
@@ -14,7 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum RecipientPattern {
     Any,
@@ -35,7 +35,7 @@ pub enum RecipientPattern {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicRecipientPattern {
     Concrete(RecipientPattern),
@@ -44,7 +44,7 @@ pub enum PolymorphicRecipientPattern {
     Agent(PolymorphicAgentRecipientPattern),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicEnvironmentRecipientPattern {
     AccountEnvironments,
@@ -52,7 +52,7 @@ pub enum PolymorphicEnvironmentRecipientPattern {
     Environment,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum PolymorphicAgentRecipientPattern {
     AccountAgents,

--- a/golem-common/src/base_model/card/subsumption_tests.rs
+++ b/golem-common/src/base_model/card/subsumption_tests.rs
@@ -176,18 +176,20 @@ fn recipient_patterns_subsume_only_matching_holder_subtrees() {
     let agent_type = AgentRecipientPattern::parse("acme/shop/prod/cart-svc/*").unwrap();
     let agent =
         AgentRecipientPattern::parse("acme/shop/prod/cart-svc/ShoppingCart(\"42\")").unwrap();
+    let other_agent =
+        AgentRecipientPattern::parse("other/shop/prod/cart-svc/ShoppingCart(\"42\")").unwrap();
 
-    assert!(account.matches_holder("acme/shop/prod/cart-svc/ShoppingCart(\"42\")"));
-    assert!(account.matches_holder("acme/shop/prod"));
+    assert!(account.subsumes(&agent));
+    assert!(account.subsumes(&environment));
     assert!(account_environments.subsumes(&environment));
-    assert!(account_environments.matches_holder("acme/shop/prod/cart-svc/ShoppingCart(\"42\")"));
-    assert!(environment.matches_holder("acme/shop/prod/cart-svc/ShoppingCart(\"42\")"));
+    assert!(account_environments.subsumes(&agent));
+    assert!(environment.subsumes(&agent));
     assert!(account_agents.subsumes(&agent));
     assert!(application_agents.subsumes(&agent));
-    assert!(!account_agents.matches_holder("acme/shop/prod"));
+    assert!(!account_agents.subsumes(&environment));
     assert!(agent_type.subsumes(&agent));
     assert!(!agent.subsumes(&agent_type));
-    assert!(!account.matches_holder("other/shop/prod/cart-svc/ShoppingCart(\"42\")"));
+    assert!(!account.subsumes(&other_agent));
 }
 
 #[test_gen]
@@ -302,32 +304,29 @@ fn generate_recipient_matching_tests(r: &mut DynamicTestRegistration) {
                 "recipient_matching_{}_{}",
                 test_name(recipient),
                 if expected {
-                    "matches_holder"
+                    "subsumes_holder"
                 } else {
-                    "does_not_match_holder"
+                    "does_not_subsume_holder"
                 }
             ),
             TestProperties::unit_test(),
             || {
                 let holder = "acme/shop/prod/cart-svc/ShoppingCart(\"42\")";
 
-                assert_eq!(recipient_matches_holder(recipient, holder), expected);
+                assert_eq!(recipient_subsumes_holder(recipient, holder), expected);
             }
         );
     }
 }
 
-fn recipient_matches_holder(recipient: &str, holder: &str) -> bool {
-    AgentRecipientPattern::parse(recipient)
-        .map(|recipient| recipient.matches_holder(holder))
-        .or_else(|_| {
-            EnvironmentRecipientPattern::parse(recipient)
-                .map(|recipient| recipient.matches_holder(holder))
-        })
-        .or_else(|_| {
-            AccountRecipientPattern::parse(recipient)
-                .map(|recipient| recipient.matches_holder(holder))
-        })
+fn recipient_subsumes_holder(recipient: &str, holder: &str) -> bool {
+    parse_recipient(recipient).subsumes(&parse_recipient(holder))
+}
+
+fn parse_recipient(value: &str) -> RecipientPattern {
+    AgentRecipientPattern::parse(value)
+        .or_else(|_| EnvironmentRecipientPattern::parse(value))
+        .or_else(|_| AccountRecipientPattern::parse(value))
         .unwrap()
 }
 

--- a/golem-common/src/base_model/card/subsumption_tests.rs
+++ b/golem-common/src/base_model/card/subsumption_tests.rs
@@ -34,6 +34,14 @@ fn fs(owner: &str, recipient: &str, resource: FilesystemResourcePattern) -> Perm
     })
 }
 
+fn fs_target(owner: &str, resource: FilesystemResourcePattern) -> PermissionTarget {
+    PermissionTarget::Filesystem(ClassPermissionTarget::<FilesystemClass> {
+        verb: Some(FilesystemVerb::Read),
+        owner: AgentOwnerPattern::parse(owner).unwrap(),
+        resource,
+    })
+}
+
 fn fs_path(segments: Vec<FilesystemPathSegmentPattern>) -> FilesystemResourcePattern {
     FilesystemResourcePattern::Path(FilesystemPathPattern { segments })
 }
@@ -930,14 +938,12 @@ fn negative_grants_override_positive_grants() {
         "acme/*/*/*/*",
         fs_path(vec![fs_lit("data"), fs_lit("secret.txt")]),
     );
-    let public = fs(
+    let public = fs_target(
         "acme/shop/prod/cart/agent",
-        "acme/*/*/*/*",
         fs_path(vec![fs_lit("data"), fs_lit("public.txt")]),
     );
-    let secret = fs(
+    let secret = fs_target(
         "acme/shop/prod/cart/agent",
-        "acme/*/*/*/*",
         fs_path(vec![fs_lit("data"), fs_lit("secret.txt")]),
     );
     let surface = GrantSurface {

--- a/golem-common/src/base_model/card/subsumption_tests.rs
+++ b/golem-common/src/base_model/card/subsumption_tests.rs
@@ -848,6 +848,7 @@ fn subsumption_requires_same_permission_class() {
 #[test]
 fn derivation_must_be_subsumed_by_parent_union() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let parent_grant = fs(
         "acme/shop/prod/cart/agent",
         "acme/shop/prod/cart/agent",
@@ -866,7 +867,7 @@ fn derivation_must_be_subsumed_by_parent_union() {
 
     let parent = card(vec![parent_grant], Vec::new());
     let parent_surface =
-        EffectiveSurface::from_cards(std::slice::from_ref(&parent), holder).unwrap();
+        EffectiveSurface::from_cards(std::slice::from_ref(&parent), &recipient).unwrap();
 
     assert!(
         parent_surface
@@ -882,6 +883,7 @@ fn derivation_must_be_subsumed_by_parent_union() {
 #[test]
 fn derivation_checks_upper_bounds_against_parent_upper_surface() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let parent_upper = fs(
         "acme/shop/prod/cart/agent",
         "acme/shop/prod/cart/agent",
@@ -899,7 +901,7 @@ fn derivation_checks_upper_bounds_against_parent_upper_surface() {
     );
     let parent = card(Vec::new(), vec![parent_upper]);
     let parent_surface =
-        EffectiveSurface::from_cards(std::slice::from_ref(&parent), holder).unwrap();
+        EffectiveSurface::from_cards(std::slice::from_ref(&parent), &recipient).unwrap();
 
     assert!(
         parent_surface

--- a/golem-common/src/base_model/card/subsumption_tests.rs
+++ b/golem-common/src/base_model/card/subsumption_tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::model::auth::TokenId;
 use crate::model::card::owner::{AgentOwnerPattern, EmptyOwnerPattern, OwnerPattern};
 use crate::model::card::recipient::RecipientPattern;
 use RecipientPattern as AccountRecipientPattern;
@@ -65,6 +66,10 @@ fn oplog_read(resource: OplogResourcePattern) -> PermissionPattern {
 
 fn fixed_uuid() -> Uuid {
     Uuid::from_u128(0x550e8400e29b41d4a716446655440000)
+}
+
+fn fixed_token_id() -> TokenId {
+    TokenId(fixed_uuid())
 }
 
 fn card(lower_positive: Vec<PermissionPattern>, upper_positive: Vec<PermissionPattern>) -> Card {
@@ -688,12 +693,12 @@ fn generate_domain_resource_subsumption_tests(r: &mut DynamicTestRegistration) {
         (
             "account_token_any_subsumes_token",
             AccountTokenResourcePattern::Any,
-            AccountTokenResourcePattern::Token(fixed_uuid()),
+            AccountTokenResourcePattern::Token(fixed_token_id()),
             true,
         ),
         (
             "account_token_token_does_not_subsume_any",
-            AccountTokenResourcePattern::Token(fixed_uuid()),
+            AccountTokenResourcePattern::Token(fixed_token_id()),
             AccountTokenResourcePattern::Any,
             false,
         ),

--- a/golem-common/src/base_model/card/tests.rs
+++ b/golem-common/src/base_model/card/tests.rs
@@ -95,6 +95,7 @@ fn recipient_depths_are_validated() {
 #[test]
 fn effective_surface_requires_lower_and_all_upper_bounds() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let read_all = fs(
         "acme/shop/prod/cart/agent",
         "acme/shop/prod/cart/agent",
@@ -128,7 +129,7 @@ fn effective_surface_requires_lower_and_all_upper_bounds() {
 
     let lower = card(vec![read_all], Vec::new());
     let ceiling = card(Vec::new(), vec![read_public.clone()]);
-    let surface = EffectiveSurface::from_cards(&[lower, ceiling], holder).unwrap();
+    let surface = EffectiveSurface::from_cards(&[lower, ceiling], &recipient).unwrap();
 
     assert!(surface.authorize(&read_public).unwrap());
     assert!(!surface.authorize(&read_secret).unwrap());
@@ -137,6 +138,7 @@ fn effective_surface_requires_lower_and_all_upper_bounds() {
 #[test]
 fn upper_negative_without_positive_is_unrestricted_except_denials() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let read_tmp = fs(
         holder,
         holder,
@@ -156,9 +158,9 @@ fn upper_negative_without_positive_is_unrestricted_except_denials() {
         Vec::new(),
         vec![reveal_secret.clone()],
     );
-    let surface = EffectiveSurface::from_cards(&[lower, ceiling.clone()], holder).unwrap();
+    let surface = EffectiveSurface::from_cards(&[lower, ceiling.clone()], &recipient).unwrap();
     let ceiling_surface =
-        EffectiveSurface::from_cards(std::slice::from_ref(&ceiling), holder).unwrap();
+        EffectiveSurface::from_cards(std::slice::from_ref(&ceiling), &recipient).unwrap();
 
     assert!(surface.authorize(&read_tmp).unwrap());
     assert!(!surface.authorize(&reveal_secret).unwrap());
@@ -176,6 +178,7 @@ fn upper_negative_without_positive_is_unrestricted_except_denials() {
 #[test]
 fn lower_negative_is_scoped_to_its_card() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let read_all = fs(
         holder,
         holder,
@@ -205,7 +208,8 @@ fn lower_negative_is_scoped_to_its_card() {
     );
     let allow_in_another_card = card(vec![read_secret.clone()], Vec::new());
     let surface =
-        EffectiveSurface::from_cards(&[deny_in_one_card, allow_in_another_card], holder).unwrap();
+        EffectiveSurface::from_cards(&[deny_in_one_card, allow_in_another_card], &recipient)
+            .unwrap();
 
     assert!(surface.authorize(&read_secret).unwrap());
 }
@@ -213,6 +217,7 @@ fn lower_negative_is_scoped_to_its_card() {
 #[test]
 fn derivation_upper_bound_uses_parent_ceiling_intersection() {
     let holder = "acme/shop/prod/cart/agent";
+    let recipient = RecipientPattern::parse(holder).unwrap();
     let read_all = fs(
         holder,
         holder,
@@ -242,7 +247,7 @@ fn derivation_upper_bound_uses_parent_ceiling_intersection() {
         vec![read_secret.clone()],
     );
     let parent_surface =
-        EffectiveSurface::from_cards(&[parent_allow, parent_deny], holder).unwrap();
+        EffectiveSurface::from_cards(&[parent_allow, parent_deny], &recipient).unwrap();
 
     assert!(matches!(
         parent_surface.validates_derivation(&[], std::slice::from_ref(&read_secret)),

--- a/golem-common/src/base_model/card/tests.rs
+++ b/golem-common/src/base_model/card/tests.rs
@@ -30,6 +30,14 @@ fn fs(owner: &str, recipient: &str, resource: FilesystemResourcePattern) -> Perm
     })
 }
 
+fn fs_target(owner: &str, resource: FilesystemResourcePattern) -> PermissionTarget {
+    PermissionTarget::Filesystem(ClassPermissionTarget::<FilesystemClass> {
+        verb: Some(FilesystemVerb::Read),
+        owner: AgentOwnerPattern::parse(owner).unwrap(),
+        resource,
+    })
+}
+
 fn secret_reveal(
     owner: &str,
     recipient: &str,
@@ -39,6 +47,14 @@ fn secret_reveal(
         verb: Some(SecretVerb::Reveal),
         owner: EnvironmentOwnerPattern::parse(owner).unwrap(),
         recipient: AgentRecipientPattern::parse(recipient).unwrap(),
+        resource,
+    })
+}
+
+fn secret_reveal_target(owner: &str, resource: SecretResourcePattern) -> PermissionTarget {
+    PermissionTarget::Secret(ClassPermissionTarget::<SecretClass> {
+        verb: Some(SecretVerb::Reveal),
+        owner: EnvironmentOwnerPattern::parse(owner).unwrap(),
         resource,
     })
 }
@@ -106,8 +122,7 @@ fn effective_surface_requires_lower_and_all_upper_bounds() {
             ],
         }),
     );
-    let read_secret = fs(
-        "acme/shop/prod/cart/agent",
+    let read_secret_target = fs_target(
         "acme/shop/prod/cart/agent",
         FilesystemResourcePattern::Path(FilesystemPathPattern {
             segments: vec![
@@ -126,13 +141,22 @@ fn effective_surface_requires_lower_and_all_upper_bounds() {
             ],
         }),
     );
+    let read_public_target = fs_target(
+        "acme/shop/prod/cart/agent",
+        FilesystemResourcePattern::Path(FilesystemPathPattern {
+            segments: vec![
+                FilesystemPathSegmentPattern::Literal("data".to_string()),
+                FilesystemPathSegmentPattern::Literal("public.txt".to_string()),
+            ],
+        }),
+    );
 
     let lower = card(vec![read_all], Vec::new());
     let ceiling = card(Vec::new(), vec![read_public.clone()]);
     let surface = EffectiveSurface::from_cards(&[lower, ceiling], &recipient).unwrap();
 
-    assert!(surface.authorize(&read_public).unwrap());
-    assert!(!surface.authorize(&read_secret).unwrap());
+    assert!(surface.authorize(&read_public_target).unwrap());
+    assert!(!surface.authorize(&read_secret_target).unwrap());
 }
 
 #[test]
@@ -149,7 +173,17 @@ fn upper_negative_without_positive_is_unrestricted_except_denials() {
             ],
         }),
     );
+    let read_tmp_target = fs_target(
+        holder,
+        FilesystemResourcePattern::Path(FilesystemPathPattern {
+            segments: vec![
+                FilesystemPathSegmentPattern::Literal("tmp".to_string()),
+                FilesystemPathSegmentPattern::Literal("file.txt".to_string()),
+            ],
+        }),
+    );
     let reveal_secret = secret_reveal("acme/shop/prod", holder, SecretResourcePattern::Any);
+    let reveal_secret_target = secret_reveal_target("acme/shop/prod", SecretResourcePattern::Any);
 
     let lower = card(vec![read_tmp.clone(), reveal_secret.clone()], Vec::new());
     let ceiling = card_with_bounds(
@@ -162,8 +196,8 @@ fn upper_negative_without_positive_is_unrestricted_except_denials() {
     let ceiling_surface =
         EffectiveSurface::from_cards(std::slice::from_ref(&ceiling), &recipient).unwrap();
 
-    assert!(surface.authorize(&read_tmp).unwrap());
-    assert!(!surface.authorize(&reveal_secret).unwrap());
+    assert!(surface.authorize(&read_tmp_target).unwrap());
+    assert!(!surface.authorize(&reveal_secret_target).unwrap());
     assert!(
         ceiling_surface
             .validates_derivation(&[], std::slice::from_ref(&read_tmp))
@@ -199,6 +233,15 @@ fn lower_negative_is_scoped_to_its_card() {
             ],
         }),
     );
+    let read_secret_target = fs_target(
+        holder,
+        FilesystemResourcePattern::Path(FilesystemPathPattern {
+            segments: vec![
+                FilesystemPathSegmentPattern::Literal("data".to_string()),
+                FilesystemPathSegmentPattern::Literal("secret.txt".to_string()),
+            ],
+        }),
+    );
 
     let deny_in_one_card = card_with_bounds(
         vec![read_all],
@@ -211,7 +254,7 @@ fn lower_negative_is_scoped_to_its_card() {
         EffectiveSurface::from_cards(&[deny_in_one_card, allow_in_another_card], &recipient)
             .unwrap();
 
-    assert!(surface.authorize(&read_secret).unwrap());
+    assert!(surface.authorize(&read_secret_target).unwrap());
 }
 
 #[test]

--- a/golem-common/src/base_model/card/types.rs
+++ b/golem-common/src/base_model/card/types.rs
@@ -26,7 +26,7 @@ newtype_uuid!(CardId);
 
 declare_revision!(CardRevision);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "full", derive(desert_rust::BinaryCodec))]
 pub enum CardManagedBy {
     AccountRoot { account_id: AccountId },
@@ -35,7 +35,7 @@ pub enum CardManagedBy {
     PermissionShare { permission_share_id: Uuid },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Card {
     pub card_id: CardId,
     pub parent_ids: Vec<CardId>,
@@ -49,7 +49,7 @@ pub struct Card {
     pub managed_by: Option<CardManagedBy>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PolymorphicCard {
     pub card_id: CardId,
     pub parent_ids: Vec<CardId>,
@@ -62,7 +62,7 @@ pub struct PolymorphicCard {
     pub system_card: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PolymorphicManifestCard {
     pub card_id: CardId,
     pub parent_ids: Vec<CardId>,

--- a/golem-debugging-service/tests/services/auth_service.rs
+++ b/golem-debugging-service/tests/services/auth_service.rs
@@ -26,6 +26,8 @@ impl AuthService for TestAuthService {
             account_plan_id: self.test_ctx.account_plan_id,
             account_roles: self.test_ctx.account_roles.clone(),
             token_root_card_id: None,
+            account_holder: self.test_ctx.account_id.to_string(),
+            auth_card: None,
         }))
     }
     async fn check_user_allowed_to_debug_in_environment(

--- a/golem-debugging-service/tests/services/worker_proxy.rs
+++ b/golem-debugging-service/tests/services/worker_proxy.rs
@@ -155,6 +155,8 @@ impl WorkerProxy for TestWorkerProxy {
             account_plan_id: self.test_ctx.account_plan_id,
             account_roles: self.test_ctx.account_roles.clone(),
             token_root_card_id: None,
+            account_holder: self.test_ctx.account_id.to_string(),
+            auth_card: None,
         });
 
         let result = loop {
@@ -211,6 +213,8 @@ impl WorkerProxy for TestWorkerProxy {
             account_plan_id: self.test_ctx.account_plan_id,
             account_roles: self.test_ctx.account_roles.clone(),
             token_root_card_id: None,
+            account_holder: self.test_ctx.account_id.to_string(),
+            auth_card: None,
         });
 
         let result = self
@@ -259,6 +263,8 @@ impl WorkerProxy for TestWorkerProxy {
             account_plan_id: self.test_ctx.account_plan_id,
             account_roles: self.test_ctx.account_roles.clone(),
             token_root_card_id: None,
+            account_holder: self.test_ctx.account_id.to_string(),
+            auth_card: None,
         });
 
         let result = self

--- a/golem-registry-service/src/services/account/mod.rs
+++ b/golem-registry-service/src/services/account/mod.rs
@@ -28,9 +28,8 @@ use golem_common::model::account::{
     Account, AccountCreation, AccountId, AccountRevision, AccountSetPlan, AccountUpdate,
 };
 use golem_common::model::card::owner::AccountOwnerPattern;
-use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
-    AccountResourcePattern, AccountVerb, ClassPermissionPattern, PermissionPattern,
+    AccountResourcePattern, AccountVerb, ClassPermissionTarget, PermissionTarget,
 };
 use golem_common::model::plan::PlanId;
 use golem_common::{SafeDisplay, error_forwarding};
@@ -341,32 +340,15 @@ fn authorize_account_permission(
     account_id: AccountId,
     verb: AccountVerb,
 ) -> Result<(), AuthorizationError> {
-    if auth.is_system() {
-        return Ok(());
-    }
-
-    let recipient = auth.principal_recipient().ok_or_else(|| {
-        AuthorizationError::PermissionNotAllowed(Box::new(account_permission(
-            account_id,
-            verb,
-            RecipientPattern::Any,
-        )))
-    })?;
-
-    auth.authorize_permission(&account_permission(account_id, verb, recipient))
+    auth.authorize_permission(&account_permission_target(account_id, verb))
 }
 
-fn account_permission(
-    account_id: AccountId,
-    verb: AccountVerb,
-    recipient: RecipientPattern,
-) -> PermissionPattern {
-    PermissionPattern::Account(ClassPermissionPattern {
+fn account_permission_target(account_id: AccountId, verb: AccountVerb) -> PermissionTarget {
+    PermissionTarget::Account(ClassPermissionTarget {
         verb: Some(verb),
         owner: AccountOwnerPattern::Account {
             account: account_id.to_string(),
         },
-        recipient,
         resource: AccountResourcePattern,
     })
 }

--- a/golem-registry-service/src/services/account/mod.rs
+++ b/golem-registry-service/src/services/account/mod.rs
@@ -27,9 +27,14 @@ use anyhow::anyhow;
 use golem_common::model::account::{
     Account, AccountCreation, AccountId, AccountRevision, AccountSetPlan, AccountUpdate,
 };
+use golem_common::model::card::owner::AccountOwnerPattern;
+use golem_common::model::card::recipient::RecipientPattern;
+use golem_common::model::card::{
+    AccountResourcePattern, AccountVerb, ClassPermissionPattern, PermissionPattern,
+};
 use golem_common::model::plan::PlanId;
 use golem_common::{SafeDisplay, error_forwarding};
-use golem_service_base::model::auth::{AccountAction, GlobalAction};
+use golem_service_base::model::auth::GlobalAction;
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -136,9 +141,9 @@ impl AccountService {
         update: AccountUpdate,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.get(account_id, auth).await?;
+        let mut account: Account = self.load(account_id).await?;
 
-        auth.authorize_account_action(account_id, AccountAction::UpdateAccount)?;
+        authorize_account_permission(auth, account_id, AccountVerb::Update)?;
 
         if update.current_revision != account.revision {
             return Err(AccountError::ConcurrentUpdate);
@@ -159,9 +164,9 @@ impl AccountService {
         update: AccountSetPlan,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.get(account_id, auth).await?;
+        let mut account: Account = self.load(account_id).await?;
 
-        auth.authorize_account_action(account_id, AccountAction::SetPlan)?;
+        authorize_account_permission(auth, account_id, AccountVerb::SetPlan)?;
 
         if update.current_revision != account.revision {
             return Err(AccountError::ConcurrentUpdate);
@@ -171,7 +176,7 @@ impl AccountService {
 
         // check that plan exists
         self.plan_service
-            .get(&update.plan, auth)
+            .get(&update.plan, &AuthCtx::System)
             .await
             .map_err(|e| match e {
                 PlanError::PlanNotFound(plan_id) => AccountError::PlanByIdNotFound(plan_id),
@@ -189,9 +194,9 @@ impl AccountService {
         current_revision: AccountRevision,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.get(account_id, auth).await?;
+        let mut account: Account = self.load(account_id).await?;
 
-        auth.authorize_account_action(account_id, AccountAction::DeleteAccount)?;
+        authorize_account_permission(auth, account_id, AccountVerb::Delete)?;
 
         if current_revision != account.revision {
             return Err(AccountError::ConcurrentUpdate);
@@ -223,17 +228,10 @@ impl AccountService {
         account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        auth.authorize_account_action(account_id, AccountAction::ViewAccount)
+        authorize_account_permission(auth, account_id, AccountVerb::View)
             .map_err(|_| AccountError::AccountNotFound(account_id))?;
 
-        let account = self
-            .account_repo
-            .get_by_id(account_id.0)
-            .await?
-            .ok_or(AccountError::AccountNotFound(account_id))?
-            .try_into()?;
-
-        Ok(account)
+        self.load(account_id).await
     }
 
     pub async fn get_by_email(
@@ -250,7 +248,7 @@ impl AccountService {
             ))?
             .try_into()?;
 
-        auth.authorize_account_action(account.id, AccountAction::ViewAccount)
+        authorize_account_permission(auth, account.id, AccountVerb::View)
             .map_err(|_| AccountError::AccountByEmailNotFound(account_email.to_string()))?;
 
         Ok(account)
@@ -304,6 +302,15 @@ impl AccountService {
         }
     }
 
+    async fn load(&self, account_id: AccountId) -> Result<Account, AccountError> {
+        self.account_repo
+            .get_by_id(account_id.0)
+            .await?
+            .ok_or(AccountError::AccountNotFound(account_id))?
+            .try_into()
+            .map_err(AccountError::from)
+    }
+
     async fn update_internal(
         &self,
         mut account: Account,
@@ -327,4 +334,39 @@ impl AccountService {
             Err(other) => Err(other)?,
         }
     }
+}
+
+fn authorize_account_permission(
+    auth: &AuthCtx,
+    account_id: AccountId,
+    verb: AccountVerb,
+) -> Result<(), AuthorizationError> {
+    if auth.is_system() {
+        return Ok(());
+    }
+
+    let recipient = auth.principal_recipient().ok_or_else(|| {
+        AuthorizationError::PermissionNotAllowed(Box::new(account_permission(
+            account_id,
+            verb,
+            RecipientPattern::Any,
+        )))
+    })?;
+
+    auth.authorize_permission(&account_permission(account_id, verb, recipient))
+}
+
+fn account_permission(
+    account_id: AccountId,
+    verb: AccountVerb,
+    recipient: RecipientPattern,
+) -> PermissionPattern {
+    PermissionPattern::Account(ClassPermissionPattern {
+        verb: Some(verb),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
+        recipient,
+        resource: AccountResourcePattern,
+    })
 }

--- a/golem-registry-service/src/services/auth.rs
+++ b/golem-registry-service/src/services/auth.rs
@@ -21,12 +21,13 @@ use crate::services::permission_share::{PermissionShareError, PermissionShareSer
 use chrono::Utc;
 use golem_common::model::account::{Account, AccountId, TokenRootCardEpoch};
 use golem_common::model::auth::{TokenId, TokenSecret};
+use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
     Card, CardAlgebraError, CardId, CardManagedBy, EffectiveSurface, PermissionPattern,
 };
 use golem_common::{SafeDisplay, error_forwarding};
 use golem_service_base::model::auth::{
-    AdminImpersonationAuthCtx, AuthCtx, GlobalAction, UserAuthCtx,
+    AdminImpersonationAuthCtx, AuthCard, AuthCtx, GlobalAction, UserAuthCtx,
 };
 use golem_service_base::repo::RepoError;
 use std::collections::BTreeSet;
@@ -107,10 +108,11 @@ impl AuthService {
             // Normal login flow
             None => {
                 let account_roles = BTreeSet::from_iter(target_account.roles.clone());
-                let token_root_card_id = self
+                let account_holder = target_account.email.as_str().to_string();
+                let token_root_card = self
                     .ensure_token_root_card(
                         target_account.id,
-                        target_account.email.as_str().to_string(),
+                        account_holder.clone(),
                         target_account.account_root_card_id,
                         target_account.token_root_card_id,
                         target_account.token_root_card_epoch,
@@ -121,7 +123,9 @@ impl AuthService {
                     account_id: target_account.id,
                     account_roles,
                     account_plan_id: target_account.plan_id,
-                    token_root_card_id: Some(token_root_card_id),
+                    token_root_card_id: Some(token_root_card.card_id),
+                    account_holder,
+                    auth_card: Some(AuthCard::from(token_root_card)),
                 }))
             }
             // Impersonation flow
@@ -140,6 +144,8 @@ impl AuthService {
                         account_roles,
                         account_plan_id: admin_account.plan_id,
                         token_root_card_id: None,
+                        account_holder: admin_account.email.as_str().to_string(),
+                        auth_card: None,
                     });
 
                     if admin_auth_ctx
@@ -155,10 +161,11 @@ impl AuthService {
                 }
 
                 let target_account_roles = BTreeSet::from_iter(target_account.roles.clone());
-                let token_root_card_id = self
+                let target_account_holder = target_account.email.as_str().to_string();
+                let token_root_card = self
                     .ensure_token_root_card(
                         target_account.id,
-                        target_account.email.as_str().to_string(),
+                        target_account_holder.clone(),
                         target_account.account_root_card_id,
                         target_account.token_root_card_id,
                         target_account.token_root_card_epoch,
@@ -170,7 +177,9 @@ impl AuthService {
                     target_account_id: target_account.id,
                     target_account_roles,
                     target_account_plan_id: target_account.plan_id,
-                    token_root_card_id: Some(token_root_card_id),
+                    token_root_card_id: Some(token_root_card.card_id),
+                    target_account_holder,
+                    auth_card: Some(AuthCard::from(token_root_card)),
                 }))
             }
         }
@@ -183,12 +192,34 @@ impl AuthService {
         mut account_root_card_id: CardId,
         snapshot_card_id: Option<CardId>,
         snapshot_epoch: TokenRootCardEpoch,
-    ) -> Result<CardId, AuthError> {
-        if let Some(card_id) = snapshot_card_id {
-            return Ok(card_id);
-        }
-
+    ) -> Result<Card, AuthError> {
         let mut expected_epoch = snapshot_epoch;
+
+        if let Some(card_id) = snapshot_card_id {
+            if let Some(card) = self.load_card(card_id).await? {
+                return Ok(card);
+            }
+
+            let account = self
+                .account_service
+                .get(account_id, &AuthCtx::System)
+                .await
+                .map_err(|e| match e {
+                    AccountError::AccountNotFound(_) => AuthError::CouldNotAuthenticate,
+                    other => other.into(),
+                })?;
+
+            if let Some(refreshed_card_id) = account.token_root_card_id {
+                return self
+                    .load_card(refreshed_card_id)
+                    .await?
+                    .ok_or_else(|| missing_token_root_card(account_id, refreshed_card_id));
+            }
+
+            account_holder = account.email.as_str().to_string();
+            account_root_card_id = account.account_root_card_id;
+            expected_epoch = account.token_root_card_epoch;
+        }
 
         for _ in 0..MAX_REDERIVE_ATTEMPTS {
             let account_root_card: Card = self
@@ -232,11 +263,15 @@ impl AuthService {
                 );
             }
 
-            EffectiveSurface::from_cards(&parent_cards, &account_holder)
+            let account_recipient = RecipientPattern::Account {
+                account: account_holder.clone(),
+            };
+
+            EffectiveSurface::from_cards(&parent_cards, &account_recipient)
                 .and_then(|surface| surface.validates_derivation(&lower_positive, &upper_positive))
                 .map_err(|err| invalid_token_root_derivation(account_id, err))?;
 
-            if let Some(card_id) = self
+            if let Some(card) = self
                 .insert_token_root_card(
                     account_id,
                     expected_epoch,
@@ -248,7 +283,7 @@ impl AuthService {
                 )
                 .await?
             {
-                return Ok(card_id);
+                return Ok(card);
             }
 
             // Creating the card failed, refetch account to ensure we are working with up-to-date data on next loop.
@@ -265,7 +300,10 @@ impl AuthService {
                 })?;
 
             if let Some(card_id) = account.token_root_card_id {
-                return Ok(card_id);
+                return self
+                    .load_card(card_id)
+                    .await?
+                    .ok_or_else(|| missing_token_root_card(account_id, card_id));
             }
 
             account_holder = account.email.as_str().to_string();
@@ -289,7 +327,7 @@ impl AuthService {
         lower_negative: Vec<PermissionPattern>,
         upper_positive: Vec<PermissionPattern>,
         upper_negative: Vec<PermissionPattern>,
-    ) -> Result<Option<CardId>, AuthError> {
+    ) -> Result<Option<Card>, AuthError> {
         let card_id = CardId(Uuid::now_v7());
         let card = CardRecord::creation(
             card_id,
@@ -308,12 +346,21 @@ impl AuthService {
             .insert_token_root_card(account_id.0, expected_epoch.into(), card)
             .await
         {
-            Ok(record) => Ok(Some(CardId(record.card_id))),
+            Ok(record) => Ok(Some(record.try_into()?)),
             Err(CardRepoError::ConcurrentModification | CardRepoError::ParentNotFound(_)) => {
                 Ok(None)
             }
             Err(err) => Err(err.into()),
         }
+    }
+
+    async fn load_card(&self, card_id: CardId) -> Result<Option<Card>, AuthError> {
+        self.card_repo
+            .get(card_id)
+            .await?
+            .map(Card::try_from)
+            .transpose()
+            .map_err(Into::into)
     }
 }
 
@@ -336,4 +383,13 @@ fn invalid_token_root_derivation(account_id: AccountId, err: CardAlgebraError) -
         account_id,
         err
     ))
+}
+
+fn missing_token_root_card(account_id: AccountId, card_id: CardId) -> AuthError {
+    tracing::warn!(
+        "Token root card {} for account {} does not exist",
+        card_id,
+        account_id
+    );
+    AuthError::CouldNotAuthenticate
 }

--- a/golem-registry-service/src/services/reports.rs
+++ b/golem-registry-service/src/services/reports.rs
@@ -59,7 +59,7 @@ impl ReportsService {
         &self,
         auth: &AuthCtx,
     ) -> Result<Vec<AccountSummaryReport>, ReportsError> {
-        auth.authorize_permission(&view_account_summaries_report_permission())?;
+        authorize_report_permission(auth, SystemVerb::ViewAccountSummariesReport)?;
 
         let summaries = self
             .reports_repo
@@ -76,7 +76,7 @@ impl ReportsService {
         &self,
         auth: &AuthCtx,
     ) -> Result<AccountCountsReport, ReportsError> {
-        auth.authorize_permission(&view_account_counts_report_permission())?;
+        authorize_report_permission(auth, SystemVerb::ViewAccountCountsReport)?;
 
         let account_counts = self.reports_repo.get_account_counts().await?.into();
 
@@ -84,19 +84,26 @@ impl ReportsService {
     }
 }
 
-fn view_account_summaries_report_permission() -> PermissionPattern {
-    system_permission(SystemVerb::ViewAccountSummariesReport)
+fn authorize_report_permission(auth: &AuthCtx, verb: SystemVerb) -> Result<(), AuthorizationError> {
+    if auth.is_system() {
+        return Ok(());
+    }
+
+    let recipient = auth.principal_recipient().ok_or_else(|| {
+        AuthorizationError::PermissionNotAllowed(Box::new(system_permission(
+            verb,
+            RecipientPattern::Any,
+        )))
+    })?;
+
+    auth.authorize_permission(&system_permission(verb, recipient))
 }
 
-fn view_account_counts_report_permission() -> PermissionPattern {
-    system_permission(SystemVerb::ViewAccountCountsReport)
-}
-
-fn system_permission(verb: SystemVerb) -> PermissionPattern {
+fn system_permission(verb: SystemVerb, recipient: RecipientPattern) -> PermissionPattern {
     PermissionPattern::System(ClassPermissionPattern {
         verb: Some(verb),
         owner: EmptyOwnerPattern,
-        recipient: RecipientPattern::Any,
+        recipient,
         resource: SystemResourcePattern,
     })
 }

--- a/golem-registry-service/src/services/reports.rs
+++ b/golem-registry-service/src/services/reports.rs
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 use crate::repo::report::ReportRepo;
+use golem_common::model::card::owner::EmptyOwnerPattern;
+use golem_common::model::card::recipient::RecipientPattern;
+use golem_common::model::card::{
+    ClassPermissionPattern, PermissionPattern, SystemResourcePattern, SystemVerb,
+};
 use golem_common::model::reports::{AccountCountsReport, AccountSummaryReport};
 use golem_common::{SafeDisplay, error_forwarding};
-use golem_service_base::model::auth::GlobalAction;
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
 use golem_service_base::repo::RepoError;
 use std::fmt::Debug;
@@ -55,7 +59,7 @@ impl ReportsService {
         &self,
         auth: &AuthCtx,
     ) -> Result<Vec<AccountSummaryReport>, ReportsError> {
-        auth.authorize_global_action(GlobalAction::GetReports)?;
+        auth.authorize_permission(&view_account_summaries_report_permission())?;
 
         let summaries = self
             .reports_repo
@@ -72,10 +76,27 @@ impl ReportsService {
         &self,
         auth: &AuthCtx,
     ) -> Result<AccountCountsReport, ReportsError> {
-        auth.authorize_global_action(GlobalAction::GetReports)?;
+        auth.authorize_permission(&view_account_counts_report_permission())?;
 
         let account_counts = self.reports_repo.get_account_counts().await?.into();
 
         Ok(account_counts)
     }
+}
+
+fn view_account_summaries_report_permission() -> PermissionPattern {
+    system_permission(SystemVerb::ViewAccountSummariesReport)
+}
+
+fn view_account_counts_report_permission() -> PermissionPattern {
+    system_permission(SystemVerb::ViewAccountCountsReport)
+}
+
+fn system_permission(verb: SystemVerb) -> PermissionPattern {
+    PermissionPattern::System(ClassPermissionPattern {
+        verb: Some(verb),
+        owner: EmptyOwnerPattern,
+        recipient: RecipientPattern::Any,
+        resource: SystemResourcePattern,
+    })
 }

--- a/golem-registry-service/src/services/reports.rs
+++ b/golem-registry-service/src/services/reports.rs
@@ -14,9 +14,8 @@
 
 use crate::repo::report::ReportRepo;
 use golem_common::model::card::owner::EmptyOwnerPattern;
-use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
-    ClassPermissionPattern, PermissionPattern, SystemResourcePattern, SystemVerb,
+    ClassPermissionTarget, PermissionTarget, SystemResourcePattern, SystemVerb,
 };
 use golem_common::model::reports::{AccountCountsReport, AccountSummaryReport};
 use golem_common::{SafeDisplay, error_forwarding};
@@ -85,25 +84,13 @@ impl ReportsService {
 }
 
 fn authorize_report_permission(auth: &AuthCtx, verb: SystemVerb) -> Result<(), AuthorizationError> {
-    if auth.is_system() {
-        return Ok(());
-    }
-
-    let recipient = auth.principal_recipient().ok_or_else(|| {
-        AuthorizationError::PermissionNotAllowed(Box::new(system_permission(
-            verb,
-            RecipientPattern::Any,
-        )))
-    })?;
-
-    auth.authorize_permission(&system_permission(verb, recipient))
+    auth.authorize_permission(&system_permission_target(verb))
 }
 
-fn system_permission(verb: SystemVerb, recipient: RecipientPattern) -> PermissionPattern {
-    PermissionPattern::System(ClassPermissionPattern {
+fn system_permission_target(verb: SystemVerb) -> PermissionTarget {
+    PermissionTarget::System(ClassPermissionTarget {
         verb: Some(verb),
         owner: EmptyOwnerPattern,
-        recipient,
         resource: SystemResourcePattern,
     })
 }

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -23,9 +23,8 @@ use golem_common::model::account::AccountId;
 use golem_common::model::auth::TokenId;
 use golem_common::model::auth::{TokenSecret, TokenWithSecret};
 use golem_common::model::card::owner::AccountOwnerPattern;
-use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
-    AccountTokenResourcePattern, AccountTokenVerb, ClassPermissionPattern, PermissionPattern,
+    AccountTokenResourcePattern, AccountTokenVerb, ClassPermissionTarget, PermissionTarget,
 };
 use golem_common::{SafeDisplay, error_forwarding};
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError, GlobalAction};
@@ -316,36 +315,19 @@ fn authorize_account_token_permission(
     verb: AccountTokenVerb,
     resource: AccountTokenResourcePattern,
 ) -> Result<(), AuthorizationError> {
-    if auth.is_system() {
-        return Ok(());
-    }
-
-    let recipient = auth.principal_recipient().ok_or_else(|| {
-        AuthorizationError::PermissionNotAllowed(Box::new(account_token_permission(
-            account_id,
-            verb,
-            resource.clone(),
-            RecipientPattern::Any,
-        )))
-    })?;
-
-    auth.authorize_permission(&account_token_permission(
-        account_id, verb, resource, recipient,
-    ))
+    auth.authorize_permission(&account_token_permission_target(account_id, verb, resource))
 }
 
-fn account_token_permission(
+fn account_token_permission_target(
     account_id: AccountId,
     verb: AccountTokenVerb,
     resource: AccountTokenResourcePattern,
-    recipient: RecipientPattern,
-) -> PermissionPattern {
-    PermissionPattern::AccountToken(ClassPermissionPattern {
+) -> PermissionTarget {
+    PermissionTarget::AccountToken(ClassPermissionTarget {
         verb: Some(verb),
         owner: AccountOwnerPattern::Account {
             account: account_id.to_string(),
         },
-        recipient,
         resource,
     })
 }

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -22,8 +22,12 @@ use chrono::{DateTime, Utc};
 use golem_common::model::account::AccountId;
 use golem_common::model::auth::TokenId;
 use golem_common::model::auth::{TokenSecret, TokenWithSecret};
+use golem_common::model::card::owner::AccountOwnerPattern;
+use golem_common::model::card::recipient::RecipientPattern;
+use golem_common::model::card::{
+    AccountTokenResourcePattern, AccountTokenVerb, ClassPermissionPattern, PermissionPattern,
+};
 use golem_common::{SafeDisplay, error_forwarding};
-use golem_service_base::model::auth::AccountAction;
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError, GlobalAction};
 use golem_service_base::repo::RepoError;
 use std::fmt::Debug;
@@ -91,8 +95,13 @@ impl TokenService {
             .ok_or(TokenError::TokenNotFound(token_id))?
             .into();
 
-        auth.authorize_account_action(token.account_id, AccountAction::ViewToken)
-            .map_err(|_| TokenError::TokenNotFound(token_id))?;
+        authorize_account_token_permission(
+            auth,
+            token.account_id,
+            AccountTokenVerb::View,
+            AccountTokenResourcePattern::Token(token_id),
+        )
+        .map_err(|_| TokenError::TokenNotFound(token_id))?;
 
         Ok(token)
     }
@@ -109,8 +118,13 @@ impl TokenService {
             .ok_or(TokenError::TokenBySecretNotFound)?
             .into();
 
-        auth.authorize_account_action(token.account_id, AccountAction::ViewToken)
-            .map_err(|_| TokenError::TokenBySecretNotFound)?;
+        authorize_account_token_permission(
+            auth,
+            token.account_id,
+            AccountTokenVerb::View,
+            AccountTokenResourcePattern::Token(token.id),
+        )
+        .map_err(|_| TokenError::TokenBySecretNotFound)?;
 
         Ok(token)
     }
@@ -135,7 +149,7 @@ impl TokenService {
         auth: &AuthCtx,
     ) -> Result<Vec<TokenWithSecret>, TokenError> {
         self.account_service
-            .get(account_id, auth)
+            .get(account_id, &AuthCtx::System)
             .await
             .map_err(|err| match err {
                 AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
@@ -144,7 +158,12 @@ impl TokenService {
                 other => other.into(),
             })?;
 
-        auth.authorize_account_action(account_id, AccountAction::ViewToken)?;
+        authorize_account_token_permission(
+            auth,
+            account_id,
+            AccountTokenVerb::View,
+            AccountTokenResourcePattern::Any,
+        )?;
 
         let tokens: Vec<TokenWithSecret> = self
             .token_repo
@@ -164,7 +183,7 @@ impl TokenService {
         auth: &AuthCtx,
     ) -> Result<TokenWithSecret, TokenError> {
         self.account_service
-            .get(account_id, auth)
+            .get(account_id, &AuthCtx::System)
             .await
             .map_err(|err| match err {
                 AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
@@ -173,7 +192,12 @@ impl TokenService {
                 other => other.into(),
             })?;
 
-        auth.authorize_account_action(account_id, AccountAction::CreateToken)?;
+        authorize_account_token_permission(
+            auth,
+            account_id,
+            AccountTokenVerb::Create,
+            AccountTokenResourcePattern::Any,
+        )?;
 
         let secret = TokenSecret::new();
         self.create_known_secret(account_id, secret, expires_at, None)
@@ -271,7 +295,12 @@ impl TokenService {
             .ok_or(TokenError::TokenNotFound(token_id))?
             .into();
 
-        auth.authorize_account_action(token.account_id, AccountAction::DeleteToken)?;
+        authorize_account_token_permission(
+            auth,
+            token.account_id,
+            AccountTokenVerb::Delete,
+            AccountTokenResourcePattern::Token(token_id),
+        )?;
 
         if let Some(account_id) = self.token_repo.delete(token_id.0).await? {
             let _ = account_id.signal_new_events_available(&self.registry_change_notifier);
@@ -279,4 +308,44 @@ impl TokenService {
 
         Ok(())
     }
+}
+
+fn authorize_account_token_permission(
+    auth: &AuthCtx,
+    account_id: AccountId,
+    verb: AccountTokenVerb,
+    resource: AccountTokenResourcePattern,
+) -> Result<(), AuthorizationError> {
+    if auth.is_system() {
+        return Ok(());
+    }
+
+    let recipient = auth.principal_recipient().ok_or_else(|| {
+        AuthorizationError::PermissionNotAllowed(Box::new(account_token_permission(
+            account_id,
+            verb,
+            resource.clone(),
+            RecipientPattern::Any,
+        )))
+    })?;
+
+    auth.authorize_permission(&account_token_permission(
+        account_id, verb, resource, recipient,
+    ))
+}
+
+fn account_token_permission(
+    account_id: AccountId,
+    verb: AccountTokenVerb,
+    resource: AccountTokenResourcePattern,
+    recipient: RecipientPattern,
+) -> PermissionPattern {
+    PermissionPattern::AccountToken(ClassPermissionPattern {
+        verb: Some(verb),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
+        recipient,
+        resource,
+    })
 }

--- a/golem-service-base/src/model/auth/mod.rs
+++ b/golem-service-base/src/model/auth/mod.rs
@@ -19,7 +19,10 @@ use axum::http::header;
 use golem_common::SafeDisplay;
 use golem_common::model::account::AccountId;
 use golem_common::model::auth::{AccountRole, EnvironmentRole, TokenSecret};
-use golem_common::model::card::CardId;
+use golem_common::model::card::recipient::RecipientPattern;
+use golem_common::model::card::{
+    Card, CardAlgebraError, CardId, EffectiveSurface, PermissionPattern,
+};
 use golem_common::model::plan::PlanId;
 use headers::Cookie as HCookie;
 use headers::HeaderMapExt;
@@ -255,6 +258,13 @@ pub enum AuthorizationError {
     AccountActionNotAllowed(AccountAction),
     #[error("The environment action {0} is not allowed")]
     EnvironmentActionNotAllowed(EnvironmentAction),
+    #[error("The permission {0:?} is not allowed")]
+    PermissionNotAllowed(Box<PermissionPattern>),
+    #[error("Failed to evaluate permission {permission:?}: {error:?}")]
+    PermissionEvaluationFailed {
+        permission: Box<PermissionPattern>,
+        error: CardAlgebraError,
+    },
 }
 
 impl SafeDisplay for AuthorizationError {
@@ -272,11 +282,34 @@ pub struct AuthDetailsForEnvironment {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AuthCard {
+    pub card_id: CardId,
+    pub lower_positive: Vec<PermissionPattern>,
+    pub lower_negative: Vec<PermissionPattern>,
+    pub upper_positive: Vec<PermissionPattern>,
+    pub upper_negative: Vec<PermissionPattern>,
+}
+
+impl From<Card> for AuthCard {
+    fn from(value: Card) -> Self {
+        Self {
+            card_id: value.card_id,
+            lower_positive: value.lower_positive,
+            lower_negative: value.lower_negative,
+            upper_positive: value.upper_positive,
+            upper_negative: value.upper_negative,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UserAuthCtx {
     pub account_id: AccountId,
     pub account_plan_id: PlanId,
     pub account_roles: BTreeSet<AccountRole>,
     pub token_root_card_id: Option<CardId>,
+    pub account_holder: String,
+    pub auth_card: Option<AuthCard>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -297,6 +330,8 @@ pub struct AdminImpersonationAuthCtx {
     pub target_account_roles: BTreeSet<AccountRole>,
     pub target_account_plan_id: PlanId,
     pub token_root_card_id: Option<CardId>,
+    pub target_account_holder: String,
+    pub auth_card: Option<AuthCard>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -337,6 +372,8 @@ impl AuthCtx {
             target_account_roles,
             target_account_plan_id,
             token_root_card_id: None,
+            target_account_holder: target_account_id.to_string(),
+            auth_card: None,
         })
     }
 
@@ -447,6 +484,43 @@ impl AuthCtx {
         }
 
         Ok(())
+    }
+
+    pub fn authorize_permission(
+        &self,
+        permission: &PermissionPattern,
+    ) -> Result<(), AuthorizationError> {
+        match self {
+            Self::System => Ok(()),
+            Self::User(user) => {
+                let recipient = self.principal_recipient().ok_or_else(|| {
+                    AuthorizationError::PermissionNotAllowed(Box::new(permission.clone()))
+                })?;
+                authorize_auth_card_permission(user.auth_card.as_ref(), &recipient, permission)
+            }
+            Self::AdminImpersonation(ctx) => {
+                let recipient = self.principal_recipient().ok_or_else(|| {
+                    AuthorizationError::PermissionNotAllowed(Box::new(permission.clone()))
+                })?;
+                authorize_auth_card_permission(ctx.auth_card.as_ref(), &recipient, permission)
+            }
+            Self::Agent(_) => Err(AuthorizationError::PermissionNotAllowed(Box::new(
+                permission.clone(),
+            ))),
+        }
+    }
+
+    pub fn principal_recipient(&self) -> Option<RecipientPattern> {
+        match self {
+            Self::System => None,
+            Self::User(user) => Some(RecipientPattern::Account {
+                account: user.account_holder.clone(),
+            }),
+            Self::AdminImpersonation(ctx) => Some(RecipientPattern::Account {
+                account: ctx.target_account_holder.clone(),
+            }),
+            Self::Agent(_) => None,
+        }
     }
 
     pub fn authorize_plan_action(
@@ -782,6 +856,43 @@ fn has_any_role<T: Eq + Hash + Ord>(roles: &BTreeSet<T>, allowed: &[T]) -> bool 
     allowed.iter().any(|r| roles.contains(r))
 }
 
+fn authorize_auth_card_permission(
+    auth_card: Option<&AuthCard>,
+    recipient: &RecipientPattern,
+    permission: &PermissionPattern,
+) -> Result<(), AuthorizationError> {
+    let Some(auth_card) = auth_card else {
+        return Err(AuthorizationError::PermissionNotAllowed(Box::new(
+            permission.clone(),
+        )));
+    };
+
+    let surface = EffectiveSurface::from_grants(
+        &auth_card.lower_positive,
+        &auth_card.lower_negative,
+        &auth_card.upper_positive,
+        &auth_card.upper_negative,
+        recipient,
+    )
+    .map_err(|error| AuthorizationError::PermissionEvaluationFailed {
+        permission: Box::new(permission.clone()),
+        error,
+    })?;
+
+    if surface.authorize(permission).map_err(|error| {
+        AuthorizationError::PermissionEvaluationFailed {
+            permission: Box::new(permission.clone()),
+            error,
+        }
+    })? {
+        Ok(())
+    } else {
+        Err(AuthorizationError::PermissionNotAllowed(Box::new(
+            permission.clone(),
+        )))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::AUTH_ERROR_MESSAGE;
@@ -1007,9 +1118,60 @@ mod test {
 mod protobuf {
     use super::AuthDetailsForEnvironment;
     use super::{
-        AdminImpersonationAuthCtx, AgentAuthCtx, AuthCtx, AuthorizationError, UserAuthCtx,
+        AdminImpersonationAuthCtx, AgentAuthCtx, AuthCard, AuthCtx, AuthorizationError, UserAuthCtx,
     };
     use golem_common::model::auth::{AccountRole, EnvironmentRole};
+    use golem_common::model::card::{CardId, PermissionPattern};
+
+    impl TryFrom<golem_api_grpc::proto::golem::auth::AuthCard> for AuthCard {
+        type Error = String;
+
+        fn try_from(
+            value: golem_api_grpc::proto::golem::auth::AuthCard,
+        ) -> Result<Self, Self::Error> {
+            Ok(Self {
+                card_id: CardId(value.card_id.ok_or("missing card_id")?.into()),
+                lower_positive: deserialize_permission_patterns(value.lower_positive)?,
+                lower_negative: deserialize_permission_patterns(value.lower_negative)?,
+                upper_positive: deserialize_permission_patterns(value.upper_positive)?,
+                upper_negative: deserialize_permission_patterns(value.upper_negative)?,
+            })
+        }
+    }
+
+    impl From<AuthCard> for golem_api_grpc::proto::golem::auth::AuthCard {
+        fn from(value: AuthCard) -> Self {
+            Self {
+                card_id: Some(value.card_id.0.into()),
+                lower_positive: serialize_permission_patterns(value.lower_positive),
+                lower_negative: serialize_permission_patterns(value.lower_negative),
+                upper_positive: serialize_permission_patterns(value.upper_positive),
+                upper_negative: serialize_permission_patterns(value.upper_negative),
+            }
+        }
+    }
+
+    fn serialize_permission_patterns(patterns: Vec<PermissionPattern>) -> Vec<Vec<u8>> {
+        patterns
+            .into_iter()
+            .map(|pattern| {
+                desert_rust::serialize_to_byte_vec(&pattern)
+                    .expect("PermissionPattern Desert serialization failed")
+            })
+            .collect()
+    }
+
+    fn deserialize_permission_patterns(
+        values: Vec<Vec<u8>>,
+    ) -> Result<Vec<PermissionPattern>, String> {
+        values
+            .into_iter()
+            .map(|value| {
+                desert_rust::deserialize(&value)
+                    .map_err(|err| format!("invalid permission pattern: {err}"))
+            })
+            .collect()
+    }
 
     impl TryFrom<golem_api_grpc::proto::golem::auth::AuthDetailsForEnvironment>
         for AuthDetailsForEnvironment
@@ -1055,14 +1217,20 @@ mod protobuf {
         fn try_from(
             value: golem_api_grpc::proto::golem::auth::UserAuthCtx,
         ) -> Result<Self, Self::Error> {
+            let account_roles = value
+                .account_roles()
+                .map(AccountRole::try_from)
+                .collect::<Result<_, _>>()?;
+            let auth_card = value.auth_card.map(AuthCard::try_from).transpose()?;
+            let token_root_card_id = auth_card.as_ref().map(|card| card.card_id);
+
             Ok(Self {
-                account_roles: value
-                    .account_roles()
-                    .map(AccountRole::try_from)
-                    .collect::<Result<_, _>>()?,
+                account_roles,
                 account_id: value.account_id.ok_or("missing account id")?.try_into()?,
                 account_plan_id: value.plan_id.ok_or("missing plan id")?.try_into()?,
-                token_root_card_id: None,
+                token_root_card_id,
+                account_holder: value.account_holder,
+                auth_card,
             })
         }
     }
@@ -1077,6 +1245,8 @@ mod protobuf {
                     .into_iter()
                     .map(|ar| golem_api_grpc::proto::golem::auth::AccountRole::from(ar).into())
                     .collect(),
+                account_holder: value.account_holder,
+                auth_card: value.auth_card.map(Into::into),
             }
         }
     }
@@ -1116,6 +1286,9 @@ mod protobuf {
                         .and_then(AccountRole::try_from)
                 })
                 .collect::<Result<_, _>>()?;
+            let auth_card = value.auth_card.map(AuthCard::try_from).transpose()?;
+            let token_root_card_id = auth_card.as_ref().map(|card| card.card_id);
+
             Ok(Self {
                 admin_account_id: value
                     .admin_account_id
@@ -1130,7 +1303,9 @@ mod protobuf {
                     .target_account_plan_id
                     .ok_or("missing target_account_plan_id")?
                     .try_into()?,
-                token_root_card_id: None,
+                token_root_card_id,
+                target_account_holder: value.target_account_holder,
+                auth_card,
             })
         }
     }
@@ -1148,6 +1323,8 @@ mod protobuf {
                     .map(|r| golem_api_grpc::proto::golem::auth::AccountRole::from(r).into())
                     .collect(),
                 target_account_plan_id: Some(value.target_account_plan_id.into()),
+                target_account_holder: value.target_account_holder,
+                auth_card: value.auth_card.map(Into::into),
             }
         }
     }

--- a/golem-service-base/src/model/auth/mod.rs
+++ b/golem-service-base/src/model/auth/mod.rs
@@ -21,7 +21,7 @@ use golem_common::model::account::AccountId;
 use golem_common::model::auth::{AccountRole, EnvironmentRole, TokenSecret};
 use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
-    Card, CardAlgebraError, CardId, EffectiveSurface, PermissionPattern,
+    Card, CardAlgebraError, CardId, EffectiveSurface, PermissionPattern, PermissionTarget,
 };
 use golem_common::model::plan::PlanId;
 use headers::Cookie as HCookie;
@@ -36,10 +36,7 @@ use std::sync::LazyLock;
 
 pub const COOKIE_KEY: &str = "GOLEM_SESSION";
 pub const AUTH_ERROR_MESSAGE: &str = "authorization error";
-static SYSTEM_ACCOUNT_ROLES: LazyLock<BTreeSet<AccountRole>> =
-    LazyLock::new(|| BTreeSet::from_iter([AccountRole::Admin]));
-static IMPERSONATED_USER_ACCOUNT_ROLES: LazyLock<BTreeSet<AccountRole>> =
-    LazyLock::new(BTreeSet::new);
+static EMPTY_ACCOUNT_ROLES: LazyLock<BTreeSet<AccountRole>> = LazyLock::new(BTreeSet::new);
 
 #[derive(SecurityScheme)]
 #[oai(rename = "Token", ty = "bearer", checker = "bearer_checker")]
@@ -258,11 +255,11 @@ pub enum AuthorizationError {
     AccountActionNotAllowed(AccountAction),
     #[error("The environment action {0} is not allowed")]
     EnvironmentActionNotAllowed(EnvironmentAction),
-    #[error("The permission {0:?} is not allowed")]
-    PermissionNotAllowed(Box<PermissionPattern>),
-    #[error("Failed to evaluate permission {permission:?}: {error:?}")]
+    #[error("The permission target {0:?} is not allowed")]
+    PermissionNotAllowed(Box<PermissionTarget>),
+    #[error("Failed to evaluate permission target {target:?}: {error:?}")]
     PermissionEvaluationFailed {
-        permission: Box<PermissionPattern>,
+        target: Box<PermissionTarget>,
         error: CardAlgebraError,
     },
 }
@@ -440,9 +437,9 @@ impl AuthCtx {
 
     pub fn account_roles(&self) -> &BTreeSet<AccountRole> {
         match self {
-            Self::System => &SYSTEM_ACCOUNT_ROLES,
+            Self::System => &EMPTY_ACCOUNT_ROLES,
             Self::User(user) => &user.account_roles,
-            Self::Agent(_) => &IMPERSONATED_USER_ACCOUNT_ROLES,
+            Self::Agent(_) => &EMPTY_ACCOUNT_ROLES,
             Self::AdminImpersonation(ctx) => &ctx.target_account_roles,
         }
     }
@@ -470,6 +467,10 @@ impl AuthCtx {
     }
 
     pub fn authorize_global_action(&self, action: GlobalAction) -> Result<(), AuthorizationError> {
+        if self.is_system() {
+            return Ok(());
+        }
+
         let is_allowed = match action {
             GlobalAction::CreateAccount => self.has_any_account_role(&[AccountRole::Admin]),
             GlobalAction::GetDefaultPlan => self.has_any_account_role(&[AccountRole::Admin]),
@@ -488,38 +489,25 @@ impl AuthCtx {
 
     pub fn authorize_permission(
         &self,
-        permission: &PermissionPattern,
+        target: &PermissionTarget,
     ) -> Result<(), AuthorizationError> {
         match self {
             Self::System => Ok(()),
             Self::User(user) => {
-                let recipient = self.principal_recipient().ok_or_else(|| {
-                    AuthorizationError::PermissionNotAllowed(Box::new(permission.clone()))
-                })?;
-                authorize_auth_card_permission(user.auth_card.as_ref(), &recipient, permission)
+                let recipient = RecipientPattern::Account {
+                    account: user.account_holder.clone(),
+                };
+                authorize_auth_card_permission(user.auth_card.as_ref(), &recipient, target)
             }
             Self::AdminImpersonation(ctx) => {
-                let recipient = self.principal_recipient().ok_or_else(|| {
-                    AuthorizationError::PermissionNotAllowed(Box::new(permission.clone()))
-                })?;
-                authorize_auth_card_permission(ctx.auth_card.as_ref(), &recipient, permission)
+                let recipient = RecipientPattern::Account {
+                    account: ctx.target_account_holder.clone(),
+                };
+                authorize_auth_card_permission(ctx.auth_card.as_ref(), &recipient, target)
             }
             Self::Agent(_) => Err(AuthorizationError::PermissionNotAllowed(Box::new(
-                permission.clone(),
+                target.clone(),
             ))),
-        }
-    }
-
-    pub fn principal_recipient(&self) -> Option<RecipientPattern> {
-        match self {
-            Self::System => None,
-            Self::User(user) => Some(RecipientPattern::Account {
-                account: user.account_holder.clone(),
-            }),
-            Self::AdminImpersonation(ctx) => Some(RecipientPattern::Account {
-                account: ctx.target_account_holder.clone(),
-            }),
-            Self::Agent(_) => None,
         }
     }
 
@@ -528,6 +516,10 @@ impl AuthCtx {
         plan_id: &PlanId,
         action: PlanAction,
     ) -> Result<(), AuthorizationError> {
+        if self.is_system() {
+            return Ok(());
+        }
+
         match action {
             PlanAction::ViewPlan => {
                 // Users are allowed to see their own plan
@@ -560,6 +552,10 @@ impl AuthCtx {
         target_account_id: AccountId,
         action: AccountAction,
     ) -> Result<(), AuthorizationError> {
+        if self.is_system() {
+            return Ok(());
+        }
+
         let is_allowed = match action {
             AccountAction::SetPlan => self.has_any_account_role(&[AccountRole::Admin]),
             _ => {
@@ -581,7 +577,11 @@ impl AuthCtx {
         roles_from_shares: &BTreeSet<EnvironmentRole>,
         action: EnvironmentAction,
     ) -> Result<(), AuthorizationError> {
-        // Environment owners, admins and system users are allowed to do everything with their environments
+        if self.is_system() {
+            return Ok(());
+        }
+
+        // Environment owners and admins are allowed to do everything with their environments.
         if self.access_account_id() == account_owning_enviroment
             || self.has_any_account_role(&[AccountRole::Admin])
         {
@@ -859,11 +859,11 @@ fn has_any_role<T: Eq + Hash + Ord>(roles: &BTreeSet<T>, allowed: &[T]) -> bool 
 fn authorize_auth_card_permission(
     auth_card: Option<&AuthCard>,
     recipient: &RecipientPattern,
-    permission: &PermissionPattern,
+    target: &PermissionTarget,
 ) -> Result<(), AuthorizationError> {
     let Some(auth_card) = auth_card else {
         return Err(AuthorizationError::PermissionNotAllowed(Box::new(
-            permission.clone(),
+            target.clone(),
         )));
     };
 
@@ -875,20 +875,20 @@ fn authorize_auth_card_permission(
         recipient,
     )
     .map_err(|error| AuthorizationError::PermissionEvaluationFailed {
-        permission: Box::new(permission.clone()),
+        target: Box::new(target.clone()),
         error,
     })?;
 
-    if surface.authorize(permission).map_err(|error| {
+    if surface.authorize(target).map_err(|error| {
         AuthorizationError::PermissionEvaluationFailed {
-            permission: Box::new(permission.clone()),
+            target: Box::new(target.clone()),
             error,
         }
     })? {
         Ok(())
     } else {
         Err(AuthorizationError::PermissionNotAllowed(Box::new(
-            permission.clone(),
+            target.clone(),
         )))
     }
 }

--- a/golem-service-base/src/model/auth/tests.rs
+++ b/golem-service-base/src/model/auth/tests.rs
@@ -14,9 +14,12 @@
 
 use super::*;
 use assert2::assert;
-use golem_common::model::card::owner::EmptyOwnerPattern;
+use golem_common::model::card::owner::{AccountOwnerPattern, EmptyOwnerPattern};
 use golem_common::model::card::recipient::RecipientPattern;
-use golem_common::model::card::{ClassPermissionPattern, SystemResourcePattern, SystemVerb};
+use golem_common::model::card::{
+    AccountResourcePattern, AccountTokenResourcePattern, AccountTokenVerb, AccountVerb,
+    ClassPermissionPattern, SystemResourcePattern, SystemVerb,
+};
 use test_r::test;
 
 fn mk_user_ctx(roles: &[AccountRole], plan_id: PlanId, account_id: AccountId) -> AuthCtx {
@@ -44,6 +47,31 @@ fn report_permission() -> PermissionPattern {
         owner: EmptyOwnerPattern,
         recipient: RecipientPattern::Any,
         resource: SystemResourcePattern,
+    })
+}
+
+fn account_token_permission(
+    account_id: AccountId,
+    recipient: RecipientPattern,
+) -> PermissionPattern {
+    PermissionPattern::AccountToken(ClassPermissionPattern {
+        verb: Some(AccountTokenVerb::Create),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
+        recipient,
+        resource: AccountTokenResourcePattern::Any,
+    })
+}
+
+fn account_permission(account_id: AccountId, recipient: RecipientPattern) -> PermissionPattern {
+    PermissionPattern::Account(ClassPermissionPattern {
+        verb: Some(AccountVerb::Update),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
+        recipient,
+        resource: AccountResourcePattern,
     })
 }
 
@@ -124,6 +152,115 @@ fn user_with_auth_card_can_authorize_permission() {
 fn user_without_auth_card_cannot_authorize_permission() {
     let permission = report_permission();
     let ctx = mk_user_ctx(&[], PlanId::new(), AccountId::new());
+
+    assert!(ctx.authorize_permission(&permission).is_err());
+}
+
+#[test]
+fn user_with_auth_card_can_authorize_account_token_permission() {
+    let account_id = AccountId::new();
+    let recipient = RecipientPattern::Account {
+        account: account_id.to_string(),
+    };
+    let permission = account_token_permission(account_id, recipient.clone());
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![permission.clone()],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+
+    assert!(ctx.authorize_permission(&permission).is_ok());
+}
+
+#[test]
+fn auth_card_account_token_grant_does_not_authorize_different_recipient() {
+    let account_id = AccountId::new();
+    let recipient = RecipientPattern::Account {
+        account: account_id.to_string(),
+    };
+    let permission = account_token_permission(account_id, recipient);
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![permission],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+    let requested = account_token_permission(
+        account_id,
+        RecipientPattern::Account {
+            account: AccountId::new().to_string(),
+        },
+    );
+
+    assert!(ctx.authorize_permission(&requested).is_err());
+}
+
+#[test]
+fn user_without_auth_card_cannot_authorize_account_token_permission() {
+    let account_id = AccountId::new();
+    let permission = account_token_permission(
+        account_id,
+        RecipientPattern::Account {
+            account: account_id.to_string(),
+        },
+    );
+    let ctx = mk_user_ctx(&[], PlanId::new(), account_id);
+
+    assert!(ctx.authorize_permission(&permission).is_err());
+}
+
+#[test]
+fn user_with_auth_card_can_authorize_account_permission() {
+    let account_id = AccountId::new();
+    let recipient = RecipientPattern::Account {
+        account: account_id.to_string(),
+    };
+    let permission = account_permission(account_id, recipient);
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![permission.clone()],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+
+    assert!(ctx.authorize_permission(&permission).is_ok());
+}
+
+#[test]
+fn user_without_auth_card_cannot_authorize_account_permission() {
+    let account_id = AccountId::new();
+    let permission = account_permission(
+        account_id,
+        RecipientPattern::Account {
+            account: account_id.to_string(),
+        },
+    );
+    let ctx = mk_user_ctx(&[], PlanId::new(), account_id);
 
     assert!(ctx.authorize_permission(&permission).is_err());
 }

--- a/golem-service-base/src/model/auth/tests.rs
+++ b/golem-service-base/src/model/auth/tests.rs
@@ -18,7 +18,8 @@ use golem_common::model::card::owner::{AccountOwnerPattern, EmptyOwnerPattern};
 use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
     AccountResourcePattern, AccountTokenResourcePattern, AccountTokenVerb, AccountVerb,
-    ClassPermissionPattern, SystemResourcePattern, SystemVerb,
+    ClassPermissionPattern, ClassPermissionTarget, PermissionTarget, SystemResourcePattern,
+    SystemVerb,
 };
 use test_r::test;
 
@@ -41,19 +42,24 @@ fn make_env_roles(roles: &[EnvironmentRole]) -> BTreeSet<EnvironmentRole> {
     roles.iter().copied().collect()
 }
 
-fn report_permission() -> PermissionPattern {
+fn report_grant(recipient: RecipientPattern) -> PermissionPattern {
     PermissionPattern::System(ClassPermissionPattern {
         verb: Some(SystemVerb::ViewAccountSummariesReport),
         owner: EmptyOwnerPattern,
-        recipient: RecipientPattern::Any,
+        recipient,
         resource: SystemResourcePattern,
     })
 }
 
-fn account_token_permission(
-    account_id: AccountId,
-    recipient: RecipientPattern,
-) -> PermissionPattern {
+fn report_target() -> PermissionTarget {
+    PermissionTarget::System(ClassPermissionTarget {
+        verb: Some(SystemVerb::ViewAccountSummariesReport),
+        owner: EmptyOwnerPattern,
+        resource: SystemResourcePattern,
+    })
+}
+
+fn account_token_grant(account_id: AccountId, recipient: RecipientPattern) -> PermissionPattern {
     PermissionPattern::AccountToken(ClassPermissionPattern {
         verb: Some(AccountTokenVerb::Create),
         owner: AccountOwnerPattern::Account {
@@ -64,13 +70,33 @@ fn account_token_permission(
     })
 }
 
-fn account_permission(account_id: AccountId, recipient: RecipientPattern) -> PermissionPattern {
+fn account_token_target(account_id: AccountId) -> PermissionTarget {
+    PermissionTarget::AccountToken(ClassPermissionTarget {
+        verb: Some(AccountTokenVerb::Create),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
+        resource: AccountTokenResourcePattern::Any,
+    })
+}
+
+fn account_grant(account_id: AccountId, recipient: RecipientPattern) -> PermissionPattern {
     PermissionPattern::Account(ClassPermissionPattern {
         verb: Some(AccountVerb::Update),
         owner: AccountOwnerPattern::Account {
             account: account_id.to_string(),
         },
         recipient,
+        resource: AccountResourcePattern,
+    })
+}
+
+fn account_target(account_id: AccountId) -> PermissionTarget {
+    PermissionTarget::Account(ClassPermissionTarget {
+        verb: Some(AccountVerb::Update),
+        owner: AccountOwnerPattern::Account {
+            account: account_id.to_string(),
+        },
         resource: AccountResourcePattern,
     })
 }
@@ -89,6 +115,30 @@ fn system_can_do_global_actions() {
     assert!(
         ctx.authorize_global_action(GlobalAction::GetReports)
             .is_ok()
+    );
+}
+
+#[test]
+fn system_authorization_bypasses_roles_and_auth_card() {
+    let ctx = AuthCtx::System;
+    assert!(!ctx.account_roles().contains(&AccountRole::Admin));
+
+    assert!(ctx.authorize_permission(&report_target()).is_ok());
+    assert!(
+        ctx.authorize_plan_action(&PlanId::new(), PlanAction::CreateOrUpdatePlan)
+            .is_ok()
+    );
+    assert!(
+        ctx.authorize_account_action(AccountId::new(), AccountAction::SetPlan)
+            .is_ok()
+    );
+    assert!(
+        ctx.authorize_environment_action(
+            AccountId::new(),
+            &make_env_roles(&[]),
+            EnvironmentAction::DeleteEnvironment,
+        )
+        .is_ok()
     );
 }
 
@@ -128,8 +178,11 @@ fn marketing_admin_can_get_reports() {
 
 #[test]
 fn user_with_auth_card_can_authorize_permission() {
-    let permission = report_permission();
     let account_id = AccountId::new();
+    let grant = report_grant(RecipientPattern::Account {
+        account: account_id.to_string(),
+    });
+    let target = report_target();
     let ctx = AuthCtx::User(UserAuthCtx {
         account_id,
         account_plan_id: PlanId::new(),
@@ -138,19 +191,19 @@ fn user_with_auth_card_can_authorize_permission() {
         account_holder: account_id.to_string(),
         auth_card: Some(AuthCard {
             card_id: CardId::new(),
-            lower_positive: vec![permission.clone()],
+            lower_positive: vec![grant],
             lower_negative: Vec::new(),
             upper_positive: Vec::new(),
             upper_negative: Vec::new(),
         }),
     });
 
-    assert!(ctx.authorize_permission(&permission).is_ok());
+    assert!(ctx.authorize_permission(&target).is_ok());
 }
 
 #[test]
 fn user_without_auth_card_cannot_authorize_permission() {
-    let permission = report_permission();
+    let permission = report_target();
     let ctx = mk_user_ctx(&[], PlanId::new(), AccountId::new());
 
     assert!(ctx.authorize_permission(&permission).is_err());
@@ -162,7 +215,8 @@ fn user_with_auth_card_can_authorize_account_token_permission() {
     let recipient = RecipientPattern::Account {
         account: account_id.to_string(),
     };
-    let permission = account_token_permission(account_id, recipient.clone());
+    let grant = account_token_grant(account_id, recipient);
+    let target = account_token_target(account_id);
     let ctx = AuthCtx::User(UserAuthCtx {
         account_id,
         account_plan_id: PlanId::new(),
@@ -171,23 +225,27 @@ fn user_with_auth_card_can_authorize_account_token_permission() {
         account_holder: account_id.to_string(),
         auth_card: Some(AuthCard {
             card_id: CardId::new(),
-            lower_positive: vec![permission.clone()],
+            lower_positive: vec![grant],
             lower_negative: Vec::new(),
             upper_positive: Vec::new(),
             upper_negative: Vec::new(),
         }),
     });
 
-    assert!(ctx.authorize_permission(&permission).is_ok());
+    assert!(ctx.authorize_permission(&target).is_ok());
 }
 
 #[test]
-fn auth_card_account_token_grant_does_not_authorize_different_recipient() {
+fn auth_card_account_token_grant_for_different_holder_does_not_authorize_target() {
     let account_id = AccountId::new();
-    let recipient = RecipientPattern::Account {
-        account: account_id.to_string(),
-    };
-    let permission = account_token_permission(account_id, recipient);
+    let other_account_id = AccountId::new();
+    let grant = account_token_grant(
+        account_id,
+        RecipientPattern::Account {
+            account: other_account_id.to_string(),
+        },
+    );
+    let target = account_token_target(account_id);
     let ctx = AuthCtx::User(UserAuthCtx {
         account_id,
         account_plan_id: PlanId::new(),
@@ -196,18 +254,68 @@ fn auth_card_account_token_grant_does_not_authorize_different_recipient() {
         account_holder: account_id.to_string(),
         auth_card: Some(AuthCard {
             card_id: CardId::new(),
-            lower_positive: vec![permission],
+            lower_positive: vec![grant],
             lower_negative: Vec::new(),
             upper_positive: Vec::new(),
             upper_negative: Vec::new(),
         }),
     });
-    let requested = account_token_permission(
+
+    assert!(ctx.authorize_permission(&target).is_err());
+}
+
+#[test]
+fn auth_card_account_token_target_ignores_recipient_after_holder_filtering() {
+    let account_id = AccountId::new();
+    let grant = account_token_grant(
         account_id,
         RecipientPattern::Account {
-            account: AccountId::new().to_string(),
+            account: account_id.to_string(),
         },
     );
+    let target = account_token_target(account_id);
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![grant],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+
+    assert!(ctx.authorize_permission(&target).is_ok());
+}
+
+#[test]
+fn auth_card_account_token_grant_does_not_authorize_different_owner_target() {
+    let account_id = AccountId::new();
+    let grant = account_token_grant(
+        account_id,
+        RecipientPattern::Account {
+            account: account_id.to_string(),
+        },
+    );
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![grant],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+    let requested = account_token_target(AccountId::new());
 
     assert!(ctx.authorize_permission(&requested).is_err());
 }
@@ -215,12 +323,7 @@ fn auth_card_account_token_grant_does_not_authorize_different_recipient() {
 #[test]
 fn user_without_auth_card_cannot_authorize_account_token_permission() {
     let account_id = AccountId::new();
-    let permission = account_token_permission(
-        account_id,
-        RecipientPattern::Account {
-            account: account_id.to_string(),
-        },
-    );
+    let permission = account_token_target(account_id);
     let ctx = mk_user_ctx(&[], PlanId::new(), account_id);
 
     assert!(ctx.authorize_permission(&permission).is_err());
@@ -232,7 +335,8 @@ fn user_with_auth_card_can_authorize_account_permission() {
     let recipient = RecipientPattern::Account {
         account: account_id.to_string(),
     };
-    let permission = account_permission(account_id, recipient);
+    let grant = account_grant(account_id, recipient);
+    let target = account_target(account_id);
     let ctx = AuthCtx::User(UserAuthCtx {
         account_id,
         account_plan_id: PlanId::new(),
@@ -241,25 +345,20 @@ fn user_with_auth_card_can_authorize_account_permission() {
         account_holder: account_id.to_string(),
         auth_card: Some(AuthCard {
             card_id: CardId::new(),
-            lower_positive: vec![permission.clone()],
+            lower_positive: vec![grant],
             lower_negative: Vec::new(),
             upper_positive: Vec::new(),
             upper_negative: Vec::new(),
         }),
     });
 
-    assert!(ctx.authorize_permission(&permission).is_ok());
+    assert!(ctx.authorize_permission(&target).is_ok());
 }
 
 #[test]
 fn user_without_auth_card_cannot_authorize_account_permission() {
     let account_id = AccountId::new();
-    let permission = account_permission(
-        account_id,
-        RecipientPattern::Account {
-            account: account_id.to_string(),
-        },
-    );
+    let permission = account_target(account_id);
     let ctx = mk_user_ctx(&[], PlanId::new(), account_id);
 
     assert!(ctx.authorize_permission(&permission).is_err());

--- a/golem-service-base/src/model/auth/tests.rs
+++ b/golem-service-base/src/model/auth/tests.rs
@@ -14,6 +14,9 @@
 
 use super::*;
 use assert2::assert;
+use golem_common::model::card::owner::EmptyOwnerPattern;
+use golem_common::model::card::recipient::RecipientPattern;
+use golem_common::model::card::{ClassPermissionPattern, SystemResourcePattern, SystemVerb};
 use test_r::test;
 
 fn mk_user_ctx(roles: &[AccountRole], plan_id: PlanId, account_id: AccountId) -> AuthCtx {
@@ -22,6 +25,8 @@ fn mk_user_ctx(roles: &[AccountRole], plan_id: PlanId, account_id: AccountId) ->
         account_plan_id: plan_id,
         account_roles: roles.iter().cloned().collect(),
         token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: None,
     })
 }
 
@@ -31,6 +36,15 @@ fn mk_impersonated(id: AccountId) -> AuthCtx {
 
 fn make_env_roles(roles: &[EnvironmentRole]) -> BTreeSet<EnvironmentRole> {
     roles.iter().copied().collect()
+}
+
+fn report_permission() -> PermissionPattern {
+    PermissionPattern::System(ClassPermissionPattern {
+        verb: Some(SystemVerb::ViewAccountSummariesReport),
+        owner: EmptyOwnerPattern,
+        recipient: RecipientPattern::Any,
+        resource: SystemResourcePattern,
+    })
 }
 
 #[test]
@@ -82,6 +96,36 @@ fn marketing_admin_can_get_reports() {
         ctx.authorize_global_action(GlobalAction::CreateAccount)
             .is_err()
     );
+}
+
+#[test]
+fn user_with_auth_card_can_authorize_permission() {
+    let permission = report_permission();
+    let account_id = AccountId::new();
+    let ctx = AuthCtx::User(UserAuthCtx {
+        account_id,
+        account_plan_id: PlanId::new(),
+        account_roles: BTreeSet::new(),
+        token_root_card_id: None,
+        account_holder: account_id.to_string(),
+        auth_card: Some(AuthCard {
+            card_id: CardId::new(),
+            lower_positive: vec![permission.clone()],
+            lower_negative: Vec::new(),
+            upper_positive: Vec::new(),
+            upper_negative: Vec::new(),
+        }),
+    });
+
+    assert!(ctx.authorize_permission(&permission).is_ok());
+}
+
+#[test]
+fn user_without_auth_card_cannot_authorize_permission() {
+    let permission = report_permission();
+    let ctx = mk_user_ctx(&[], PlanId::new(), AccountId::new());
+
+    assert!(ctx.authorize_permission(&permission).is_err());
 }
 
 #[test]

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -571,6 +571,8 @@ impl TestWorkerExecutor {
             account_plan_id: self.context.account_plan_id,
             account_roles: self.context.account_roles.clone(),
             token_root_card_id: None,
+            account_holder: self.context.account_id.to_string(),
+            auth_card: None,
         })
     }
 

--- a/golem-worker-executor/tests/api.rs
+++ b/golem-worker-executor/tests/api.rs
@@ -3728,6 +3728,8 @@ async fn worker_created_by_reflects_component_owner_not_caller(
         account_plan_id: context.account_plan_id,
         account_roles: context.account_roles.clone(),
         token_root_card_id: None,
+        account_holder: caller_account_id.to_string(),
+        auth_card: None,
     })
     .into();
 
@@ -3817,6 +3819,8 @@ async fn worker_environment_reflects_component_not_caller(
         account_plan_id: context.account_plan_id,
         account_roles: context.account_roles.clone(),
         token_root_card_id: None,
+        account_holder: caller_account_id.to_string(),
+        auth_card: None,
     })
     .into();
 
@@ -3957,6 +3961,8 @@ async fn resource_limits_initialized_for_component_owner_not_caller(
         account_plan_id: context.account_plan_id,
         account_roles: context.account_roles.clone(),
         token_root_card_id: None,
+        account_holder: caller_account_id.to_string(),
+        auth_card: None,
     })
     .into();
 


### PR DESCRIPTION
Start migrating the existing checks over while also doing miscellaneous cleanups to the card logic 