### PR TITLE
agent-permissions: various  repo and service cleanups

### DIFF
--- a/docs/src/content/next/rest-api/environment-plugin-grants.mdx
+++ b/docs/src/content/next/rest-api/environment-plugin-grants.mdx
@@ -76,11 +76,7 @@ Path|Method|Protected
 
 
 
-**Query Parameters**
 
-Name|Type|Required|Description
----|---|---|---
-include_deleted|boolean|No|-
 
 
 

--- a/golem-common/src/base_model/card/class/account.rs
+++ b/golem-common/src/base_model/card/class/account.rs
@@ -48,11 +48,13 @@ pub enum AccountVerb {
     Update,
     Delete,
     SetPlan,
+    ViewPlan,
 }
 impl VerbPattern for AccountVerb {
     fn parse_verb(verb: &str) -> Option<Self> {
         match verb {
             "view" => Some(Self::View),
+            "view-plan" => Some(Self::ViewPlan),
             "update" => Some(Self::Update),
             "delete" => Some(Self::Delete),
             "set-plan" => Some(Self::SetPlan),

--- a/golem-common/src/base_model/card/class/environment_mcp_deployment.rs
+++ b/golem-common/src/base_model/card/class/environment_mcp_deployment.rs
@@ -115,7 +115,7 @@ fn parse_environment_mcp_deployment_identifier(value: &str) -> Result<String, St
     if chars
         .next()
         .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-        && chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
     {
         Ok(value.to_string())
     } else {

--- a/golem-common/src/base_model/card/parsing_tests.rs
+++ b/golem-common/src/base_model/card/parsing_tests.rs
@@ -681,6 +681,16 @@ fn parses_runtime_class_examples_from_spec(r: &mut DynamicTestRegistration) {
             }),
         ),
         (
+            "account_view_plan",
+            "account(acme) @ acme : view-plan :",
+            PermissionPattern::Account(ClassPermissionPattern::<AccountClass> {
+                verb: Some(AccountVerb::ViewPlan),
+                owner: account_owner("acme"),
+                recipient: account_recipient("acme"),
+                resource: AccountResourcePattern,
+            }),
+        ),
+        (
             "account_usage",
             "account.usage(acme) @ acme : view :",
             PermissionPattern::AccountUsage(ClassPermissionPattern::<AccountUsageClass> {

--- a/golem-common/src/base_model/card/parsing_tests.rs
+++ b/golem-common/src/base_model/card/parsing_tests.rs
@@ -874,7 +874,7 @@ fn parses_runtime_class_examples_from_spec(r: &mut DynamicTestRegistration) {
         ),
         (
             "environment_mcp_deployment",
-            "environment.mcp-deployment(acme/shop/prod) @ acme/shop/prod : view : mcp-a",
+            "environment.mcp-deployment(acme/shop/prod) @ acme/shop/prod : view : mcp.example.com",
             PermissionPattern::EnvironmentMcpDeployment(ClassPermissionPattern::<
                 EnvironmentMcpDeploymentClass,
             > {
@@ -882,7 +882,7 @@ fn parses_runtime_class_examples_from_spec(r: &mut DynamicTestRegistration) {
                 owner: environment_owner("acme", "shop", "prod"),
                 recipient: environment_recipient("acme", "shop", "prod"),
                 resource: EnvironmentMcpDeploymentResourcePattern::Name(
-                    EnvironmentMcpDeploymentName("mcp-a".to_string()),
+                    EnvironmentMcpDeploymentName("mcp.example.com".to_string()),
                 ),
             }),
         ),

--- a/golem-registry-service/src/api/accounts.rs
+++ b/golem-registry-service/src/api/accounts.rs
@@ -15,7 +15,6 @@
 use super::ApiResult;
 use crate::services::account::AccountService;
 use crate::services::auth::AuthService;
-use crate::services::plan::PlanService;
 use crate::services::token::TokenService;
 use golem_common::model::Empty;
 use golem_common::model::Page;
@@ -36,7 +35,6 @@ use tracing::Instrument;
 
 pub struct AccountsApi {
     account_service: Arc<AccountService>,
-    plan_service: Arc<PlanService>,
     token_service: Arc<TokenService>,
     auth_service: Arc<AuthService>,
 }
@@ -49,13 +47,11 @@ pub struct AccountsApi {
 impl AccountsApi {
     pub fn new(
         account_service: Arc<AccountService>,
-        plan_service: Arc<PlanService>,
         token_service: Arc<TokenService>,
         auth_service: Arc<AuthService>,
     ) -> Self {
         Self {
             account_service,
-            plan_service,
             token_service,
             auth_service,
         }
@@ -147,8 +143,7 @@ impl AccountsApi {
         account_id: AccountId,
         auth: AuthCtx,
     ) -> ApiResult<Json<Plan>> {
-        let account = self.account_service.get(account_id, &auth).await?;
-        let plan = self.plan_service.get(&account.plan_id, &auth).await?;
+        let plan = self.account_service.get_plan(account_id, &auth).await?;
 
         Ok(Json(plan))
     }

--- a/golem-registry-service/src/api/environment_plugin_grants.rs
+++ b/golem-registry-service/src/api/environment_plugin_grants.rs
@@ -27,7 +27,7 @@ use golem_service_base::api_tags::ApiTags;
 use golem_service_base::model::auth::AuthCtx;
 use golem_service_base::model::auth::GolemSecurityScheme;
 use poem_openapi::OpenApi;
-use poem_openapi::param::{Path, Query};
+use poem_openapi::param::Path;
 use poem_openapi::payload::Json;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -144,23 +144,17 @@ impl EnvironmentPluginGrantsApi {
     pub async fn get_environment_plugin_grant(
         &self,
         environment_plugin_grant_id: Path<EnvironmentPluginGrantId>,
-        #[oai(default)] include_deleted: Query<bool>,
         token: GolemSecurityScheme,
     ) -> ApiResult<Json<EnvironmentPluginGrantWithDetails>> {
         let record = recorded_http_api_request!(
             "get_environment_plugin_grant",
-            environment_plugin_grant_id = environment_plugin_grant_id.0.to_string(),
-            include_deleted = %include_deleted.0
+            environment_plugin_grant_id = environment_plugin_grant_id.0.to_string()
         );
 
         let auth = self.auth_service.authenticate_token(token.secret()).await?;
 
         let response = self
-            .get_environment_plugin_grant_internal(
-                environment_plugin_grant_id.0,
-                include_deleted.0,
-                auth,
-            )
+            .get_environment_plugin_grant_internal(environment_plugin_grant_id.0, auth)
             .instrument(record.span.clone())
             .await;
 
@@ -170,12 +164,11 @@ impl EnvironmentPluginGrantsApi {
     async fn get_environment_plugin_grant_internal(
         &self,
         environment_plugin_grant_id: EnvironmentPluginGrantId,
-        include_deleted: bool,
         auth: AuthCtx,
     ) -> ApiResult<Json<EnvironmentPluginGrantWithDetails>> {
         let grant = self
             .environment_plugin_grant_service
-            .get_by_id(environment_plugin_grant_id, include_deleted, &auth)
+            .get_by_id(environment_plugin_grant_id, &auth)
             .await?;
 
         Ok(Json(grant))

--- a/golem-registry-service/src/api/error.rs
+++ b/golem-registry-service/src/api/error.rs
@@ -603,6 +603,9 @@ impl From<PermissionShareError> for ApiError {
             | PermissionShareError::InvalidRecipient { .. } => {
                 Self::bad_request(api::error_code::INVALID_PERMISSION_SHARE_GRANT, error)
             }
+            PermissionShareError::GrantNotDelegable(_) => {
+                Self::forbidden(api::error_code::AUTH_FORBIDDEN, error)
+            }
             PermissionShareError::Unauthorized(inner) => inner.into(),
             PermissionShareError::InternalError(_) => Self::InternalError(Json(ErrorBody {
                 error,

--- a/golem-registry-service/src/api/mod.rs
+++ b/golem-registry-service/src/api/mod.rs
@@ -86,7 +86,6 @@ pub fn make_open_api_service(services: &Services) -> OpenApiService<Apis, ()> {
             HealthcheckApi,
             AccountsApi::new(
                 services.account_service.clone(),
-                services.plan_service.clone(),
                 services.token_service.clone(),
                 services.auth_service.clone(),
             ),

--- a/golem-registry-service/src/api/plugin_registrations.rs
+++ b/golem-registry-service/src/api/plugin_registrations.rs
@@ -168,7 +168,7 @@ impl PluginRegistrationsApi {
     ) -> ApiResult<Json<PluginRegistrationDto>> {
         let plugin_registration = self
             .plugin_registration_service
-            .get_plugin(plugin_id, false, &auth)
+            .get_plugin(plugin_id, &auth)
             .await?;
         Ok(Json(plugin_registration.into()))
     }

--- a/golem-registry-service/src/repo/agent_secret.rs
+++ b/golem-registry-service/src/repo/agent_secret.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::model::agent_secrets::{
-    AgentSecretCreationRecord, AgentSecretExtRevisionRecord, AgentSecretRepoError,
-    AgentSecretRevisionRecord,
+    AgentSecretAuthExtRevisionRecord, AgentSecretCreationRecord, AgentSecretExtRevisionRecord,
+    AgentSecretRepoError, AgentSecretRevisionRecord,
 };
 use super::registry_change::{RequiresNotificationSignal, RequiresSignalExt};
 use crate::repo::model::BindFields;
@@ -52,7 +52,7 @@ pub trait AgentSecretRepo: Send + Sync {
     async fn get_by_id(
         &self,
         agent_secret_id: Uuid,
-    ) -> Result<Option<AgentSecretExtRevisionRecord>, AgentSecretRepoError>;
+    ) -> Result<Option<AgentSecretAuthExtRevisionRecord>, AgentSecretRepoError>;
 
     async fn get_for_environment(
         &self,
@@ -112,7 +112,7 @@ impl<Repo: AgentSecretRepo> AgentSecretRepo for LoggedAgentSecretRepo<Repo> {
     async fn get_by_id(
         &self,
         agent_secret_id: Uuid,
-    ) -> Result<Option<AgentSecretExtRevisionRecord>, AgentSecretRepoError> {
+    ) -> Result<Option<AgentSecretAuthExtRevisionRecord>, AgentSecretRepoError> {
         self.repo
             .get_by_id(agent_secret_id)
             .instrument(Self::span_agent_secret_id(agent_secret_id))
@@ -329,14 +329,27 @@ impl AgentSecretRepo for DbAgentSecretRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         agent_secret_id: Uuid,
-    ) -> Result<Option<AgentSecretExtRevisionRecord>, AgentSecretRepoError> {
-        let result: Option<AgentSecretExtRevisionRecord> = self.with_ro("get_by_id")
+    ) -> Result<Option<AgentSecretAuthExtRevisionRecord>, AgentSecretRepoError> {
+        let result: Option<AgentSecretAuthExtRevisionRecord> = self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! {r#"
-                    SELECT sec.environment_id, sec.path, sec.agent_secret_data, sec.created_at AS entity_created_at, secr.agent_secret_id, secr.revision_id, secr.agent_secret_revision_data, secr.created_at, secr.created_by, secr.deleted
+                    SELECT sec.environment_id, sec.path, sec.agent_secret_data, sec.created_at AS entity_created_at, secr.agent_secret_id, secr.revision_id, secr.agent_secret_revision_data, secr.created_at, secr.created_by, secr.deleted,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM agent_secrets sec
+                    JOIN environments e ON e.environment_id = sec.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     JOIN agent_secret_revisions secr ON secr.agent_secret_id = sec.agent_secret_id AND secr.revision_id = sec.current_revision_id
-                    WHERE sec.agent_secret_id = $1 AND sec.deleted_at IS NULL
+                    WHERE sec.agent_secret_id = $1
+                        AND sec.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(agent_secret_id),
             )

--- a/golem-registry-service/src/repo/application.rs
+++ b/golem-registry-service/src/repo/application.rs
@@ -19,7 +19,7 @@ use super::registry_change::{
     DbRegistryChangeRepo, NewRegistryChangeEvent, RequiresNotificationSignal, RequiresSignalExt,
 };
 use crate::repo::model::BindFields;
-use crate::repo::model::application::{ApplicationRecord, ApplicationRevisionRecord};
+use crate::repo::model::application::{ApplicationRevisionRecord, ApplicationScopedRecord};
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
 use futures::FutureExt;
@@ -56,17 +56,17 @@ pub trait ApplicationRepo: Send + Sync {
         &self,
         account_id: Uuid,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError>;
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError>;
 
     async fn update(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError>;
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError>;
 
     async fn delete(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<ApplicationExtRevisionRecord>, ApplicationRepoError>;
+    ) -> Result<RequiresNotificationSignal<ApplicationScopedExtRevisionRecord>, ApplicationRepoError>;
 }
 
 pub struct LoggedApplicationRepo<Repo: ApplicationRepo> {
@@ -130,7 +130,7 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
         &self,
         account_id: Uuid,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError> {
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError> {
         self.repo
             .create(account_id, revision)
             .instrument(Self::span_owner_id(account_id))
@@ -140,7 +140,7 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn update(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError> {
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError> {
         let span = Self::span_app_id(revision.application_id);
         self.repo.update(revision).instrument(span).await
     }
@@ -148,7 +148,7 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn delete(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<ApplicationExtRevisionRecord>, ApplicationRepoError>
+    ) -> Result<RequiresNotificationSignal<ApplicationScopedExtRevisionRecord>, ApplicationRepoError>
     {
         let span = Self::span_app_id(revision.application_id);
         self.repo.delete(revision).instrument(span).await
@@ -291,16 +291,15 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
         &self,
         account_id: Uuid,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError> {
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError> {
         self.with_tx_err("create", |tx| async move {
-            let application_record: ApplicationRecord = tx.fetch_one_as(
+            let application_record: ApplicationScopedRecord = tx.fetch_one_as(
                 sqlx::query_as(indoc! { r#"
                     INSERT INTO applications
                     (application_id, name, account_id, created_at, updated_at, deleted_at, modified_by, current_revision_id)
                     VALUES ($1, $2, $3, $4, $4, NULL, $5, 0)
                     RETURNING application_id, name, account_id,
-                        (SELECT email FROM accounts WHERE account_id = applications.account_id) AS account_email,
-                        created_at, updated_at, deleted_at, modified_by, current_revision_id
+                        created_at, updated_at, deleted_at, modified_by
                 "# })
                     .bind(revision.application_id)
                     .bind(&revision.name)
@@ -312,10 +311,9 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
 
             let revision = Self::insert_revision(tx, revision).await?;
 
-            Ok(ApplicationExtRevisionRecord {
+            Ok(ApplicationScopedExtRevisionRecord {
                 account_id,
-                account_email: application_record.account_email,
-                entity_created_at: revision.audit.created_at.clone(),
+                entity_created_at: application_record.audit.created_at,
                 revision,
             })
         }.boxed()).await
@@ -324,33 +322,34 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn update(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<ApplicationExtRevisionRecord, ApplicationRepoError> {
+    ) -> Result<ApplicationScopedExtRevisionRecord, ApplicationRepoError> {
         self.with_tx_err("update", |tx| {
             async move {
                 let revision = Self::insert_revision(tx, revision).await?;
 
-                let application_record: ApplicationRecord = tx.fetch_optional_as(
-                    sqlx::query_as(indoc! { r#"
+                let application_record: ApplicationScopedRecord = tx
+                    .fetch_optional_as(
+                        sqlx::query_as(indoc! { r#"
                         UPDATE applications
                         SET name = $1, updated_at = $2, modified_by = $3, current_revision_id = $4
                         WHERE application_id = $5
                         RETURNING application_id, name, account_id,
-                            (SELECT email FROM accounts WHERE account_id = applications.account_id) AS account_email,
-                            created_at, updated_at, deleted_at, modified_by, current_revision_id
+                            created_at, updated_at, deleted_at, modified_by
                     "#})
-                    .bind(&revision.name)
-                    .bind(&revision.audit.created_at)
-                    .bind(revision.audit.created_by)
-                    .bind(revision.revision_id)
-                    .bind(revision.application_id)
-                )
-                .await
-                .to_error_on_unique_violation(ApplicationRepoError::ApplicationViolatesUniqueness)?
-                .ok_or(ApplicationRepoError::ConcurrentModification)?;
+                        .bind(&revision.name)
+                        .bind(&revision.audit.created_at)
+                        .bind(revision.audit.created_by)
+                        .bind(revision.revision_id)
+                        .bind(revision.application_id),
+                    )
+                    .await
+                    .to_error_on_unique_violation(
+                        ApplicationRepoError::ApplicationViolatesUniqueness,
+                    )?
+                    .ok_or(ApplicationRepoError::ConcurrentModification)?;
 
-                Ok(ApplicationExtRevisionRecord {
+                Ok(ApplicationScopedExtRevisionRecord {
                     account_id: application_record.account_id,
-                    account_email: application_record.account_email,
                     entity_created_at: application_record.audit.created_at,
                     revision,
                 })
@@ -363,20 +362,19 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn delete(
         &self,
         revision: ApplicationRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<ApplicationExtRevisionRecord>, ApplicationRepoError>
+    ) -> Result<RequiresNotificationSignal<ApplicationScopedExtRevisionRecord>, ApplicationRepoError>
     {
         self.with_tx_err("delete", |tx| {
             async move {
                 let revision = Self::insert_revision(tx, revision).await?;
 
-                let application_record: ApplicationRecord = tx.fetch_optional_as(
+                let application_record: ApplicationScopedRecord = tx.fetch_optional_as(
                     sqlx::query_as(indoc! { r#"
                         UPDATE applications
                         SET name = $1, updated_at = $2, deleted_at = $2, modified_by = $3, current_revision_id = $4
                         WHERE application_id = $5
                         RETURNING application_id, name, account_id,
-                            (SELECT email FROM accounts WHERE account_id = applications.account_id) AS account_email,
-                            created_at, updated_at, deleted_at, modified_by, current_revision_id
+                            created_at, updated_at, deleted_at, modified_by
                     "#})
                     .bind(&revision.name)
                     .bind(&revision.audit.created_at)
@@ -421,9 +419,8 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
                 )
                 .await?;
 
-                Ok(ApplicationExtRevisionRecord {
+                Ok(ApplicationScopedExtRevisionRecord {
                     account_id: application_record.account_id,
-                    account_email: application_record.account_email,
                     entity_created_at: application_record.audit.created_at,
                     revision,
                 })

--- a/golem-registry-service/src/repo/application.rs
+++ b/golem-registry-service/src/repo/application.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::model::application::{ApplicationExtRevisionRecord, ApplicationRepoError};
+use super::model::application::{
+    ApplicationExtRevisionRecord, ApplicationRepoError, ApplicationScopedExtRevisionRecord,
+};
 use super::registry_change::{
     DbRegistryChangeRepo, NewRegistryChangeEvent, RequiresNotificationSignal, RequiresSignalExt,
 };
@@ -37,9 +39,8 @@ pub trait ApplicationRepo: Send + Sync {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
         name: &str,
-    ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError>;
+    ) -> Result<Option<ApplicationScopedExtRevisionRecord>, ApplicationRepoError>;
 
     async fn get_by_id(
         &self,
@@ -49,8 +50,7 @@ pub trait ApplicationRepo: Send + Sync {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError>;
+    ) -> Result<Vec<ApplicationScopedExtRevisionRecord>, ApplicationRepoError>;
 
     async fn create(
         &self,
@@ -98,11 +98,10 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
         name: &str,
-    ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError> {
+    ) -> Result<Option<ApplicationScopedExtRevisionRecord>, ApplicationRepoError> {
         self.repo
-            .get_by_name(owner_account_id, owner_account_email, name)
+            .get_by_name(owner_account_id, name)
             .instrument(Self::span_name(name))
             .await
     }
@@ -120,10 +119,9 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError> {
+    ) -> Result<Vec<ApplicationScopedExtRevisionRecord>, ApplicationRepoError> {
         self.repo
-            .list_by_owner(owner_account_id, owner_account_email)
+            .list_by_owner(owner_account_id)
             .instrument(Self::span_owner_id(owner_account_id))
             .await
     }
@@ -200,16 +198,14 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
         name: &str,
-    ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError> {
-        let result: Option<ApplicationExtRevisionRecord> = self
+    ) -> Result<Option<ApplicationScopedExtRevisionRecord>, ApplicationRepoError> {
+        let result: Option<ApplicationScopedExtRevisionRecord> = self
             .with_ro("get_by_name")
             .fetch_optional_as(
                 sqlx::query_as(indoc! {r#"
                     SELECT
                         ap.account_id,
-                        $2 as account_email,
                         ap.created_at as entity_created_at,
                         r.application_id, r.revision_id, r.name,
                         r.created_at, r.created_by, r.deleted
@@ -219,11 +215,10 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
                         AND r.revision_id = ap.current_revision_id
                     WHERE
                         ap.account_id = $1
-                        AND ap.name = $3
+                        AND ap.name = $2
                         AND ap.deleted_at IS NULL
                 "#})
                 .bind(owner_account_id)
-                .bind(owner_account_email)
                 .bind(name),
             )
             .await?;
@@ -266,15 +261,13 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError> {
+    ) -> Result<Vec<ApplicationScopedExtRevisionRecord>, ApplicationRepoError> {
         let result = self
             .with_ro("list_by_owner")
             .fetch_all_as(
                 sqlx::query_as(indoc! {r#"
                     SELECT
                         ap.account_id,
-                        $2 as account_email,
                         ap.created_at as entity_created_at,
                         r.application_id, r.revision_id, r.name,
                         r.created_at, r.created_by, r.deleted
@@ -287,8 +280,7 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
                         AND ap.deleted_at IS NULL
                     ORDER BY r.name
                 "#})
-                .bind(owner_account_id)
-                .bind(owner_account_email),
+                .bind(owner_account_id),
             )
             .await?;
 

--- a/golem-registry-service/src/repo/application.rs
+++ b/golem-registry-service/src/repo/application.rs
@@ -37,6 +37,7 @@ pub trait ApplicationRepo: Send + Sync {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
         name: &str,
     ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError>;
 
@@ -48,6 +49,7 @@ pub trait ApplicationRepo: Send + Sync {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError>;
 
     async fn create(
@@ -96,10 +98,11 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
         name: &str,
     ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError> {
         self.repo
-            .get_by_name(owner_account_id, name)
+            .get_by_name(owner_account_id, owner_account_email, name)
             .instrument(Self::span_name(name))
             .await
     }
@@ -117,9 +120,10 @@ impl<Repo: ApplicationRepo> ApplicationRepo for LoggedApplicationRepo<Repo> {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError> {
         self.repo
-            .list_by_owner(owner_account_id)
+            .list_by_owner(owner_account_id, owner_account_email)
             .instrument(Self::span_owner_id(owner_account_id))
             .await
     }
@@ -196,6 +200,7 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn get_by_name(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
         name: &str,
     ) -> Result<Option<ApplicationExtRevisionRecord>, ApplicationRepoError> {
         let result: Option<ApplicationExtRevisionRecord> = self
@@ -204,23 +209,21 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
                 sqlx::query_as(indoc! {r#"
                     SELECT
                         ap.account_id,
-                        a.email as account_email,
+                        $2 as account_email,
                         ap.created_at as entity_created_at,
                         r.application_id, r.revision_id, r.name,
                         r.created_at, r.created_by, r.deleted
-                    FROM accounts a
-                    JOIN applications ap
-                        ON ap.account_id = a.account_id
+                    FROM applications ap
                     JOIN application_revisions r
                         ON r.application_id = ap.application_id
                         AND r.revision_id = ap.current_revision_id
                     WHERE
-                        a.account_id = $1
-                        AND ap.name = $2
-                        AND a.deleted_at IS NULL
+                        ap.account_id = $1
+                        AND ap.name = $3
                         AND ap.deleted_at IS NULL
                 "#})
                 .bind(owner_account_id)
+                .bind(owner_account_email)
                 .bind(name),
             )
             .await?;
@@ -263,6 +266,7 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
     async fn list_by_owner(
         &self,
         owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> Result<Vec<ApplicationExtRevisionRecord>, ApplicationRepoError> {
         let result = self
             .with_ro("list_by_owner")
@@ -270,23 +274,21 @@ impl ApplicationRepo for DbApplicationRepo<PostgresPool> {
                 sqlx::query_as(indoc! {r#"
                     SELECT
                         ap.account_id,
-                        a.email as account_email,
+                        $2 as account_email,
                         ap.created_at as entity_created_at,
                         r.application_id, r.revision_id, r.name,
                         r.created_at, r.created_by, r.deleted
-                    FROM accounts a
-                    JOIN applications ap
-                        ON ap.account_id = a.account_id
+                    FROM applications ap
                     JOIN application_revisions r
                         ON r.application_id = ap.application_id
                         AND r.revision_id = ap.current_revision_id
                     WHERE
-                        a.account_id = $1
-                        AND a.deleted_at IS NULL
+                        ap.account_id = $1
                         AND ap.deleted_at IS NULL
                     ORDER BY r.name
                 "#})
-                .bind(owner_account_id),
+                .bind(owner_account_id)
+                .bind(owner_account_email),
             )
             .await?;
 

--- a/golem-registry-service/src/repo/component.rs
+++ b/golem-registry-service/src/repo/component.rs
@@ -14,8 +14,8 @@
 
 use crate::repo::model::BindFields;
 use crate::repo::model::component::{
-    ComponentExtRevisionRecord, ComponentRepoError, ComponentRevisionIdentityRecord,
-    ComponentRevisionRecord,
+    ComponentAuthExtRevisionRecord, ComponentExtRevisionRecord, ComponentRepoError,
+    ComponentRevisionIdentityRecord, ComponentRevisionRecord,
 };
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
@@ -55,7 +55,7 @@ pub trait ComponentRepo: Send + Sync {
     async fn get_staged_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>>;
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>>;
 
     async fn get_staged_by_name(
         &self,
@@ -66,7 +66,7 @@ pub trait ComponentRepo: Send + Sync {
     async fn get_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>>;
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>>;
 
     async fn get_deployed_by_name(
         &self,
@@ -77,14 +77,14 @@ pub trait ComponentRepo: Send + Sync {
     async fn get_all_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Vec<ComponentExtRevisionRecord>>;
+    ) -> RepoResult<Vec<ComponentAuthExtRevisionRecord>>;
 
     async fn get_by_id_and_revision(
         &self,
         component_id: Uuid,
         revision_id: i64,
         include_deleted: bool,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>>;
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>>;
 
     async fn list_staged(
         &self,
@@ -187,7 +187,7 @@ impl<Repo: ComponentRepo> ComponentRepo for LoggedComponentRepo<Repo> {
     async fn get_staged_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
         self.repo
             .get_staged_by_id(component_id)
             .instrument(Self::span_id(component_id))
@@ -208,7 +208,7 @@ impl<Repo: ComponentRepo> ComponentRepo for LoggedComponentRepo<Repo> {
     async fn get_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
         self.repo
             .get_deployed_by_id(component_id)
             .instrument(Self::span_id(component_id))
@@ -229,7 +229,7 @@ impl<Repo: ComponentRepo> ComponentRepo for LoggedComponentRepo<Repo> {
     async fn get_all_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Vec<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Vec<ComponentAuthExtRevisionRecord>> {
         self.repo
             .get_all_deployed_by_id(component_id)
             .instrument(Self::span_id(component_id))
@@ -241,7 +241,7 @@ impl<Repo: ComponentRepo> ComponentRepo for LoggedComponentRepo<Repo> {
         component_id: Uuid,
         revision_id: i64,
         include_deleted: bool,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
         self.repo
             .get_by_id_and_revision(component_id, revision_id, include_deleted)
             .instrument(Self::span_id_and_revision(component_id, revision_id))
@@ -472,18 +472,36 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
     async fn get_staged_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
-        let revision: Option<ComponentExtRevisionRecord> = self.with_ro("get_staged_by_id")
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
+        let revision: Option<ComponentAuthExtRevisionRecord> = self.with_ro("get_staged_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT c.environment_id, c.name,
                            cr.component_id, cr.revision_id, cr.hash,
                            cr.created_at, cr.created_by, cr.deleted,
                            cr.size, cr.metadata,
-                           cr.object_store_key, cr.binary_hash
+                           cr.object_store_key, cr.binary_hash,
+                           ap.application_id, ap.name AS application_name,
+                           a.account_id AS owner_account_id,
+                           a.email AS owner_account_email,
+                           er.name AS environment_name,
+                           er.revision_id AS environment_revision_id,
+                           er.compatibility_check AS environment_compatibility_check,
+                           er.version_check AS environment_version_check,
+                           er.security_overrides AS environment_security_overrides
                     FROM components c
+                    JOIN environments e ON e.environment_id = c.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     JOIN component_revisions cr ON c.component_id = cr.component_id AND c.current_revision_id = cr.revision_id
-                    WHERE c.component_id = $1 AND c.deleted_at IS NULL
+                    WHERE c.component_id = $1
+                        AND c.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(component_id),
             )
@@ -526,7 +544,7 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
     async fn get_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
         let revision = self.with_ro("get_deployed_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -534,7 +552,15 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
                         cr.component_id, cr.revision_id, cr.hash,
                         cr.created_at, cr.created_by, cr.deleted,
                            cr.size, cr.metadata,
-                           cr.object_store_key, cr.binary_hash
+                           cr.object_store_key, cr.binary_hash,
+                           ap.application_id, ap.name AS application_name,
+                           a.account_id AS owner_account_id,
+                           a.email AS owner_account_email,
+                           er.name AS environment_name,
+                           er.revision_id AS environment_revision_id,
+                           er.compatibility_check AS environment_compatibility_check,
+                           er.version_check AS environment_version_check,
+                           er.security_overrides AS environment_security_overrides
                     FROM current_deployments cd
                     JOIN current_deployment_revisions cdr
                         ON cdr.environment_id = cd.environment_id AND cdr.revision_id = cd.current_revision_id
@@ -543,8 +569,18 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
                     JOIN component_revisions cr
                         ON cr.component_id = dcr.component_id AND cr.revision_id = dcr.component_revision_id
                     JOIN components c
-                        ON c.component_id  = cr.component_id
+                        ON c.component_id  = cr.component_id AND c.environment_id = cd.environment_id
+                    JOIN environments e ON e.environment_id = c.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     WHERE c.component_id = $1
+                        AND c.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(component_id),
             )
@@ -594,7 +630,7 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
     async fn get_all_deployed_by_id(
         &self,
         component_id: Uuid,
-    ) -> RepoResult<Vec<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Vec<ComponentAuthExtRevisionRecord>> {
         let revisions = self.with_ro("get_all_deployed_by_id")
             .fetch_all_as(
                 sqlx::query_as(indoc! { r#"
@@ -614,13 +650,31 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
                            cr.component_id, cr.revision_id, cr.hash,
                            cr.created_at, cr.created_by, cr.deleted,
                            cr.size, cr.metadata,
-                           cr.object_store_key, cr.binary_hash
+                           cr.object_store_key, cr.binary_hash,
+                           ap.application_id, ap.name AS application_name,
+                           a.account_id AS owner_account_id,
+                           a.email AS owner_account_email,
+                           er.name AS environment_name,
+                           er.revision_id AS environment_revision_id,
+                           er.compatibility_check AS environment_compatibility_check,
+                           er.version_check AS environment_version_check,
+                           er.security_overrides AS environment_security_overrides
                     FROM distinct_revs dr
                     JOIN component_revisions cr
                         ON cr.revision_id = dr.revision_id
                     JOIN components c
                         ON c.component_id = cr.component_id
+                    JOIN environments e ON e.environment_id = c.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     WHERE c.component_id = $1
+                        AND c.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                     ORDER BY cr.revision_id;
                 "#})
                     .bind(component_id),
@@ -635,7 +689,7 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
         component_id: Uuid,
         revision_id: i64,
         include_deleted: bool,
-    ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
+    ) -> RepoResult<Option<ComponentAuthExtRevisionRecord>> {
         let revision = self
             .with_ro("get_by_id_and_revision")
             .fetch_optional_as(
@@ -644,10 +698,29 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
                            cr.component_id, cr.revision_id, cr.hash,
                            cr.created_at, cr.created_by, cr.deleted,
                            cr.size, cr.metadata,
-                           cr.object_store_key, cr.binary_hash
+                           cr.object_store_key, cr.binary_hash,
+                           ap.application_id, ap.name AS application_name,
+                           a.account_id AS owner_account_id,
+                           a.email AS owner_account_email,
+                           er.name AS environment_name,
+                           er.revision_id AS environment_revision_id,
+                           er.compatibility_check AS environment_compatibility_check,
+                           er.version_check AS environment_version_check,
+                           er.security_overrides AS environment_security_overrides
                     FROM components c
+                    JOIN environments e ON e.environment_id = c.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     JOIN component_revisions cr ON c.component_id = cr.component_id
-                    WHERE c.component_id = $1 AND cr.revision_id = $2 AND ($3 OR c.deleted_at IS NULL)
+                    WHERE c.component_id = $1
+                        AND cr.revision_id = $2
+                        AND ($3 OR c.deleted_at IS NULL)
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                 .bind(component_id)
                 .bind(revision_id)
@@ -749,7 +822,8 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
         deployment_revision_id: i64,
         name: &str,
     ) -> RepoResult<Option<ComponentExtRevisionRecord>> {
-        let revision = self.with_ro("get_deployed_by_name")
+        let revision = self
+            .with_ro("get_deployed_by_name")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT c.environment_id, c.name,
@@ -759,12 +833,15 @@ impl ComponentRepo for DbComponentRepo<PostgresPool> {
                            cr.object_store_key, cr.binary_hash
                     FROM components c
                     JOIN component_revisions cr ON c.component_id = cr.component_id
-                    JOIN deployment_component_revisions dcr ON dcr.component_id = c.component_id AND dcr.component_revision_id = cr.revision_id
+                    JOIN deployment_component_revisions dcr
+                        ON dcr.component_id = c.component_id
+                            AND dcr.component_revision_id = cr.revision_id
+                            AND dcr.environment_id = $1
                     WHERE c.environment_id = $1 AND dcr.deployment_revision_id = $2 AND c.name = $3
                 "#})
-                    .bind(environment_id)
-                    .bind(deployment_revision_id)
-                    .bind(name),
+                .bind(environment_id)
+                .bind(deployment_revision_id)
+                .bind(name),
             )
             .await?;
 

--- a/golem-registry-service/src/repo/deployment.rs
+++ b/golem-registry-service/src/repo/deployment.rs
@@ -23,7 +23,7 @@ use super::model::deployment::{
 use super::model::deployment::{
     DeploymentCompiledRouteRecord, DeploymentComponentRevisionRecord,
     DeploymentHttpApiDeploymentRevisionRecord, DeploymentMcpDeploymentRevisionRecord,
-    DeploymentRegisteredAgentTypeRecord,
+    DeploymentRegisteredAgentTypeRecord, DeploymentRegisteredAgentTypeScopedRecord,
 };
 use super::model::resource_definition::ResourceDefinitionRepoError;
 use super::model::retry_policy::RetryPolicyRepoError;
@@ -124,17 +124,13 @@ pub trait DeploymentRepo: Send + Sync {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>>;
+    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeScopedRecord>>;
 
     async fn list_deployment_agent_types(
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>>;
+    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeScopedRecord>>;
 
     async fn get_deployed_agent_type(
         &self,
@@ -368,17 +364,9 @@ impl<Repo: DeploymentRepo> DeploymentRepo for LoggedDeploymentRepo<Repo> {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>> {
+    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeScopedRecord>> {
         self.repo
-            .get_deployment_agent_type(
-                environment_id,
-                deployment_revision_id,
-                agent_type_name,
-                owner_account_id,
-                owner_account_email,
-            )
+            .get_deployment_agent_type(environment_id, deployment_revision_id, agent_type_name)
             .instrument(info_span!(
                 SPAN_NAME,
                 environment_id = %environment_id,
@@ -392,16 +380,9 @@ impl<Repo: DeploymentRepo> DeploymentRepo for LoggedDeploymentRepo<Repo> {
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>> {
+    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeScopedRecord>> {
         self.repo
-            .list_deployment_agent_types(
-                environment_id,
-                deployment_revision_id,
-                owner_account_id,
-                owner_account_email,
-            )
+            .list_deployment_agent_types(environment_id, deployment_revision_id)
             .instrument(info_span!(
                 SPAN_NAME,
                 environment_id = %environment_id,
@@ -1112,9 +1093,7 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>> {
+    ) -> RepoResult<Option<DeploymentRegisteredAgentTypeScopedRecord>> {
         self.with_ro("get_deployment_agent_type")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -1126,8 +1105,6 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         r.component_id,
                         c.name AS component_name,
                         r.component_revision_id,
-                        $4 AS owner_account_id,
-                        $5 AS owner_account_email,
                         r.webhook_prefix_authority_and_path,
                         r.agent_type
                     FROM deployment_registered_agent_types r
@@ -1139,9 +1116,7 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                 "#})
                 .bind(environment_id)
                 .bind(deployment_revision_id)
-                .bind(agent_type_name)
-                .bind(owner_account_id)
-                .bind(owner_account_email),
+                .bind(agent_type_name),
             )
             .await
     }
@@ -1150,9 +1125,7 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
-        owner_account_id: Uuid,
-        owner_account_email: &str,
-    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>> {
+    ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeScopedRecord>> {
         self.with_ro("list_deployment_agent_types")
             .fetch_all_as(
                 sqlx::query_as(indoc! { r#"
@@ -1164,8 +1137,6 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         r.component_id,
                         c.name AS component_name,
                         r.component_revision_id,
-                        $3 AS owner_account_id,
-                        $4 AS owner_account_email,
                         r.webhook_prefix_authority_and_path,
                         r.agent_type
                     FROM deployment_registered_agent_types r
@@ -1176,9 +1147,7 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                     ORDER BY r.agent_type_name
                 "#})
                 .bind(environment_id)
-                .bind(deployment_revision_id)
-                .bind(owner_account_id)
-                .bind(owner_account_email),
+                .bind(deployment_revision_id),
             )
             .await
     }

--- a/golem-registry-service/src/repo/deployment.rs
+++ b/golem-registry-service/src/repo/deployment.rs
@@ -124,12 +124,16 @@ pub trait DeploymentRepo: Send + Sync {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>>;
 
     async fn list_deployment_agent_types(
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>>;
 
     async fn get_deployed_agent_type(
@@ -364,9 +368,17 @@ impl<Repo: DeploymentRepo> DeploymentRepo for LoggedDeploymentRepo<Repo> {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>> {
         self.repo
-            .get_deployment_agent_type(environment_id, deployment_revision_id, agent_type_name)
+            .get_deployment_agent_type(
+                environment_id,
+                deployment_revision_id,
+                agent_type_name,
+                owner_account_id,
+                owner_account_email,
+            )
             .instrument(info_span!(
                 SPAN_NAME,
                 environment_id = %environment_id,
@@ -380,9 +392,16 @@ impl<Repo: DeploymentRepo> DeploymentRepo for LoggedDeploymentRepo<Repo> {
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>> {
         self.repo
-            .list_deployment_agent_types(environment_id, deployment_revision_id)
+            .list_deployment_agent_types(
+                environment_id,
+                deployment_revision_id,
+                owner_account_id,
+                owner_account_email,
+            )
             .instrument(info_span!(
                 SPAN_NAME,
                 environment_id = %environment_id,
@@ -1093,6 +1112,8 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
         environment_id: Uuid,
         deployment_revision_id: i64,
         agent_type_name: &str,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Option<DeploymentRegisteredAgentTypeRecord>> {
         self.with_ro("get_deployment_agent_type")
             .fetch_optional_as(
@@ -1105,29 +1126,22 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         r.component_id,
                         c.name AS component_name,
                         r.component_revision_id,
-                        a.account_id AS owner_account_id,
-                        ac.email AS owner_account_email,
+                        $4 AS owner_account_id,
+                        $5 AS owner_account_email,
                         r.webhook_prefix_authority_and_path,
                         r.agent_type
                     FROM deployment_registered_agent_types r
                     JOIN components c
                         ON c.component_id = r.component_id
-                        AND c.deleted_at IS NULL
-                    JOIN environments e
-                        ON e.environment_id = r.environment_id
-                        AND e.deleted_at IS NULL
-                    JOIN applications a
-                        ON a.application_id = e.application_id
-                        AND a.deleted_at IS NULL
-                    JOIN accounts ac
-                        ON ac.account_id = a.account_id
-                        AND ac.deleted_at IS NULL
+                        AND c.environment_id = r.environment_id
                     WHERE r.environment_id = $1 AND r.deployment_revision_id = $2
                         AND r.agent_type_name = $3
                 "#})
                 .bind(environment_id)
                 .bind(deployment_revision_id)
-                .bind(agent_type_name),
+                .bind(agent_type_name)
+                .bind(owner_account_id)
+                .bind(owner_account_email),
             )
             .await
     }
@@ -1136,6 +1150,8 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
         &self,
         environment_id: Uuid,
         deployment_revision_id: i64,
+        owner_account_id: Uuid,
+        owner_account_email: &str,
     ) -> RepoResult<Vec<DeploymentRegisteredAgentTypeRecord>> {
         self.with_ro("list_deployment_agent_types")
             .fetch_all_as(
@@ -1148,28 +1164,21 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         r.component_id,
                         c.name AS component_name,
                         r.component_revision_id,
-                        a.account_id AS owner_account_id,
-                        ac.email AS owner_account_email,
+                        $3 AS owner_account_id,
+                        $4 AS owner_account_email,
                         r.webhook_prefix_authority_and_path,
                         r.agent_type
                     FROM deployment_registered_agent_types r
                     JOIN components c
                         ON c.component_id = r.component_id
-                        AND c.deleted_at IS NULL
-                    JOIN environments e
-                        ON e.environment_id = r.environment_id
-                        AND e.deleted_at IS NULL
-                    JOIN applications a
-                        ON a.application_id = e.application_id
-                        AND a.deleted_at IS NULL
-                    JOIN accounts ac
-                        ON ac.account_id = a.account_id
-                        AND ac.deleted_at IS NULL
+                        AND c.environment_id = r.environment_id
                     WHERE r.environment_id = $1 AND r.deployment_revision_id = $2
                     ORDER BY r.agent_type_name
                 "#})
                 .bind(environment_id)
-                .bind(deployment_revision_id),
+                .bind(deployment_revision_id)
+                .bind(owner_account_id)
+                .bind(owner_account_email),
             )
             .await
     }

--- a/golem-registry-service/src/repo/deployment.rs
+++ b/golem-registry-service/src/repo/deployment.rs
@@ -1112,12 +1112,16 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                     FROM deployment_registered_agent_types r
                     JOIN components c
                         ON c.component_id = r.component_id
+                        AND c.deleted_at IS NULL
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE r.environment_id = $1 AND r.deployment_revision_id = $2
                         AND r.agent_type_name = $3
                 "#})
@@ -1151,12 +1155,16 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                     FROM deployment_registered_agent_types r
                     JOIN components c
                         ON c.component_id = r.component_id
+                        AND c.deleted_at IS NULL
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE r.environment_id = $1 AND r.deployment_revision_id = $2
                     ORDER BY r.agent_type_name
                 "#})
@@ -1193,12 +1201,16 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         ON r.environment_id = cdr.environment_id AND r.deployment_revision_id = cdr.deployment_revision_id
                     JOIN components c
                         ON c.component_id = r.component_id
+                        AND c.deleted_at IS NULL
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE cd.environment_id = $1 AND r.agent_type_name = $2
                 "#})
                 .bind(environment_id)
@@ -1233,12 +1245,16 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         ON r.environment_id = cdr.environment_id AND r.deployment_revision_id = cdr.deployment_revision_id
                     JOIN components c
                         ON c.component_id = r.component_id
+                        AND c.deleted_at IS NULL
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE cd.environment_id = $1
                     ORDER BY r.agent_type_name
                 "#})
@@ -1412,10 +1428,13 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                         ON c.component_id = r.component_id
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE r.environment_id = $1
                         AND r.deployment_revision_id = (
                             SELECT deployment_revision_id FROM deployment_registered_agent_types
@@ -1458,12 +1477,16 @@ impl DeploymentRepo for DbDeploymentRepo<PostgresPool> {
                     FROM deployment_registered_agent_types r
                     JOIN components c
                         ON c.component_id = r.component_id
+                        AND c.deleted_at IS NULL
                     JOIN environments e
                         ON e.environment_id = r.environment_id
+                        AND e.deleted_at IS NULL
                     JOIN applications a
                         ON a.application_id = e.application_id
+                        AND a.deleted_at IS NULL
                     JOIN accounts ac
                         ON ac.account_id = a.account_id
+                        AND ac.deleted_at IS NULL
                     WHERE r.environment_id = $1
                         AND r.deployment_revision_id = (
                             SELECT deployment_revision_id FROM deployment_registered_agent_types

--- a/golem-registry-service/src/repo/domain_registration.rs
+++ b/golem-registry-service/src/repo/domain_registration.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::model::domain_registration::{DomainRegistrationRecord, DomainRegistrationRepoError};
+use super::model::domain_registration::{
+    DomainRegistrationAuthRecord, DomainRegistrationRecord, DomainRegistrationRepoError,
+};
 use crate::repo::model::BindFields;
 use crate::repo::registry_change::{
     DbRegistryChangeRepo, NewRegistryChangeEvent, RequiresNotificationSignal, RequiresSignalExt,
@@ -52,7 +54,7 @@ pub trait DomainRegistrationRepo: Send + Sync {
     async fn get_by_id(
         &self,
         domain_registration_id: Uuid,
-    ) -> Result<Option<DomainRegistrationRecord>, DomainRegistrationRepoError>;
+    ) -> Result<Option<DomainRegistrationAuthRecord>, DomainRegistrationRepoError>;
 
     async fn get_in_environment(
         &self,
@@ -115,7 +117,7 @@ impl<Repo: DomainRegistrationRepo> DomainRegistrationRepo for LoggedDomainRegist
     async fn get_by_id(
         &self,
         domain_registration_id: Uuid,
-    ) -> Result<Option<DomainRegistrationRecord>, DomainRegistrationRepoError> {
+    ) -> Result<Option<DomainRegistrationAuthRecord>, DomainRegistrationRepoError> {
         let span = Self::span_id(domain_registration_id);
         self.repo
             .get_by_id(domain_registration_id)
@@ -297,18 +299,30 @@ impl DomainRegistrationRepo for DbDomainRegistrationRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         domain_registration_id: Uuid,
-    ) -> Result<Option<DomainRegistrationRecord>, DomainRegistrationRepoError> {
+    ) -> Result<Option<DomainRegistrationAuthRecord>, DomainRegistrationRepoError> {
         let result = self
             .with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! {r#"
                     SELECT
-                        domain_registration_id, environment_id, domain,
-                        created_at, created_by, deleted_at, deleted_by
-                    FROM domain_registrations
+                        dr.domain_registration_id, dr.environment_id, dr.domain,
+                        dr.created_at, dr.created_by, dr.deleted_at, dr.deleted_by,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
+                    FROM domain_registrations dr
+                    JOIN environments e ON e.environment_id = dr.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     WHERE
-                        domain_registration_id = $1
-                        AND deleted_at IS NULL
+                        dr.domain_registration_id = $1
+                        AND dr.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                 .bind(domain_registration_id),
             )

--- a/golem-registry-service/src/repo/environment.rs
+++ b/golem-registry-service/src/repo/environment.rs
@@ -128,20 +128,17 @@ pub trait EnvironmentRepo: Send + Sync {
         &self,
         application_id: Uuid,
         name: &str,
-        actor: Uuid,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn get_by_id(
         &self,
         environment_id: Uuid,
-        actor: Uuid,
         include_deleted: bool,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn list_by_app(
         &self,
         application_id: Uuid,
-        actor: Uuid,
     ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn create(
@@ -207,10 +204,9 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
         &self,
         application_id: Uuid,
         name: &str,
-        actor: Uuid,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         self.repo
-            .get_by_name(application_id, name, actor)
+            .get_by_name(application_id, name)
             .instrument(Self::span_name(application_id, name))
             .await
     }
@@ -218,11 +214,10 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
     async fn get_by_id(
         &self,
         environment_id: Uuid,
-        actor: Uuid,
         include_deleted: bool,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         self.repo
-            .get_by_id(environment_id, actor, include_deleted)
+            .get_by_id(environment_id, include_deleted)
             .instrument(Self::span_env(environment_id))
             .await
     }
@@ -230,10 +225,9 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
     async fn list_by_app(
         &self,
         application_id: Uuid,
-        actor: Uuid,
     ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         self.repo
-            .list_by_app(application_id, actor)
+            .list_by_app(application_id)
             .instrument(Self::span_env(application_id))
             .await
     }
@@ -351,7 +345,6 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
         &self,
         application_id: Uuid,
         name: &str,
-        _actor: Uuid,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         let result = self
             .with_ro("get_by_name")
@@ -406,7 +399,6 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         environment_id: Uuid,
-        _actor: Uuid,
         include_deleted: bool,
     ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         let result = self
@@ -461,7 +453,6 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
     async fn list_by_app(
         &self,
         application_id: Uuid,
-        _actor: Uuid,
     ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
         let result = self
             .with_ro("list_by_owner")

--- a/golem-registry-service/src/repo/environment.rs
+++ b/golem-registry-service/src/repo/environment.rs
@@ -129,7 +129,7 @@ pub trait EnvironmentRepo: Send + Sync {
         &self,
         application_id: Uuid,
         name: &str,
-    ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
+    ) -> Result<Option<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn get_by_id(
         &self,
@@ -140,7 +140,7 @@ pub trait EnvironmentRepo: Send + Sync {
     async fn list_by_app(
         &self,
         application_id: Uuid,
-    ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
+    ) -> Result<Vec<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn create(
         &self,
@@ -205,7 +205,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
         &self,
         application_id: Uuid,
         name: &str,
-    ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
+    ) -> Result<Option<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError> {
         self.repo
             .get_by_name(application_id, name)
             .instrument(Self::span_name(application_id, name))
@@ -226,7 +226,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
     async fn list_by_app(
         &self,
         application_id: Uuid,
-    ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
+    ) -> Result<Vec<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError> {
         self.repo
             .list_by_app(application_id)
             .instrument(Self::span_env(application_id))
@@ -346,29 +346,22 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
         &self,
         application_id: Uuid,
         name: &str,
-    ) -> Result<Option<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
+    ) -> Result<Option<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError> {
         let result = self
             .with_ro("get_by_name")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT
-                        e.name, e.application_id, ap.name AS application_name,
-                        r.environment_id, r.revision_id, r.hash,
+                        e.application_id,
+                        r.environment_id, r.revision_id, r.name, r.hash,
                         r.created_at, r.created_by, r.deleted,
                         r.compatibility_check, r.version_check, r.security_overrides,
-
-                        a.account_id as owner_account_id,
-                        a.email as owner_account_email,
 
                         cdr.revision_id as current_deployment_revision,
                         dr.revision_id as current_deployment_deployment_revision,
                         dr.version as current_deployment_deployment_version,
                         dr.hash as current_deployment_deployment_hash
-                    FROM accounts a
-                    JOIN applications ap
-                        ON ap.account_id = a.account_id
-                    JOIN environments e
-                        ON e.application_id = ap.application_id
+                    FROM environments e
                     JOIN environment_revisions r
                         ON r.environment_id = e.environment_id
                         AND r.revision_id = e.current_revision_id
@@ -383,10 +376,8 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                         AND dr.revision_id = cdr.deployment_revision_id
 
                     WHERE
-                        ap.application_id = $1
+                        e.application_id = $1
                         AND e.name = $2
-                        AND a.deleted_at IS NULL
-                        AND ap.deleted_at IS NULL
                         AND e.deleted_at IS NULL
                 "# })
                 .bind(application_id)
@@ -454,32 +445,22 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
     async fn list_by_app(
         &self,
         application_id: Uuid,
-    ) -> Result<Vec<EnvironmentExtRevisionRecord>, EnvironmentRepoError> {
+    ) -> Result<Vec<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError> {
         let result = self
             .with_ro("list_by_owner")
             .fetch_all_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT
-                        e.name, e.application_id, ap.name AS application_name,
-                        r.environment_id, r.revision_id, r.hash,
+                        e.application_id,
+                        r.environment_id, r.revision_id, r.name, r.hash,
                         r.created_at, r.created_by, r.deleted,
                         r.compatibility_check, r.version_check, r.security_overrides,
-
-                        a.account_id as owner_account_id,
-                        a.email as owner_account_email,
 
                         cdr.revision_id as current_deployment_revision,
                         dr.revision_id as current_deployment_deployment_revision,
                         dr.version as current_deployment_deployment_version,
                         dr.hash as current_deployment_deployment_hash
-                    FROM accounts a
-                    JOIN applications ap
-                        ON ap.account_id = a.account_id
-                        AND ap.deleted_at IS NULL
-
-                    JOIN environments e
-                        ON e.application_id = ap.application_id
-                        AND e.deleted_at IS NULL
+                    FROM environments e
                     JOIN environment_revisions r
                         ON r.environment_id = e.environment_id
                         AND r.revision_id = e.current_revision_id
@@ -494,8 +475,8 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                         AND dr.revision_id = cdr.deployment_revision_id
 
                     WHERE
-                        ap.application_id = $1
-                        AND a.deleted_at IS NULL
+                        e.application_id = $1
+                        AND e.deleted_at IS NULL
                     ORDER BY e.name
                 "#})
                 .bind(application_id),

--- a/golem-registry-service/src/repo/environment.rs
+++ b/golem-registry-service/src/repo/environment.rs
@@ -16,6 +16,7 @@ use super::model::environment::{EnvironmentRepoError, EnvironmentWithDetailsReco
 use crate::repo::model::BindFields;
 pub use crate::repo::model::environment::{
     EnvironmentExtRecord, EnvironmentExtRevisionRecord, EnvironmentRevisionRecord,
+    EnvironmentScopedExtRevisionRecord, EnvironmentScopedRecord,
 };
 use crate::repo::model::environment_plugin_grant::EnvironmentPluginGrantRecord;
 use crate::repo::registry_change::{
@@ -145,24 +146,24 @@ pub trait EnvironmentRepo: Send + Sync {
         &self,
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError>;
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError>;
 
     async fn create_with_plugin_grants(
         &self,
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
         plugin_grants: Vec<EnvironmentPluginGrantRecord>,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError>;
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError>;
 
     async fn update(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError>;
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError>;
 
     async fn delete(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<EnvironmentExtRevisionRecord>, EnvironmentRepoError>;
+    ) -> Result<RequiresNotificationSignal<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError>;
 
     async fn list_visible_to_account(
         &self,
@@ -236,7 +237,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
         &self,
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         self.repo
             .create(application_id, revision)
             .instrument(Self::span_app_id(application_id))
@@ -248,7 +249,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
         plugin_grants: Vec<EnvironmentPluginGrantRecord>,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         let span = Self::span_app_id(application_id);
         self.repo
             .create_with_plugin_grants(application_id, revision, plugin_grants)
@@ -259,7 +260,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
     async fn update(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         let span = Self::span_env(revision.environment_id);
         self.repo.update(revision).instrument(span).await
     }
@@ -267,7 +268,7 @@ impl<Repo: EnvironmentRepo> EnvironmentRepo for LoggedEnvironmentRepo<Repo> {
     async fn delete(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<EnvironmentExtRevisionRecord>, EnvironmentRepoError>
+    ) -> Result<RequiresNotificationSignal<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError>
     {
         let span = Self::span_env(revision.environment_id);
         self.repo.delete(revision).instrument(span).await
@@ -508,10 +509,10 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
         &self,
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         // Note no {access,deletion}-based filtering is done here. That needs to be handled in higher layer before ever calling this function
         self.with_tx_err("create", |tx| async move {
-            let environment_record: EnvironmentExtRecord = tx.fetch_one_as(
+            let environment_record: EnvironmentScopedRecord = tx.fetch_one_as(
                 sqlx::query_as(indoc! { r#"
                     INSERT INTO environments
                       (environment_id, name, application_id, created_at, updated_at, deleted_at, modified_by, current_revision_id)
@@ -521,25 +522,11 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                       environment_id,
                       name,
                       application_id,
-                      (SELECT ap.name
-                       FROM applications ap
-                       WHERE ap.application_id = environments.application_id) AS application_name,
                       created_at,
                       updated_at,
                       deleted_at,
                       modified_by,
                       current_revision_id,
-
-                      -- Owner account id via scalar subquery
-                      (SELECT a.account_id
-                       FROM applications ap
-                       JOIN accounts a ON a.account_id = ap.account_id
-                       WHERE ap.application_id = environments.application_id) AS owner_account_id,
-                      (SELECT a.email
-                       FROM applications ap
-                       JOIN accounts a ON a.account_id = ap.account_id
-                       WHERE ap.application_id = environments.application_id) AS owner_account_email,
-
                       NULL AS current_deployment_revision,
                       NULL AS current_deployment_deployment_revision,
                       NULL AS current_deployment_deployment_version,
@@ -555,14 +542,9 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
 
             let revision = Self::insert_revision(tx, revision).await?;
 
-            Ok(EnvironmentExtRevisionRecord {
+            Ok(EnvironmentScopedExtRevisionRecord {
                 application_id,
-                application_name: environment_record.application_name,
                 revision,
-
-                owner_account_id: environment_record.owner_account_id,
-                owner_account_email: environment_record.owner_account_email,
-
                 current_deployment_revision: environment_record.current_deployment_revision,
                 current_deployment_deployment_revision: environment_record.current_deployment_deployment_revision,
                 current_deployment_deployment_version: environment_record.current_deployment_deployment_version,
@@ -576,9 +558,9 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
         application_id: Uuid,
         revision: EnvironmentRevisionRecord,
         plugin_grants: Vec<EnvironmentPluginGrantRecord>,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         self.with_tx_err("create_with_plugin_grants", |tx| async move {
-            let environment_record: EnvironmentExtRecord = tx.fetch_one_as(
+            let environment_record: EnvironmentScopedRecord = tx.fetch_one_as(
                 sqlx::query_as(indoc! { r#"
                     INSERT INTO environments
                       (environment_id, name, application_id, created_at, updated_at, deleted_at, modified_by, current_revision_id)
@@ -588,25 +570,11 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                       environment_id,
                       name,
                       application_id,
-                      (SELECT ap.name
-                       FROM applications ap
-                       WHERE ap.application_id = environments.application_id) AS application_name,
                       created_at,
                       updated_at,
                       deleted_at,
                       modified_by,
                       current_revision_id,
-
-                      -- Owner account id via scalar subquery
-                      (SELECT a.account_id
-                       FROM applications ap
-                       JOIN accounts a ON a.account_id = ap.account_id
-                       WHERE ap.application_id = environments.application_id) AS owner_account_id,
-                      (SELECT a.email
-                       FROM applications ap
-                       JOIN accounts a ON a.account_id = ap.account_id
-                       WHERE ap.application_id = environments.application_id) AS owner_account_email,
-
                       NULL AS current_deployment_revision,
                       NULL AS current_deployment_deployment_revision,
                       NULL AS current_deployment_deployment_version,
@@ -640,14 +608,9 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                 .map_err(|e| EnvironmentRepoError::InternalError(e.into()))?;
             }
 
-            Ok(EnvironmentExtRevisionRecord {
+            Ok(EnvironmentScopedExtRevisionRecord {
                 application_id,
-                application_name: environment_record.application_name,
                 revision,
-
-                owner_account_id: environment_record.owner_account_id,
-                owner_account_email: environment_record.owner_account_email,
-
                 current_deployment_revision: environment_record.current_deployment_revision,
                 current_deployment_deployment_revision: environment_record.current_deployment_deployment_revision,
                 current_deployment_deployment_version: environment_record.current_deployment_deployment_version,
@@ -659,7 +622,7 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
     async fn update(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<EnvironmentExtRevisionRecord, EnvironmentRepoError> {
+    ) -> Result<EnvironmentScopedExtRevisionRecord, EnvironmentRepoError> {
         self.with_tx_err("update", |tx| {
             async move {
                 let revision: EnvironmentRevisionRecord =
@@ -675,8 +638,9 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                 //       so we avoid selecting the same tables multiple times, same goes for logical DELETE
 
                 // Note no {access,deletion}-based filtering is done here. That needs to be handled in higher layer before ever calling this function
-                let environment_record: EnvironmentExtRecord = tx.fetch_optional_as(
-                    sqlx::query_as(indoc! { r#"
+                let environment_record: EnvironmentScopedRecord = tx
+                    .fetch_optional_as(
+                        sqlx::query_as(indoc! { r#"
                         UPDATE environments
                         SET name = $1,
                             updated_at = $2,
@@ -687,24 +651,11 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                             environment_id,
                             name,
                             application_id,
-                            (SELECT ap.name
-                             FROM applications ap
-                             WHERE ap.application_id = environments.application_id) AS application_name,
                             created_at,
                             updated_at,
                             deleted_at,
                             modified_by,
                             current_revision_id,
-
-                            -- Owner account id
-                            (SELECT a.account_id
-                             FROM applications ap
-                             JOIN accounts a ON a.account_id = ap.account_id
-                             WHERE ap.application_id = environments.application_id) AS owner_account_id,
-                            (SELECT a.email
-                             FROM applications ap
-                             JOIN accounts a ON a.account_id = ap.account_id
-                             WHERE ap.application_id = environments.application_id) AS owner_account_email,
 
                             -- Current deployment info
                             (
@@ -746,24 +697,21 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                                 WHERE cd.environment_id = environments.environment_id
                             ) AS current_deployment_deployment_hash;
                     "#})
-                    .bind(&revision.name)
-                    .bind(&revision.audit.created_at)
-                    .bind(revision.audit.created_by)
-                    .bind(revision.revision_id)
-                    .bind(revision.environment_id),
-                )
-                .await
-                .to_error_on_unique_violation(EnvironmentRepoError::EnvironmentViolatesUniqueness)?
-                .ok_or(EnvironmentRepoError::ConcurrentModification)?;
+                        .bind(&revision.name)
+                        .bind(&revision.audit.created_at)
+                        .bind(revision.audit.created_by)
+                        .bind(revision.revision_id)
+                        .bind(revision.environment_id),
+                    )
+                    .await
+                    .to_error_on_unique_violation(
+                        EnvironmentRepoError::EnvironmentViolatesUniqueness,
+                    )?
+                    .ok_or(EnvironmentRepoError::ConcurrentModification)?;
 
-                Ok(EnvironmentExtRevisionRecord {
+                Ok(EnvironmentScopedExtRevisionRecord {
                     application_id: environment_record.application_id,
-                    application_name: environment_record.application_name,
                     revision,
-
-                    owner_account_id: environment_record.owner_account_id,
-                    owner_account_email: environment_record.owner_account_email,
-
                     current_deployment_revision: environment_record.current_deployment_revision,
                     current_deployment_deployment_revision: environment_record
                         .current_deployment_deployment_revision,
@@ -781,15 +729,16 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
     async fn delete(
         &self,
         revision: EnvironmentRevisionRecord,
-    ) -> Result<RequiresNotificationSignal<EnvironmentExtRevisionRecord>, EnvironmentRepoError>
+    ) -> Result<RequiresNotificationSignal<EnvironmentScopedExtRevisionRecord>, EnvironmentRepoError>
     {
         self.with_tx_err("delete", |tx| {
             async move {
                 let revision: EnvironmentRevisionRecord =
                     Self::insert_revision(tx, revision).await?;
 
-                let environment_record: EnvironmentExtRecord = tx.fetch_optional_as(
-                    sqlx::query_as(indoc! { r#"
+                let environment_record: EnvironmentScopedRecord = tx
+                    .fetch_optional_as(
+                        sqlx::query_as(indoc! { r#"
                         UPDATE environments
                         SET name = $1,
                             updated_at = $2,
@@ -801,24 +750,11 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                             environment_id,
                             name,
                             application_id,
-                            (SELECT ap.name
-                             FROM applications ap
-                             WHERE ap.application_id = environments.application_id) AS application_name,
                             created_at,
                             updated_at,
                             deleted_at,
                             modified_by,
                             current_revision_id,
-
-                            -- Owner account id
-                            (SELECT a.account_id
-                             FROM applications ap
-                             JOIN accounts a ON a.account_id = ap.account_id
-                             WHERE ap.application_id = environments.application_id) AS owner_account_id,
-                            (SELECT a.email
-                             FROM applications ap
-                             JOIN accounts a ON a.account_id = ap.account_id
-                             WHERE ap.application_id = environments.application_id) AS owner_account_email,
 
                             -- Current deployment info
                             (
@@ -861,14 +797,14 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                             ) AS current_deployment_deployment_hash;
 
                     "#})
-                    .bind(&revision.name)
-                    .bind(&revision.audit.created_at)
-                    .bind(revision.audit.created_by)
-                    .bind(revision.revision_id)
-                    .bind(revision.environment_id),
-                )
-                .await?
-                .ok_or(EnvironmentRepoError::ConcurrentModification)?;
+                        .bind(&revision.name)
+                        .bind(&revision.audit.created_at)
+                        .bind(revision.audit.created_by)
+                        .bind(revision.revision_id)
+                        .bind(revision.environment_id),
+                    )
+                    .await?
+                    .ok_or(EnvironmentRepoError::ConcurrentModification)?;
 
                 // Emit an EnvironmentDeleted invalidation event carrying the
                 // human-readable app_name and env_name so subscribers can perform
@@ -894,14 +830,9 @@ impl EnvironmentRepo for DbEnvironmentRepo<PostgresPool> {
                 DbRegistryChangeRepo::<PostgresPool>::create_change_event_in_tx(tx, &change_event)
                     .await?;
 
-                Ok(EnvironmentExtRevisionRecord {
+                Ok(EnvironmentScopedExtRevisionRecord {
                     application_id: environment_record.application_id,
-                    application_name: environment_record.application_name,
                     revision,
-
-                    owner_account_id: environment_record.owner_account_id,
-                    owner_account_email: environment_record.owner_account_email,
-
                     current_deployment_revision: environment_record.current_deployment_revision,
                     current_deployment_deployment_revision: environment_record
                         .current_deployment_deployment_revision,

--- a/golem-registry-service/src/repo/environment_plugin_grant.rs
+++ b/golem-registry-service/src/repo/environment_plugin_grant.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::model::environment_plugin_grant::{
-    EnvironmentPluginGrantRecord, EnvironmentPluginGrantRepoError,
-    EnvironmentPluginGrantWithDetailsRecord,
+    EnvironmentPluginGrantAuthWithDetailsRecord, EnvironmentPluginGrantRecord,
+    EnvironmentPluginGrantRepoError, EnvironmentPluginGrantWithDetailsRecord,
 };
 use crate::repo::model::BindFields;
 use async_trait::async_trait;
@@ -47,7 +47,7 @@ pub trait EnvironmentPluginGrantRepo: Send + Sync {
         &self,
         environment_plugin_grant_id: Uuid,
         include_deleted: bool,
-    ) -> Result<Option<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError>;
+    ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>;
 
     async fn list_by_environment(
         &self,
@@ -109,7 +109,7 @@ impl<Repo: EnvironmentPluginGrantRepo> EnvironmentPluginGrantRepo
         &self,
         environment_plugin_grant_id: Uuid,
         include_deleted: bool,
-    ) -> Result<Option<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError>
+    ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>
     {
         let span = Self::span_id(environment_plugin_grant_id);
         self.repo
@@ -229,7 +229,7 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
         &self,
         environment_plugin_grant_id: Uuid,
         include_deleted: bool,
-    ) -> Result<Option<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError>
+    ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>
     {
         let result = self
             .with_ro("get_by_id")
@@ -266,9 +266,22 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
                         p.created_at AS plugin_created_at,
                         p.created_by AS plugin_created_by,
                         p.deleted_at AS plugin_deleted_at,
-                        p.deleted_by AS plugin_deleted_by
+                        p.deleted_by AS plugin_deleted_by,
+
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
 
                         FROM environment_plugin_grants epg
+                        INNER JOIN environments e
+                            ON e.environment_id = epg.environment_id
+                        INNER JOIN environment_revisions er
+                            ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                        INNER JOIN applications ap
+                            ON ap.application_id = e.application_id
+                        INNER JOIN accounts a
+                            ON a.account_id = ap.account_id
                         INNER JOIN plugins p
                             ON p.plugin_id = epg.plugin_id
                         INNER JOIN accounts pa
@@ -286,6 +299,9 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
                                     AND pa.deleted_at IS NULL
                                 )
                             )
+                            AND e.deleted_at IS NULL
+                            AND ap.deleted_at IS NULL
+                            AND a.deleted_at IS NULL
                 "#})
                 .bind(environment_plugin_grant_id)
                 .bind(include_deleted),

--- a/golem-registry-service/src/repo/environment_plugin_grant.rs
+++ b/golem-registry-service/src/repo/environment_plugin_grant.rs
@@ -46,7 +46,6 @@ pub trait EnvironmentPluginGrantRepo: Send + Sync {
     async fn get_by_id(
         &self,
         environment_plugin_grant_id: Uuid,
-        include_deleted: bool,
     ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>;
 
     async fn list_by_environment(
@@ -56,8 +55,8 @@ pub trait EnvironmentPluginGrantRepo: Send + Sync {
 
     async fn get_by_ids(
         &self,
+        environment_id: Uuid,
         environment_plugin_grant_ids: &[Uuid],
-        include_deleted: bool,
     ) -> Result<Vec<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError>;
 }
 
@@ -108,12 +107,11 @@ impl<Repo: EnvironmentPluginGrantRepo> EnvironmentPluginGrantRepo
     async fn get_by_id(
         &self,
         environment_plugin_grant_id: Uuid,
-        include_deleted: bool,
     ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>
     {
         let span = Self::span_id(environment_plugin_grant_id);
         self.repo
-            .get_by_id(environment_plugin_grant_id, include_deleted)
+            .get_by_id(environment_plugin_grant_id)
             .instrument(span)
             .await
     }
@@ -131,12 +129,12 @@ impl<Repo: EnvironmentPluginGrantRepo> EnvironmentPluginGrantRepo
 
     async fn get_by_ids(
         &self,
+        environment_id: Uuid,
         environment_plugin_grant_ids: &[Uuid],
-        include_deleted: bool,
     ) -> Result<Vec<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError> {
-        let span = info_span!(SPAN_NAME);
+        let span = Self::span_environment(environment_id);
         self.repo
-            .get_by_ids(environment_plugin_grant_ids, include_deleted)
+            .get_by_ids(environment_id, environment_plugin_grant_ids)
             .instrument(span)
             .await
     }
@@ -228,7 +226,6 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         environment_plugin_grant_id: Uuid,
-        include_deleted: bool,
     ) -> Result<Option<EnvironmentPluginGrantAuthWithDetailsRecord>, EnvironmentPluginGrantRepoError>
     {
         let result = self
@@ -291,20 +288,14 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
                             AND par.revision_id = pa.current_revision_id
                         WHERE
                             epg.environment_plugin_grant_id = $1
-                            AND (
-                                $2
-                                OR (
-                                    epg.deleted_at IS NULL
-                                    AND p.deleted_at IS NULL
-                                    AND pa.deleted_at IS NULL
-                                )
-                            )
+                            AND epg.deleted_at IS NULL
+                            AND p.deleted_at IS NULL
+                            AND pa.deleted_at IS NULL
                             AND e.deleted_at IS NULL
                             AND ap.deleted_at IS NULL
                             AND a.deleted_at IS NULL
                 "#})
-                .bind(environment_plugin_grant_id)
-                .bind(include_deleted),
+                .bind(environment_plugin_grant_id),
             )
             .await?;
 
@@ -375,14 +366,14 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
 
     async fn get_by_ids(
         &self,
+        environment_id: Uuid,
         environment_plugin_grant_ids: &[Uuid],
-        include_deleted: bool,
     ) -> Result<Vec<EnvironmentPluginGrantWithDetailsRecord>, EnvironmentPluginGrantRepoError> {
         if environment_plugin_grant_ids.is_empty() {
             return Ok(vec![]);
         }
 
-        // $1 = include_deleted; IDs are bound starting at $2
+        // $1 = environment_id; IDs are bound starting at $2
         let mut binding_stack = BindingsStack::new(2);
         let in_clause = environment_plugin_grant_ids
             .iter()
@@ -435,21 +426,18 @@ impl EnvironmentPluginGrantRepo for DbEnvironmentPluginGrantRepo<PostgresPool> {
                 ON par.account_id = pa.account_id
                 AND par.revision_id = pa.current_revision_id
             WHERE
+                epg.environment_id = $1
+                AND
                 epg.environment_plugin_grant_id IN ({in_clause})
-                AND (
-                    $1
-                    OR (
-                        epg.deleted_at IS NULL
-                        AND p.deleted_at IS NULL
-                        AND pa.deleted_at IS NULL
-                    )
-                )
+                AND epg.deleted_at IS NULL
+                AND p.deleted_at IS NULL
+                AND pa.deleted_at IS NULL
         "# };
 
         let query_as = {
             let binding_stack = binding_stack;
             sqlx::query_as(&query)
-                .bind(include_deleted)
+                .bind(environment_id)
                 .pipe(|q| binding_stack.apply(q))
         };
 

--- a/golem-registry-service/src/repo/http_api_deployment.rs
+++ b/golem-registry-service/src/repo/http_api_deployment.rs
@@ -14,8 +14,9 @@
 
 use crate::repo::model::BindFields;
 use crate::repo::model::http_api_deployment::{
-    HttpApiDeploymentExtRevisionRecord, HttpApiDeploymentRecord, HttpApiDeploymentRepoError,
-    HttpApiDeploymentRevisionIdentityRecord, HttpApiDeploymentRevisionRecord,
+    HttpApiDeploymentAuthExtRevisionRecord, HttpApiDeploymentExtRevisionRecord,
+    HttpApiDeploymentRecord, HttpApiDeploymentRepoError, HttpApiDeploymentRevisionIdentityRecord,
+    HttpApiDeploymentRevisionRecord,
 };
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
@@ -55,7 +56,7 @@ pub trait HttpApiDeploymentRepo: Send + Sync {
     async fn get_staged_by_id(
         &self,
         http_api_deployment_id: Uuid,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>>;
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>>;
 
     async fn get_staged_by_domain(
         &self,
@@ -67,7 +68,7 @@ pub trait HttpApiDeploymentRepo: Send + Sync {
         &self,
         http_api_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>>;
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>>;
 
     async fn list_staged(
         &self,
@@ -157,7 +158,7 @@ impl<Repo: HttpApiDeploymentRepo> HttpApiDeploymentRepo for LoggedHttpApiDeploym
     async fn get_staged_by_id(
         &self,
         http_api_deployment_id: Uuid,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>> {
         self.repo
             .get_staged_by_id(http_api_deployment_id)
             .instrument(Self::span_id(http_api_deployment_id))
@@ -179,7 +180,7 @@ impl<Repo: HttpApiDeploymentRepo> HttpApiDeploymentRepo for LoggedHttpApiDeploym
         &self,
         http_api_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>> {
         self.repo
             .get_by_id_and_revision(http_api_deployment_id, revision_id)
             .instrument(Self::span_id_and_revision(
@@ -416,18 +417,34 @@ impl HttpApiDeploymentRepo for DbHttpApiDeploymentRepo<PostgresPool> {
     async fn get_staged_by_id(
         &self,
         http_api_deployment_id: Uuid,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>> {
         self.with_ro("get_staged_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT d.environment_id, d.domain, dr.http_api_deployment_id,
                         dr.revision_id, dr.hash, dr.data,
                         dr.created_at, dr.created_by, dr.deleted,
-                        d.created_at as entity_created_at
+                        d.created_at as entity_created_at,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM http_api_deployments d
+                    JOIN environments e
+                        ON e.environment_id = d.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN http_api_deployment_revisions dr
                         ON d.http_api_deployment_id = dr.http_api_deployment_id AND d.current_revision_id = dr.revision_id
-                    WHERE d.http_api_deployment_id = $1 AND d.deleted_at IS NULL
+                    WHERE d.http_api_deployment_id = $1
+                        AND d.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(http_api_deployment_id),
             )
@@ -461,21 +478,38 @@ impl HttpApiDeploymentRepo for DbHttpApiDeploymentRepo<PostgresPool> {
         &self,
         http_api_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<HttpApiDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<HttpApiDeploymentAuthExtRevisionRecord>> {
         self.with_ro("get_by_id_and_revision")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT d.environment_id, d.domain, dr.http_api_deployment_id,
                         dr.revision_id, dr.hash, dr.data,
                         dr.created_at, dr.created_by, dr.deleted,
-                        d.created_at as entity_created_at
+                        d.created_at as entity_created_at,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM http_api_deployments d
+                    JOIN environments e
+                        ON e.environment_id = d.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN http_api_deployment_revisions dr
                         ON d.http_api_deployment_id = dr.http_api_deployment_id
-                    WHERE d.http_api_deployment_id = $1 AND dr.revision_id = $2 AND d.deleted_at IS NULL
+                    WHERE d.http_api_deployment_id = $1
+                        AND dr.revision_id = $2
+                        AND d.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
-                    .bind(http_api_deployment_id)
-                    .bind(revision_id),
+                .bind(http_api_deployment_id)
+                .bind(revision_id),
             )
             .await
     }

--- a/golem-registry-service/src/repo/mcp_deployment.rs
+++ b/golem-registry-service/src/repo/mcp_deployment.rs
@@ -14,8 +14,8 @@
 
 use crate::repo::model::BindFields;
 use crate::repo::model::mcp_deployment::{
-    McpDeploymentExtRevisionRecord, McpDeploymentRepoError, McpDeploymentRevisionIdentityRecord,
-    McpDeploymentRevisionRecord,
+    McpDeploymentAuthExtRevisionRecord, McpDeploymentExtRevisionRecord, McpDeploymentRepoError,
+    McpDeploymentRevisionIdentityRecord, McpDeploymentRevisionRecord,
 };
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
@@ -56,7 +56,7 @@ pub trait McpDeploymentRepo: Send + Sync {
     async fn get_staged_by_id(
         &self,
         mcp_deployment_id: Uuid,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>>;
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>>;
 
     async fn get_staged_by_domain(
         &self,
@@ -68,7 +68,7 @@ pub trait McpDeploymentRepo: Send + Sync {
         &self,
         mcp_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>>;
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>>;
 
     async fn list_staged(
         &self,
@@ -158,7 +158,7 @@ impl<Repo: McpDeploymentRepo> McpDeploymentRepo for LoggedMcpDeploymentRepo<Repo
     async fn get_staged_by_id(
         &self,
         mcp_deployment_id: Uuid,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>> {
         self.repo
             .get_staged_by_id(mcp_deployment_id)
             .instrument(Self::span_id(mcp_deployment_id))
@@ -180,7 +180,7 @@ impl<Repo: McpDeploymentRepo> McpDeploymentRepo for LoggedMcpDeploymentRepo<Repo
         &self,
         mcp_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>> {
         self.repo
             .get_by_id_and_revision(mcp_deployment_id, revision_id)
             .instrument(Self::span_id_and_revision(mcp_deployment_id, revision_id))
@@ -406,19 +406,35 @@ impl McpDeploymentRepo for DbMcpDeploymentRepo<PostgresPool> {
     async fn get_staged_by_id(
         &self,
         mcp_deployment_id: Uuid,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>> {
         self.with_ro("get_staged_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT m.environment_id, m.domain, mr.mcp_deployment_id,
                         mr.revision_id, mr.hash, mr.data,
                         mr.created_at, mr.created_by, mr.deleted,
-                        m.created_at as entity_created_at
+                        m.created_at as entity_created_at,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM mcp_deployments m
+                    JOIN environments e
+                        ON e.environment_id = m.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN mcp_deployment_revisions mr
                         ON m.mcp_deployment_id = mr.mcp_deployment_id
                             AND m.current_revision_id = mr.revision_id
-                    WHERE m.mcp_deployment_id = $1 AND m.deleted_at IS NULL
+                    WHERE m.mcp_deployment_id = $1
+                        AND m.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "# })
                 .bind(mcp_deployment_id),
             )
@@ -453,18 +469,35 @@ impl McpDeploymentRepo for DbMcpDeploymentRepo<PostgresPool> {
         &self,
         mcp_deployment_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<McpDeploymentExtRevisionRecord>> {
+    ) -> RepoResult<Option<McpDeploymentAuthExtRevisionRecord>> {
         self.with_ro("get_by_id_and_revision")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT m.environment_id, m.domain, mr.mcp_deployment_id,
                         mr.revision_id, mr.hash, mr.data,
                         mr.created_at, mr.created_by, mr.deleted,
-                        m.created_at as entity_created_at
+                        m.created_at as entity_created_at,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM mcp_deployments m
+                    JOIN environments e
+                        ON e.environment_id = m.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN mcp_deployment_revisions mr
                         ON m.mcp_deployment_id = mr.mcp_deployment_id
-                    WHERE m.mcp_deployment_id = $1 AND mr.revision_id = $2 AND m.deleted_at IS NULL
+                    WHERE m.mcp_deployment_id = $1
+                        AND mr.revision_id = $2
+                        AND m.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "# })
                 .bind(mcp_deployment_id)
                 .bind(revision_id),

--- a/golem-registry-service/src/repo/model/agent_secrets.rs
+++ b/golem-registry-service/src/repo/model/agent_secrets.rs
@@ -153,6 +153,16 @@ pub struct AgentSecretExtRevisionRecord {
     pub revision: AgentSecretRevisionRecord,
 }
 
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct AgentSecretAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub agent_secret: AgentSecretExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<AgentSecretExtRevisionRecord> for AgentSecret {
     type Error = AgentSecretRepoError;
     fn try_from(value: AgentSecretExtRevisionRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/application.rs
+++ b/golem-registry-service/src/repo/model/application.rs
@@ -74,6 +74,31 @@ pub struct ApplicationExtRevisionRecord {
     pub revision: ApplicationRevisionRecord,
 }
 
+#[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct ApplicationScopedExtRevisionRecord {
+    pub account_id: Uuid,
+
+    pub entity_created_at: SqlDateTime,
+
+    #[sqlx(flatten)]
+    pub revision: ApplicationRevisionRecord,
+}
+
+impl ApplicationScopedExtRevisionRecord {
+    pub fn try_into_model(
+        self,
+        account_email: AccountEmail,
+    ) -> Result<Application, ApplicationRepoError> {
+        Ok(Application {
+            id: ApplicationId(self.revision.application_id),
+            revision: self.revision.revision_id.try_into()?,
+            account_id: AccountId(self.account_id),
+            account_email,
+            name: ApplicationName(self.revision.name),
+        })
+    }
+}
+
 impl TryFrom<ApplicationExtRevisionRecord> for Application {
     type Error = ApplicationRepoError;
 

--- a/golem-registry-service/src/repo/model/application.rs
+++ b/golem-registry-service/src/repo/model/application.rs
@@ -44,6 +44,15 @@ pub struct ApplicationRecord {
 }
 
 #[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct ApplicationScopedRecord {
+    pub application_id: Uuid,
+    pub name: String,
+    pub account_id: Uuid,
+    #[sqlx(flatten)]
+    pub audit: AuditFields,
+}
+
+#[derive(Debug, Clone, FromRow, PartialEq)]
 pub struct ApplicationRevisionRecord {
     pub application_id: Uuid,
     pub revision_id: i64,

--- a/golem-registry-service/src/repo/model/component.rs
+++ b/golem-registry-service/src/repo/model/component.rs
@@ -240,6 +240,44 @@ pub struct ComponentExtRevisionRecord {
     pub revision: ComponentRevisionRecord,
 }
 
+#[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct ComponentAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub component: ComponentExtRevisionRecord,
+
+    pub application_id: Uuid,
+    pub application_name: String,
+    pub owner_account_id: Uuid,
+    pub owner_account_email: String,
+    pub environment_name: String,
+    pub environment_revision_id: i64,
+    pub environment_compatibility_check: bool,
+    pub environment_version_check: bool,
+    pub environment_security_overrides: bool,
+}
+
+impl ComponentAuthExtRevisionRecord {
+    pub fn try_into_model(self) -> Result<Component, RepoError> {
+        let Self {
+            component,
+            application_id,
+            application_name,
+            owner_account_id,
+            owner_account_email,
+            environment_name,
+            ..
+        } = self;
+
+        component.try_into_model(
+            ApplicationId(application_id),
+            AccountId(owner_account_id),
+            AccountEmail::new(owner_account_email),
+            ApplicationName(application_name),
+            EnvironmentName(environment_name),
+        )
+    }
+}
+
 impl ComponentExtRevisionRecord {
     pub fn try_into_model(
         self,

--- a/golem-registry-service/src/repo/model/deployment.rs
+++ b/golem-registry-service/src/repo/model/deployment.rs
@@ -434,6 +434,40 @@ impl TryFrom<DeploymentRegisteredAgentTypeRecord> for DeployedRegisteredAgentTyp
 }
 
 #[derive(Debug, Clone, PartialEq, FromRow)]
+pub struct DeploymentRegisteredAgentTypeScopedRecord {
+    pub environment_id: Uuid,
+    pub deployment_revision_id: i64,
+    pub agent_type_name: String,
+    pub canonical_agent_type_name: String,
+
+    pub component_id: Uuid,
+    pub component_name: String,
+    pub component_revision_id: i64,
+    pub webhook_prefix_authority_and_path: Option<String>,
+    pub agent_type: Blob<AgentType>,
+}
+
+impl DeploymentRegisteredAgentTypeScopedRecord {
+    pub fn try_into_deployed(
+        self,
+        owner_account_id: AccountId,
+        owner_account_email: AccountEmail,
+    ) -> Result<DeployedRegisteredAgentType, DeployRepoError> {
+        Ok(DeployedRegisteredAgentType {
+            agent_type: self.agent_type.into_value(),
+            implemented_by: RegisteredAgentTypeImplementer {
+                component_id: self.component_id.into(),
+                component_revision: self.component_revision_id.try_into()?,
+                component_name: self.component_name,
+                account_id: owner_account_id,
+                account_email: owner_account_email,
+            },
+            webhook_prefix_authority_and_path: self.webhook_prefix_authority_and_path,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromRow)]
 pub struct ResolvedAgentTypeRecord {
     pub environment_id: Uuid,
     pub deployment_revision_id: i64,

--- a/golem-registry-service/src/repo/model/domain_registration.rs
+++ b/golem-registry-service/src/repo/model/domain_registration.rs
@@ -40,6 +40,16 @@ pub struct DomainRegistrationRecord {
     pub audit: ImmutableAuditFields,
 }
 
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct DomainRegistrationAuthRecord {
+    #[sqlx(flatten)]
+    pub domain_registration: DomainRegistrationRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl DomainRegistrationRecord {
     pub fn from_model(model: DomainRegistration, audit: ImmutableAuditFields) -> Self {
         Self {

--- a/golem-registry-service/src/repo/model/environment.rs
+++ b/golem-registry-service/src/repo/model/environment.rs
@@ -63,6 +63,21 @@ pub struct EnvironmentExtRecord {
 }
 
 #[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct EnvironmentScopedRecord {
+    pub environment_id: Uuid,
+    pub name: String,
+    pub application_id: Uuid,
+    #[sqlx(flatten)]
+    pub audit: AuditFields,
+    pub current_revision_id: i64,
+
+    pub current_deployment_revision: Option<i64>,
+    pub current_deployment_deployment_revision: Option<i64>,
+    pub current_deployment_deployment_version: Option<String>,
+    pub current_deployment_deployment_hash: Option<SqlBlake3Hash>,
+}
+
+#[derive(Debug, Clone, FromRow, PartialEq)]
 pub struct EnvironmentRevisionRecord {
     pub environment_id: Uuid,
     pub revision_id: i64,
@@ -141,6 +156,41 @@ pub struct EnvironmentExtRevisionRecord {
     pub current_deployment_deployment_revision: Option<i64>,
     pub current_deployment_deployment_version: Option<String>,
     pub current_deployment_deployment_hash: Option<SqlBlake3Hash>,
+}
+
+#[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct EnvironmentScopedExtRevisionRecord {
+    pub application_id: Uuid,
+
+    #[sqlx(flatten)]
+    pub revision: EnvironmentRevisionRecord,
+
+    pub current_deployment_revision: Option<i64>,
+    pub current_deployment_deployment_revision: Option<i64>,
+    pub current_deployment_deployment_version: Option<String>,
+    pub current_deployment_deployment_hash: Option<SqlBlake3Hash>,
+}
+
+impl EnvironmentScopedExtRevisionRecord {
+    pub fn try_into_model(
+        self,
+        application_name: ApplicationName,
+        owner_account_id: AccountId,
+        owner_account_email: AccountEmail,
+    ) -> Result<Environment, EnvironmentRepoError> {
+        EnvironmentExtRevisionRecord {
+            application_id: self.application_id,
+            application_name: application_name.0,
+            revision: self.revision,
+            owner_account_id: owner_account_id.0,
+            owner_account_email: owner_account_email.into_inner(),
+            current_deployment_revision: self.current_deployment_revision,
+            current_deployment_deployment_revision: self.current_deployment_deployment_revision,
+            current_deployment_deployment_version: self.current_deployment_deployment_version,
+            current_deployment_deployment_hash: self.current_deployment_deployment_hash,
+        }
+        .try_into()
+    }
 }
 
 impl TryFrom<EnvironmentExtRevisionRecord> for Environment {

--- a/golem-registry-service/src/repo/model/environment_plugin_grant.rs
+++ b/golem-registry-service/src/repo/model/environment_plugin_grant.rs
@@ -116,6 +116,16 @@ pub struct EnvironmentPluginGrantWithDetailsRecord {
     pub plugin_account_email: String,
 }
 
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct EnvironmentPluginGrantAuthWithDetailsRecord {
+    #[sqlx(flatten)]
+    pub grant: EnvironmentPluginGrantWithDetailsRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<EnvironmentPluginGrantWithDetailsRecord> for EnvironmentPluginGrantWithDetails {
     type Error = anyhow::Error;
     fn try_from(value: EnvironmentPluginGrantWithDetailsRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/http_api_deployment.rs
+++ b/golem-registry-service/src/repo/model/http_api_deployment.rs
@@ -193,6 +193,16 @@ pub struct HttpApiDeploymentExtRevisionRecord {
     pub revision: HttpApiDeploymentRevisionRecord,
 }
 
+#[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct HttpApiDeploymentAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub deployment: HttpApiDeploymentExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<HttpApiDeploymentExtRevisionRecord> for HttpApiDeployment {
     type Error = HttpApiDeploymentRepoError;
     fn try_from(value: HttpApiDeploymentExtRevisionRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/mcp_deployment.rs
+++ b/golem-registry-service/src/repo/model/mcp_deployment.rs
@@ -174,6 +174,16 @@ pub struct McpDeploymentExtRevisionRecord {
     pub revision: McpDeploymentRevisionRecord,
 }
 
+#[derive(Debug, Clone, FromRow, PartialEq)]
+pub struct McpDeploymentAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub deployment: McpDeploymentExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<McpDeploymentExtRevisionRecord> for McpDeployment {
     type Error = McpDeploymentRepoError;
 

--- a/golem-registry-service/src/repo/model/permission_share.rs
+++ b/golem-registry-service/src/repo/model/permission_share.rs
@@ -15,7 +15,7 @@
 use crate::repo::model::audit::{AuditFields, DeletableRevisionAuditFields};
 use crate::repo::model::card::CardRepoError;
 use golem_common::error_forwarding;
-use golem_common::model::account::AccountId;
+use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::card::CardId;
 use golem_common::model::permission_share::{
     PermissionShare, PermissionShareData, PermissionShareId, PermissionShareName,
@@ -143,6 +143,24 @@ pub struct PermissionShareExtRevisionRecord {
 
     #[sqlx(flatten)]
     pub revision: PermissionShareRevisionRecord,
+}
+
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct PermissionShareAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub share: PermissionShareExtRevisionRecord,
+    pub owner_account_email: String,
+    pub target_account_email: String,
+}
+
+impl PermissionShareAuthExtRevisionRecord {
+    pub fn owner_account_email(&self) -> AccountEmail {
+        AccountEmail::new(self.owner_account_email.clone())
+    }
+
+    pub fn target_account_email(&self) -> AccountEmail {
+        AccountEmail::new(self.target_account_email.clone())
+    }
 }
 
 impl TryFrom<PermissionShareExtRevisionRecord> for PermissionShare {

--- a/golem-registry-service/src/repo/model/plugin.rs
+++ b/golem-registry-service/src/repo/model/plugin.rs
@@ -15,7 +15,7 @@
 use super::audit::ImmutableAuditFields;
 use super::hash::SqlBlake3Hash;
 use anyhow::anyhow;
-use golem_common::model::account::AccountId;
+use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::component::ComponentId;
 use golem_common::model::plugin_registration::{OplogProcessorPluginSpec, PluginRegistrationId};
 use golem_service_base::model::plugin_registration::{PluginRegistration, PluginSpec};
@@ -53,6 +53,19 @@ pub struct PluginRecord {
 
     // for Library and App plugin type
     pub wasm_content_hash: Option<SqlBlake3Hash>,
+}
+
+#[derive(Debug, Clone, PartialEq, FromRow)]
+pub struct PluginAuthRecord {
+    #[sqlx(flatten)]
+    pub plugin: PluginRecord,
+    pub account_email: String,
+}
+
+impl PluginAuthRecord {
+    pub fn account_email(&self) -> AccountEmail {
+        AccountEmail::new(self.account_email.clone())
+    }
 }
 
 impl PluginRecord {

--- a/golem-registry-service/src/repo/model/resource_definition.rs
+++ b/golem-registry-service/src/repo/model/resource_definition.rs
@@ -163,6 +163,16 @@ pub struct ResourceDefinitionExtRevisionRecord {
     pub revision: ResourceDefinitionRevisionRecord,
 }
 
+#[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
+pub struct ResourceDefinitionAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub resource_definition: ResourceDefinitionExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<ResourceDefinitionExtRevisionRecord> for ResourceDefinition {
     type Error = ResourceDefinitionRepoError;
     fn try_from(value: ResourceDefinitionExtRevisionRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/retry_policy.rs
+++ b/golem-registry-service/src/repo/model/retry_policy.rs
@@ -116,6 +116,16 @@ pub struct RetryPolicyExtRevisionRecord {
     pub revision: RetryPolicyRevisionRecord,
 }
 
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct RetryPolicyAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub retry_policy: RetryPolicyExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<RetryPolicyExtRevisionRecord> for StoredRetryPolicy {
     type Error = RetryPolicyRepoError;
     fn try_from(value: RetryPolicyExtRevisionRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/security_scheme.rs
+++ b/golem-registry-service/src/repo/model/security_scheme.rs
@@ -146,6 +146,16 @@ pub struct SecuritySchemeExtRevisionRecord {
     pub revision: SecuritySchemeRevisionRecord,
 }
 
+#[derive(FromRow, Debug, Clone, PartialEq)]
+pub struct SecuritySchemeAuthExtRevisionRecord {
+    #[sqlx(flatten)]
+    pub security_scheme: SecuritySchemeExtRevisionRecord,
+
+    pub environment_name: String,
+    pub application_name: String,
+    pub owner_account_email: String,
+}
+
 impl TryFrom<SecuritySchemeExtRevisionRecord> for SecurityScheme {
     type Error = SecuritySchemeRepoError;
     fn try_from(value: SecuritySchemeExtRevisionRecord) -> Result<Self, Self::Error> {

--- a/golem-registry-service/src/repo/model/token.rs
+++ b/golem-registry-service/src/repo/model/token.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use golem_common::model::account::AccountId;
+use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::auth::{Token, TokenId, TokenSecret, TokenWithSecret};
 use golem_service_base::repo::SqlDateTime;
 use sqlx::FromRow;
@@ -30,6 +30,19 @@ pub struct TokenRecord {
     /// here and is used as the actor (created_by) in audit trails, while `account_id`
     /// is the target account used for access checks.
     pub impersonated_by: Option<Uuid>,
+}
+
+#[derive(FromRow, Clone, PartialEq)]
+pub struct TokenAuthRecord {
+    #[sqlx(flatten)]
+    pub token: TokenRecord,
+    pub account_email: String,
+}
+
+impl TokenAuthRecord {
+    pub fn account_email(&self) -> AccountEmail {
+        AccountEmail::new(self.account_email.clone())
+    }
 }
 
 impl Debug for TokenRecord {

--- a/golem-registry-service/src/repo/permission_share.rs
+++ b/golem-registry-service/src/repo/permission_share.rs
@@ -404,10 +404,8 @@ impl PermissionShareRepo for DbPermissionShareRepo<PostgresPool> {
                     FROM permission_shares ps
                     JOIN accounts owner
                         ON owner.account_id = ps.owner_account_id
-                       AND owner.deleted_at IS NULL
                     JOIN accounts target
                         ON target.account_id = ps.target_account_id
-                       AND target.deleted_at IS NULL
                     JOIN permission_share_revisions psr
                         ON psr.permission_share_id = ps.permission_share_id
                        AND psr.revision_id = ps.current_revision_id

--- a/golem-registry-service/src/repo/permission_share.rs
+++ b/golem-registry-service/src/repo/permission_share.rs
@@ -16,8 +16,8 @@ use crate::repo::card::DbCardRepo;
 use crate::repo::model::BindFields;
 use crate::repo::model::card::CardRecord;
 use crate::repo::model::permission_share::{
-    PermissionShareExtRevisionRecord, PermissionShareRecord, PermissionShareRepoError,
-    PermissionShareRevisionRecord,
+    PermissionShareAuthExtRevisionRecord, PermissionShareExtRevisionRecord, PermissionShareRecord,
+    PermissionShareRepoError, PermissionShareRevisionRecord,
 };
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
@@ -55,7 +55,7 @@ pub trait PermissionShareRepo: Send + Sync {
     async fn get_by_id(
         &self,
         permission_share_id: Uuid,
-    ) -> Result<Option<PermissionShareExtRevisionRecord>, PermissionShareRepoError>;
+    ) -> Result<Option<PermissionShareAuthExtRevisionRecord>, PermissionShareRepoError>;
 
     async fn get_by_owner_and_name(
         &self,
@@ -137,7 +137,7 @@ impl<Repo: PermissionShareRepo> PermissionShareRepo for LoggedPermissionShareRep
     async fn get_by_id(
         &self,
         permission_share_id: Uuid,
-    ) -> Result<Option<PermissionShareExtRevisionRecord>, PermissionShareRepoError> {
+    ) -> Result<Option<PermissionShareAuthExtRevisionRecord>, PermissionShareRepoError> {
         self.repo
             .get_by_id(permission_share_id)
             .instrument(Self::span_permission_share_id(permission_share_id))
@@ -393,13 +393,21 @@ impl PermissionShareRepo for DbPermissionShareRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         permission_share_id: Uuid,
-    ) -> Result<Option<PermissionShareExtRevisionRecord>, PermissionShareRepoError> {
+    ) -> Result<Option<PermissionShareAuthExtRevisionRecord>, PermissionShareRepoError> {
         self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT ps.owner_account_id, ps.target_account_id,
-                           psr.permission_share_id, psr.revision_id, psr.name, psr.card_id, psr.data, psr.created_at, psr.created_by, psr.deleted
+                           psr.permission_share_id, psr.revision_id, psr.name, psr.card_id, psr.data, psr.created_at, psr.created_by, psr.deleted,
+                           owner.email AS owner_account_email,
+                           target.email AS target_account_email
                     FROM permission_shares ps
+                    JOIN accounts owner
+                        ON owner.account_id = ps.owner_account_id
+                       AND owner.deleted_at IS NULL
+                    JOIN accounts target
+                        ON target.account_id = ps.target_account_id
+                       AND target.deleted_at IS NULL
                     JOIN permission_share_revisions psr
                         ON psr.permission_share_id = ps.permission_share_id
                        AND psr.revision_id = ps.current_revision_id

--- a/golem-registry-service/src/repo/plugin.rs
+++ b/golem-registry-service/src/repo/plugin.rs
@@ -17,11 +17,7 @@ pub trait PluginRepo: Send + Sync {
 
     async fn delete(&self, plugin_id: Uuid, actor: Uuid) -> RepoResult<Option<PluginRecord>>;
 
-    async fn get_by_id(
-        &self,
-        plugin_id: Uuid,
-        include_deleted: bool,
-    ) -> RepoResult<Option<PluginAuthRecord>>;
+    async fn get_by_id(&self, plugin_id: Uuid) -> RepoResult<Option<PluginAuthRecord>>;
 
     async fn get_by_name_and_version(
         &self,
@@ -71,13 +67,9 @@ impl<Repo: PluginRepo> PluginRepo for LoggedPluginRepo<Repo> {
             .await
     }
 
-    async fn get_by_id(
-        &self,
-        plugin_id: Uuid,
-        include_deleted: bool,
-    ) -> RepoResult<Option<PluginAuthRecord>> {
+    async fn get_by_id(&self, plugin_id: Uuid) -> RepoResult<Option<PluginAuthRecord>> {
         self.repo
-            .get_by_id(plugin_id, include_deleted)
+            .get_by_id(plugin_id)
             .instrument(Self::span_id(plugin_id))
             .await
     }
@@ -199,11 +191,7 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
             .await
     }
 
-    async fn get_by_id(
-        &self,
-        plugin_id: Uuid,
-        include_deleted: bool,
-    ) -> RepoResult<Option<PluginAuthRecord>> {
+    async fn get_by_id(&self, plugin_id: Uuid) -> RepoResult<Option<PluginAuthRecord>> {
         self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -221,13 +209,10 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
                         ON p.account_id = a.account_id
                     WHERE
                         p.plugin_id = $1
-                        AND (
-                            $2
-                            OR (a.deleted_at IS NULL AND p.deleted_at IS NULL)
-                        )
+                        AND a.deleted_at IS NULL
+                        AND p.deleted_at IS NULL
                 "#})
-                .bind(plugin_id)
-                .bind(include_deleted),
+                .bind(plugin_id),
             )
             .await
     }

--- a/golem-registry-service/src/repo/plugin.rs
+++ b/golem-registry-service/src/repo/plugin.rs
@@ -1,5 +1,5 @@
 use crate::repo::model::BindFields;
-use crate::repo::model::plugin::PluginRecord;
+use crate::repo::model::plugin::{PluginAuthRecord, PluginRecord};
 use async_trait::async_trait;
 use conditional_trait_gen::trait_gen;
 use golem_service_base::db::postgres::PostgresPool;
@@ -21,7 +21,7 @@ pub trait PluginRepo: Send + Sync {
         &self,
         plugin_id: Uuid,
         include_deleted: bool,
-    ) -> RepoResult<Option<PluginRecord>>;
+    ) -> RepoResult<Option<PluginAuthRecord>>;
 
     async fn get_by_name_and_version(
         &self,
@@ -75,7 +75,7 @@ impl<Repo: PluginRepo> PluginRepo for LoggedPluginRepo<Repo> {
         &self,
         plugin_id: Uuid,
         include_deleted: bool,
-    ) -> RepoResult<Option<PluginRecord>> {
+    ) -> RepoResult<Option<PluginAuthRecord>> {
         self.repo
             .get_by_id(plugin_id, include_deleted)
             .instrument(Self::span_id(plugin_id))
@@ -203,7 +203,7 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
         &self,
         plugin_id: Uuid,
         include_deleted: bool,
-    ) -> RepoResult<Option<PluginRecord>> {
+    ) -> RepoResult<Option<PluginAuthRecord>> {
         self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -214,7 +214,8 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
                         p.provided_wit_package,
                         p.json_schema, p.validate_url, p.transform_url,
                         p.component_id, p.component_revision_id,
-                        p.wasm_content_hash
+                        p.wasm_content_hash,
+                        a.email AS account_email
                     FROM accounts a
                     JOIN plugins p
                         ON p.account_id = a.account_id
@@ -248,14 +249,11 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
                         p.json_schema, p.validate_url, p.transform_url,
                         p.component_id, p.component_revision_id,
                         p.wasm_content_hash
-                    FROM accounts a
-                    JOIN plugins p
-                        ON p.account_id = a.account_id
+                    FROM plugins p
                     WHERE
-                        a.account_id = $1
+                        p.account_id = $1
                         AND p.name = $2
                         AND p.version = $3
-                        AND a.deleted_at IS NULL
                         AND p.deleted_at IS NULL
                 "#})
                 .bind(account_id)
@@ -277,12 +275,9 @@ impl PluginRepo for DbPluginRepo<PostgresPool> {
                         p.json_schema, p.validate_url, p.transform_url,
                         p.component_id, p.component_revision_id,
                         p.wasm_content_hash
-                    FROM accounts a
-                    JOIN plugins p
-                        ON p.account_id = a.account_id
+                    FROM plugins p
                     WHERE
-                        a.account_id = $1
-                        AND a.deleted_at IS NULL
+                        p.account_id = $1
                         AND p.deleted_at IS NULL
                 "#})
                 .bind(account_id),

--- a/golem-registry-service/src/repo/resource_definition.rs
+++ b/golem-registry-service/src/repo/resource_definition.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use super::model::resource_definition::{
-    ResourceDefinitionCreationArgs, ResourceDefinitionExtRevisionRecord,
-    ResourceDefinitionRepoError, ResourceDefinitionRevisionRecord,
+    ResourceDefinitionAuthExtRevisionRecord, ResourceDefinitionCreationArgs,
+    ResourceDefinitionExtRevisionRecord, ResourceDefinitionRepoError,
+    ResourceDefinitionRevisionRecord,
 };
 use crate::repo::model::BindFields;
 use crate::repo::model::resource_definition::ResourceDefinitionRecord;
@@ -59,7 +60,7 @@ pub trait ResourceDefinitionRepo: Send + Sync {
     async fn get(
         &self,
         resource_definition_id: Uuid,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>>;
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>>;
 
     async fn get_by_environment_and_name(
         &self,
@@ -71,7 +72,7 @@ pub trait ResourceDefinitionRepo: Send + Sync {
         &self,
         resource_definition_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>>;
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>>;
 
     async fn list_in_environment(
         &self,
@@ -139,7 +140,7 @@ impl<Repo: ResourceDefinitionRepo> ResourceDefinitionRepo for LoggedResourceDefi
     async fn get(
         &self,
         resource_definition_id: Uuid,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>> {
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>> {
         let span = info_span!(
             SPAN_NAME,
             resource_definition_id = %resource_definition_id,
@@ -169,7 +170,7 @@ impl<Repo: ResourceDefinitionRepo> ResourceDefinitionRepo for LoggedResourceDefi
         &self,
         resource_definition_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>> {
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>> {
         let span = info_span!(
             SPAN_NAME,
             resource_definition_id = %resource_definition_id,
@@ -445,7 +446,7 @@ impl ResourceDefinitionRepo for DbResourceDefinitionRepo<PostgresPool> {
     async fn get(
         &self,
         resource_definition_id: Uuid,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>> {
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>> {
         self.with_ro("get_staged_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -465,11 +466,27 @@ impl ResourceDefinitionRepo for DbResourceDefinitionRepo<PostgresPool> {
                         rr.limit_max,
                         rr.enforcement_action,
                         rr.unit,
-                        rr.units
+                        rr.units,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM resource_definitions r
+                    JOIN environments e
+                        ON e.environment_id = r.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN resource_definition_revisions rr
                         ON rr.resource_definition_id = r.resource_definition_id AND r.current_revision_id = rr.revision_id
-                    WHERE r.resource_definition_id = $1 AND r.deleted_at IS NULL
+                    WHERE r.resource_definition_id = $1
+                        AND r.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(resource_definition_id),
             )
@@ -516,7 +533,7 @@ impl ResourceDefinitionRepo for DbResourceDefinitionRepo<PostgresPool> {
         &self,
         resource_definition_id: Uuid,
         revision_id: i64,
-    ) -> RepoResult<Option<ResourceDefinitionExtRevisionRecord>> {
+    ) -> RepoResult<Option<ResourceDefinitionAuthExtRevisionRecord>> {
         self.with_ro("get_by_id_and_revision")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
@@ -536,14 +553,31 @@ impl ResourceDefinitionRepo for DbResourceDefinitionRepo<PostgresPool> {
                         rr.limit_max,
                         rr.enforcement_action,
                         rr.unit,
-                        rr.units
+                        rr.units,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM resource_definitions r
+                    JOIN environments e
+                        ON e.environment_id = r.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                            AND er.revision_id = e.current_revision_id
+                    JOIN applications ap
+                        ON ap.application_id = e.application_id
+                    JOIN accounts a
+                        ON a.account_id = ap.account_id
                     JOIN resource_definition_revisions rr
-                        ON rr.resource_definition_id = r.resource_definition_id AND r.current_revision_id = rr.revision_id
-                    WHERE r.resource_definition_id = $1 AND rr.revision_id = $2 AND r.deleted_at IS NULL
+                        ON rr.resource_definition_id = r.resource_definition_id
+                    WHERE r.resource_definition_id = $1
+                        AND rr.revision_id = $2
+                        AND r.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
-                    .bind(resource_definition_id)
-                    .bind(revision_id),
+                .bind(resource_definition_id)
+                .bind(revision_id),
             )
             .await
     }

--- a/golem-registry-service/src/repo/retry_policy.rs
+++ b/golem-registry-service/src/repo/retry_policy.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::model::retry_policy::{
-    RetryPolicyCreationRecord, RetryPolicyExtRevisionRecord, RetryPolicyRepoError,
-    RetryPolicyRevisionRecord,
+    RetryPolicyAuthExtRevisionRecord, RetryPolicyCreationRecord, RetryPolicyExtRevisionRecord,
+    RetryPolicyRepoError, RetryPolicyRevisionRecord,
 };
 use super::registry_change::{
     DbRegistryChangeRepo, NewRegistryChangeEvent, RequiresNotificationSignal, RequiresSignalExt,
@@ -52,7 +52,7 @@ pub trait RetryPolicyRepo: Send + Sync {
     async fn get_by_id(
         &self,
         retry_policy_id: Uuid,
-    ) -> Result<Option<RetryPolicyExtRevisionRecord>, RetryPolicyRepoError>;
+    ) -> Result<Option<RetryPolicyAuthExtRevisionRecord>, RetryPolicyRepoError>;
 
     async fn get_for_environment(
         &self,
@@ -112,7 +112,7 @@ impl<Repo: RetryPolicyRepo> RetryPolicyRepo for LoggedRetryPolicyRepo<Repo> {
     async fn get_by_id(
         &self,
         retry_policy_id: Uuid,
-    ) -> Result<Option<RetryPolicyExtRevisionRecord>, RetryPolicyRepoError> {
+    ) -> Result<Option<RetryPolicyAuthExtRevisionRecord>, RetryPolicyRepoError> {
         self.repo
             .get_by_id(retry_policy_id)
             .instrument(Self::span_retry_policy_id(retry_policy_id))
@@ -326,14 +326,27 @@ impl RetryPolicyRepo for DbRetryPolicyRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         retry_policy_id: Uuid,
-    ) -> Result<Option<RetryPolicyExtRevisionRecord>, RetryPolicyRepoError> {
-        let result: Option<RetryPolicyExtRevisionRecord> = self.with_ro("get_by_id")
+    ) -> Result<Option<RetryPolicyAuthExtRevisionRecord>, RetryPolicyRepoError> {
+        let result: Option<RetryPolicyAuthExtRevisionRecord> = self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! {r#"
-                    SELECT rp.environment_id, rp.name, rp.created_at AS entity_created_at, rev.retry_policy_id, rev.revision_id, rev.priority, rev.predicate_json, rev.policy_json, rev.created_at, rev.created_by, rev.deleted
+                    SELECT rp.environment_id, rp.name, rp.created_at AS entity_created_at, rev.retry_policy_id, rev.revision_id, rev.priority, rev.predicate_json, rev.policy_json, rev.created_at, rev.created_by, rev.deleted,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM retry_policies rp
+                    JOIN environments e ON e.environment_id = rp.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     JOIN retry_policy_revisions rev ON rev.retry_policy_id = rp.retry_policy_id AND rev.revision_id = rp.current_revision_id
-                    WHERE rp.retry_policy_id = $1 AND rp.deleted_at IS NULL
+                    WHERE rp.retry_policy_id = $1
+                        AND rp.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(retry_policy_id),
             )

--- a/golem-registry-service/src/repo/security_scheme.rs
+++ b/golem-registry-service/src/repo/security_scheme.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use super::model::security_scheme::{
-    SecuritySchemeExtRevisionRecord, SecuritySchemeRepoError, SecuritySchemeRevisionRecord,
+    SecuritySchemeAuthExtRevisionRecord, SecuritySchemeExtRevisionRecord, SecuritySchemeRepoError,
+    SecuritySchemeRevisionRecord,
 };
 use crate::repo::model::BindFields;
 pub use crate::repo::model::account::AccountRecord;
@@ -59,7 +60,7 @@ pub trait SecuritySchemeRepo: Send + Sync {
     async fn get_by_id(
         &self,
         security_scheme_id: Uuid,
-    ) -> Result<Option<SecuritySchemeExtRevisionRecord>, SecuritySchemeRepoError>;
+    ) -> Result<Option<SecuritySchemeAuthExtRevisionRecord>, SecuritySchemeRepoError>;
 
     async fn get_for_environment(
         &self,
@@ -138,7 +139,7 @@ impl<Repo: SecuritySchemeRepo> SecuritySchemeRepo for LoggedSecuritySchemeRepo<R
     async fn get_by_id(
         &self,
         security_scheme_id: Uuid,
-    ) -> Result<Option<SecuritySchemeExtRevisionRecord>, SecuritySchemeRepoError> {
+    ) -> Result<Option<SecuritySchemeAuthExtRevisionRecord>, SecuritySchemeRepoError> {
         self.repo
             .get_by_id(security_scheme_id)
             .instrument(Self::span_security_scheme_id(security_scheme_id))
@@ -389,14 +390,27 @@ impl SecuritySchemeRepo for DbSecuritySchemeRepo<PostgresPool> {
     async fn get_by_id(
         &self,
         security_scheme_id: Uuid,
-    ) -> Result<Option<SecuritySchemeExtRevisionRecord>, SecuritySchemeRepoError> {
-        let result: Option<SecuritySchemeExtRevisionRecord> = self.with_ro("get_by_id")
+    ) -> Result<Option<SecuritySchemeAuthExtRevisionRecord>, SecuritySchemeRepoError> {
+        let result: Option<SecuritySchemeAuthExtRevisionRecord> = self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! {r#"
-                    SELECT ss.environment_id, ss.name, ss.created_at AS entity_created_at, ssr.security_scheme_id, ssr.revision_id, ssr.provider_type, ssr.client_id, ssr.client_secret, ssr.redirect_url, ssr.scopes, ssr.custom_provider_name, ssr.custom_issuer_url, ssr.created_at, ssr.created_by, ssr.deleted
+                    SELECT ss.environment_id, ss.name, ss.created_at AS entity_created_at, ssr.security_scheme_id, ssr.revision_id, ssr.provider_type, ssr.client_id, ssr.client_secret, ssr.redirect_url, ssr.scopes, ssr.custom_provider_name, ssr.custom_issuer_url, ssr.created_at, ssr.created_by, ssr.deleted,
+                        er.name AS environment_name,
+                        ap.name AS application_name,
+                        a.email AS owner_account_email
                     FROM security_schemes ss
+                    JOIN environments e ON e.environment_id = ss.environment_id
+                    JOIN environment_revisions er
+                        ON er.environment_id = e.environment_id
+                        AND er.revision_id = e.current_revision_id
+                    JOIN applications ap ON ap.application_id = e.application_id
+                    JOIN accounts a ON a.account_id = ap.account_id
                     JOIN security_scheme_revisions ssr ON ssr.security_scheme_id = ss.security_scheme_id AND ssr.revision_id = ss.current_revision_id
-                    WHERE ss.security_scheme_id = $1 AND ss.deleted_at IS NULL
+                    WHERE ss.security_scheme_id = $1
+                        AND ss.deleted_at IS NULL
+                        AND e.deleted_at IS NULL
+                        AND ap.deleted_at IS NULL
+                        AND a.deleted_at IS NULL
                 "#})
                     .bind(security_scheme_id),
             )

--- a/golem-registry-service/src/repo/token.rs
+++ b/golem-registry-service/src/repo/token.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::repo::model::token::TokenRecord;
+use crate::repo::model::token::{TokenAuthRecord, TokenRecord};
 use crate::repo::registry_change::{
     DbRegistryChangeRepo, NewRegistryChangeEvent, RequiresNotificationSignal, RequiresSignalExt,
 };
@@ -33,9 +33,9 @@ use uuid::Uuid;
 pub trait TokenRepo: Send + Sync {
     async fn create(&self, token: TokenRecord) -> RepoResult<Option<TokenRecord>>;
 
-    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenRecord>>;
+    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenAuthRecord>>;
 
-    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenRecord>>;
+    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenAuthRecord>>;
 
     async fn get_by_account(&self, account_id: Uuid) -> RepoResult<Vec<TokenRecord>>;
 
@@ -69,14 +69,14 @@ impl<Repo: TokenRepo> TokenRepo for LoggedTokenRepo<Repo> {
         self.repo.create(token).instrument(span).await
     }
 
-    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenRecord>> {
+    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenAuthRecord>> {
         self.repo
             .get_by_id(token_id)
             .instrument(Self::span_id(token_id))
             .await
     }
 
-    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenRecord>> {
+    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenAuthRecord>> {
         self.repo
             .get_by_secret(secret)
             .instrument(info_span!(SPAN_NAME))
@@ -161,12 +161,12 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
             .none_on_unique_violation()
     }
 
-    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenRecord>> {
+    async fn get_by_id(&self, token_id: Uuid) -> RepoResult<Option<TokenAuthRecord>> {
         self.with_ro("get_by_id")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
-                           t.impersonated_by
+                           t.impersonated_by, a.email AS account_email
                     FROM accounts a
                     JOIN tokens t
                         ON t.account_id = a.account_id
@@ -179,12 +179,12 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
             .await
     }
 
-    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenRecord>> {
+    async fn get_by_secret(&self, secret: &str) -> RepoResult<Option<TokenAuthRecord>> {
         self.with_ro("get_by_secret")
             .fetch_optional_as(
                 sqlx::query_as(indoc! { r#"
                     SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
-                           t.impersonated_by
+                           t.impersonated_by, a.email AS account_email
                     FROM accounts a
                     JOIN tokens t
                         ON t.account_id = a.account_id
@@ -203,12 +203,9 @@ impl TokenRepo for DbTokenRepo<PostgresPool> {
                 sqlx::query_as(indoc! { r#"
                     SELECT t.token_id, t.secret, t.account_id, t.created_at, t.expires_at,
                            t.impersonated_by
-                    FROM accounts a
-                    JOIN tokens t
-                        ON t.account_id = a.account_id
+                    FROM tokens t
                     WHERE
-                        a.account_id = $1
-                        AND a.deleted_at IS NULL
+                        t.account_id = $1
                     ORDER BY token_id
                 "#})
                 .bind(account_id),

--- a/golem-registry-service/src/services/account/mod.rs
+++ b/golem-registry-service/src/services/account/mod.rs
@@ -33,7 +33,7 @@ use golem_common::model::card::{
     AccountResourcePattern, AccountVerb, ClassPermissionTarget, PermissionTarget,
     SystemResourcePattern, SystemVerb,
 };
-use golem_common::model::plan::PlanId;
+use golem_common::model::plan::{Plan, PlanId};
 use golem_common::{SafeDisplay, error_forwarding};
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
 use std::collections::HashMap;
@@ -233,6 +233,23 @@ impl AccountService {
             .map_err(|_| AccountError::AccountNotFound(account_id))?;
 
         Ok(account)
+    }
+
+    pub async fn get_plan(
+        &self,
+        account_id: AccountId,
+        auth: &AuthCtx,
+    ) -> Result<Plan, AccountError> {
+        let account = self.get(account_id, auth).await?;
+        authorize_account_permission(auth, &account.email, AccountVerb::ViewPlan)?;
+
+        self.plan_service
+            .get(&account.plan_id, &AuthCtx::System)
+            .await
+            .map_err(|e| match e {
+                PlanError::PlanNotFound(plan_id) => AccountError::PlanByIdNotFound(plan_id),
+                other => other.into(),
+            })
     }
 
     pub async fn get_by_email(

--- a/golem-registry-service/src/services/account/mod.rs
+++ b/golem-registry-service/src/services/account/mod.rs
@@ -102,21 +102,23 @@ impl AccountService {
         accounts: &HashMap<String, PrecreatedAccount>,
     ) -> Result<(), AccountError> {
         for (name, account) in accounts {
-            let existing_account = self.get_optional(account.id, &AuthCtx::System).await?;
-
-            if existing_account.is_none() {
-                info!("Creating initial account {} with id {}", name, account.id);
-                self.create_internal(
-                    account.id,
-                    AccountCreation {
-                        name: account.name.clone(),
-                        email: account.email.clone(),
-                        roles: vec![account.role],
-                    },
-                    account.plan_id,
-                    &AuthCtx::System,
-                )
-                .await?;
+            match self.get(account.id, &AuthCtx::System).await {
+                Ok(_) => {}
+                Err(AccountError::AccountNotFound(_)) => {
+                    info!("Creating initial account {} with id {}", name, account.id);
+                    self.create_internal(
+                        account.id,
+                        AccountCreation {
+                            name: account.name.clone(),
+                            email: account.email.clone(),
+                            roles: vec![account.role],
+                        },
+                        account.plan_id,
+                        &AuthCtx::System,
+                    )
+                    .await?;
+                }
+                Err(other) => return Err(other),
             }
         }
         Ok(())
@@ -141,7 +143,7 @@ impl AccountService {
         update: AccountUpdate,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.load(account_id).await?;
+        let mut account = self.get(account_id, auth).await?;
 
         authorize_account_permission(auth, &account.email, AccountVerb::Update)?;
 
@@ -164,7 +166,7 @@ impl AccountService {
         update: AccountSetPlan,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.load(account_id).await?;
+        let mut account = self.get(account_id, auth).await?;
 
         authorize_account_permission(auth, &account.email, AccountVerb::SetPlan)?;
 
@@ -194,7 +196,7 @@ impl AccountService {
         current_revision: AccountRevision,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let mut account: Account = self.load(account_id).await?;
+        let mut account = self.get(account_id, auth).await?;
 
         authorize_account_permission(auth, &account.email, AccountVerb::Delete)?;
 
@@ -228,7 +230,12 @@ impl AccountService {
         account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Account, AccountError> {
-        let account = self.load(account_id).await?;
+        let account: Account = self
+            .account_repo
+            .get_by_id(account_id.0)
+            .await?
+            .ok_or(AccountError::AccountNotFound(account_id))?
+            .try_into()?;
         authorize_account_permission(auth, &account.email, AccountVerb::View)
             .map_err(|_| AccountError::AccountNotFound(account_id))?;
 
@@ -272,18 +279,6 @@ impl AccountService {
         Ok(account)
     }
 
-    pub async fn get_optional(
-        &self,
-        account_id: AccountId,
-        auth: &AuthCtx,
-    ) -> Result<Option<Account>, AccountError> {
-        match self.get(account_id, auth).await {
-            Ok(account) => Ok(Some(account)),
-            Err(AccountError::AccountNotFound(_)) => Ok(None),
-            Err(other) => Err(other),
-        }
-    }
-
     async fn create_internal(
         &self,
         id: AccountId,
@@ -318,15 +313,6 @@ impl AccountService {
             }
             Err(other) => Err(other)?,
         }
-    }
-
-    async fn load(&self, account_id: AccountId) -> Result<Account, AccountError> {
-        self.account_repo
-            .get_by_id(account_id.0)
-            .await?
-            .ok_or(AccountError::AccountNotFound(account_id))?
-            .try_into()
-            .map_err(AccountError::from)
     }
 
     async fn update_internal(

--- a/golem-registry-service/src/services/account_usage/mod.rs
+++ b/golem-registry-service/src/services/account_usage/mod.rs
@@ -243,7 +243,7 @@ impl AccountUsageService {
             .ok_or_else(|| AccountUsageError::AccountNotfound(account_id))?;
 
         let account = account_service
-            .get(account_id, &AuthCtx::System)
+            .get(account_id, auth)
             .await
             .map_err(|err| match err {
                 AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {

--- a/golem-registry-service/src/services/agent_secret.rs
+++ b/golem-registry-service/src/services/agent_secret.rs
@@ -16,20 +16,23 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use super::registry_change_notifier::{RegistryChangeNotifier, RequiresNotificationSignalExt};
 use crate::repo::agent_secret::AgentSecretRepo;
 use crate::repo::model::agent_secrets::{
-    AgentSecretCreationRecord, AgentSecretRepoError, AgentSecretRevisionRecord,
+    AgentSecretAuthExtRevisionRecord, AgentSecretCreationRecord, AgentSecretRepoError,
+    AgentSecretRevisionRecord,
 };
 use crate::repo::model::audit::DeletableRevisionAuditFields;
+use golem_common::model::account::AccountEmail;
 use golem_common::model::agent_secret::{
     AgentSecretCreation, AgentSecretId, AgentSecretRevision, AgentSecretUpdate,
     CanonicalAgentSecretPath,
 };
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentAgentSecretKeyPathPattern,
     EnvironmentAgentSecretKeySegmentPattern, EnvironmentAgentSecretResourcePattern,
     EnvironmentAgentSecretVerb, PermissionTarget,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::optional_field_update::OptionalFieldUpdate;
 use golem_common::schema::adapters::analysed_type::{
     analysed_type_to_schema_graph, schema_graph_to_analysed_type,
@@ -66,14 +69,28 @@ fn authorize_agent_secret_permission(
     key: Option<&CanonicalAgentSecretPath>,
     verb: EnvironmentAgentSecretVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_agent_secret_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        key,
+        verb,
+    )
+}
+
+fn authorize_agent_secret_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    key: Option<&[String]>,
+    verb: EnvironmentAgentSecretVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentAgentSecret(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: key
                 .map(|key| {
                     EnvironmentAgentSecretResourcePattern::Key(
@@ -90,6 +107,16 @@ fn authorize_agent_secret_permission(
                 .unwrap_or(EnvironmentAgentSecretResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_agent_secret(
+    agent_secret: &AgentSecretAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(agent_secret.owner_account_email.clone()),
+        application: ApplicationName(agent_secret.application_name.clone()),
+        environment: EnvironmentName(agent_secret.environment_name.clone()),
+    }
 }
 
 impl SafeDisplay for AgentSecretError {
@@ -215,12 +242,11 @@ impl AgentSecretService {
         update: AgentSecretUpdate,
         auth: &AuthCtx,
     ) -> Result<AgentSecret, AgentSecretError> {
-        let (mut agent_secret, environment) =
-            self.get_with_environment(agent_secret_id, auth).await?;
+        let (mut agent_secret, owner) = self.get_with_environment(agent_secret_id, auth).await?;
 
-        authorize_agent_secret_permission(
+        authorize_agent_secret_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&agent_secret.path),
             EnvironmentAgentSecretVerb::Update,
         )?;
@@ -284,12 +310,11 @@ impl AgentSecretService {
         current_revision: AgentSecretRevision,
         auth: &AuthCtx,
     ) -> Result<AgentSecret, AgentSecretError> {
-        let (mut agent_secret, environment) =
-            self.get_with_environment(agent_secret_id, auth).await?;
+        let (mut agent_secret, owner) = self.get_with_environment(agent_secret_id, auth).await?;
 
-        authorize_agent_secret_permission(
+        authorize_agent_secret_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&agent_secret.path),
             EnvironmentAgentSecretVerb::Delete,
         )?;
@@ -383,33 +408,24 @@ impl AgentSecretService {
         &self,
         agent_secret_id: AgentSecretId,
         auth: &AuthCtx,
-    ) -> Result<(AgentSecret, Environment), AgentSecretError> {
-        let agent_secret: AgentSecret = self
+    ) -> Result<(AgentSecret, EnvironmentOwnerPattern), AgentSecretError> {
+        let record = self
             .agent_secret_repo
             .get_by_id(agent_secret_id.0)
             .await?
-            .ok_or(AgentSecretError::AgentSecretNotFound(agent_secret_id))?
-            .try_into()?;
+            .ok_or(AgentSecretError::AgentSecretNotFound(agent_secret_id))?;
 
-        let environment = self
-            .environment_service
-            .get(agent_secret.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    AgentSecretError::AgentSecretNotFound(agent_secret_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_agent_secret(&record);
+        let agent_secret: AgentSecret = record.agent_secret.try_into()?;
 
-        authorize_agent_secret_permission(
+        authorize_agent_secret_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             Some(&agent_secret.path),
             EnvironmentAgentSecretVerb::View,
         )
         .map_err(|_| AgentSecretError::AgentSecretNotFound(agent_secret_id))?;
 
-        Ok((agent_secret, environment))
+        Ok((agent_secret, owner))
     }
 }

--- a/golem-registry-service/src/services/agent_secret.rs
+++ b/golem-registry-service/src/services/agent_secret.rs
@@ -376,16 +376,20 @@ impl AgentSecretService {
         environment: &Environment,
         auth: &AuthCtx,
     ) -> Result<Vec<AgentSecret>, AgentSecretError> {
-        authorize_agent_secret_permission(
-            auth,
-            environment,
-            None,
-            EnvironmentAgentSecretVerb::View,
-        )?;
-
         let result = self.list_in_environment_unchecked(environment.id).await?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .filter(|agent_secret| {
+                authorize_agent_secret_permission(
+                    auth,
+                    environment,
+                    Some(&agent_secret.path.0),
+                    EnvironmentAgentSecretVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     // list in environment without checking auth / confirming the environment is not deleted.

--- a/golem-registry-service/src/services/agent_secret.rs
+++ b/golem-registry-service/src/services/agent_secret.rs
@@ -84,7 +84,7 @@ fn authorize_agent_secret_permission(
 fn authorize_agent_secret_permission_for_owner(
     auth: &AuthCtx,
     owner: EnvironmentOwnerPattern,
-    key: Option<&[String]>,
+    key: Option<&CanonicalAgentSecretPath>,
     verb: EnvironmentAgentSecretVerb,
 ) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentAgentSecret(
@@ -384,7 +384,7 @@ impl AgentSecretService {
                 authorize_agent_secret_permission(
                     auth,
                     environment,
-                    Some(&agent_secret.path.0),
+                    Some(&agent_secret.path),
                     EnvironmentAgentSecretVerb::View,
                 )
                 .is_ok()

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -275,11 +275,16 @@ impl ApplicationService {
         name: &ApplicationName,
         auth: &AuthCtx,
     ) -> Result<Application, ApplicationError> {
-        let account = self
-            .account_service
-            .get_optional(account_id, auth)
-            .await?
-            .ok_or_else(|| ApplicationError::ApplicationByNameNotFound(name.clone()))?;
+        let account =
+            self.account_service
+                .get(account_id, auth)
+                .await
+                .map_err(|err| match err {
+                    AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
+                        ApplicationError::ParentAccountNotFound(account_id)
+                    }
+                    other => other.into(),
+                })?;
 
         authorize_application_permission(
             auth,
@@ -304,21 +309,16 @@ impl ApplicationService {
         account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Vec<Application>, ApplicationError> {
-        // TODO: fetch account information from db as part of query
-        // This is done this way to not leak existence of accounts
-        let account = self
-            .account_service
-            .get_optional(account_id, auth)
-            .await?
-            .ok_or_else(|| {
-                ApplicationError::Unauthorized(AuthorizationError::PermissionNotAllowed(Box::new(
-                    PermissionTarget::Application(ClassPermissionTarget {
-                        verb: Some(ApplicationVerb::View),
-                        owner: AccountOwnerPattern::Any,
-                        resource: ApplicationResourcePattern::Any,
-                    }),
-                )))
-            })?;
+        let account =
+            self.account_service
+                .get(account_id, auth)
+                .await
+                .map_err(|err| match err {
+                    AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
+                        ApplicationError::ParentAccountNotFound(account_id)
+                    }
+                    other => other.into(),
+                })?;
 
         let result = self
             .application_repo

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -290,10 +290,10 @@ impl ApplicationService {
 
         let result: Application = self
             .application_repo
-            .get_by_name(account_id.0, account.email.as_str(), &name.0)
+            .get_by_name(account_id.0, &name.0)
             .await?
             .ok_or(ApplicationError::ApplicationByNameNotFound(name.clone()))?
-            .try_into()?;
+            .try_into_model(account.email)?;
 
         Ok(result)
     }
@@ -328,10 +328,10 @@ impl ApplicationService {
 
         let result = self
             .application_repo
-            .list_by_owner(account_id.0, account.email.as_str())
+            .list_by_owner(account_id.0)
             .await?
             .into_iter()
-            .map(|r| r.try_into())
+            .map(|r| r.try_into_model(account.email.clone()))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(result)

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -320,13 +320,6 @@ impl ApplicationService {
                 )))
             })?;
 
-        authorize_application_permission(
-            auth,
-            &account.email,
-            ApplicationVerb::View,
-            ApplicationResourcePattern::Any,
-        )?;
-
         let result = self
             .application_repo
             .list_by_owner(account_id.0)
@@ -335,7 +328,20 @@ impl ApplicationService {
             .map(|r| r.try_into_model(account.email.clone()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .filter(|application| {
+                authorize_application_permission(
+                    auth,
+                    &account.email,
+                    ApplicationVerb::View,
+                    ApplicationResourcePattern::Application(CardApplicationName(
+                        application.name.0.clone(),
+                    )),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 }
 

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -290,7 +290,7 @@ impl ApplicationService {
 
         let result: Application = self
             .application_repo
-            .get_by_name(account_id.0, &name.0)
+            .get_by_name(account_id.0, account.email.as_str(), &name.0)
             .await?
             .ok_or(ApplicationError::ApplicationByNameNotFound(name.clone()))?
             .try_into()?;
@@ -328,7 +328,7 @@ impl ApplicationService {
 
         let result = self
             .application_repo
-            .list_by_owner(account_id.0)
+            .list_by_owner(account_id.0, account.email.as_str())
             .await?
             .into_iter()
             .map(|r| r.try_into())

--- a/golem-registry-service/src/services/application.rs
+++ b/golem-registry-service/src/services/application.rs
@@ -151,7 +151,7 @@ impl ApplicationService {
                 }
                 other => other.into(),
             })?
-            .try_into()?;
+            .try_into_model(account.email)?;
 
         Ok(result)
     }
@@ -182,6 +182,7 @@ impl ApplicationService {
             application.name = new_name
         };
 
+        let account_email = application.account_email.clone();
         let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
         let record = ApplicationRevisionRecord::from_model(application, audit);
 
@@ -198,7 +199,7 @@ impl ApplicationService {
                 }
                 other => other.into(),
             })?
-            .try_into()?;
+            .try_into_model(account_email)?;
 
         Ok(result)
     }

--- a/golem-registry-service/src/services/component/mod.rs
+++ b/golem-registry-service/src/services/component/mod.rs
@@ -213,14 +213,7 @@ impl ComponentService {
     ) -> Result<Vec<Component>, ComponentError> {
         info!(environment_id = %environment.id, "Get staged components");
 
-        authorize_component_permission(
-            auth,
-            environment,
-            ComponentVerb::View,
-            ComponentResourcePattern::Any,
-        )?;
-
-        let result = self
+        let result: Vec<Component> = self
             .component_repo
             .list_staged(environment.id.0)
             .await?
@@ -236,7 +229,20 @@ impl ComponentService {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .filter(|component: &Component| {
+                authorize_component_permission(
+                    auth,
+                    environment,
+                    ComponentVerb::View,
+                    ComponentResourcePattern::Component(CardComponentName(
+                        component.component_name.0.clone(),
+                    )),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_staged_component_by_name(
@@ -363,14 +369,7 @@ impl ComponentService {
                 other => other.into(),
             })?;
 
-        authorize_component_permission(
-            auth,
-            &environment,
-            ComponentVerb::View,
-            ComponentResourcePattern::Any,
-        )?;
-
-        let result = self
+        let result: Vec<Component> = self
             .component_repo
             .list_by_deployment(environment_id.0, deployment_revision.into())
             .await?
@@ -386,7 +385,20 @@ impl ComponentService {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .filter(|component: &Component| {
+                authorize_component_permission(
+                    auth,
+                    &environment,
+                    ComponentVerb::View,
+                    ComponentResourcePattern::Component(CardComponentName(
+                        component.component_name.0.clone(),
+                    )),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_deployment_component_by_name(

--- a/golem-registry-service/src/services/component/mod.rs
+++ b/golem-registry-service/src/services/component/mod.rs
@@ -22,9 +22,12 @@ use super::component_object_store::ComponentObjectStore;
 use super::deployment::DeploymentService;
 use super::environment::EnvironmentService;
 use crate::repo::component::ComponentRepo;
+use crate::repo::model::component::ComponentAuthExtRevisionRecord;
 use crate::services::deployment::DeploymentError;
 use crate::services::environment::EnvironmentError;
 use futures::stream::BoxStream;
+use golem_common::model::account::{AccountEmail, AccountId};
+use golem_common::model::application::{ApplicationId, ApplicationName};
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, ComponentName as CardComponentName, ComponentResourcePattern,
@@ -33,7 +36,8 @@ use golem_common::model::card::{
 use golem_common::model::component::ComponentId;
 use golem_common::model::component::{ComponentName, ComponentRevision};
 use golem_common::model::deployment::DeploymentRevision;
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::diff::DIFF_MODEL_VERSION;
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_service_base::model::auth::AuthCtx;
 use golem_service_base::model::auth::AuthorizationError;
 use golem_service_base::model::component::Component;
@@ -75,32 +79,17 @@ impl ComponentService {
             .await?
             .ok_or(ComponentError::ComponentNotFound(component_id))?;
 
-        let environment = self
-            .environment_service
-            .get(EnvironmentId(record.environment_id), false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = environment_from_component_record(&record)?;
 
         authorize_component_permission(
             auth,
             &environment,
             ComponentVerb::View,
-            ComponentResourcePattern::Component(CardComponentName(record.name.clone())),
+            ComponentResourcePattern::Component(CardComponentName(record.component.name.clone())),
         )
         .map_err(|_| ComponentError::ComponentNotFound(component_id))?;
 
-        Ok(record.try_into_model(
-            environment.application_id,
-            environment.owner_account_id,
-            environment.owner_account_email,
-            environment.application_name,
-            environment.name,
-        )?)
+        Ok(record.try_into_model()?)
     }
 
     pub async fn get_deployed_component(
@@ -119,32 +108,17 @@ impl ComponentService {
             .await?
             .ok_or(ComponentError::ComponentNotFound(component_id))?;
 
-        let environment = self
-            .environment_service
-            .get(EnvironmentId(record.environment_id), false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = environment_from_component_record(&record)?;
 
         authorize_component_permission(
             auth,
             &environment,
             ComponentVerb::View,
-            ComponentResourcePattern::Component(CardComponentName(record.name.clone())),
+            ComponentResourcePattern::Component(CardComponentName(record.component.name.clone())),
         )
         .map_err(|_| ComponentError::ComponentNotFound(component_id))?;
 
-        Ok(record.try_into_model(
-            environment.application_id,
-            environment.owner_account_id,
-            environment.owner_account_email,
-            environment.application_name,
-            environment.name,
-        )?)
+        Ok(record.try_into_model()?)
     }
 
     pub async fn get_all_deployed_component_versions(
@@ -159,23 +133,11 @@ impl ComponentService {
             .get_all_deployed_by_id(component_id.0)
             .await?;
 
-        let environment_id: EnvironmentId =
-            if let Some(environment_id) = records.first().map(|r| &r.environment_id) {
-                (*environment_id).into()
-            } else {
-                return Err(ComponentError::ComponentNotFound(component_id));
-            };
-
-        let environment = self
-            .environment_service
-            .get(environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = if let Some(record) = records.first() {
+            environment_from_component_record(record)?
+        } else {
+            return Err(ComponentError::ComponentNotFound(component_id));
+        };
 
         authorize_component_permission(
             auth,
@@ -187,15 +149,7 @@ impl ComponentService {
 
         let components = records
             .into_iter()
-            .map(|r| {
-                r.try_into_model(
-                    environment.application_id,
-                    environment.owner_account_id,
-                    environment.owner_account_email.clone(),
-                    environment.application_name.clone(),
-                    environment.name.clone(),
-                )
-            })
+            .map(|r| r.try_into_model())
             .collect::<Result<_, _>>()?;
 
         Ok(components)
@@ -216,35 +170,20 @@ impl ComponentService {
             .await?
             .ok_or(ComponentError::ComponentNotFound(component_id))?;
 
-        let environment = self
-            .environment_service
-            .get(EnvironmentId(record.environment_id), false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = environment_from_component_record(&record)?;
 
         authorize_component_permission(
             auth,
             &environment,
             ComponentVerb::View,
             ComponentResourcePattern::Revision {
-                component: CardComponentName(record.name.clone()),
+                component: CardComponentName(record.component.name.clone()),
                 revision: revision.into(),
             },
         )
         .map_err(|_| ComponentError::ComponentNotFound(component_id))?;
 
-        Ok(record.try_into_model(
-            environment.application_id,
-            environment.owner_account_id,
-            environment.owner_account_email,
-            environment.application_name,
-            environment.name,
-        )?)
+        Ok(record.try_into_model()?)
     }
 
     pub async fn list_staged_components(
@@ -542,4 +481,23 @@ fn authorize_component_permission(
         },
         resource,
     }))
+}
+
+pub(super) fn environment_from_component_record(
+    record: &ComponentAuthExtRevisionRecord,
+) -> Result<Environment, ComponentError> {
+    Ok(Environment {
+        id: EnvironmentId(record.component.environment_id),
+        revision: record.environment_revision_id.try_into()?,
+        application_id: ApplicationId(record.application_id),
+        application_name: ApplicationName(record.application_name.clone()),
+        name: EnvironmentName(record.environment_name.clone()),
+        diff_model_version: DIFF_MODEL_VERSION,
+        compatibility_check: record.environment_compatibility_check,
+        version_check: record.environment_version_check,
+        security_overrides: record.environment_security_overrides,
+        owner_account_id: AccountId(record.owner_account_id),
+        owner_account_email: AccountEmail::new(record.owner_account_email.clone()),
+        current_deployment: None,
+    })
 }

--- a/golem-registry-service/src/services/component/write.rs
+++ b/golem-registry-service/src/services/component/write.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::ComponentError;
+use super::{ComponentError, environment_from_component_record};
 use crate::metrics::storage::record_component_uploaded;
 use crate::repo::component::ComponentRepo;
 use crate::repo::model::component::{ComponentRepoError, ComponentRevisionRecord};
@@ -279,18 +279,9 @@ impl ComponentWriteService {
             .await?
             .ok_or(ComponentError::ComponentNotFound(component_id))?;
 
-        let environment = self
-            .environment_service
-            .get(EnvironmentId(component_record.environment_id), false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = environment_from_component_record(&component_record)?;
 
-        let component_name = ComponentName(component_record.name.clone());
+        let component_name = ComponentName(component_record.component.name.clone());
 
         authorize_component_permission(auth, &environment, &component_name, ComponentVerb::View)
             .map_err(|_| ComponentError::ComponentNotFound(component_id))?;
@@ -300,13 +291,7 @@ impl ComponentWriteService {
             return Err(ComponentError::ResetOverrideRequiresCompatibilityCheckDisabled);
         }
 
-        let mut component = component_record.try_into_model(
-            environment.application_id,
-            environment.owner_account_id,
-            environment.owner_account_email.clone(),
-            environment.application_name.clone(),
-            environment.name.clone(),
-        )?;
+        let mut component = component_record.try_into_model()?;
 
         if component_update.current_revision != component.revision {
             Err(ComponentError::ConcurrentUpdate)?
@@ -482,29 +467,14 @@ impl ComponentWriteService {
             .await?
             .ok_or(ComponentError::ComponentNotFound(component_id))?;
 
-        let environment = self
-            .environment_service
-            .get(EnvironmentId(component_record.environment_id), false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ComponentError::ComponentNotFound(component_id)
-                }
-                other => other.into(),
-            })?;
+        let environment = environment_from_component_record(&component_record)?;
 
-        let component_name = ComponentName(component_record.name.clone());
+        let component_name = ComponentName(component_record.component.name.clone());
         authorize_component_permission(auth, &environment, &component_name, ComponentVerb::View)
             .map_err(|_| ComponentError::ComponentNotFound(component_id))?;
         authorize_component_permission(auth, &environment, &component_name, ComponentVerb::Delete)?;
 
-        let component = component_record.try_into_model(
-            environment.application_id,
-            environment.owner_account_id,
-            environment.owner_account_email,
-            environment.application_name,
-            environment.name,
-        )?;
+        let component = component_record.try_into_model()?;
 
         if current_revision != component.revision {
             Err(ComponentError::ConcurrentUpdate)?

--- a/golem-registry-service/src/services/deployment/read.rs
+++ b/golem-registry-service/src/services/deployment/read.rs
@@ -318,6 +318,8 @@ impl DeploymentService {
                 environment_id.0,
                 deployment_revision.into(),
                 &agent_type_name.0,
+                environment.owner_account_id.0,
+                environment.owner_account_email.as_str(),
             )
             .await?
             .ok_or(DeploymentError::AgentTypeNotFound(
@@ -342,7 +344,12 @@ impl DeploymentService {
 
         let agent_types = self
             .deployment_repo
-            .list_deployment_agent_types(environment_id.0, deployment_revision.into())
+            .list_deployment_agent_types(
+                environment_id.0,
+                deployment_revision.into(),
+                environment.owner_account_id.0,
+                environment.owner_account_email.as_str(),
+            )
             .await?
             .into_iter()
             .map(|r| r.try_into())
@@ -471,6 +478,8 @@ impl DeploymentService {
                 environment.id.0,
                 deployment_revision.into(),
                 &agent_type_name.0,
+                environment.owner_account_id.0,
+                environment.owner_account_email.as_str(),
             )
             .await?
             .ok_or(DeploymentError::AgentTypeNotFound(

--- a/golem-registry-service/src/services/deployment/read.rs
+++ b/golem-registry-service/src/services/deployment/read.rs
@@ -318,14 +318,15 @@ impl DeploymentService {
                 environment_id.0,
                 deployment_revision.into(),
                 &agent_type_name.0,
-                environment.owner_account_id.0,
-                environment.owner_account_email.as_str(),
             )
             .await?
             .ok_or(DeploymentError::AgentTypeNotFound(
                 agent_type_name.0.clone(),
             ))?
-            .try_into()?;
+            .try_into_deployed(
+                environment.owner_account_id,
+                environment.owner_account_email,
+            )?;
 
         Ok(agent_types)
     }
@@ -344,15 +345,15 @@ impl DeploymentService {
 
         let agent_types = self
             .deployment_repo
-            .list_deployment_agent_types(
-                environment_id.0,
-                deployment_revision.into(),
-                environment.owner_account_id.0,
-                environment.owner_account_email.as_str(),
-            )
+            .list_deployment_agent_types(environment_id.0, deployment_revision.into())
             .await?
             .into_iter()
-            .map(|r| r.try_into())
+            .map(|r| {
+                r.try_into_deployed(
+                    environment.owner_account_id,
+                    environment.owner_account_email.clone(),
+                )
+            })
             .collect::<Result<_, _>>()?;
 
         Ok(agent_types)
@@ -478,14 +479,15 @@ impl DeploymentService {
                 environment.id.0,
                 deployment_revision.into(),
                 &agent_type_name.0,
-                environment.owner_account_id.0,
-                environment.owner_account_email.as_str(),
             )
             .await?
             .ok_or(DeploymentError::AgentTypeNotFound(
                 agent_type_name.0.clone(),
             ))?
-            .try_into()?;
+            .try_into_deployed(
+                environment.owner_account_id,
+                environment.owner_account_email,
+            )?;
 
         Ok(agent_type)
     }

--- a/golem-registry-service/src/services/deployment/read.rs
+++ b/golem-registry-service/src/services/deployment/read.rs
@@ -369,6 +369,8 @@ impl DeploymentService {
             .get_in_application(application.id, environment_name, auth)
             .await?;
 
+        authorize_environment_permission(auth, &environment, EnvironmentVerb::ViewAgentTypes)?;
+
         self.get_deployed_agent_type(environment.id, agent_type_name)
             .await
     }
@@ -454,6 +456,8 @@ impl DeploymentService {
             .environment_service
             .get_in_application(application.id, environment_name, auth)
             .await?;
+
+        authorize_environment_permission(auth, &environment, EnvironmentVerb::ViewAgentTypes)?;
 
         // Validate that the deployment revision exists in this environment
         self.deployment_repo

--- a/golem-registry-service/src/services/domain_registration/mod.rs
+++ b/golem-registry-service/src/services/domain_registration/mod.rs
@@ -212,13 +212,6 @@ impl DomainRegistrationService {
                 other => other.into(),
             })?;
 
-        authorize_domain_registration_permission(
-            auth,
-            &environment,
-            None,
-            EnvironmentDomainRegistrationVerb::View,
-        )?;
-
         let domain_registrations: Vec<DomainRegistration> = self
             .domain_registration_repo
             .list_by_environment(environment_id.0)
@@ -227,7 +220,18 @@ impl DomainRegistrationService {
             .map(|r| r.into())
             .collect();
 
-        Ok(domain_registrations)
+        Ok(domain_registrations
+            .into_iter()
+            .filter(|domain_registration| {
+                authorize_domain_registration_permission(
+                    auth,
+                    &environment,
+                    Some(&domain_registration.domain),
+                    EnvironmentDomainRegistrationVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     async fn get_by_id_with_environment(

--- a/golem-registry-service/src/services/domain_registration/mod.rs
+++ b/golem-registry-service/src/services/domain_registration/mod.rs
@@ -19,7 +19,7 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use crate::repo::domain_registration::DomainRegistrationRepo;
 use crate::repo::model::audit::ImmutableAuditFields;
 use crate::repo::model::domain_registration::{
-    DomainRegistrationRecord, DomainRegistrationRepoError,
+    DomainRegistrationAuthRecord, DomainRegistrationRecord, DomainRegistrationRepoError,
 };
 use crate::services::registry_change_notifier::{
     RegistryChangeNotifier, RequiresNotificationSignalExt,
@@ -28,6 +28,8 @@ pub use config::{
     AvailableDomainsConfig, DomainRegistrationConfig, RestrictedAvailableDomainsConfig,
 };
 pub use errors::DomainRegistrationError;
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, DomainLabel, DomainNamePattern,
@@ -37,7 +39,7 @@ use golem_common::model::card::{
 use golem_common::model::domain_registration::{
     Domain, DomainRegistration, DomainRegistrationCreation, DomainRegistrationId,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
 use regex::Regex;
 use std::sync::Arc;
@@ -130,13 +132,13 @@ impl DomainRegistrationService {
         domain_registration_id: DomainRegistrationId,
         auth: &AuthCtx,
     ) -> Result<DomainRegistration, DomainRegistrationError> {
-        let (domain_registration, environment) = self
+        let (domain_registration, owner) = self
             .get_by_id_with_environment(domain_registration_id, auth)
             .await?;
 
-        authorize_domain_registration_permission(
+        authorize_domain_registration_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&domain_registration.domain),
             EnvironmentDomainRegistrationVerb::Delete,
         )?;
@@ -232,36 +234,27 @@ impl DomainRegistrationService {
         &self,
         domain_registration_id: DomainRegistrationId,
         auth: &AuthCtx,
-    ) -> Result<(DomainRegistration, Environment), DomainRegistrationError> {
-        let domain_registration: DomainRegistration = self
+    ) -> Result<(DomainRegistration, EnvironmentOwnerPattern), DomainRegistrationError> {
+        let record = self
             .domain_registration_repo
             .get_by_id(domain_registration_id.0)
             .await?
             .ok_or(DomainRegistrationError::DomainRegistrationNotFound(
                 domain_registration_id,
-            ))?
-            .into();
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(domain_registration.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    DomainRegistrationError::DomainRegistrationNotFound(domain_registration_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_domain_registration(&record);
+        let domain_registration: DomainRegistration = record.domain_registration.into();
 
-        authorize_domain_registration_permission(
+        authorize_domain_registration_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             Some(&domain_registration.domain),
             EnvironmentDomainRegistrationVerb::View,
         )
         .map_err(|_| DomainRegistrationError::DomainRegistrationNotFound(domain_registration_id))?;
 
-        Ok((domain_registration, environment))
+        Ok((domain_registration, owner))
     }
 
     pub fn validate_domain_for_http_api(
@@ -378,14 +371,28 @@ fn authorize_domain_registration_permission(
     domain: Option<&Domain>,
     verb: EnvironmentDomainRegistrationVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_domain_registration_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        domain,
+        verb,
+    )
+}
+
+fn authorize_domain_registration_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    domain: Option<&Domain>,
+    verb: EnvironmentDomainRegistrationVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentDomainRegistration(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: domain
                 .map(|domain| {
                     EnvironmentDomainRegistrationResourcePattern::Domain(DomainNamePattern {
@@ -399,6 +406,16 @@ fn authorize_domain_registration_permission(
                 .unwrap_or(EnvironmentDomainRegistrationResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_domain_registration(
+    domain_registration: &DomainRegistrationAuthRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(domain_registration.owner_account_email.clone()),
+        application: ApplicationName(domain_registration.application_name.clone()),
+        environment: EnvironmentName(domain_registration.environment_name.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -146,8 +146,7 @@ impl EnvironmentService {
             &application.name,
             EnvironmentVerb::Create,
             EnvironmentResourcePattern::Environment(CardEnvironmentName(data.name.0.clone())),
-        )
-        .map_err(|_| EnvironmentError::ParentApplicationNotFound(application_id))?;
+        )?;
 
         self.account_usage_service
             .ensure_environment_within_limits(application.account_id)
@@ -194,8 +193,7 @@ impl EnvironmentService {
     ) -> Result<Environment, EnvironmentError> {
         let mut environment = self.get(environment_id, false, auth).await?;
 
-        authorize_environment_model(auth, &environment, EnvironmentVerb::Update)
-            .map_err(|_| EnvironmentError::EnvironmentNotFound(environment_id))?;
+        authorize_environment_model(auth, &environment, EnvironmentVerb::Update)?;
 
         if update.current_revision != environment.revision {
             return Err(EnvironmentError::ConcurrentModification);
@@ -244,8 +242,7 @@ impl EnvironmentService {
     ) -> Result<(), EnvironmentError> {
         let mut environment = self.get(environment_id, false, auth).await?;
 
-        authorize_environment_model(auth, &environment, EnvironmentVerb::Delete)
-            .map_err(|_| EnvironmentError::EnvironmentNotFound(environment_id))?;
+        authorize_environment_model(auth, &environment, EnvironmentVerb::Delete)?;
 
         if current_revision != environment.revision {
             return Err(EnvironmentError::ConcurrentModification);

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -349,15 +349,7 @@ impl EnvironmentService {
                 other => other.into(),
             })?;
 
-        authorize_environment_permission(
-            auth,
-            &application.account_email,
-            &application.name,
-            EnvironmentVerb::View,
-            EnvironmentResourcePattern::Any,
-        )?;
-
-        Ok(self
+        let environments = self
             .environment_repo
             .list_by_app(application_id.0)
             .await?
@@ -369,7 +361,14 @@ impl EnvironmentService {
                     application.account_email.clone(),
                 )
             })
-            .collect::<Result<Vec<_>, _>>()?)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(environments
+            .into_iter()
+            .filter(|environment| {
+                authorize_environment_model(auth, environment, EnvironmentVerb::View).is_ok()
+            })
+            .collect())
     }
 
     pub async fn list_visible_environments(

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -299,15 +299,36 @@ impl EnvironmentService {
         name: &EnvironmentName,
         auth: &AuthCtx,
     ) -> Result<Environment, EnvironmentError> {
-        let result: Environment = self
+        let application = self
+            .application_service
+            .get(application_id, auth)
+            .await
+            .map_err(|err| match err {
+                ApplicationError::ApplicationNotFound(application_id) => {
+                    EnvironmentError::ParentApplicationNotFound(application_id)
+                }
+                other => other.into(),
+            })?;
+
+        authorize_environment_permission(
+            auth,
+            &application.account_email,
+            &application.name,
+            EnvironmentVerb::View,
+            EnvironmentResourcePattern::Environment(CardEnvironmentName(name.0.clone())),
+        )
+        .map_err(|_| EnvironmentError::EnvironmentByNameNotFound(name.clone()))?;
+
+        let result = self
             .environment_repo
             .get_by_name(application_id.0, &name.0)
             .await?
             .ok_or(EnvironmentError::EnvironmentByNameNotFound(name.clone()))?
-            .try_into()?;
-
-        authorize_environment_model(auth, &result, EnvironmentVerb::View)
-            .map_err(|_| EnvironmentError::EnvironmentByNameNotFound(name.clone()))?;
+            .try_into_model(
+                application.name,
+                application.account_id,
+                application.account_email,
+            )?;
 
         Ok(result)
     }
@@ -341,7 +362,13 @@ impl EnvironmentService {
             .list_by_app(application_id.0)
             .await?
             .into_iter()
-            .map(Environment::try_from)
+            .map(|record| {
+                record.try_into_model(
+                    application.name.clone(),
+                    application.account_id,
+                    application.account_email.clone(),
+                )
+            })
             .collect::<Result<Vec<_>, _>>()?)
     }
 

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -275,11 +275,7 @@ impl EnvironmentService {
     ) -> Result<Environment, EnvironmentError> {
         let environment: Environment = self
             .environment_repo
-            .get_by_id(
-                environment_id.0,
-                auth.access_account_id().0,
-                include_deleted,
-            )
+            .get_by_id(environment_id.0, include_deleted)
             .await?
             .ok_or(EnvironmentError::EnvironmentNotFound(environment_id))?
             .try_into()?;
@@ -298,7 +294,7 @@ impl EnvironmentService {
     ) -> Result<Environment, EnvironmentError> {
         let result: Environment = self
             .environment_repo
-            .get_by_name(application_id.0, &name.0, auth.access_account_id().0)
+            .get_by_name(application_id.0, &name.0)
             .await?
             .ok_or(EnvironmentError::EnvironmentByNameNotFound(name.clone()))?
             .try_into()?;
@@ -335,7 +331,7 @@ impl EnvironmentService {
 
         Ok(self
             .environment_repo
-            .list_by_app(application_id.0, auth.access_account_id().0)
+            .list_by_app(application_id.0)
             .await?
             .into_iter()
             .map(Environment::try_from)

--- a/golem-registry-service/src/services/environment.rs
+++ b/golem-registry-service/src/services/environment.rs
@@ -180,7 +180,11 @@ impl EnvironmentService {
                 }
                 other => other.into(),
             })?
-            .try_into()?;
+            .try_into_model(
+                application.name,
+                application.account_id,
+                application.account_email,
+            )?;
 
         Ok(result)
     }
@@ -213,6 +217,9 @@ impl EnvironmentService {
             environment.security_overrides = security_overrides;
         }
 
+        let application_name = environment.application_name.clone();
+        let owner_account_id = environment.owner_account_id;
+        let owner_account_email = environment.owner_account_email.clone();
         let audit = DeletableRevisionAuditFields::new(auth.actor_account_id().0);
         let record = EnvironmentRevisionRecord::from_model(environment, audit);
 
@@ -229,7 +236,7 @@ impl EnvironmentService {
                 }
                 other => other.into(),
             })?
-            .try_into()?;
+            .try_into_model(application_name, owner_account_id, owner_account_email)?;
 
         Ok(result)
     }

--- a/golem-registry-service/src/services/environment_plugin_grant.rs
+++ b/golem-registry-service/src/services/environment_plugin_grant.rs
@@ -16,15 +16,17 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use super::plugin_registration::{PluginRegistrationError, PluginRegistrationService};
 use crate::repo::environment_plugin_grant::EnvironmentPluginGrantRepo;
 use crate::repo::model::environment_plugin_grant::{
-    EnvironmentPluginGrantRecord, EnvironmentPluginGrantRepoError,
+    EnvironmentPluginGrantAuthWithDetailsRecord, EnvironmentPluginGrantRecord,
+    EnvironmentPluginGrantRepoError,
 };
-use golem_common::model::account::AccountId;
+use golem_common::model::account::{AccountEmail, AccountId};
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentPluginGrantName, EnvironmentPluginGrantResourcePattern,
     EnvironmentPluginGrantVerb, PermissionTarget,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::environment_plugin_grant::{
     EnvironmentPluginGrant, EnvironmentPluginGrantCreation, EnvironmentPluginGrantId,
     EnvironmentPluginGrantWithDetails,
@@ -158,13 +160,13 @@ impl EnvironmentPluginGrantService {
         environment_plugin_grant_id: EnvironmentPluginGrantId,
         auth: &AuthCtx,
     ) -> Result<(), EnvironmentPluginGrantError> {
-        let (grant, environment) = self
+        let (grant, owner) = self
             .get_by_id_with_environment(environment_plugin_grant_id, false, auth)
             .await?;
 
-        authorize_environment_plugin_grant_permission(
+        authorize_environment_plugin_grant_permission_for_owner(
             auth,
-            &environment,
+            owner,
             EnvironmentPluginGrantVerb::Delete,
             EnvironmentPluginGrantResourcePattern::Name(EnvironmentPluginGrantName(
                 grant.plugin.name,
@@ -246,6 +248,7 @@ impl EnvironmentPluginGrantService {
             .ok_or(EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(
                 environment_plugin_grant_id,
             ))?
+            .grant
             .try_into()?;
 
         if grant.environment_id != environment.id {
@@ -328,32 +331,24 @@ impl EnvironmentPluginGrantService {
         environment_plugin_grant_id: EnvironmentPluginGrantId,
         include_deleted: bool,
         auth: &AuthCtx,
-    ) -> Result<(EnvironmentPluginGrantWithDetails, Environment), EnvironmentPluginGrantError> {
-        let grant: EnvironmentPluginGrantWithDetails = self
+    ) -> Result<
+        (EnvironmentPluginGrantWithDetails, EnvironmentOwnerPattern),
+        EnvironmentPluginGrantError,
+    > {
+        let record = self
             .environment_plugin_grant_repo
             .get_by_id(environment_plugin_grant_id.0, include_deleted)
             .await?
             .ok_or(EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(
                 environment_plugin_grant_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(grant.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(
-                        environment_plugin_grant_id,
-                    )
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_plugin_grant(&record);
+        let grant: EnvironmentPluginGrantWithDetails = record.grant.try_into()?;
 
-        authorize_environment_plugin_grant_permission(
+        authorize_environment_plugin_grant_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             EnvironmentPluginGrantVerb::View,
             EnvironmentPluginGrantResourcePattern::Name(EnvironmentPluginGrantName(
                 grant.plugin.name.clone(),
@@ -363,7 +358,7 @@ impl EnvironmentPluginGrantService {
             EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(environment_plugin_grant_id)
         })?;
 
-        Ok((grant, environment))
+        Ok((grant, owner))
     }
 }
 
@@ -373,15 +368,39 @@ fn authorize_environment_plugin_grant_permission(
     verb: EnvironmentPluginGrantVerb,
     resource: EnvironmentPluginGrantResourcePattern,
 ) -> Result<(), AuthorizationError> {
+    authorize_environment_plugin_grant_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        verb,
+        resource,
+    )
+}
+
+fn authorize_environment_plugin_grant_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    verb: EnvironmentPluginGrantVerb,
+    resource: EnvironmentPluginGrantResourcePattern,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentPluginGrant(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource,
         },
     ))
+}
+
+fn environment_owner_from_plugin_grant(
+    grant: &EnvironmentPluginGrantAuthWithDetailsRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(grant.owner_account_email.clone()),
+        application: ApplicationName(grant.application_name.clone()),
+        environment: EnvironmentName(grant.environment_name.clone()),
+    }
 }

--- a/golem-registry-service/src/services/environment_plugin_grant.rs
+++ b/golem-registry-service/src/services/environment_plugin_grant.rs
@@ -204,13 +204,6 @@ impl EnvironmentPluginGrantService {
                 other => other.into(),
             })?;
 
-        authorize_environment_plugin_grant_permission(
-            auth,
-            &environment,
-            EnvironmentPluginGrantVerb::View,
-            EnvironmentPluginGrantResourcePattern::Any,
-        )?;
-
         let grants: Vec<EnvironmentPluginGrantWithDetails> = self
             .environment_plugin_grant_repo
             .list_by_environment(environment_id.0)
@@ -219,7 +212,20 @@ impl EnvironmentPluginGrantService {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(grants)
+        Ok(grants
+            .into_iter()
+            .filter(|grant| {
+                authorize_environment_plugin_grant_permission(
+                    auth,
+                    &environment,
+                    EnvironmentPluginGrantVerb::View,
+                    EnvironmentPluginGrantResourcePattern::Name(EnvironmentPluginGrantName(
+                        grant.plugin.name.clone(),
+                    )),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_by_id(

--- a/golem-registry-service/src/services/environment_plugin_grant.rs
+++ b/golem-registry-service/src/services/environment_plugin_grant.rs
@@ -118,7 +118,7 @@ impl EnvironmentPluginGrantService {
 
         let plugin = self
             .plugin_registration_service
-            .get_plugin(data.plugin_registration_id, false, auth)
+            .get_plugin(data.plugin_registration_id, auth)
             .await
             .map_err(|err| match err {
                 PluginRegistrationError::PluginRegistrationNotFound(plugin_registration_id) => {
@@ -161,7 +161,7 @@ impl EnvironmentPluginGrantService {
         auth: &AuthCtx,
     ) -> Result<(), EnvironmentPluginGrantError> {
         let (grant, owner) = self
-            .get_by_id_with_environment(environment_plugin_grant_id, false, auth)
+            .get_by_id_with_environment(environment_plugin_grant_id, auth)
             .await?;
 
         authorize_environment_plugin_grant_permission_for_owner(
@@ -225,11 +225,10 @@ impl EnvironmentPluginGrantService {
     pub async fn get_by_id(
         &self,
         environment_plugin_grant_id: EnvironmentPluginGrantId,
-        include_deleted: bool,
         auth: &AuthCtx,
     ) -> Result<EnvironmentPluginGrantWithDetails, EnvironmentPluginGrantError> {
         Ok(self
-            .get_by_id_with_environment(environment_plugin_grant_id, include_deleted, auth)
+            .get_by_id_with_environment(environment_plugin_grant_id, auth)
             .await?
             .0)
     }
@@ -243,7 +242,7 @@ impl EnvironmentPluginGrantService {
     ) -> Result<EnvironmentPluginGrantWithDetails, EnvironmentPluginGrantError> {
         let grant: EnvironmentPluginGrantWithDetails = self
             .environment_plugin_grant_repo
-            .get_by_id(environment_plugin_grant_id.0, false)
+            .get_by_id(environment_plugin_grant_id.0)
             .await?
             .ok_or(EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(
                 environment_plugin_grant_id,
@@ -298,7 +297,7 @@ impl EnvironmentPluginGrantService {
 
         let records = self
             .environment_plugin_grant_repo
-            .get_by_ids(&ids, false)
+            .get_by_ids(environment.id.0, &ids)
             .await?;
 
         // Build result map, verifying each grant belongs to this environment
@@ -329,7 +328,6 @@ impl EnvironmentPluginGrantService {
     async fn get_by_id_with_environment(
         &self,
         environment_plugin_grant_id: EnvironmentPluginGrantId,
-        include_deleted: bool,
         auth: &AuthCtx,
     ) -> Result<
         (EnvironmentPluginGrantWithDetails, EnvironmentOwnerPattern),
@@ -337,7 +335,7 @@ impl EnvironmentPluginGrantService {
     > {
         let record = self
             .environment_plugin_grant_repo
-            .get_by_id(environment_plugin_grant_id.0, include_deleted)
+            .get_by_id(environment_plugin_grant_id.0)
             .await?
             .ok_or(EnvironmentPluginGrantError::EnvironmentPluginGrantNotFound(
                 environment_plugin_grant_id,

--- a/golem-registry-service/src/services/http_api_deployment.rs
+++ b/golem-registry-service/src/services/http_api_deployment.rs
@@ -18,8 +18,11 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use crate::repo::http_api_deployment::HttpApiDeploymentRepo;
 use crate::repo::model::audit::DeletableRevisionAuditFields;
 use crate::repo::model::http_api_deployment::{
-    HttpApiDeploymentRepoError, HttpApiDeploymentRevisionRecord,
+    HttpApiDeploymentAuthExtRevisionRecord, HttpApiDeploymentRepoError,
+    HttpApiDeploymentRevisionRecord,
 };
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentHttpApiDeploymentResourcePattern,
@@ -27,7 +30,7 @@ use golem_common::model::card::{
 };
 use golem_common::model::deployment::DeploymentRevision;
 use golem_common::model::domain_registration::Domain;
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::http_api_deployment::{
     HttpApiDeployment, HttpApiDeploymentCreation, HttpApiDeploymentId, HttpApiDeploymentRevision,
     HttpApiDeploymentUpdate,
@@ -74,14 +77,28 @@ fn authorize_http_api_deployment_permission(
     domain: Option<&Domain>,
     verb: EnvironmentHttpApiDeploymentVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_http_api_deployment_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        domain,
+        verb,
+    )
+}
+
+fn authorize_http_api_deployment_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    domain: Option<&Domain>,
+    verb: EnvironmentHttpApiDeploymentVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentHttpApiDeployment(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: domain
                 .map(
                     |domain| EnvironmentHttpApiDeploymentResourcePattern::DomainPath {
@@ -92,6 +109,16 @@ fn authorize_http_api_deployment_permission(
                 .unwrap_or(EnvironmentHttpApiDeploymentResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_deployment(
+    deployment: &HttpApiDeploymentAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(deployment.owner_account_email.clone()),
+        application: ApplicationName(deployment.application_name.clone()),
+        environment: EnvironmentName(deployment.environment_name.clone()),
+    }
 }
 
 impl SafeDisplay for HttpApiDeploymentError {
@@ -226,38 +253,30 @@ impl HttpApiDeploymentService {
         update: HttpApiDeploymentUpdate,
         auth: &AuthCtx,
     ) -> Result<HttpApiDeployment, HttpApiDeploymentError> {
-        let mut http_api_deployment: HttpApiDeployment = self
+        let deployment_record = self
             .http_api_deployment_repo
             .get_staged_by_id(http_api_deployment_id.0)
             .await?
             .ok_or(HttpApiDeploymentError::HttpApiDeploymentNotFound(
                 http_api_deployment_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(http_api_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let mut http_api_deployment: HttpApiDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner.clone(),
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::View,
         )
         .map_err(|_| HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id))?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::Update,
         )?;
 
@@ -304,38 +323,30 @@ impl HttpApiDeploymentService {
         current_revision: HttpApiDeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<(), HttpApiDeploymentError> {
-        let http_api_deployment: HttpApiDeployment = self
+        let deployment_record = self
             .http_api_deployment_repo
             .get_staged_by_id(http_api_deployment_id.0)
             .await?
             .ok_or(HttpApiDeploymentError::HttpApiDeploymentNotFound(
                 http_api_deployment_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(http_api_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let http_api_deployment: HttpApiDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner.clone(),
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::View,
         )
         .map_err(|_| HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id))?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::Delete,
         )?;
 
@@ -366,30 +377,22 @@ impl HttpApiDeploymentService {
         revision: HttpApiDeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<HttpApiDeployment, HttpApiDeploymentError> {
-        let http_api_deployment: HttpApiDeployment = self
+        let deployment_record = self
             .http_api_deployment_repo
             .get_by_id_and_revision(http_api_deployment_id.0, revision.into())
             .await?
             .ok_or(HttpApiDeploymentError::HttpApiDeploymentNotFound(
                 http_api_deployment_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(http_api_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let http_api_deployment: HttpApiDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::View,
         )
         .map_err(|_| HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id))?;
@@ -479,30 +482,22 @@ impl HttpApiDeploymentService {
         http_api_deployment_id: HttpApiDeploymentId,
         auth: &AuthCtx,
     ) -> Result<HttpApiDeployment, HttpApiDeploymentError> {
-        let http_api_deployment: HttpApiDeployment = self
+        let deployment_record = self
             .http_api_deployment_repo
             .get_staged_by_id(http_api_deployment_id.0)
             .await?
             .ok_or(HttpApiDeploymentError::HttpApiDeploymentNotFound(
                 http_api_deployment_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(http_api_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let http_api_deployment: HttpApiDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_http_api_deployment_permission(
+        authorize_http_api_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&http_api_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentHttpApiDeploymentVerb::View,
         )
         .map_err(|_| HttpApiDeploymentError::HttpApiDeploymentNotFound(http_api_deployment_id))?;

--- a/golem-registry-service/src/services/http_api_deployment.rs
+++ b/golem-registry-service/src/services/http_api_deployment.rs
@@ -448,13 +448,16 @@ impl HttpApiDeploymentService {
         deployment_revision: DeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<Vec<HttpApiDeployment>, HttpApiDeploymentError> {
-        let environment = self
-            .environment_service
-            .get(environment_id, false, auth)
+        let (_, environment) = self
+            .deployment_service
+            .get_deployment_and_environment(environment_id, deployment_revision, auth)
             .await
             .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(environment_id) => {
+                DeploymentError::ParentEnvironmentNotFound(environment_id) => {
                     HttpApiDeploymentError::ParentEnvironmentNotFound(environment_id)
+                }
+                DeploymentError::DeploymentNotFound(deployment_revision) => {
+                    HttpApiDeploymentError::DeploymentRevisionNotFound(deployment_revision)
                 }
                 other => other.into(),
             })?;

--- a/golem-registry-service/src/services/http_api_deployment.rs
+++ b/golem-registry-service/src/services/http_api_deployment.rs
@@ -424,13 +424,6 @@ impl HttpApiDeploymentService {
         environment: &Environment,
         auth: &AuthCtx,
     ) -> Result<Vec<HttpApiDeployment>, HttpApiDeploymentError> {
-        authorize_http_api_deployment_permission(
-            auth,
-            environment,
-            None,
-            EnvironmentHttpApiDeploymentVerb::View,
-        )?;
-
         let http_api_deployments: Vec<HttpApiDeployment> = self
             .http_api_deployment_repo
             .list_staged(environment.id.0)
@@ -439,7 +432,18 @@ impl HttpApiDeploymentService {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(http_api_deployments)
+        Ok(http_api_deployments
+            .into_iter()
+            .filter(|http_api_deployment| {
+                authorize_http_api_deployment_permission(
+                    auth,
+                    environment,
+                    Some(&http_api_deployment.domain),
+                    EnvironmentHttpApiDeploymentVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn list_in_deployment(
@@ -462,13 +466,6 @@ impl HttpApiDeploymentService {
                 other => other.into(),
             })?;
 
-        authorize_http_api_deployment_permission(
-            auth,
-            &environment,
-            None,
-            EnvironmentHttpApiDeploymentVerb::View,
-        )?;
-
         let http_api_deployments: Vec<HttpApiDeployment> = self
             .http_api_deployment_repo
             .list_by_deployment(environment_id.0, deployment_revision.into())
@@ -477,7 +474,18 @@ impl HttpApiDeploymentService {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(http_api_deployments)
+        Ok(http_api_deployments
+            .into_iter()
+            .filter(|http_api_deployment| {
+                authorize_http_api_deployment_permission(
+                    auth,
+                    &environment,
+                    Some(&http_api_deployment.domain),
+                    EnvironmentHttpApiDeploymentVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_staged(

--- a/golem-registry-service/src/services/mcp_deployment.rs
+++ b/golem-registry-service/src/services/mcp_deployment.rs
@@ -17,7 +17,11 @@ use super::domain_registration::{DomainRegistrationError, DomainRegistrationServ
 use super::environment::{EnvironmentError, EnvironmentService};
 use crate::repo::mcp_deployment::McpDeploymentRepo;
 use crate::repo::model::audit::DeletableRevisionAuditFields;
-use crate::repo::model::mcp_deployment::{McpDeploymentRepoError, McpDeploymentRevisionRecord};
+use crate::repo::model::mcp_deployment::{
+    McpDeploymentAuthExtRevisionRecord, McpDeploymentRepoError, McpDeploymentRevisionRecord,
+};
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentMcpDeploymentName, EnvironmentMcpDeploymentResourcePattern,
@@ -25,7 +29,7 @@ use golem_common::model::card::{
 };
 use golem_common::model::deployment::DeploymentRevision;
 use golem_common::model::domain_registration::Domain;
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::mcp_deployment::{
     McpDeployment, McpDeploymentCreation, McpDeploymentId, McpDeploymentRevision,
     McpDeploymentUpdate,
@@ -72,14 +76,28 @@ fn authorize_mcp_deployment_permission(
     domain: Option<&Domain>,
     verb: EnvironmentMcpDeploymentVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_mcp_deployment_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        domain,
+        verb,
+    )
+}
+
+fn authorize_mcp_deployment_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    domain: Option<&Domain>,
+    verb: EnvironmentMcpDeploymentVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentMcpDeployment(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: domain
                 .map(|domain| {
                     EnvironmentMcpDeploymentResourcePattern::Name(EnvironmentMcpDeploymentName(
@@ -89,6 +107,16 @@ fn authorize_mcp_deployment_permission(
                 .unwrap_or(EnvironmentMcpDeploymentResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_deployment(
+    deployment: &McpDeploymentAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(deployment.owner_account_email.clone()),
+        application: ApplicationName(deployment.application_name.clone()),
+        environment: EnvironmentName(deployment.environment_name.clone()),
+    }
 }
 
 impl SafeDisplay for McpDeploymentError {
@@ -216,36 +244,28 @@ impl McpDeploymentService {
         update: McpDeploymentUpdate,
         auth: &AuthCtx,
     ) -> Result<McpDeployment, McpDeploymentError> {
-        let mut mcp_deployment: McpDeployment = self
+        let deployment_record = self
             .mcp_deployment_repo
             .get_staged_by_id(mcp_deployment_id.0)
             .await?
-            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?
-            .try_into()?;
+            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        let environment = self
-            .environment_service
-            .get(mcp_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let mut mcp_deployment: McpDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner.clone(),
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::View,
         )
         .map_err(|_| McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::Update,
         )?;
 
@@ -284,36 +304,28 @@ impl McpDeploymentService {
         current_revision: McpDeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<(), McpDeploymentError> {
-        let mcp_deployment: McpDeployment = self
+        let deployment_record = self
             .mcp_deployment_repo
             .get_staged_by_id(mcp_deployment_id.0)
             .await?
-            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?
-            .try_into()?;
+            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        let environment = self
-            .environment_service
-            .get(mcp_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let mcp_deployment: McpDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner.clone(),
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::View,
         )
         .map_err(|_| McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::Delete,
         )?;
 
@@ -343,28 +355,20 @@ impl McpDeploymentService {
         mcp_deployment_id: McpDeploymentId,
         auth: &AuthCtx,
     ) -> Result<McpDeployment, McpDeploymentError> {
-        let mcp_deployment: McpDeployment = self
+        let deployment_record = self
             .mcp_deployment_repo
             .get_staged_by_id(mcp_deployment_id.0)
             .await?
-            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?
-            .try_into()?;
+            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        let environment = self
-            .environment_service
-            .get(mcp_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let mcp_deployment: McpDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::View,
         )
         .map_err(|_| McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
@@ -457,28 +461,20 @@ impl McpDeploymentService {
         revision: McpDeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<McpDeployment, McpDeploymentError> {
-        let mcp_deployment: McpDeployment = self
+        let deployment_record = self
             .mcp_deployment_repo
             .get_by_id_and_revision(mcp_deployment_id.0, revision.into())
             .await?
-            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?
-            .try_into()?;
+            .ok_or(McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
 
-        let environment = self
-            .environment_service
-            .get(mcp_deployment.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_deployment(&deployment_record);
+        let domain = Domain(deployment_record.deployment.domain.clone());
+        let mcp_deployment: McpDeployment = deployment_record.deployment.try_into()?;
 
-        authorize_mcp_deployment_permission(
+        authorize_mcp_deployment_permission_for_owner(
             auth,
-            &environment,
-            Some(&mcp_deployment.domain),
+            owner,
+            Some(&domain),
             EnvironmentMcpDeploymentVerb::View,
         )
         .map_err(|_| McpDeploymentError::McpDeploymentNotFound(mcp_deployment_id))?;
@@ -533,13 +529,16 @@ impl McpDeploymentService {
         deployment_revision: DeploymentRevision,
         auth: &AuthCtx,
     ) -> Result<Vec<McpDeployment>, McpDeploymentError> {
-        let environment = self
-            .environment_service
-            .get(environment_id, false, auth)
+        let (_, environment) = self
+            .deployment_service
+            .get_deployment_and_environment(environment_id, deployment_revision, auth)
             .await
             .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(environment_id) => {
+                DeploymentError::ParentEnvironmentNotFound(environment_id) => {
                     McpDeploymentError::ParentEnvironmentNotFound(environment_id)
+                }
+                DeploymentError::DeploymentNotFound(deployment_revision) => {
+                    McpDeploymentError::DeploymentRevisionNotFound(deployment_revision)
                 }
                 other => other.into(),
             })?;

--- a/golem-registry-service/src/services/mcp_deployment.rs
+++ b/golem-registry-service/src/services/mcp_deployment.rs
@@ -400,13 +400,6 @@ impl McpDeploymentService {
         environment: &Environment,
         auth: &AuthCtx,
     ) -> Result<Vec<McpDeployment>, McpDeploymentError> {
-        authorize_mcp_deployment_permission(
-            auth,
-            environment,
-            None,
-            EnvironmentMcpDeploymentVerb::View,
-        )?;
-
         let mcp_deployments: Vec<McpDeployment> = self
             .mcp_deployment_repo
             .list_staged(environment.id.0)
@@ -415,7 +408,18 @@ impl McpDeploymentService {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(mcp_deployments)
+        Ok(mcp_deployments
+            .into_iter()
+            .filter(|mcp_deployment| {
+                authorize_mcp_deployment_permission(
+                    auth,
+                    environment,
+                    Some(&mcp_deployment.domain),
+                    EnvironmentMcpDeploymentVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_staged_by_domain(
@@ -543,13 +547,6 @@ impl McpDeploymentService {
                 other => other.into(),
             })?;
 
-        authorize_mcp_deployment_permission(
-            auth,
-            &environment,
-            None,
-            EnvironmentMcpDeploymentVerb::View,
-        )?;
-
         let mcp_deployments: Vec<McpDeployment> = self
             .mcp_deployment_repo
             .list_by_deployment(environment_id.0, deployment_revision.into())
@@ -558,6 +555,17 @@ impl McpDeploymentService {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(mcp_deployments)
+        Ok(mcp_deployments
+            .into_iter()
+            .filter(|mcp_deployment| {
+                authorize_mcp_deployment_permission(
+                    auth,
+                    &environment,
+                    Some(&mcp_deployment.domain),
+                    EnvironmentMcpDeploymentVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 }

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -339,19 +339,27 @@ impl PermissionShareService {
         auth: &AuthCtx,
     ) -> Result<Vec<PermissionShare>, PermissionShareError> {
         let owner_account = self.get_account(owner_account_id).await?;
-        authorize_permission_share_permission(
-            auth,
-            &owner_account.email,
-            AccountPermissionShareVerb::View,
-            AccountPermissionShareResourcePattern::Any,
-        )?;
 
-        self.permission_share_repo
+        let shares = self
+            .permission_share_repo
             .get_for_owner(owner_account_id.0)
             .await?
             .into_iter()
             .map(|record| record.try_into().map_err(Into::into))
-            .collect()
+            .collect::<Result<Vec<_>, PermissionShareError>>()?;
+
+        Ok(shares
+            .into_iter()
+            .filter(|share: &PermissionShare| {
+                authorize_permission_share_permission(
+                    auth,
+                    &owner_account.email,
+                    AccountPermissionShareVerb::View,
+                    AccountPermissionShareResourcePattern::Name(share.name.clone()),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_for_target(
@@ -360,19 +368,27 @@ impl PermissionShareService {
         auth: &AuthCtx,
     ) -> Result<Vec<PermissionShare>, PermissionShareError> {
         let target_account = self.get_account(target_account_id).await?;
-        authorize_permission_share_permission(
-            auth,
-            &target_account.email,
-            AccountPermissionShareVerb::View,
-            AccountPermissionShareResourcePattern::Any,
-        )?;
 
-        self.permission_share_repo
+        let shares = self
+            .permission_share_repo
             .get_for_target(target_account_id.0)
             .await?
             .into_iter()
             .map(|record| record.try_into().map_err(Into::into))
-            .collect()
+            .collect::<Result<Vec<_>, PermissionShareError>>()?;
+
+        Ok(shares
+            .into_iter()
+            .filter(|share: &PermissionShare| {
+                authorize_permission_share_permission(
+                    auth,
+                    &target_account.email,
+                    AccountPermissionShareVerb::View,
+                    AccountPermissionShareResourcePattern::Name(share.name.clone()),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn active_share_cards_for_target(

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -23,8 +23,9 @@ use golem_common::model::account::{Account, AccountEmail, AccountId};
 use golem_common::model::card::owner::AccountOwnerPattern;
 use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::card::{
-    AccountPermissionShareResourcePattern, AccountPermissionShareVerb, Card, CardId, CardManagedBy,
-    CardParseError, ClassPermissionTarget, PermissionPattern, PermissionTarget,
+    AccountPermissionShareResourcePattern, AccountPermissionShareVerb, Card, CardAlgebraError,
+    CardId, CardManagedBy, CardParseError, ClassPermissionTarget, EffectiveSurface,
+    PermissionPattern, PermissionTarget,
 };
 use golem_common::model::permission_share::{
     PermissionShare, PermissionShareCreation, PermissionShareData, PermissionShareId,
@@ -52,6 +53,8 @@ pub enum PermissionShareError {
     InvalidGrant { grant: String, message: String },
     #[error("Permission grant recipient must be '*' or target account '{target_account}'")]
     InvalidRecipient { target_account: String },
+    #[error("Permission grants are not delegable by the caller: {0}")]
+    GrantNotDelegable(String),
     #[error("Concurrent update attempt")]
     ConcurrentModification,
     #[error(transparent)]
@@ -69,6 +72,7 @@ impl SafeDisplay for PermissionShareError {
             Self::TargetAccountNotFound(_) => self.to_string(),
             Self::InvalidGrant { .. } => self.to_string(),
             Self::InvalidRecipient { .. } => self.to_string(),
+            Self::GrantNotDelegable(_) => self.to_string(),
             Self::ConcurrentModification => self.to_string(),
             Self::Unauthorized(inner) => inner.to_safe_string(),
             Self::InternalError(_) => "Internal error".to_string(),
@@ -113,7 +117,8 @@ impl PermissionShareService {
             .await?;
 
         let id = PermissionShareId::new();
-        let card = self.permission_share_card(id, &data.data, target_account.email.as_str())?;
+        let card =
+            self.permission_share_card(id, &data.data, target_account.email.as_str(), auth)?;
         let revision = PermissionShareRevisionRecord::creation(
             id,
             data.name,
@@ -172,6 +177,7 @@ impl PermissionShareService {
             permission_share_id,
             &update.data,
             target_account.email.as_str(),
+            auth,
         )?;
 
         share.revision = share.revision.next()?;
@@ -264,7 +270,14 @@ impl PermissionShareService {
             ))?
             .try_into()?;
 
-        self.authorize_view(&share, auth).await?;
+        self.authorize_view(&share, auth)
+            .await
+            .map_err(|err| match err {
+                PermissionShareError::Unauthorized(_) => {
+                    PermissionShareError::PermissionShareNotFound(permission_share_id)
+                }
+                other => other,
+            })?;
 
         Ok(share)
     }
@@ -384,12 +397,13 @@ impl PermissionShareService {
         permission_share_id: PermissionShareId,
         data: &PermissionShareData,
         target_account: &str,
+        auth: &AuthCtx,
     ) -> Result<CardRecord, PermissionShareError> {
         let parsed = self.parse_and_validate_data_for_target(data, target_account)?;
-        let card_id = Uuid::now_v7();
+        validate_derivation(auth, &parsed)?;
 
         Ok(CardRecord::creation(
-            CardId(card_id),
+            CardId::new(),
             Vec::new(),
             parsed.lower_positive,
             parsed.lower_negative,
@@ -492,6 +506,37 @@ fn validate_recipient(
             target_account: target_account.to_string(),
         }),
     }
+}
+
+fn validate_derivation(
+    auth: &AuthCtx,
+    parsed: &ParsedPermissionShareData,
+) -> Result<(), PermissionShareError> {
+    match auth {
+        AuthCtx::System => Ok(()),
+        AuthCtx::User(user) => {
+            validate_effective_surface_derivation(&user.effective_surface, parsed)
+        }
+        AuthCtx::AdminImpersonation(ctx) => {
+            validate_effective_surface_derivation(&ctx.effective_surface, parsed)
+        }
+        AuthCtx::Agent(_) => Err(PermissionShareError::GrantNotDelegable(
+            "agent contexts cannot delegate permission grants".to_string(),
+        )),
+    }
+}
+
+fn validate_effective_surface_derivation(
+    effective_surface: &EffectiveSurface,
+    parsed: &ParsedPermissionShareData,
+) -> Result<(), PermissionShareError> {
+    effective_surface
+        .validates_derivation(&parsed.lower_positive, &parsed.upper_positive)
+        .map_err(derivation_error)
+}
+
+fn derivation_error(error: CardAlgebraError) -> PermissionShareError {
+    PermissionShareError::GrantNotDelegable(format!("{error:?}"))
 }
 
 fn invalid_grant(grant: &str, err: CardParseError) -> PermissionShareError {

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -16,7 +16,7 @@ use super::account::{AccountError, AccountService};
 use crate::repo::model::audit::DeletableRevisionAuditFields;
 use crate::repo::model::card::CardRecord;
 use crate::repo::model::permission_share::{
-    PermissionShareRepoError, PermissionShareRevisionRecord,
+    PermissionShareAuthExtRevisionRecord, PermissionShareRepoError, PermissionShareRevisionRecord,
 };
 use crate::repo::permission_share::PermissionShareRepo;
 use golem_common::model::account::{Account, AccountEmail, AccountId};
@@ -158,11 +158,13 @@ impl PermissionShareService {
         update: PermissionShareUpdate,
         auth: &AuthCtx,
     ) -> Result<PermissionShare, PermissionShareError> {
-        let mut share = self.get(permission_share_id, auth).await?;
-        let owner_account = self.get_account(share.owner_account_id).await?;
+        let record = self.get_record_by_id(permission_share_id).await?;
+        let owner_account_email = record.owner_account_email();
+        let target_account_email = record.target_account_email();
+        let mut share: PermissionShare = record.share.try_into()?;
         authorize_permission_share_permission(
             auth,
-            &owner_account.email,
+            &owner_account_email,
             AccountPermissionShareVerb::Update,
             AccountPermissionShareResourcePattern::Name(share.name.clone()),
         )?;
@@ -171,11 +173,10 @@ impl PermissionShareService {
             return Err(PermissionShareError::ConcurrentModification);
         }
 
-        let target_account = self.get_account(share.target_account_id).await?;
         let replacement_card = self.permission_share_card(
             permission_share_id,
             &update.data,
-            target_account.email.as_str(),
+            target_account_email.as_str(),
             auth,
         )?;
 
@@ -218,11 +219,12 @@ impl PermissionShareService {
         current_revision: PermissionShareRevision,
         auth: &AuthCtx,
     ) -> Result<PermissionShare, PermissionShareError> {
-        let mut share = self.get(permission_share_id, auth).await?;
-        let owner_account = self.get_account(share.owner_account_id).await?;
+        let record = self.get_record_by_id(permission_share_id).await?;
+        let owner_account_email = record.owner_account_email();
+        let mut share: PermissionShare = record.share.try_into()?;
         authorize_permission_share_permission(
             auth,
-            &owner_account.email,
+            &owner_account_email,
             AccountPermissionShareVerb::Delete,
             AccountPermissionShareResourcePattern::Name(share.name.clone()),
         )?;
@@ -260,17 +262,12 @@ impl PermissionShareService {
         permission_share_id: PermissionShareId,
         auth: &AuthCtx,
     ) -> Result<PermissionShare, PermissionShareError> {
-        let share: PermissionShare = self
-            .permission_share_repo
-            .get_by_id(permission_share_id.0)
-            .await?
-            .ok_or(PermissionShareError::PermissionShareNotFound(
-                permission_share_id,
-            ))?
-            .try_into()?;
+        let record = self.get_record_by_id(permission_share_id).await?;
+        let owner_account_email = record.owner_account_email();
+        let target_account_email = record.target_account_email();
+        let share: PermissionShare = record.share.try_into()?;
 
-        self.authorize_view(&share, auth)
-            .await
+        self.authorize_view(&share, &owner_account_email, &target_account_email, auth)
             .map_err(|err| match err {
                 PermissionShareError::Unauthorized(_) => {
                     PermissionShareError::PermissionShareNotFound(permission_share_id)
@@ -279,6 +276,18 @@ impl PermissionShareService {
             })?;
 
         Ok(share)
+    }
+
+    async fn get_record_by_id(
+        &self,
+        permission_share_id: PermissionShareId,
+    ) -> Result<PermissionShareAuthExtRevisionRecord, PermissionShareError> {
+        self.permission_share_repo
+            .get_by_id(permission_share_id.0)
+            .await?
+            .ok_or(PermissionShareError::PermissionShareNotFound(
+                permission_share_id,
+            ))
     }
 
     pub async fn get_by_owner_and_name(
@@ -429,23 +438,23 @@ impl PermissionShareService {
         })
     }
 
-    async fn authorize_view(
+    fn authorize_view(
         &self,
         share: &PermissionShare,
+        owner_account_email: &AccountEmail,
+        target_account_email: &AccountEmail,
         auth: &AuthCtx,
     ) -> Result<(), PermissionShareError> {
-        let owner_account = self.get_account(share.owner_account_id).await?;
-        let target_account = self.get_account(share.target_account_id).await?;
         authorize_permission_share_permission(
             auth,
-            &owner_account.email,
+            owner_account_email,
             AccountPermissionShareVerb::View,
             AccountPermissionShareResourcePattern::Name(share.name.clone()),
         )
         .or_else(|_| {
             authorize_permission_share_permission(
                 auth,
-                &target_account.email,
+                target_account_email,
                 AccountPermissionShareVerb::View,
                 AccountPermissionShareResourcePattern::Name(share.name.clone()),
             )

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -162,6 +162,15 @@ impl PermissionShareService {
         let owner_account_email = record.owner_account_email();
         let target_account_email = record.target_account_email();
         let mut share: PermissionShare = record.share.try_into()?;
+
+        self.authorize_view(&share, &owner_account_email, &target_account_email, auth)
+            .map_err(|err| match err {
+                PermissionShareError::Unauthorized(_) => {
+                    PermissionShareError::PermissionShareNotFound(permission_share_id)
+                }
+                other => other,
+            })?;
+
         authorize_permission_share_permission(
             auth,
             &owner_account_email,
@@ -221,7 +230,17 @@ impl PermissionShareService {
     ) -> Result<PermissionShare, PermissionShareError> {
         let record = self.get_record_by_id(permission_share_id).await?;
         let owner_account_email = record.owner_account_email();
+        let target_account_email = record.target_account_email();
         let mut share: PermissionShare = record.share.try_into()?;
+
+        self.authorize_view(&share, &owner_account_email, &target_account_email, auth)
+            .map_err(|err| match err {
+                PermissionShareError::Unauthorized(_) => {
+                    PermissionShareError::PermissionShareNotFound(permission_share_id)
+                }
+                other => other,
+            })?;
+
         authorize_permission_share_permission(
             auth,
             &owner_account_email,

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -103,7 +103,7 @@ impl PermissionShareService {
         data: PermissionShareCreation,
         auth: &AuthCtx,
     ) -> Result<PermissionShare, PermissionShareError> {
-        let owner_account = self.get_account(owner_account_id).await?;
+        let owner_account = self.get_account(owner_account_id, auth).await?;
         authorize_permission_share_permission(
             auth,
             &owner_account.email,
@@ -315,7 +315,7 @@ impl PermissionShareService {
         name: &str,
         auth: &AuthCtx,
     ) -> Result<PermissionShare, PermissionShareError> {
-        let owner_account = self.get_account(owner_account_id).await?;
+        let owner_account = self.get_account(owner_account_id, auth).await?;
         authorize_permission_share_permission(
             auth,
             &owner_account.email,
@@ -338,7 +338,7 @@ impl PermissionShareService {
         owner_account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Vec<PermissionShare>, PermissionShareError> {
-        let owner_account = self.get_account(owner_account_id).await?;
+        let owner_account = self.get_account(owner_account_id, auth).await?;
 
         let shares = self
             .permission_share_repo
@@ -367,7 +367,7 @@ impl PermissionShareService {
         target_account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Vec<PermissionShare>, PermissionShareError> {
-        let target_account = self.get_account(target_account_id).await?;
+        let target_account = self.get_account(target_account_id, auth).await?;
 
         let shares = self
             .permission_share_repo
@@ -408,9 +408,13 @@ impl PermissionShareService {
             .collect()
     }
 
-    async fn get_account(&self, account_id: AccountId) -> Result<Account, PermissionShareError> {
+    async fn get_account(
+        &self,
+        account_id: AccountId,
+        auth: &AuthCtx,
+    ) -> Result<Account, PermissionShareError> {
         self.account_service
-            .get(account_id, &AuthCtx::System)
+            .get(account_id, auth)
             .await
             .map_err(|err| match err {
                 AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {

--- a/golem-registry-service/src/services/permission_share.rs
+++ b/golem-registry-service/src/services/permission_share.rs
@@ -35,7 +35,6 @@ use golem_common::{SafeDisplay, error_forwarding};
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
 use std::str::FromStr;
 use std::sync::Arc;
-use uuid::Uuid;
 
 const MAX_CARD_TREE_DELETE_ATTEMPTS: usize = 5;
 

--- a/golem-registry-service/src/services/plugin_registration.rs
+++ b/golem-registry-service/src/services/plugin_registration.rs
@@ -228,13 +228,6 @@ impl PluginRegistrationService {
                     other => other.into(),
                 })?;
 
-        authorize_account_plugin_permission(
-            auth,
-            &account.email,
-            AccountPluginVerb::View,
-            AccountPluginResourcePattern::Any,
-        )?;
-
         let plugins: Vec<PluginRegistration> = self
             .plugin_repo
             .list_by_account(account_id.0)
@@ -243,7 +236,18 @@ impl PluginRegistrationService {
             .map(|r| r.try_into())
             .collect::<Result<_, _>>()?;
 
-        Ok(plugins)
+        Ok(plugins
+            .into_iter()
+            .filter(|plugin| {
+                authorize_account_plugin_permission(
+                    auth,
+                    &account.email,
+                    AccountPluginVerb::View,
+                    AccountPluginResourcePattern::Name(AccountPluginName(plugin.name.clone())),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     async fn validate_oplog_processor_plugin(

--- a/golem-registry-service/src/services/plugin_registration.rs
+++ b/golem-registry-service/src/services/plugin_registration.rs
@@ -150,9 +150,17 @@ impl PluginRegistrationService {
         plugin_id: PluginRegistrationId,
         auth: &AuthCtx,
     ) -> Result<PluginRegistration, PluginRegistrationError> {
-        let record = self.get_plugin_record(plugin_id, false).await?;
+        let record = self.get_plugin_record(plugin_id).await?;
         let account_email = record.account_email();
         let plugin: PluginRegistration = record.plugin.try_into()?;
+
+        authorize_account_plugin_permission(
+            auth,
+            &account_email,
+            AccountPluginVerb::View,
+            AccountPluginResourcePattern::Name(AccountPluginName(plugin.name.clone())),
+        )
+        .map_err(|_| PluginRegistrationError::PluginRegistrationNotFound(plugin_id))?;
 
         authorize_account_plugin_permission(
             auth,
@@ -176,10 +184,9 @@ impl PluginRegistrationService {
     pub async fn get_plugin(
         &self,
         plugin_id: PluginRegistrationId,
-        include_deleted: bool,
         auth: &AuthCtx,
     ) -> Result<PluginRegistration, PluginRegistrationError> {
-        let record = self.get_plugin_record(plugin_id, include_deleted).await?;
+        let record = self.get_plugin_record(plugin_id).await?;
         let account_email = record.account_email();
         let plugin: PluginRegistration = record.plugin.try_into()?;
 
@@ -197,14 +204,10 @@ impl PluginRegistrationService {
     async fn get_plugin_record(
         &self,
         plugin_id: PluginRegistrationId,
-        include_deleted: bool,
     ) -> Result<PluginAuthRecord, PluginRegistrationError> {
-        self.plugin_repo
-            .get_by_id(plugin_id.0, include_deleted)
-            .await?
-            .ok_or(PluginRegistrationError::PluginRegistrationNotFound(
-                plugin_id,
-            ))
+        self.plugin_repo.get_by_id(plugin_id.0).await?.ok_or(
+            PluginRegistrationError::PluginRegistrationNotFound(plugin_id),
+        )
     }
 
     pub async fn list_plugins_in_account(

--- a/golem-registry-service/src/services/plugin_registration.rs
+++ b/golem-registry-service/src/services/plugin_registration.rs
@@ -15,7 +15,7 @@
 use super::account::{AccountError, AccountService};
 use super::component::{ComponentError, ComponentService};
 use crate::repo::model::audit::ImmutableAuditFields;
-use crate::repo::model::plugin::PluginRecord;
+use crate::repo::model::plugin::{PluginAuthRecord, PluginRecord};
 use crate::repo::plugin::PluginRepo;
 use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::card::owner::AccountOwnerPattern;
@@ -150,16 +150,13 @@ impl PluginRegistrationService {
         plugin_id: PluginRegistrationId,
         auth: &AuthCtx,
     ) -> Result<PluginRegistration, PluginRegistrationError> {
-        let plugin = self.get_plugin(plugin_id, false, auth).await?;
-        let account = self
-            .account_service
-            .get(plugin.account_id, &AuthCtx::System)
-            .await
-            .map_err(|_| PluginRegistrationError::PluginRegistrationNotFound(plugin_id))?;
+        let record = self.get_plugin_record(plugin_id, false).await?;
+        let account_email = record.account_email();
+        let plugin: PluginRegistration = record.plugin.try_into()?;
 
         authorize_account_plugin_permission(
             auth,
-            &account.email,
+            &account_email,
             AccountPluginVerb::Delete,
             AccountPluginResourcePattern::Name(AccountPluginName(plugin.name.clone())),
         )?;
@@ -182,30 +179,32 @@ impl PluginRegistrationService {
         include_deleted: bool,
         auth: &AuthCtx,
     ) -> Result<PluginRegistration, PluginRegistrationError> {
-        let plugin: PluginRegistration = self
-            .plugin_repo
-            .get_by_id(plugin_id.0, include_deleted)
-            .await?
-            .ok_or(PluginRegistrationError::PluginRegistrationNotFound(
-                plugin_id,
-            ))?
-            .try_into()?;
-
-        let account = self
-            .account_service
-            .get(plugin.account_id, &AuthCtx::System)
-            .await
-            .map_err(|_| PluginRegistrationError::PluginRegistrationNotFound(plugin_id))?;
+        let record = self.get_plugin_record(plugin_id, include_deleted).await?;
+        let account_email = record.account_email();
+        let plugin: PluginRegistration = record.plugin.try_into()?;
 
         authorize_account_plugin_permission(
             auth,
-            &account.email,
+            &account_email,
             AccountPluginVerb::View,
             AccountPluginResourcePattern::Name(AccountPluginName(plugin.name.clone())),
         )
         .map_err(|_| PluginRegistrationError::PluginRegistrationNotFound(plugin_id))?;
 
         Ok(plugin)
+    }
+
+    async fn get_plugin_record(
+        &self,
+        plugin_id: PluginRegistrationId,
+        include_deleted: bool,
+    ) -> Result<PluginAuthRecord, PluginRegistrationError> {
+        self.plugin_repo
+            .get_by_id(plugin_id.0, include_deleted)
+            .await?
+            .ok_or(PluginRegistrationError::PluginRegistrationNotFound(
+                plugin_id,
+            ))
     }
 
     pub async fn list_plugins_in_account(

--- a/golem-registry-service/src/services/resource_definition.rs
+++ b/golem-registry-service/src/services/resource_definition.rs
@@ -415,13 +415,6 @@ impl ResourceDefinitionService {
         environment: &Environment,
         auth: &AuthCtx,
     ) -> Result<Vec<ResourceDefinition>, ResourceDefinitionError> {
-        authorize_resource_definition_permission(
-            auth,
-            environment,
-            None,
-            EnvironmentResourceDefinitionVerb::View,
-        )?;
-
         let resource_definitions: Vec<ResourceDefinition> = self
             .resource_definition_repo
             .list_in_environment(environment.id.0)
@@ -430,7 +423,18 @@ impl ResourceDefinitionService {
             .map(TryInto::try_into)
             .collect::<Result<_, _>>()?;
 
-        Ok(resource_definitions)
+        Ok(resource_definitions
+            .into_iter()
+            .filter(|resource_definition| {
+                authorize_resource_definition_permission(
+                    auth,
+                    environment,
+                    Some(&resource_definition.name),
+                    EnvironmentResourceDefinitionVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     async fn get_with_environment(

--- a/golem-registry-service/src/services/resource_definition.rs
+++ b/golem-registry-service/src/services/resource_definition.rs
@@ -356,7 +356,10 @@ impl ResourceDefinitionService {
             &environment,
             Some(resource_name),
             EnvironmentResourceDefinitionVerb::View,
-        )?;
+        )
+        .map_err(|_| {
+            ResourceDefinitionError::ResourceDefinitionByNameNotFound(resource_name.clone())
+        })?;
 
         let resource_definition: ResourceDefinition = self
             .resource_definition_repo

--- a/golem-registry-service/src/services/resource_definition.rs
+++ b/golem-registry-service/src/services/resource_definition.rs
@@ -16,16 +16,19 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use super::registry_change_notifier::{RegistryChangeNotifier, RequiresNotificationSignalExt};
 use crate::repo::model::audit::DeletableRevisionAuditFields;
 use crate::repo::model::resource_definition::{
-    ResourceDefinitionCreationArgs, ResourceDefinitionRepoError, ResourceDefinitionRevisionRecord,
+    ResourceDefinitionAuthExtRevisionRecord, ResourceDefinitionCreationArgs,
+    ResourceDefinitionRepoError, ResourceDefinitionRevisionRecord,
 };
 use crate::repo::resource_definition::ResourceDefinitionRepo;
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentResourceDefinitionName,
     EnvironmentResourceDefinitionResourcePattern, EnvironmentResourceDefinitionVerb,
     PermissionTarget,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::quota::{
     ResourceDefinition, ResourceDefinitionCreation, ResourceDefinitionId,
     ResourceDefinitionRevision, ResourceDefinitionUpdate, ResourceLimit, ResourceName,
@@ -61,14 +64,28 @@ fn authorize_resource_definition_permission(
     name: Option<&ResourceName>,
     verb: EnvironmentResourceDefinitionVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_resource_definition_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        name,
+        verb,
+    )
+}
+
+fn authorize_resource_definition_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    name: Option<&ResourceName>,
+    verb: EnvironmentResourceDefinitionVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentResourceDefinition(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: name
                 .map(|name| {
                     EnvironmentResourceDefinitionResourcePattern::Name(
@@ -78,6 +95,16 @@ fn authorize_resource_definition_permission(
                 .unwrap_or(EnvironmentResourceDefinitionResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_resource_definition(
+    resource_definition: &ResourceDefinitionAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(resource_definition.owner_account_email.clone()),
+        application: ApplicationName(resource_definition.application_name.clone()),
+        environment: EnvironmentName(resource_definition.environment_name.clone()),
+    }
 }
 
 impl SafeDisplay for ResourceDefinitionError {
@@ -182,13 +209,13 @@ impl ResourceDefinitionService {
         update: ResourceDefinitionUpdate,
         auth: &AuthCtx,
     ) -> Result<ResourceDefinition, ResourceDefinitionError> {
-        let (mut resource_definition, environment) = self
+        let (mut resource_definition, owner) = self
             .get_with_environment(resource_definition_id, auth)
             .await?;
 
-        authorize_resource_definition_permission(
+        authorize_resource_definition_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&resource_definition.name),
             EnvironmentResourceDefinitionVerb::Update,
         )?;
@@ -250,13 +277,13 @@ impl ResourceDefinitionService {
         current_revision: ResourceDefinitionRevision,
         auth: &AuthCtx,
     ) -> Result<(), ResourceDefinitionError> {
-        let (mut resource_definition, environment) = self
+        let (mut resource_definition, owner) = self
             .get_with_environment(resource_definition_id, auth)
             .await?;
 
-        authorize_resource_definition_permission(
+        authorize_resource_definition_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&resource_definition.name),
             EnvironmentResourceDefinitionVerb::Delete,
         )?;
@@ -303,29 +330,20 @@ impl ResourceDefinitionService {
         revision: ResourceDefinitionRevision,
         auth: &AuthCtx,
     ) -> Result<ResourceDefinition, ResourceDefinitionError> {
-        let resource_definition: ResourceDefinition = self
+        let record = self
             .resource_definition_repo
             .get_revision(resource_definition_id.0, revision.into())
             .await?
             .ok_or_else(|| {
                 ResourceDefinitionError::ResourceDefinitionNotFound(resource_definition_id)
-            })?
-            .try_into()?;
-
-        let environment = self
-            .environment_service
-            .get(resource_definition.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ResourceDefinitionError::ResourceDefinitionNotFound(resource_definition_id)
-                }
-                other => other.into(),
             })?;
 
-        authorize_resource_definition_permission(
+        let owner = environment_owner_from_resource_definition(&record);
+        let resource_definition: ResourceDefinition = record.resource_definition.try_into()?;
+
+        authorize_resource_definition_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&resource_definition.name),
             EnvironmentResourceDefinitionVerb::View,
         )
@@ -419,35 +437,26 @@ impl ResourceDefinitionService {
         &self,
         resource_definition_id: ResourceDefinitionId,
         auth: &AuthCtx,
-    ) -> Result<(ResourceDefinition, Environment), ResourceDefinitionError> {
-        let resource_definition: ResourceDefinition = self
+    ) -> Result<(ResourceDefinition, EnvironmentOwnerPattern), ResourceDefinitionError> {
+        let record = self
             .resource_definition_repo
             .get(resource_definition_id.0)
             .await?
             .ok_or_else(|| {
                 ResourceDefinitionError::ResourceDefinitionNotFound(resource_definition_id)
-            })?
-            .try_into()?;
-
-        let environment = self
-            .environment_service
-            .get(resource_definition.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    ResourceDefinitionError::ResourceDefinitionNotFound(resource_definition_id)
-                }
-                other => other.into(),
             })?;
 
-        authorize_resource_definition_permission(
+        let owner = environment_owner_from_resource_definition(&record);
+        let resource_definition: ResourceDefinition = record.resource_definition.try_into()?;
+
+        authorize_resource_definition_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             Some(&resource_definition.name),
             EnvironmentResourceDefinitionVerb::View,
         )
         .map_err(|_| ResourceDefinitionError::ResourceDefinitionNotFound(resource_definition_id))?;
 
-        Ok((resource_definition, environment))
+        Ok((resource_definition, owner))
     }
 }

--- a/golem-registry-service/src/services/retry_policy.rs
+++ b/golem-registry-service/src/services/retry_policy.rs
@@ -266,16 +266,20 @@ impl RetryPolicyService {
         environment: &Environment,
         auth: &AuthCtx,
     ) -> Result<Vec<StoredRetryPolicy>, RetryPolicyError> {
-        authorize_retry_policy_permission(
-            auth,
-            environment,
-            None,
-            EnvironmentRetryPolicyVerb::View,
-        )?;
-
         let result = self.list_in_environment_unchecked(environment.id).await?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .filter(|retry_policy| {
+                authorize_retry_policy_permission(
+                    auth,
+                    environment,
+                    Some(&retry_policy.name),
+                    EnvironmentRetryPolicyVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn list_in_environment_unchecked(

--- a/golem-registry-service/src/services/retry_policy.rs
+++ b/golem-registry-service/src/services/retry_policy.rs
@@ -16,15 +16,18 @@ use super::environment::{EnvironmentError, EnvironmentService};
 use super::registry_change_notifier::{RegistryChangeNotifier, RequiresNotificationSignalExt};
 use crate::repo::model::audit::DeletableRevisionAuditFields;
 use crate::repo::model::retry_policy::{
-    RetryPolicyCreationRecord, RetryPolicyRepoError, RetryPolicyRevisionRecord,
+    RetryPolicyAuthExtRevisionRecord, RetryPolicyCreationRecord, RetryPolicyRepoError,
+    RetryPolicyRevisionRecord,
 };
 use crate::repo::retry_policy::RetryPolicyRepo;
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentRetryPolicyName, EnvironmentRetryPolicyResourcePattern,
     EnvironmentRetryPolicyVerb, PermissionTarget,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::retry_policy::{
     RetryPolicyCreation, RetryPolicyId, RetryPolicyRevision, RetryPolicyUpdate,
 };
@@ -146,12 +149,11 @@ impl RetryPolicyService {
         update: RetryPolicyUpdate,
         auth: &AuthCtx,
     ) -> Result<StoredRetryPolicy, RetryPolicyError> {
-        let (mut retry_policy, environment) =
-            self.get_with_environment(retry_policy_id, auth).await?;
+        let (mut retry_policy, owner) = self.get_with_environment(retry_policy_id, auth).await?;
 
-        authorize_retry_policy_permission(
+        authorize_retry_policy_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&retry_policy.name),
             EnvironmentRetryPolicyVerb::Update,
         )?;
@@ -198,12 +200,11 @@ impl RetryPolicyService {
         current_revision: RetryPolicyRevision,
         auth: &AuthCtx,
     ) -> Result<StoredRetryPolicy, RetryPolicyError> {
-        let (mut retry_policy, environment) =
-            self.get_with_environment(retry_policy_id, auth).await?;
+        let (mut retry_policy, owner) = self.get_with_environment(retry_policy_id, auth).await?;
 
-        authorize_retry_policy_permission(
+        authorize_retry_policy_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&retry_policy.name),
             EnvironmentRetryPolicyVerb::Delete,
         )?;
@@ -296,34 +297,35 @@ impl RetryPolicyService {
         &self,
         retry_policy_id: RetryPolicyId,
         auth: &AuthCtx,
-    ) -> Result<(StoredRetryPolicy, Environment), RetryPolicyError> {
-        let retry_policy: StoredRetryPolicy = self
+    ) -> Result<(StoredRetryPolicy, EnvironmentOwnerPattern), RetryPolicyError> {
+        let record = self
             .retry_policy_repo
             .get_by_id(retry_policy_id.0)
             .await?
-            .ok_or(RetryPolicyError::RetryPolicyNotFound(retry_policy_id))?
-            .try_into()?;
+            .ok_or(RetryPolicyError::RetryPolicyNotFound(retry_policy_id))?;
 
-        let environment = self
-            .environment_service
-            .get(retry_policy.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    RetryPolicyError::RetryPolicyNotFound(retry_policy_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_retry_policy(&record);
+        let retry_policy: StoredRetryPolicy = record.retry_policy.try_into()?;
 
-        authorize_retry_policy_permission(
+        authorize_retry_policy_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             Some(&retry_policy.name),
             EnvironmentRetryPolicyVerb::View,
         )
         .map_err(|_| RetryPolicyError::RetryPolicyNotFound(retry_policy_id))?;
 
-        Ok((retry_policy, environment))
+        Ok((retry_policy, owner))
+    }
+}
+
+fn environment_owner_from_retry_policy(
+    retry_policy: &RetryPolicyAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(retry_policy.owner_account_email.clone()),
+        application: ApplicationName(retry_policy.application_name.clone()),
+        environment: EnvironmentName(retry_policy.environment_name.clone()),
     }
 }
 
@@ -333,14 +335,28 @@ fn authorize_retry_policy_permission(
     name: Option<&str>,
     verb: EnvironmentRetryPolicyVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_retry_policy_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        name,
+        verb,
+    )
+}
+
+fn authorize_retry_policy_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    name: Option<&str>,
+    verb: EnvironmentRetryPolicyVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentRetryPolicy(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: name
                 .map(|name| {
                     EnvironmentRetryPolicyResourcePattern::Name(EnvironmentRetryPolicyName(

--- a/golem-registry-service/src/services/security_scheme.rs
+++ b/golem-registry-service/src/services/security_scheme.rs
@@ -357,14 +357,7 @@ impl SecuritySchemeService {
                 other => other.into(),
             })?;
 
-        authorize_security_scheme_permission(
-            auth,
-            &environment,
-            None,
-            EnvironmentSecuritySchemeVerb::View,
-        )?;
-
-        let result = self
+        let security_schemes: Vec<SecurityScheme> = self
             .security_scheme_repo
             .get_for_environment(environment_id.0)
             .await?
@@ -372,7 +365,18 @@ impl SecuritySchemeService {
             .map(|r| r.try_into())
             .collect::<Result<_, _>>()?;
 
-        Ok(result)
+        Ok(security_schemes
+            .into_iter()
+            .filter(|security_scheme: &SecurityScheme| {
+                authorize_security_scheme_permission(
+                    auth,
+                    &environment,
+                    Some(&security_scheme.name),
+                    EnvironmentSecuritySchemeVerb::View,
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn get_security_scheme_for_environment_and_name(

--- a/golem-registry-service/src/services/security_scheme.rs
+++ b/golem-registry-service/src/services/security_scheme.rs
@@ -358,7 +358,8 @@ impl SecuritySchemeService {
             environment,
             Some(name),
             EnvironmentSecuritySchemeVerb::View,
-        )?;
+        )
+        .map_err(|_| SecuritySchemeError::SecuritySchemeForNameNotFound(name.clone()))?;
 
         let result = self
             .security_scheme_repo

--- a/golem-registry-service/src/services/security_scheme.rs
+++ b/golem-registry-service/src/services/security_scheme.rs
@@ -15,17 +15,21 @@
 use super::environment::{EnvironmentError, EnvironmentService};
 use crate::model::security_scheme::SecurityScheme;
 use crate::repo::model::audit::DeletableRevisionAuditFields;
-use crate::repo::model::security_scheme::{SecuritySchemeRepoError, SecuritySchemeRevisionRecord};
+use crate::repo::model::security_scheme::{
+    SecuritySchemeAuthExtRevisionRecord, SecuritySchemeRepoError, SecuritySchemeRevisionRecord,
+};
 use crate::repo::security_scheme::SecuritySchemeRepo;
 use crate::services::registry_change_notifier::{
     RegistryChangeNotifier, RequiresNotificationSignalExt,
 };
+use golem_common::model::account::AccountEmail;
+use golem_common::model::application::ApplicationName;
 use golem_common::model::card::owner::EnvironmentOwnerPattern;
 use golem_common::model::card::{
     ClassPermissionTarget, EnvironmentSecuritySchemeName, EnvironmentSecuritySchemeResourcePattern,
     EnvironmentSecuritySchemeVerb, PermissionTarget,
 };
-use golem_common::model::environment::{Environment, EnvironmentId};
+use golem_common::model::environment::{Environment, EnvironmentId, EnvironmentName};
 use golem_common::model::security_scheme::{
     SecuritySchemeCreation, SecuritySchemeId, SecuritySchemeName, SecuritySchemeRevision,
     SecuritySchemeUpdate,
@@ -64,14 +68,28 @@ fn authorize_security_scheme_permission(
     name: Option<&SecuritySchemeName>,
     verb: EnvironmentSecuritySchemeVerb,
 ) -> Result<(), AuthorizationError> {
+    authorize_security_scheme_permission_for_owner(
+        auth,
+        EnvironmentOwnerPattern::Environment {
+            account: environment.owner_account_email.clone(),
+            application: environment.application_name.clone(),
+            environment: environment.name.clone(),
+        },
+        name,
+        verb,
+    )
+}
+
+fn authorize_security_scheme_permission_for_owner(
+    auth: &AuthCtx,
+    owner: EnvironmentOwnerPattern,
+    name: Option<&SecuritySchemeName>,
+    verb: EnvironmentSecuritySchemeVerb,
+) -> Result<(), AuthorizationError> {
     auth.authorize_permission(&PermissionTarget::EnvironmentSecurityScheme(
         ClassPermissionTarget {
             verb: Some(verb),
-            owner: EnvironmentOwnerPattern::Environment {
-                account: environment.owner_account_email.clone(),
-                application: environment.application_name.clone(),
-                environment: environment.name.clone(),
-            },
+            owner,
             resource: name
                 .map(|name| {
                     EnvironmentSecuritySchemeResourcePattern::Name(EnvironmentSecuritySchemeName(
@@ -81,6 +99,16 @@ fn authorize_security_scheme_permission(
                 .unwrap_or(EnvironmentSecuritySchemeResourcePattern::Any),
         },
     ))
+}
+
+fn environment_owner_from_security_scheme(
+    security_scheme: &SecuritySchemeAuthExtRevisionRecord,
+) -> EnvironmentOwnerPattern {
+    EnvironmentOwnerPattern::Environment {
+        account: AccountEmail::new(security_scheme.owner_account_email.clone()),
+        application: ApplicationName(security_scheme.application_name.clone()),
+        environment: EnvironmentName(security_scheme.environment_name.clone()),
+    }
 }
 
 impl SafeDisplay for SecuritySchemeError {
@@ -195,12 +223,12 @@ impl SecuritySchemeService {
         update: SecuritySchemeUpdate,
         auth: &AuthCtx,
     ) -> Result<SecurityScheme, SecuritySchemeError> {
-        let (mut security_scheme, environment) =
+        let (mut security_scheme, owner) =
             self.get_with_environment(security_scheme_id, auth).await?;
 
-        authorize_security_scheme_permission(
+        authorize_security_scheme_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&security_scheme.name),
             EnvironmentSecuritySchemeVerb::Update,
         )?;
@@ -265,12 +293,12 @@ impl SecuritySchemeService {
         current_revision: SecuritySchemeRevision,
         auth: &AuthCtx,
     ) -> Result<SecurityScheme, SecuritySchemeError> {
-        let (mut security_scheme, environment) =
+        let (mut security_scheme, owner) =
             self.get_with_environment(security_scheme_id, auth).await?;
 
-        authorize_security_scheme_permission(
+        authorize_security_scheme_permission_for_owner(
             auth,
-            &environment,
+            owner,
             Some(&security_scheme.name),
             EnvironmentSecuritySchemeVerb::Delete,
         )?;
@@ -377,35 +405,26 @@ impl SecuritySchemeService {
         &self,
         security_scheme_id: SecuritySchemeId,
         auth: &AuthCtx,
-    ) -> Result<(SecurityScheme, Environment), SecuritySchemeError> {
-        let security_scheme: SecurityScheme = self
+    ) -> Result<(SecurityScheme, EnvironmentOwnerPattern), SecuritySchemeError> {
+        let record = self
             .security_scheme_repo
             .get_by_id(security_scheme_id.0)
             .await?
             .ok_or(SecuritySchemeError::SecuritySchemeNotFound(
                 security_scheme_id,
-            ))?
-            .try_into()?;
+            ))?;
 
-        let environment = self
-            .environment_service
-            .get(security_scheme.environment_id, false, auth)
-            .await
-            .map_err(|err| match err {
-                EnvironmentError::EnvironmentNotFound(_) => {
-                    SecuritySchemeError::SecuritySchemeNotFound(security_scheme_id)
-                }
-                other => other.into(),
-            })?;
+        let owner = environment_owner_from_security_scheme(&record);
+        let security_scheme: SecurityScheme = record.security_scheme.try_into()?;
 
-        authorize_security_scheme_permission(
+        authorize_security_scheme_permission_for_owner(
             auth,
-            &environment,
+            owner.clone(),
             Some(&security_scheme.name),
             EnvironmentSecuritySchemeVerb::View,
         )
         .map_err(|_| SecuritySchemeError::SecuritySchemeNotFound(security_scheme_id))?;
 
-        Ok((security_scheme, environment))
+        Ok((security_scheme, owner))
     }
 }

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -150,16 +150,16 @@ impl TokenService {
         account_id: AccountId,
         auth: &AuthCtx,
     ) -> Result<Vec<TokenWithSecret>, TokenError> {
-        let account = self
-            .account_service
-            .get(account_id, &AuthCtx::System)
-            .await
-            .map_err(|err| match err {
-                AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
-                    TokenError::ParentAccountNotFound(account_id)
-                }
-                other => other.into(),
-            })?;
+        let account =
+            self.account_service
+                .get(account_id, auth)
+                .await
+                .map_err(|err| match err {
+                    AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
+                        TokenError::ParentAccountNotFound(account_id)
+                    }
+                    other => other.into(),
+                })?;
 
         let tokens: Vec<TokenWithSecret> = self
             .token_repo
@@ -189,16 +189,16 @@ impl TokenService {
         expires_at: DateTime<Utc>,
         auth: &AuthCtx,
     ) -> Result<TokenWithSecret, TokenError> {
-        let account = self
-            .account_service
-            .get(account_id, &AuthCtx::System)
-            .await
-            .map_err(|err| match err {
-                AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
-                    TokenError::ParentAccountNotFound(account_id)
-                }
-                other => other.into(),
-            })?;
+        let account =
+            self.account_service
+                .get(account_id, auth)
+                .await
+                .map_err(|err| match err {
+                    AccountError::AccountNotFound(_) | AccountError::Unauthorized(_) => {
+                        TokenError::ParentAccountNotFound(account_id)
+                    }
+                    other => other.into(),
+                })?;
 
         authorize_account_token_permission(
             auth,

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -161,13 +161,6 @@ impl TokenService {
                 other => other.into(),
             })?;
 
-        authorize_account_token_permission(
-            auth,
-            &account.email,
-            AccountTokenVerb::View,
-            AccountTokenResourcePattern::Any,
-        )?;
-
         let tokens: Vec<TokenWithSecret> = self
             .token_repo
             .get_by_account(account_id.0)
@@ -176,7 +169,18 @@ impl TokenService {
             .map(|r| r.into())
             .collect();
 
-        Ok(tokens)
+        Ok(tokens
+            .into_iter()
+            .filter(|token| {
+                authorize_account_token_permission(
+                    auth,
+                    &account.email,
+                    AccountTokenVerb::View,
+                    AccountTokenResourcePattern::Token(token.id),
+                )
+                .is_ok()
+            })
+            .collect())
     }
 
     pub async fn create(

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -88,22 +88,17 @@ impl TokenService {
         token_id: TokenId,
         auth: &AuthCtx,
     ) -> Result<TokenWithSecret, TokenError> {
-        let token: TokenWithSecret = self
+        let record = self
             .token_repo
             .get_by_id(token_id.0)
             .await?
-            .ok_or(TokenError::TokenNotFound(token_id))?
-            .into();
-
-        let account = self
-            .account_service
-            .get(token.account_id, &AuthCtx::System)
-            .await
-            .map_err(|_| TokenError::TokenNotFound(token_id))?;
+            .ok_or(TokenError::TokenNotFound(token_id))?;
+        let account_email = record.account_email();
+        let token: TokenWithSecret = record.token.into();
 
         authorize_account_token_permission(
             auth,
-            &account.email,
+            &account_email,
             AccountTokenVerb::View,
             AccountTokenResourcePattern::Token(token_id),
         )
@@ -117,22 +112,17 @@ impl TokenService {
         secret: &TokenSecret,
         auth: &AuthCtx,
     ) -> Result<TokenWithSecret, TokenError> {
-        let token: TokenWithSecret = self
+        let record = self
             .token_repo
             .get_by_secret(secret.secret())
             .await?
-            .ok_or(TokenError::TokenBySecretNotFound)?
-            .into();
-
-        let account = self
-            .account_service
-            .get(token.account_id, &AuthCtx::System)
-            .await
-            .map_err(|_| TokenError::TokenBySecretNotFound)?;
+            .ok_or(TokenError::TokenBySecretNotFound)?;
+        let account_email = record.account_email();
+        let token: TokenWithSecret = record.token.into();
 
         authorize_account_token_permission(
             auth,
-            &account.email,
+            &account_email,
             AccountTokenVerb::View,
             AccountTokenResourcePattern::Token(token.id),
         )
@@ -302,22 +292,16 @@ impl TokenService {
     }
 
     pub async fn delete(&self, token_id: TokenId, auth: &AuthCtx) -> Result<(), TokenError> {
-        let token: TokenWithSecret = self
+        let record = self
             .token_repo
             .get_by_id(token_id.0)
             .await?
-            .ok_or(TokenError::TokenNotFound(token_id))?
-            .into();
-
-        let account = self
-            .account_service
-            .get(token.account_id, &AuthCtx::System)
-            .await
-            .map_err(|_| TokenError::TokenNotFound(token_id))?;
+            .ok_or(TokenError::TokenNotFound(token_id))?;
+        let account_email = record.account_email();
 
         authorize_account_token_permission(
             auth,
-            &account.email,
+            &account_email,
             AccountTokenVerb::Delete,
             AccountTokenResourcePattern::Token(token_id),
         )?;

--- a/golem-registry-service/src/services/token.rs
+++ b/golem-registry-service/src/services/token.rs
@@ -302,6 +302,14 @@ impl TokenService {
         authorize_account_token_permission(
             auth,
             &account_email,
+            AccountTokenVerb::View,
+            AccountTokenResourcePattern::Token(token_id),
+        )
+        .map_err(|_| TokenError::TokenNotFound(token_id))?;
+
+        authorize_account_token_permission(
+            auth,
+            &account_email,
             AccountTokenVerb::Delete,
             AccountTokenResourcePattern::Token(token_id),
         )?;

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -935,9 +935,9 @@ pub async fn test_http_api_deployment_stage(deps: &Deps) {
         .await
         .unwrap();
     let_assert!(Some(get_revision_0) = get_revision_0);
-    assert!(revision_0 == get_revision_0.revision);
-    assert!(get_revision_0.environment_id == env.revision.environment_id);
-    assert!(get_revision_0.domain == domain);
+    assert!(revision_0 == get_revision_0.deployment.revision);
+    assert!(get_revision_0.deployment.environment_id == env.revision.environment_id);
+    assert!(get_revision_0.deployment.domain == domain);
 
     let get_revision_0 = deps
         .http_api_deployment_repo

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -162,7 +162,7 @@ pub async fn test_application_create(deps: &Deps) {
 
     let app = deps
         .application_repo
-        .get_by_name(owner.revision.account_id, &owner.revision.email, &app_name)
+        .get_by_name(owner.revision.account_id, &app_name)
         .await
         .unwrap();
     assert!(app.is_none());
@@ -190,12 +190,14 @@ pub async fn test_application_create(deps: &Deps) {
 
     let app_2 = deps
         .application_repo
-        .get_by_name(owner.revision.account_id, &owner.revision.email, &app_name)
+        .get_by_name(owner.revision.account_id, &app_name)
         .await
         .unwrap();
     let_assert!(Some(app_2) = app_2);
 
-    check!(app == app_2);
+    check!(app.account_id == app_2.account_id);
+    check!(app.entity_created_at == app_2.entity_created_at);
+    check!(app.revision == app_2.revision);
 }
 
 pub async fn test_application_create_concurrent(deps: &Deps) {
@@ -261,7 +263,7 @@ pub async fn test_application_delete(deps: &Deps) {
     assert!(get_by_id.is_none());
     let get_by_name = deps
         .application_repo
-        .get_by_name(user.revision.account_id, &user.revision.email, &app.revision.name)
+        .get_by_name(user.revision.account_id, &app.revision.name)
         .await
         .unwrap();
     assert!(get_by_name.is_none());
@@ -298,11 +300,7 @@ pub async fn test_environment_create(deps: &Deps) {
 
     assert!(
         deps.environment_repo
-            .get_by_name(
-                app.revision.application_id,
-                env_name,
-                user.revision.account_id,
-            )
+            .get_by_name(app.revision.application_id, env_name)
             .await
             .unwrap()
             .is_none()
@@ -332,11 +330,7 @@ pub async fn test_environment_create(deps: &Deps) {
 
     let env_by_name = deps
         .environment_repo
-        .get_by_name(
-            app.revision.application_id,
-            env_name,
-            user.revision.account_id,
-        )
+        .get_by_name(app.revision.application_id, env_name)
         .await
         .unwrap();
     let_assert!(Some(env_by_name) = env_by_name);
@@ -344,7 +338,7 @@ pub async fn test_environment_create(deps: &Deps) {
 
     let env_by_id = deps
         .environment_repo
-        .get_by_id(env.revision.environment_id, user.revision.account_id, false)
+        .get_by_id(env.revision.environment_id, false)
         .await
         .unwrap();
     let_assert!(Some(env_by_id) = env_by_id);
@@ -538,11 +532,7 @@ pub async fn test_environment_update(deps: &Deps) {
 
     let rev_1_by_name = deps
         .environment_repo
-        .get_by_name(
-            env_rev_0.application_id,
-            &env_rev_0.revision.name,
-            user.revision.account_id,
-        )
+        .get_by_name(env_rev_0.application_id, &env_rev_0.revision.name)
         .await
         .unwrap();
     let_assert!(Some(rev_1_by_name) = rev_1_by_name);
@@ -552,7 +542,7 @@ pub async fn test_environment_update(deps: &Deps) {
 
     let rev_1_by_id = deps
         .environment_repo
-        .get_by_id(env_rev_1.environment_id, user.revision.account_id, false)
+        .get_by_id(env_rev_1.environment_id, false)
         .await
         .unwrap();
     let_assert!(Some(rev_1_by_id) = rev_1_by_id);
@@ -591,11 +581,7 @@ pub async fn test_environment_update(deps: &Deps) {
 
     let rev_2_by_name = deps
         .environment_repo
-        .get_by_name(
-            env_rev_0.application_id,
-            &env_rev_0.revision.name,
-            user.revision.account_id,
-        )
+        .get_by_name(env_rev_0.application_id, &env_rev_0.revision.name)
         .await
         .unwrap();
     let_assert!(Some(rev_2_by_name) = rev_2_by_name);
@@ -605,7 +591,7 @@ pub async fn test_environment_update(deps: &Deps) {
 
     let rev_2_by_id = deps
         .environment_repo
-        .get_by_id(env_rev_2.environment_id, user.revision.account_id, false)
+        .get_by_id(env_rev_2.environment_id, false)
         .await
         .unwrap();
     let_assert!(Some(rev_2_by_id) = rev_2_by_id);

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -162,7 +162,7 @@ pub async fn test_application_create(deps: &Deps) {
 
     let app = deps
         .application_repo
-        .get_by_name(owner.revision.account_id, &app_name)
+        .get_by_name(owner.revision.account_id, &owner.revision.email, &app_name)
         .await
         .unwrap();
     assert!(app.is_none());
@@ -190,7 +190,7 @@ pub async fn test_application_create(deps: &Deps) {
 
     let app_2 = deps
         .application_repo
-        .get_by_name(owner.revision.account_id, &app_name)
+        .get_by_name(owner.revision.account_id, &owner.revision.email, &app_name)
         .await
         .unwrap();
     let_assert!(Some(app_2) = app_2);
@@ -261,7 +261,7 @@ pub async fn test_application_delete(deps: &Deps) {
     assert!(get_by_id.is_none());
     let get_by_name = deps
         .application_repo
-        .get_by_name(user.revision.account_id, &app.revision.name)
+        .get_by_name(user.revision.account_id, &user.revision.email, &app.revision.name)
         .await
         .unwrap();
     assert!(get_by_name.is_none());
@@ -760,9 +760,9 @@ pub async fn test_component_stage(deps: &Deps) {
         .await
         .unwrap();
     let_assert!(Some(get_revision_0) = get_revision_0);
-    assert!(revision_0 == get_revision_0.revision);
-    assert!(get_revision_0.environment_id == env.revision.environment_id);
-    assert!(get_revision_0.name == component_name);
+    assert!(revision_0 == get_revision_0.component.revision);
+    assert!(get_revision_0.component.environment_id == env.revision.environment_id);
+    assert!(get_revision_0.component.name == component_name);
 
     let get_revision_0 = deps
         .component_repo
@@ -1554,8 +1554,8 @@ pub async fn test_mcp_deployment_create_and_update(deps: &Deps) {
         .await
         .unwrap();
     let_assert!(Some(fetched_deployment) = fetched_deployment);
-    assert!(fetched_deployment.revision.revision_id == revision_0.revision_id);
-    assert!(fetched_deployment.domain == domain);
+    assert!(fetched_deployment.deployment.revision.revision_id == revision_0.revision_id);
+    assert!(fetched_deployment.deployment.domain == domain);
 
     let fetched_by_domain = deps
         .mcp_deployment_repo

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -334,7 +334,8 @@ pub async fn test_environment_create(deps: &Deps) {
         .await
         .unwrap();
     let_assert!(Some(env_by_name) = env_by_name);
-    check!(env == env_by_name);
+    check!(env.application_id == env_by_name.application_id);
+    check!(env.revision == env_by_name.revision);
 
     let env_by_id = deps
         .environment_repo
@@ -342,7 +343,8 @@ pub async fn test_environment_create(deps: &Deps) {
         .await
         .unwrap();
     let_assert!(Some(env_by_id) = env_by_id);
-    check!(env == env_by_id);
+    check!(env.application_id == env_by_id.application_id);
+    check!(env.revision == env_by_id.revision);
 }
 
 pub async fn test_environment_list_visible_to_account_uses_visibility_filter(deps: &Deps) {

--- a/golem-registry-service/tests/repo/mod.rs
+++ b/golem-registry-service/tests/repo/mod.rs
@@ -28,12 +28,12 @@ use golem_registry_service::repo::model::account::{
     AccountExtRevisionRecord, AccountRevisionRecord,
 };
 use golem_registry_service::repo::model::application::{
-    ApplicationExtRevisionRecord, ApplicationRevisionRecord,
+    ApplicationExtRevisionRecord, ApplicationRevisionRecord, ApplicationScopedExtRevisionRecord,
 };
 use golem_registry_service::repo::model::audit::DeletableRevisionAuditFields;
 use golem_registry_service::repo::model::card::CardRecord;
 use golem_registry_service::repo::model::environment::{
-    EnvironmentExtRevisionRecord, EnvironmentRevisionRecord,
+    EnvironmentExtRevisionRecord, EnvironmentRevisionRecord, EnvironmentScopedExtRevisionRecord,
 };
 use golem_registry_service::repo::model::new_repo_uuid;
 use golem_registry_service::repo::model::plan::PlanRecord;
@@ -220,7 +220,14 @@ impl Deps {
     pub async fn create_application(&self, owner_account_id: Uuid) -> ApplicationExtRevisionRecord {
         let user = self.create_account().await;
 
-        self.application_repo
+        let owner = self
+            .account_repo
+            .get_by_id(owner_account_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let scoped = self
+            .application_repo
             .create(
                 owner_account_id,
                 ApplicationRevisionRecord {
@@ -231,12 +238,20 @@ impl Deps {
                 },
             )
             .await
-            .unwrap()
+            .unwrap();
+        application_ext(scoped, owner.revision.email)
     }
 
     pub async fn create_env(&self, parent_application_id: Uuid) -> EnvironmentExtRevisionRecord {
         let user = self.create_account().await;
-        self.environment_repo
+        let app = self
+            .application_repo
+            .get_by_id(parent_application_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let scoped = self
+            .environment_repo
             .create(
                 parent_application_id,
                 EnvironmentRevisionRecord {
@@ -251,6 +266,38 @@ impl Deps {
                 },
             )
             .await
-            .unwrap()
+            .unwrap();
+        environment_ext(scoped, app.revision.name, app.account_id, app.account_email)
+    }
+}
+
+fn application_ext(
+    scoped: ApplicationScopedExtRevisionRecord,
+    account_email: String,
+) -> ApplicationExtRevisionRecord {
+    ApplicationExtRevisionRecord {
+        account_id: scoped.account_id,
+        account_email,
+        entity_created_at: scoped.entity_created_at,
+        revision: scoped.revision,
+    }
+}
+
+fn environment_ext(
+    scoped: EnvironmentScopedExtRevisionRecord,
+    application_name: String,
+    owner_account_id: Uuid,
+    owner_account_email: String,
+) -> EnvironmentExtRevisionRecord {
+    EnvironmentExtRevisionRecord {
+        application_id: scoped.application_id,
+        application_name,
+        revision: scoped.revision,
+        owner_account_id,
+        owner_account_email,
+        current_deployment_revision: scoped.current_deployment_revision,
+        current_deployment_deployment_revision: scoped.current_deployment_deployment_revision,
+        current_deployment_deployment_version: scoped.current_deployment_deployment_version,
+        current_deployment_deployment_hash: scoped.current_deployment_deployment_hash,
     }
 }

--- a/integration-tests/tests/api/account.rs
+++ b/integration-tests/tests/api/account.rs
@@ -16,7 +16,7 @@ use golem_client::api::{RegistryServiceClient, RegistryServiceCreateAccountError
 use golem_client::model::AccountUpdate;
 use golem_common::model::account::{AccountCreation, AccountEmail, AccountRevision};
 use golem_test_framework::config::{EnvBasedTestDependencies, TestDependencies};
-use pretty_assertions::assert_eq;
+use pretty_assertions::{assert_eq, assert_matches};
 use test_r::{inherit_test_dep, test};
 use uuid::Uuid;
 
@@ -37,12 +37,11 @@ async fn get_account(deps: &EnvBasedTestDependencies) -> anyhow::Result<()> {
         assert_eq!(account.roles, Vec::new());
     }
 
-    // TODO(agent-permissions): accessing plan requires permissions for the specific plan resource
     // get account plan
-    // {
-    //     let result = client.get_account_plan(&user.account_id.0).await;
-    //     assert_matches!(result, Ok(_))
-    // }
+    {
+        let result = client.get_account_plan(&user.account_id.0).await;
+        assert_matches!(result, Ok(_))
+    }
 
     // get account tokens
     {

--- a/integration-tests/tests/api/application.rs
+++ b/integration-tests/tests/api/application.rs
@@ -113,7 +113,7 @@ async fn other_users_cannot_get_applications(
         assert!(matches!(
             result,
             Err(golem_client::Error::Item(
-                RegistryServiceListAccountApplicationsError::Error403(_)
+                RegistryServiceListAccountApplicationsError::Error404(_)
             ))
         ));
     }
@@ -146,7 +146,7 @@ async fn deleting_account_hides_applications(
         assert!(matches!(
             result,
             Err(golem_client::Error::Item(
-                RegistryServiceListAccountApplicationsError::Error403(_)
+                RegistryServiceListAccountApplicationsError::Error404(_)
             ))
         ));
     }

--- a/integration-tests/tests/api/environment.rs
+++ b/integration-tests/tests/api/environment.rs
@@ -324,13 +324,21 @@ async fn list_visible_environments_shows_owned_and_shared(
                 target_account_email: grantee.account_email.clone(),
                 name: PermissionShareName("visible-environment-access".to_string()),
                 data: PermissionShareData {
-                    lower_positive: vec![format!(
-                        "environment({}/{}) @ {} : view : {}",
-                        owner.account_email.as_str(),
-                        app_1.name.0,
-                        grantee.account_email.as_str(),
-                        env_1b.name.0,
-                    )],
+                    lower_positive: vec![
+                        format!(
+                            "application({}) @ {} : view : {}",
+                            owner.account_email.as_str(),
+                            grantee.account_email.as_str(),
+                            app_1.name.0,
+                        ),
+                        format!(
+                            "environment({}/{}) @ {} : view : {}",
+                            owner.account_email.as_str(),
+                            app_1.name.0,
+                            grantee.account_email.as_str(),
+                            env_1b.name.0,
+                        ),
+                    ],
                     lower_negative: Vec::new(),
                     upper_positive: Vec::new(),
                     upper_negative: Vec::new(),
@@ -365,17 +373,15 @@ async fn list_visible_environments_shows_owned_and_shared(
     assert!(grantee_env_ids.contains(&env_1b.id));
     assert!(!grantee_env_ids.contains(&env_2a.id));
 
-    // A single-environment grant is not enough for the application-scoped listing endpoint.
-    // Partial listing is intentionally handled by list_visible_environments instead.
-    let list_application_result = client_grantee
+    // The application-scoped listing endpoint returns only environments visible to the caller.
+    let listed_env_ids = client_grantee
         .list_application_environments(&app_1.id.0)
-        .await;
-    assert_matches!(
-        list_application_result,
-        Err(golem_client::Error::Item(
-            RegistryServiceListApplicationEnvironmentsError::Error404(_)
-        ))
-    );
+        .await?
+        .values
+        .into_iter()
+        .map(|env| env.id)
+        .collect::<HashSet<_>>();
+    assert_eq!(listed_env_ids, HashSet::from_iter([env_1b.id]));
 
     Ok(())
 }

--- a/integration-tests/tests/api/environment_plugin_grants.rs
+++ b/integration-tests/tests/api/environment_plugin_grants.rs
@@ -194,7 +194,7 @@ async fn can_grant_plugin_to_shared_env(deps: &EnvBasedTestDependencies) -> anyh
     // both users can see the plugin grant when getting by id
     for client in [&client_1, &client_2] {
         let fetched = client
-            .get_environment_plugin_grant(&plugin_grant.id.0, Some(false))
+            .get_environment_plugin_grant(&plugin_grant.id.0)
             .await?;
 
         assert_eq!(fetched.id, plugin_grant.id);
@@ -238,7 +238,7 @@ async fn can_grant_plugin_to_shared_env(deps: &EnvBasedTestDependencies) -> anyh
     // both users cannot get the plugin grant by id anymore
     for client in [&client_1, &client_2] {
         let result = client
-            .get_environment_plugin_grant(&plugin_grant.id.0, Some(false))
+            .get_environment_plugin_grant(&plugin_grant.id.0)
             .await;
         assert!(matches!(
             result,
@@ -246,18 +246,6 @@ async fn can_grant_plugin_to_shared_env(deps: &EnvBasedTestDependencies) -> anyh
                 RegistryServiceGetEnvironmentPluginGrantError::Error404(_)
             ))
         ));
-    }
-
-    // both users can see the plugin grant when explicitly fetching deleted
-    for client in [&client_1, &client_2] {
-        let fetched = client
-            .get_environment_plugin_grant(&plugin_grant.id.0, Some(true))
-            .await?;
-
-        assert_eq!(fetched.id, plugin_grant.id);
-        assert_eq!(fetched.environment_id, shared_env.id);
-        assert_eq!(fetched.plugin.id, plugin.id);
-        assert_eq!(fetched.plugin_account.id, user_1.account_id);
     }
 
     Ok(())
@@ -400,7 +388,7 @@ async fn member_of_env_cannot_see_plugin_or_plugin_component(
     // But can see it via the grant
     {
         let fetched = client_2
-            .get_environment_plugin_grant(&plugin_grant.id.0, Some(false))
+            .get_environment_plugin_grant(&plugin_grant.id.0)
             .await?;
 
         assert_eq!(fetched.plugin.id, plugin.id);
@@ -692,188 +680,6 @@ async fn shared_user_cannot_list_grants_after_share_revoked(
 
 #[test]
 #[tracing::instrument]
-async fn environment_owner_can_fetch_deleted_grant_with_include_deleted(
-    deps: &EnvBasedTestDependencies,
-) -> anyhow::Result<()> {
-    let owner = deps.user().await?;
-    let client_owner = owner.registry_service_client().await;
-
-    let (_, env) = owner.app_and_env().await?;
-    let component = owner
-        .component(&env.id, "oplog_processor_release")
-        .store()
-        .await?;
-
-    let plugin = client_owner
-        .create_plugin(
-            &owner.account_id.0,
-            &PluginRegistrationCreation {
-                name: "plugin".into(),
-                version: "1.0.0".into(),
-                description: "desc".into(),
-                icon: Base64(vec![]),
-                homepage: "https://golem.cloud".into(),
-                spec: PluginSpecDto::OplogProcessor(OplogProcessorPluginSpec {
-                    component_id: component.id,
-                    component_revision: component.revision,
-                }),
-            },
-        )
-        .await?;
-
-    let grant = client_owner
-        .create_environment_plugin_grant(
-            &env.id.0,
-            &EnvironmentPluginGrantCreation {
-                plugin_registration_id: plugin.id,
-            },
-        )
-        .await?;
-
-    client_owner
-        .delete_environment_plugin_grant(&grant.id.0)
-        .await?;
-
-    let fetched = client_owner
-        .get_environment_plugin_grant(&grant.id.0, Some(true))
-        .await?;
-
-    assert_eq!(fetched.id, grant.id);
-    Ok(())
-}
-
-#[test]
-#[tracing::instrument]
-async fn shared_user_can_fetch_deleted_grant_with_include_deleted(
-    deps: &EnvBasedTestDependencies,
-) -> anyhow::Result<()> {
-    let owner = deps.user().await?;
-    let shared = deps.user().await?;
-
-    let client_owner = owner.registry_service_client().await;
-    let client_shared = shared.registry_service_client().await;
-
-    let (_, env) = owner.app_and_env().await?;
-    create_permission_share(
-        &client_owner,
-        owner.account_id,
-        shared.account_email.clone(),
-        "fetch-deleted-grant-access",
-        vec![
-            environment_view_grant(
-                owner.account_email.as_str(),
-                &env.application_name.0,
-                &env.name.0,
-                shared.account_email.as_str(),
-            ),
-            environment_plugin_grant_grant(
-                owner.account_email.as_str(),
-                &env.application_name.0,
-                &env.name.0,
-                shared.account_email.as_str(),
-                "view",
-            ),
-        ],
-    )
-    .await?;
-
-    let component = owner
-        .component(&env.id, "oplog_processor_release")
-        .store()
-        .await?;
-    let plugin = client_owner
-        .create_plugin(
-            &owner.account_id.0,
-            &PluginRegistrationCreation {
-                name: "plugin".into(),
-                version: "1.0.0".into(),
-                description: "desc".into(),
-                icon: Base64(vec![]),
-                homepage: "https://golem.cloud".into(),
-                spec: PluginSpecDto::OplogProcessor(OplogProcessorPluginSpec {
-                    component_id: component.id,
-                    component_revision: component.revision,
-                }),
-            },
-        )
-        .await?;
-
-    let grant = client_owner
-        .create_environment_plugin_grant(
-            &env.id.0,
-            &EnvironmentPluginGrantCreation {
-                plugin_registration_id: plugin.id,
-            },
-        )
-        .await?;
-
-    client_owner
-        .delete_environment_plugin_grant(&grant.id.0)
-        .await?;
-
-    let fetched = client_shared
-        .get_environment_plugin_grant(&grant.id.0, Some(true))
-        .await?;
-    assert_eq!(fetched.id, grant.id);
-
-    Ok(())
-}
-
-#[test]
-#[tracing::instrument]
-async fn fetch_deleted_grant_with_deleted_plugin_and_account(
-    deps: &EnvBasedTestDependencies,
-) -> anyhow::Result<()> {
-    let owner = deps.user().await?;
-    let client_owner = owner.registry_service_client().await;
-
-    let (_, env) = owner.app_and_env().await?;
-    let component = owner
-        .component(&env.id, "oplog_processor_release")
-        .store()
-        .await?;
-
-    let plugin = client_owner
-        .create_plugin(
-            &owner.account_id.0,
-            &PluginRegistrationCreation {
-                name: "plugin".into(),
-                version: "1.0.0".into(),
-                description: "desc".into(),
-                icon: Base64(vec![]),
-                homepage: "https://golem.cloud".into(),
-                spec: PluginSpecDto::OplogProcessor(OplogProcessorPluginSpec {
-                    component_id: component.id,
-                    component_revision: component.revision,
-                }),
-            },
-        )
-        .await?;
-
-    let grant = client_owner
-        .create_environment_plugin_grant(
-            &env.id.0,
-            &EnvironmentPluginGrantCreation {
-                plugin_registration_id: plugin.id,
-            },
-        )
-        .await?;
-
-    client_owner.delete_plugin(&plugin.id.0).await?;
-
-    let fetched = client_owner
-        .get_environment_plugin_grant(&grant.id.0, Some(true))
-        .await?;
-
-    assert_eq!(fetched.id, grant.id);
-    assert_eq!(fetched.plugin.id, plugin.id);
-    assert_eq!(fetched.plugin_account.id, owner.account_id);
-
-    Ok(())
-}
-
-#[test]
-#[tracing::instrument]
 async fn revoked_user_cannot_fetch_grant(deps: &EnvBasedTestDependencies) -> anyhow::Result<()> {
     let owner = deps.user().await?;
     let revoked_user = deps.user().await?;
@@ -939,18 +745,15 @@ async fn revoked_user_cannot_fetch_grant(deps: &EnvBasedTestDependencies) -> any
         .delete_permission_share(&permission_share.id.0, permission_share.revision.into())
         .await?;
 
-    for include_deleted in [false, true] {
-        let result = client_revoked
-            .get_environment_plugin_grant(&grant.id.0, Some(include_deleted))
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(golem_client::Error::Item(
-                RegistryServiceGetEnvironmentPluginGrantError::Error404(_)
-            ))
-        ));
-    }
+    let result = client_revoked
+        .get_environment_plugin_grant(&grant.id.0)
+        .await;
+    assert!(matches!(
+        result,
+        Err(golem_client::Error::Item(
+            RegistryServiceGetEnvironmentPluginGrantError::Error404(_)
+        ))
+    ));
 
     Ok(())
 }

--- a/integration-tests/tests/api/permission_share.rs
+++ b/integration-tests/tests/api/permission_share.rs
@@ -48,7 +48,8 @@ async fn create_list_update_and_delete_permission_share(
         target_account_email: target.account_email.clone(),
         name: PermissionShareName("team-access".to_string()),
         data: share_data(&format!(
-            "application(owner) @ {} : view : shop",
+            "application({}) @ {} : view : shop",
+            owner.account_email.as_str(),
             target.account_email.as_str()
         )),
     };
@@ -93,7 +94,10 @@ async fn create_list_update_and_delete_permission_share(
     let update = PermissionShareUpdate {
         current_revision: share.revision,
         name: PermissionShareName("team-access-renamed".to_string()),
-        data: share_data("application(owner) @ * : create : *"),
+        data: share_data(&format!(
+            "application({}) @ * : create : *",
+            owner.account_email.as_str()
+        )),
     };
 
     let updated = client.update_permission_share(&share.id.0, &update).await?;
@@ -137,7 +141,10 @@ async fn permission_share_names_are_unique_per_owner(
     let creation = PermissionShareCreation {
         target_account_email: target_1.account_email.clone(),
         name: PermissionShareName("shared-name".to_string()),
-        data: share_data("application(owner) @ * : view : shop"),
+        data: share_data(&format!(
+            "application({}) @ * : view : shop",
+            owner.account_email.as_str()
+        )),
     };
 
     client
@@ -147,7 +154,10 @@ async fn permission_share_names_are_unique_per_owner(
     let duplicate = PermissionShareCreation {
         target_account_email: target_2.account_email.clone(),
         name: creation.name.clone(),
-        data: share_data("application(owner) @ * : create : *"),
+        data: share_data(&format!(
+            "application({}) @ * : create : *",
+            owner.account_email.as_str()
+        )),
     };
 
     let result = client
@@ -178,7 +188,8 @@ async fn permission_share_rejects_third_party_recipient(
         target_account_email: target.account_email.clone(),
         name: PermissionShareName("bad-recipient".to_string()),
         data: share_data(&format!(
-            "application(owner) @ {} : view : shop",
+            "application({}) @ {} : view : shop",
+            owner.account_email.as_str(),
             third_party.account_email.as_str()
         )),
     };
@@ -191,6 +202,41 @@ async fn permission_share_rejects_third_party_recipient(
         result,
         Err(golem_client::Error::Item(
             RegistryServiceCreatePermissionShareError::Error400(_)
+        ))
+    ));
+
+    Ok(())
+}
+
+#[test]
+#[tracing::instrument]
+async fn permission_share_rejects_non_derivable_grant(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let owner = deps.user().await?;
+    let other_owner = deps.user().await?;
+    let target = deps.user().await?;
+
+    let client = deps.registry_service().client(&owner.token).await;
+
+    let creation = PermissionShareCreation {
+        target_account_email: target.account_email.clone(),
+        name: PermissionShareName("bad-owner".to_string()),
+        data: share_data(&format!(
+            "application({}) @ {} : view : shop",
+            other_owner.account_email.as_str(),
+            target.account_email.as_str()
+        )),
+    };
+
+    let result = client
+        .create_permission_share(&owner.account_id.0, &creation)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(golem_client::Error::Item(
+            RegistryServiceCreatePermissionShareError::Error403(_)
         ))
     ));
 

--- a/openapi/golem-registry-service.yaml
+++ b/openapi/golem-registry-service.yaml
@@ -2713,14 +2713,6 @@ paths:
         required: true
         deprecated: false
         explode: true
-      - name: include_deleted
-        schema:
-          type: boolean
-          default: false
-        in: query
-        required: false
-        deprecated: false
-        explode: true
       responses:
         '200':
           description: ''

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -4674,14 +4674,6 @@ paths:
           format: uuid
         explode: true
         style: simple
-      - in: query
-        name: include_deleted
-        deprecated: false
-        schema:
-          default: false
-          type: boolean
-        explode: true
-        style: form
       responses:
         '200':
           description: ''


### PR DESCRIPTION
Flows I tried to go for:

get by id:
* read entity + all joined, non-deleted parent entities
* 404 on permission denied

get by name (e.g. /envs/:env_id/components/:component_name):
* read parent using get by id
* 404 on parent not found (which includes denied due to the rules in get by id)
* check permission to access child, 404 on denied
* fetch child without joining parent data
* project into domain model using parent data fetched in (1)

get fixed subresource (e.g. /accounts/:account_id/plan):
* read parent using get by id
* 404 on parent not found (which includes denied due to the rules in get by id)
* check permission to access child, 403 on not found
* fetch child without joining parent data
* project into domain model using parent data fetched in (1)

list subresources (e.g. /accounts/:account_id/applications):
* read parent using get by id
* 404 on parent not found (which includes denied due to the rules in get by id)
* fetch all children without joining parent data
* filter fetched children using auth, skip filtered children
* project into domain model using parent data fetched in (1)

There are few exceptions to this:
* list_visible_environments breaks the usual hierarchy and is implemented by compiling a filter down to sql. That is reasonably tested and works, though I might clean up the compilation / sql later
* the various get agent types. These pass all of our current tests, but I'm not yet 100% sure how I want to handle deleted parents / joining with parent data here. I'll do another pass on these separately and review what is should be done there
