### PR TITLE
website: add Google Ads and Contentsquare tracking tags

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -40,6 +40,29 @@ const ogImage = new URL("/og-image.jpg", Astro.site).href;
     <meta name="twitter:image" content={ogImage} />
 
     <title>{pageTitle}</title>
+
+    <!-- Google tag (gtag.js) -->
+    <script
+      is:inline
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=AW-18172281472"
+    ></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "AW-18172281472");
+    </script>
+
+    <!-- Contentsquare tag -->
+    <script
+      is:inline
+      async
+      src="https://t.contentsquare.net/uxa/ed8fdf824ed4d.js"
+    ></script>
   </head>
   <body>
     <slot />

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -23,6 +23,10 @@ const ogImage = new URL("/og-image.jpg", Astro.site).href;
     <link rel="canonical" href={canonicalURL} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
+    <meta
+      name="google-site-verification"
+      content="KAcSFOLtxxv0lh8e1l9qZuyIkzGg9CpWHnfeUH5UNrk"
+    />
     <meta name="description" content={pageDescription} />
 
     <!-- Open Graph -->


### PR DESCRIPTION
## Summary
- Adds the Google gtag.js snippet (AW-18172281472) to `BaseLayout.astro`
- Adds the Contentsquare tracking snippet (ed8fdf824ed4d) to `BaseLayout.astro`
- Both load site-wide since `BlogPostLayout` and `ContentPage` wrap `BaseLayout`
- Uses `is:inline` on all script tags so Astro doesn't bundle them as ES modules

## Test plan
- [x] `npm run build` succeeds
- [x] Verified both tags render unmangled in built HTML output