### PR TITLE
Fix oplog index race behind checkout_v2_regressions flakiness

### DIFF
--- a/golem-worker-executor/src/durable_host/golem/v1x.rs
+++ b/golem-worker-executor/src/durable_host/golem/v1x.rs
@@ -325,8 +325,16 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         if self.state.snapshotting_mode.is_some() {
             Ok(self.state.current_oplog_index().await.into())
         } else if self.state.is_live() {
-            self.state.oplog.add(OplogEntry::no_op()).await;
-            let marker = self.state.current_oplog_index().await;
+            // Use the index returned by `add` — a concurrently running host task (a durable
+            // call's terminal write, a drop-event `Cancelled`, a log hint entry) may append
+            // between this `add` and a subsequent `current_oplog_index` read, so re-reading the
+            // tip would nondeterministically point past the `NoOp` entry. Debugging sessions
+            // discard writes and return `NONE` from `add`; fall back to the session's replay
+            // target there so the guest never observes an invalid index.
+            let marker = match self.state.oplog.add(OplogEntry::no_op()).await {
+                OplogIndex::NONE => self.state.current_oplog_index().await,
+                index => index,
+            };
             // This `NoOp` index is the realistic `set_oplog_index` target; pin the mid-invocation
             // checkpoint watermark to the earliest one so a checkpoint at `<= marker` survives a
             // later jump back to it. (No checkpoint is taken here — there is no commit at this
@@ -443,11 +451,23 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             let next_idempotency_key_oplog_index = self
                 .state
                 .current_atomic_region_idempotency_key_oplog_index();
-            self.state
+            // Use the index returned by `add` — a concurrently running host task (a durable
+            // call's terminal write, a drop-event `Cancelled`, a log hint entry) may append
+            // between this `add` and a subsequent `current_oplog_index` read. Reading the tip
+            // afterwards would record a begin index past the `BeginAtomicRegion` entry, making
+            // `Error.retry_from` diverge from the persisted region marker and breaking the
+            // retry-budget grouping keyed on it. Debugging sessions discard writes and return
+            // `NONE` from `add`; fall back to the session's replay target there, matching the
+            // index the guest observed before.
+            let begin_index = match self
+                .state
                 .oplog
                 .add(OplogEntry::begin_atomic_region())
-                .await;
-            let begin_index = self.state.current_oplog_index().await;
+                .await
+            {
+                OplogIndex::NONE => self.state.current_oplog_index().await,
+                index => index,
+            };
             let next_idempotency_key_oplog_index =
                 next_idempotency_key_oplog_index.unwrap_or_else(|| begin_index.next());
             self.state


### PR DESCRIPTION
Fixes the `checkout_v2_regressions` flakiness observed on CI since the WASI P3 migration (#3638).

## Root cause

The flakiness is a TOCTOU race in `mark_begin_operation` (and the same pattern in `get_oplog_index`) in `golem-worker-executor/src/durable_host/golem/v1x.rs`: the code appended `BeginAtomicRegion` with `oplog.add(...)` but discarded the returned index, then re-read `current_oplog_index()` in a *separate* await to learn "the index of the entry I just wrote".

Before the P3 migration that was safe — nothing else appended to the oplog during a guest call. Since P3, background host tasks append concurrently:

- durable-call terminal `End` writes (`durable_host/concurrent/call.rs`),
- drop-event `Cancelled` entries for aborted calls (`durable_host/concurrent/drop_events.rs`),
- log hint entries (`durable_host/logging/policy.rs`).

When one of those lands between the two awaits, the recorded atomic-region begin index is off by one — exactly what the CI failure showed (`Error.retry_from=OplogIndex(208)` while the `BeginAtomicRegion` entry was at 207). The S2 scenario (an `AbortController` aborting a hung fetch, whose `Cancelled` write races the next retry's `atomically()` begin) hits the window most often.

One wrong begin index explains all four flaky tests:

- **S2**: the persisted `Error.retry_from` diverges from the `BeginAtomicRegion` index, failing the test's oplog assertion; it also breaks retry-budget grouping, which is keyed on `retry_from`.
- **S1/S3/S4**: `EndAtomicRegion { begin_index }` records the shifted index, so on any later replay `is_end_atomic_region` never matches the real `BeginAtomicRegion` → the region looks uncommitted → the whole atomic block is re-executed live, re-issuing the HTTP calls and violating the "each endpoint succeeds exactly once" assertions.

## Fix

`Oplog::add` already assigns and returns the entry's index atomically (serialized job queue in `services/oplog/primary.rs`), so both sites now use that return value directly.

One subtlety: the debugging service's `DebugOplog::add` discards writes and returns `OplogIndex::NONE`, so both sites fall back to `current_oplog_index()` on `NONE` — preserving the exact pre-change behavior for debug sessions (previously the guest received the playback-target index there, and returning `NONE`/0 would have leaked an invalid index to guest code).

## Verification

- `cargo test -p golem-worker-executor --test integration -- checkout_v2` — all 4 tests green, run twice.
- `cargo test -p golem-worker-executor --test integration -- transactions::` — all 13 tests covering atomic regions, jumps, and oplog-index manipulation pass.
- `cargo fmt --check` and `clippy` clean.

Being a race, local green isn't absolute proof, but the mechanism matches the CI failure signature exactly and the fix removes the window entirely. No test suites were modified.
