### PR TITLE
docs: fix README grammar in Golem description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Golem Logo](golem-logo-black.jpg)
 
-This repository contains Golem - a set of services enable you to run WebAssembly components in a distributed cloud environment. Golem supports building agents in Rust, TypeScript, Scala, and MoonBit.
+This repository contains Golem - a set of services that enable you to run WebAssembly components in a distributed cloud environment. Golem supports building agents in Rust, TypeScript, Scala, and MoonBit.
 
 ## Getting started with Golem
 See [Golem Cloud](https://golem.cloud) for more information, and [the Golem Developer Documentation](https://learn.golem.cloud) for getting started.


### PR DESCRIPTION
## Summary
- Fix a small grammar issue in the README introduction (`services enable` -> `services that enable`).

## Testing
- Documentation-only change; no tests run.