### PR TITLE
Trap-based retry delay and interruption handling fixes

### DIFF
--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -104,7 +104,9 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
     /// - Suspending the worker
     /// - Process the retry decision
     pub async fn run(&mut self) {
-        loop {
+        let mut deferred_wakeups = VecDeque::new();
+
+        'outer: loop {
             debug!("Invocation queue loop creating the instance");
 
             let (instance, store) = if let Some((instance, store)) = self.create_instance().await {
@@ -144,6 +146,7 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                     idle_snapshot_task: None,
                     concurrent_agent_permit: &mut self.concurrent_agent_permit,
                     resume_replay_pending: self.resume_replay_pending.clone(),
+                    deferred_wakeups: &mut deferred_wakeups,
                 };
 
                 final_decision = inner_loop.run().await;
@@ -152,26 +155,13 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
             self.suspend_worker(&store).await;
 
             if let Some(kind) = final_interrupt {
-                store
-                    .lock()
-                    .await
-                    .data_mut()
-                    .on_invocation_failure("interrupted during retry", &TrapType::Interrupt(kind))
-                    .await;
+                self.record_retry_interrupt_failure(&store, kind).await;
             }
 
             match final_decision {
                 None | Some(RetryDecision::None) => {
                     debug!("Invocation queue loop notifying parent about being stopped");
-                    self.parent
-                        .stop_internal(
-                            true,
-                            None,
-                            FinalWorkerState::Unloaded {
-                                startup_failure: None,
-                            },
-                        )
-                        .await;
+                    self.stop_unloaded().await;
                     break;
                 }
                 Some(RetryDecision::TryStop(ts)) => {
@@ -182,15 +172,7 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                         continue;
                     } else {
                         debug!("Invocation queue loop notifying parent about being stopped");
-                        self.parent
-                            .stop_internal(
-                                true,
-                                None,
-                                FinalWorkerState::Unloaded {
-                                    startup_failure: None,
-                                },
-                            )
-                            .await;
+                        self.stop_unloaded().await;
                         break;
                     }
                 }
@@ -200,64 +182,59 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                 }
                 Some(RetryDecision::Delayed(delay)) => {
                     debug!("Invocation queue loop sleeping for {delay:?} for delayed restart");
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {
-                            debug!("Invocation queue loop restarting after delay");
-                            continue;
-                        }
-                        command = self.receiver.recv() => {
-                            if let Some((kind, decision)) = self.pending_interrupt().await {
-                                debug!(?decision, "Invocation queue loop interrupted during delayed retry");
-                                if !matches!(kind, InterruptKind::Restart | InterruptKind::Jump) {
-                                    store
-                                        .lock()
-                                        .await
-                                        .data_mut()
-                                        .on_invocation_failure("interrupted during retry", &TrapType::Interrupt(kind))
-                                        .await;
-                                }
-                                match decision {
-                                    RetryDecision::Immediate => continue,
-                                    RetryDecision::None => {
-                                        self.parent
-                                            .stop_internal(
-                                                true,
-                                                None,
-                                                FinalWorkerState::Unloaded {
-                                                    startup_failure: None,
-                                                },
-                                            )
-                                            .await;
-                                        break;
-                                    }
-                                    RetryDecision::Delayed(_) | RetryDecision::TryStop(_) | RetryDecision::ReacquirePermits => {
-                                        unreachable!("interrupt decisions are only immediate or none")
-                                    }
-                                }
+                    let sleep = tokio::time::sleep(delay);
+                    tokio::pin!(sleep);
+                    loop {
+                        tokio::select! {
+                            _ = &mut sleep => {
+                                debug!("Invocation queue loop restarting after delay");
+                                continue 'outer;
                             }
+                            command = self.receiver.recv() => {
+                                let command = match command {
+                                    Some(command) => command,
+                                    None => {
+                                        debug!("Invocation queue loop command channel closed during delayed retry");
+                                        self.stop_unloaded().await;
+                                        break 'outer;
+                                    }
+                                };
 
-                            match command {
-                                Some(WorkerCommand::Unblock) => {
-                                    debug!("Invocation queue loop woke up during delayed retry");
-                                    continue;
+                                if let Some((kind, decision)) = self.pending_interrupt().await {
+                                    debug!(?decision, "Invocation queue loop interrupted during delayed retry");
+                                    if !matches!(kind, InterruptKind::Restart | InterruptKind::Jump) {
+                                        self.record_retry_interrupt_failure(&store, kind).await;
+                                    }
+                                    match decision {
+                                        RetryDecision::Immediate => {
+                                            Self::defer_wakeup(&mut deferred_wakeups, command);
+                                            continue 'outer;
+                                        }
+                                        RetryDecision::None => {
+                                            self.stop_unloaded().await;
+                                            break 'outer;
+                                        }
+                                        RetryDecision::Delayed(_) | RetryDecision::TryStop(_) | RetryDecision::ReacquirePermits => {
+                                            unreachable!("interrupt decisions are only immediate or none")
+                                        }
+                                    }
                                 }
-                                Some(WorkerCommand::ResumeReplay) => {
-                                    self.resume_replay_pending.store(false, Ordering::Release);
-                                    debug!("Invocation queue loop woke up for resume replay during delayed retry");
-                                    continue;
-                                }
-                                None => {
-                                    debug!("Invocation queue loop command channel closed during delayed retry");
-                                    self.parent
-                                        .stop_internal(
-                                            true,
-                                            None,
-                                            FinalWorkerState::Unloaded {
-                                                startup_failure: None,
-                                            },
-                                        )
-                                        .await;
-                                    break;
+
+                                match command {
+                                    WorkerCommand::InternalStatusChanged => {
+                                        debug!("Invocation queue loop ignored internal status change during delayed retry");
+                                        continue;
+                                    }
+                                    WorkerCommand::WorkAvailable => {
+                                        debug!("Invocation queue loop woke up during delayed retry");
+                                        Self::defer_wakeup(&mut deferred_wakeups, WorkerCommand::WorkAvailable);
+                                        continue 'outer;
+                                    }
+                                    WorkerCommand::ResumeReplay => {
+                                        debug!("Invocation queue loop woke up for resume replay during delayed retry");
+                                        Self::defer_wakeup(&mut deferred_wakeups, WorkerCommand::ResumeReplay);
+                                        continue 'outer;
+                                    }
                                 }
                             }
                         }
@@ -278,6 +255,43 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                     break;
                 }
             }
+        }
+    }
+
+    async fn stop_unloaded(&self) {
+        self.parent
+            .stop_internal(
+                true,
+                None,
+                FinalWorkerState::Unloaded {
+                    startup_failure: None,
+                },
+            )
+            .await;
+    }
+
+    async fn record_retry_interrupt_failure(&self, store: &Mutex<Store<Ctx>>, kind: InterruptKind) {
+        store
+            .lock()
+            .await
+            .data_mut()
+            .on_invocation_failure("interrupted during retry", &TrapType::Interrupt(kind))
+            .await;
+    }
+
+    fn defer_wakeup(deferred_wakeups: &mut VecDeque<WorkerCommand>, command: WorkerCommand) {
+        let already_deferred = match command {
+            WorkerCommand::WorkAvailable => deferred_wakeups
+                .iter()
+                .any(|command| matches!(command, WorkerCommand::WorkAvailable)),
+            WorkerCommand::ResumeReplay => deferred_wakeups
+                .iter()
+                .any(|command| matches!(command, WorkerCommand::ResumeReplay)),
+            WorkerCommand::InternalStatusChanged => true,
+        };
+
+        if !already_deferred {
+            deferred_wakeups.push_back(command);
         }
     }
 
@@ -402,6 +416,7 @@ struct InnerInvocationLoop<'a, Ctx: WorkerCtx> {
     /// permit back to the semaphore pool) and re-acquired on wake.
     concurrent_agent_permit: &'a mut Option<crate::services::active_workers::ConcurrentAgentPermit>,
     resume_replay_pending: Arc<AtomicBool>,
+    deferred_wakeups: &'a mut VecDeque<WorkerCommand>,
 }
 
 impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
@@ -428,13 +443,13 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
         // from the same account can start without evicting this one.
         self.waiting_for_command.store(true, Ordering::Release);
         self.release_concurrent_agent_permit();
-        while let Some(cmd) = self.next_wakeup().await {
+        while let Some(cmd) = self.next_wakeup_or_initial().await {
             // Waking from idle: re-acquire the concurrent-agent permit before
             // processing any commands.
             self.acquire_concurrent_agent_permit().await;
             self.waiting_for_command.store(false, Ordering::Release);
             let outcome = match cmd {
-                WorkerCommand::Unblock => {
+                WorkerCommand::WorkAvailable | WorkerCommand::InternalStatusChanged => {
                     loop {
                         if let Some(kind) = self.interrupt_signal.lock().await.take() {
                             break self.interrupt(kind).await;
@@ -495,6 +510,13 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
         final_decision
     }
 
+    async fn next_wakeup_or_initial(&mut self) -> Option<WorkerCommand> {
+        match self.deferred_wakeups.pop_front() {
+            Some(command) => Some(command),
+            None => self.next_wakeup().await,
+        }
+    }
+
     /// Release the concurrent-agent permit back to the semaphore pool.
     /// Called when the agent enters idle state. No-op if already released.
     fn release_concurrent_agent_permit(&mut self) {
@@ -537,7 +559,7 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
 
                     match self.receiver.try_recv() {
                         Ok(cmd) => Some(cmd),
-                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Some(WorkerCommand::Unblock),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Some(WorkerCommand::WorkAvailable),
                         Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => None,
                     }
                 }

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -1189,8 +1189,12 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         let instance_guard = self.lock_non_stopping_worker().await;
         self.bump_read_only_cache_epoch();
         let entry = OplogEntry::pending_update(update_description.clone());
-        self.add_and_commit_oplog_internal(&instance_guard, entry)
-            .await;
+        self.add_and_commit_oplog_internal(
+            &instance_guard,
+            entry,
+            Some(WorkerCommand::WorkAvailable),
+        )
+        .await;
         drop(instance_guard);
     }
 
@@ -1313,18 +1317,12 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     // should only be called from invocation loop
     pub async fn store_invocation_failure(&self, key: &IdempotencyKey, trap_type: &TrapType) {
-        let pending = self.pending_invocations().await;
-        let keys_to_fail = [
-            vec![key],
-            pending
-                .iter()
-                .filter_map(|entry| entry.idempotency_key())
-                .collect(),
-        ]
-        .concat();
+        let status = self.last_known_status.read().await.clone();
+        let keys_to_fail = invocation_keys_to_fail(&status, Some(key));
+        let stderr = self.worker_event_service.get_last_invocation_errors();
+        let golem_error = trap_type.as_golem_error(&stderr);
         let mut map = self.invocation_results.write().await;
-        for key in keys_to_fail {
-            let stderr = self.worker_event_service.get_last_invocation_errors();
+        for key in &keys_to_fail {
             map.insert(
                 key.clone(),
                 InvocationResult::Cached {
@@ -1334,12 +1332,11 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                     }),
                 },
             );
-            let golem_error = trap_type.as_golem_error(&stderr);
-            if let Some(golem_error) = golem_error {
+            if let Some(golem_error) = &golem_error {
                 self.events().publish(Event::InvocationCompleted {
                     agent_id: self.owned_agent_id.agent_id(),
                     idempotency_key: key.clone(),
-                    result: Err(golem_error),
+                    result: Err(golem_error.clone()),
                 });
             }
         }
@@ -1777,7 +1774,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 | read_only_cache::InvocationEffect::UnknownAssumeMutating => None,
             };
 
-            self.add_and_commit_oplog_internal(&instance_guard, entry)
+            self.add_and_commit_oplog_internal(&instance_guard, entry, None)
                 .await;
 
             if let Some(idempotency_key) = timestamped_invocation.invocation.idempotency_key() {
@@ -1788,7 +1785,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             }
 
             if let WorkerInstance::Running(running) = &*instance_guard {
-                running.sender.send(WorkerCommand::Unblock).unwrap();
+                running.sender.send(WorkerCommand::WorkAvailable).unwrap();
             };
 
             drop(instance_guard);
@@ -1827,7 +1824,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         // - Worker is starting, it will process the request when it is started
 
         if let WorkerInstance::Running(running) = &*instance_guard {
-            running.sender.send(WorkerCommand::Unblock).unwrap();
+            running.sender.send(WorkerCommand::WorkAvailable).unwrap();
         };
 
         drop(instance_guard);
@@ -1859,7 +1856,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             .push_back(QueuedWorkerInvocation::ReadFile { path, sender });
 
         if let WorkerInstance::Running(running) = &*instance_guard {
-            running.sender.send(WorkerCommand::Unblock).unwrap();
+            running.sender.send(WorkerCommand::WorkAvailable).unwrap();
         };
 
         drop(instance_guard);
@@ -1888,7 +1885,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             .push_back(QueuedWorkerInvocation::AwaitReadyToProcessCommands { sender });
 
         if let WorkerInstance::Running(running) = &*instance_guard {
-            running.sender.send(WorkerCommand::Unblock).unwrap();
+            running.sender.send(WorkerCommand::WorkAvailable).unwrap();
         };
 
         drop(instance_guard);
@@ -1908,7 +1905,10 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         if changed {
             let instance_guard = self.instance.lock().await;
             if let WorkerInstance::Running(running) = &*instance_guard {
-                running.sender.send(WorkerCommand::Unblock).unwrap();
+                running
+                    .sender
+                    .send(WorkerCommand::InternalStatusChanged)
+                    .unwrap();
             };
         }
         result
@@ -1943,14 +1943,18 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         &self,
         instance_guard: &MutexGuard<'_, WorkerInstance>,
         entry: OplogEntry,
+        wakeup: Option<WorkerCommand>,
     ) -> OplogIndex {
         let result = self.add_to_oplog(entry).await;
         let (_, changed) = self
             .commit_oplog_and_update_state_internal(CommitLevel::Always)
             .await;
 
-        if changed && let WorkerInstance::Running(running) = &**instance_guard {
-            running.sender.send(WorkerCommand::Unblock).unwrap();
+        if changed
+            && let Some(wakeup) = wakeup
+            && let WorkerInstance::Running(running) = &**instance_guard
+        {
+            running.sender.send(wakeup).unwrap();
         };
 
         result
@@ -1973,6 +1977,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self.add_and_commit_oplog_internal(
             &instance_guard,
             OplogEntry::activate_plugin(plugin_grant_id),
+            Some(WorkerCommand::WorkAvailable),
         )
         .await;
 
@@ -1997,6 +2002,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self.add_and_commit_oplog_internal(
             &instance_guard,
             OplogEntry::deactivate_plugin(plugin_grant_id),
+            Some(WorkerCommand::WorkAvailable),
         )
         .await;
 
@@ -2047,6 +2053,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self.add_and_commit_oplog_internal(
             &instance_guard,
             OplogEntry::cancel_pending_invocation(idempotency_key),
+            Some(WorkerCommand::WorkAvailable),
         )
         .await;
 
@@ -2118,12 +2125,12 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             self.bump_read_only_cache_epoch();
 
             // this commit will detach the worker status, immediately reattach it so we see the up to date status.
-            self.add_and_commit_oplog_internal(&instance_guard, OplogEntry::revert(region))
+            self.add_and_commit_oplog_internal(&instance_guard, OplogEntry::revert(region), None)
                 .await;
             self.reattach_worker_status().await;
 
             if let WorkerInstance::Running(running) = &*instance_guard {
-                running.sender.send(WorkerCommand::Unblock).unwrap();
+                running.sender.send(WorkerCommand::WorkAvailable).unwrap();
             };
             drop(instance_guard);
             Ok(())
@@ -2392,18 +2399,8 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             }
         }
 
-        // Collect all idempotency keys to fail: pending invocations + currently running invocation
         let status = self.last_known_status.read().await.clone();
-        let mut keys_to_fail: Vec<IdempotencyKey> = status
-            .pending_invocations
-            .iter()
-            .filter_map(|inv| inv.idempotency_key().cloned())
-            .collect();
-        if let Some(current_key) = &status.current_idempotency_key
-            && !keys_to_fail.contains(current_key)
-        {
-            keys_to_fail.push(current_key.clone());
-        }
+        let keys_to_fail = invocation_keys_to_fail(&status, None);
 
         let mut invocation_results = self.invocation_results.write().await;
         for idempotency_key in &keys_to_fail {
@@ -3244,7 +3241,7 @@ impl RunningWorker {
         oom_retry_count: u32,
     ) -> Self {
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-        sender.send(WorkerCommand::Unblock).unwrap();
+        sender.send(WorkerCommand::WorkAvailable).unwrap();
 
         let active_clone = queue.clone();
         let owned_agent_id_clone = owned_agent_id.clone();
@@ -3320,7 +3317,7 @@ impl RunningWorker {
 
     async fn interrupt(&self, kind: InterruptKind) {
         *self.interrupt_signal.lock().await = Some(kind);
-        let _ = self.sender.send(WorkerCommand::Unblock);
+        let _ = self.sender.send(WorkerCommand::WorkAvailable);
     }
 
     async fn create_instance<Ctx: WorkerCtx>(
@@ -3940,9 +3937,39 @@ fn is_snapshot_capable_oplog_processor(
     metadata.has_oplog_processor() && metadata.has_save_snapshot() && metadata.has_load_snapshot()
 }
 
+fn invocation_keys_to_fail(
+    status: &AgentStatusRecord,
+    first_key: Option<&IdempotencyKey>,
+) -> Vec<IdempotencyKey> {
+    let mut keys = Vec::new();
+
+    if let Some(key) = first_key {
+        keys.push(key.clone());
+    }
+
+    for pending_key in status
+        .pending_invocations
+        .iter()
+        .filter_map(|entry| entry.idempotency_key())
+    {
+        if !keys.contains(pending_key) {
+            keys.push(pending_key.clone());
+        }
+    }
+
+    if let Some(current_key) = &status.current_idempotency_key
+        && !keys.contains(current_key)
+    {
+        keys.push(current_key.clone());
+    }
+
+    keys
+}
+
 #[derive(Debug)]
 enum WorkerCommand {
-    Unblock,
+    WorkAvailable,
+    InternalStatusChanged,
     ResumeReplay,
 }
 


### PR DESCRIPTION
This fixes two issues I've discovered by looking at a flaky worker-executor test:

- The invocation loop, when waiting for a delayed retry attempt was cancelling the retry in case an explicit incoming request comes to the agent, forcing it to replay+retry immediately. This was intentional (and like this since the beginning) but now other recent changes made it awake just by updating the agent status asynchronously, which basically made the retry itself cancel the retry delay. Now it distinguishes multiple unblock reasons
- When interrupting during an outer retry delay, the idempotency keys to be notified about the interrupt were not always containing all of the ones needed.