### PR TITLE
Scope spans to operations and link handed-off work

### DIFF
--- a/.agents/skills/investigating-benchmark-performance/SKILL.md
+++ b/.agents/skills/investigating-benchmark-performance/SKILL.md
@@ -65,6 +65,11 @@ This produces the binary at `target/benchmarks/benchmarks`.
 
 The benchmarks binary is at `integration-tests/src/benchmarks/all.rs` and is built as the `benchmarks` binary from the `integration-tests` crate. It has a built-in `--otlp` flag that configures all spawned Golem services to export traces.
 
+`--otlp` exports at `info`. To change what is exported, set `GOLEM_OTLP_FILTER` — it takes
+`RUST_LOG` syntax and is used exactly as written, so `GOLEM_OTLP_FILTER=info,h2=off` quietens
+one crate and `debug` widens everything. The filter in force is logged at startup as
+`otlp_filter`. See the `investigating-executor-performance` skill for the target names.
+
 ### Running a single benchmark
 
 The CLI takes the benchmark name as a positional argument, followed by the `spawned` subcommand (which tells it to spawn services locally). The `--build-target` defaults to `target/release` which is the correct path for the service binaries.
@@ -280,7 +285,10 @@ Long-lived spans from background loops can dominate the trace data. Filter them 
 python3 -c "
 import json
 data = json.load(open('tmp/traces.json'))
-NOISE = {'Oplog background transfer', 'Scheduler loop', 'broadcast loop'}
+NOISE = {'oplog_background_transfer', 'ephemeral_oplog_background_transfer',
+         'oplog_forwarding_flush', 'oplog_forwarding_threshold_flush',
+         'scheduler_tick', 'quota_renewal',
+         'resource_limits_batch_update', 'agent_status_flush_sweep'}
 clean = [t for t in data['data']
          if not any(s['operationName'] in NOISE for s in t['spans'])]
 print(f'Total: {len(data[\"data\"])}, After filtering noise: {len(clean)}')

--- a/.agents/skills/investigating-executor-performance/SKILL.md
+++ b/.agents/skills/investigating-executor-performance/SKILL.md
@@ -35,6 +35,7 @@ GOLEM__TRACING__OTLP__ENABLED=true \
 GOLEM__TRACING__OTLP__HOST=localhost \
 GOLEM__TRACING__OTLP__PORT=4318 \
 GOLEM__TRACING__OTLP__SERVICE_NAME=worker-executor-tests \
+GOLEM_OTLP_FILTER=info \
 RUST_LOG=info,h2=warn,hyper=warn \
 cargo make worker-executor-tests-group1
 ```
@@ -46,6 +47,7 @@ GOLEM__TRACING__OTLP__ENABLED=true \
 GOLEM__TRACING__OTLP__HOST=localhost \
 GOLEM__TRACING__OTLP__PORT=4318 \
 GOLEM__TRACING__OTLP__SERVICE_NAME=worker-executor-tests \
+GOLEM_OTLP_FILTER=info \
 RUST_LOG=info,h2=warn,hyper=warn \
 cargo test -p golem-worker-executor --test integration -- <test_name> --report-time --nocapture
 ```
@@ -58,6 +60,31 @@ TracingConfig::test_pretty_without_time("worker-executor-tests").with_env_overri
 ```
 
 The `.with_env_overrides()` call uses Figment to merge `GOLEM__*` env vars into the `TracingConfig`, which includes `OtlpConfig` (defined in `golem-common/src/tracing.rs`). Since worker-executor tests run in-process (not spawned as child processes), the OTLP config applies to the single test process directly.
+
+### Choosing what to export
+
+`GOLEM_OTLP_FILTER` is `RUST_LOG` syntax over the trace pipeline, and it is required:
+unset means `off`, so the four `GOLEM__TRACING__OTLP__*` variables on their own export
+nothing. It is separate from `RUST_LOG` because console verbosity and what is worth
+sending to a trace store are different questions.
+
+`info` is the level worth starting from: the spans bounding an operation — requests,
+invocations, worker admission, background loop ticks — are `info`, and the detail inside
+them is `debug`, so `debug` deepens a trace rather than changing what it is about.
+Anything less verbose than `info` exports nothing at all, since no span is emitted at
+`warn` or `error`.
+
+Two high-volume sources have targets of their own and can be turned up when you are
+chasing them specifically:
+
+| Target | What it is |
+|---|---|
+| `golem::plugin_log` | log output from oplog-processor plugin agents |
+| `golem::agent_rdbms` | SQL an agent runs against its own database |
+
+So `GOLEM_OTLP_FILTER=info,golem::agent_rdbms=debug` adds per-statement SQL without
+raising anything else. The filter actually in force is logged at startup as
+`otlp_filter`, alongside which variable it came from.
 
 ### Suppressing noise
 
@@ -166,9 +193,18 @@ for size, count in sorted(sizes.items()):
 "
 ```
 
-#### Detect single-span orphan traces
+#### Detect single-span traces
 
-Single-span traces often indicate missing context propagation — the span was created but not linked to a parent trace.
+Handed-off work is a linked root by design, so a single-span trace is usually expected
+rather than broken. The rule, rather than a list that goes stale: any span built with
+`related_span!` starts its own trace and carries a link back to whatever handed the work
+off. For example the invocation hand-off (`invocation_queue_pickup`), the retry tasks
+(`rpc_invoke_retry`, `http_request_retry`), the oplog transfer and flush spans, and every
+worker phase span (`create_instance`, `recover_instance_state`, `suspend_worker`,
+`resume_replay`, and the admission waits). Check the link, not the parent.
+
+What this is good for is spotting a span that is *neither* a linked root *nor* connected
+— that is a genuine propagation gap.
 
 ```python
 python3 -c "
@@ -179,7 +215,7 @@ orphans = Counter()
 for t in data['data']:
     if len(t['spans']) == 1:
         orphans[t['spans'][0]['operationName']] += 1
-print(f'Total single-span orphan traces: {sum(orphans.values())}')
+print(f'Total single-span traces: {sum(orphans.values())}')
 for op, count in orphans.most_common(15):
     print(f'{count:4d}  {op}')
 "
@@ -187,13 +223,16 @@ for op, count in orphans.most_common(15):
 
 #### Identify background noise traces
 
-Long-lived spans from background loops (e.g., "Oplog background transfer", "Scheduler loop") can dominate the trace data. Filter them out for focused analysis:
+Background-loop spans can dominate the trace data. Filter them out for focused analysis:
 
 ```python
 python3 -c "
 import json
 data = json.load(open('tmp/traces.json'))
-NOISE = {'Oplog background transfer', 'Scheduler loop', 'broadcast loop'}
+NOISE = {'oplog_background_transfer', 'ephemeral_oplog_background_transfer',
+         'oplog_forwarding_flush', 'oplog_forwarding_threshold_flush',
+         'scheduler_tick', 'quota_renewal',
+         'resource_limits_batch_update', 'agent_status_flush_sweep'}
 clean = [t for t in data['data']
          if not any(s['operationName'] in NOISE for s in t['spans'])]
 print(f'Total: {len(data[\"data\"])}, After filtering noise: {len(clean)}')
@@ -202,7 +241,8 @@ print(f'Total: {len(data[\"data\"])}, After filtering noise: {len(clean)}')
 
 ## Known Caveats
 
-- **Trace context propagation works end-to-end**: The `OtelGrpcLayer` on both client and server sides correctly injects/extracts `traceparent` headers. Test spans, gRPC client spans, and gRPC server handler spans (e.g., `invocation`, `replaying`) all appear in a single connected trace. If you see orphan traces, verify the `GOLEM__TRACING__OTLP__*` env vars are set — without them, the `tracing_opentelemetry` layer is not added to the subscriber, so spans have no OTel context and the propagator injects nothing.
+- **An invocation spans two traces, joined by a link**: the request side ends at `wait_for_invocation_result`, and the execution is the root of its own trace linked back to `enqueue_invocation`. That is deliberate — the worker runs the invocation independently and outlives the caller, so nesting would report a child outliving its parent. To follow one to the other, search on the `idempotency_key` both sides carry. gRPC client and server spans within a single service's request path do still connect normally via `traceparent`.
+- **Nothing exported at all**: check `GOLEM_OTLP_FILTER` first — unset means `off`, so the `GOLEM__TRACING__OTLP__*` variables on their own produce nothing. The effective filter is logged at startup as `otlp_filter`. If that looks right, then verify the `GOLEM__TRACING__OTLP__*` variables, without which the `tracing_opentelemetry` layer is never added to the subscriber.
 - **Span queue size (`OTEL_BSP_MAX_QUEUE_SIZE`)**: The `BatchSpanProcessor` has a default queue size of 2048 spans. Under high-throughput tests this queue can overflow, causing spans to be silently dropped. Set `OTEL_BSP_MAX_QUEUE_SIZE=65536` alongside the other env vars to avoid this. Example: `OTEL_BSP_MAX_QUEUE_SIZE=65536 GOLEM__TRACING__OTLP__ENABLED=true ... cargo test ...`.
 - **Background loop noise**: Long-lived background tasks create traces spanning the entire test duration (~90s). These are not performance issues but can obscure real test traces.
 - **Fresh Jaeger**: Always restart Jaeger with `docker compose down && docker compose up -d` before a new investigation to avoid mixing traces from different runs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4329,6 +4329,7 @@ dependencies = [
  "tonic-reflection",
  "tonic-tracing-opentelemetry",
  "tracing",
+ "tracing-subscriber",
  "try_match",
  "tryhard",
  "url",

--- a/golem-common/src/cache.rs
+++ b/golem-common/src/cache.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
-use tracing::Instrument;
 
 use crate::metrics::caching::{
     record_cache_capacity, record_cache_eviction, record_cache_hit, record_cache_miss,
@@ -440,8 +439,12 @@ impl<
                             if eviction_needed {
                                 self_clone.evict().await;
                             }
-                        }
-                        .in_current_span(),
+                        }, // NOT `.in_current_span()`: this owner outlives the caller by
+                           // design, so cloning the caller's span would hold it open for
+                           // the owner's whole life. Callers that want the work traced
+                           // must instrument the future they hand in - see the
+                           // `read_only_invocation` span in the worker executor for the
+                           // shape: capture a `TraceOrigin` and link, do not nest.
                     );
                 } else {
                     record_cache_hit(self.name);
@@ -508,44 +511,43 @@ impl<
                         let pending_value_clone = pending_value.clone();
                         let self_clone = self.clone();
 
-                        tokio::task::spawn(
-                            async move {
-                                let value = f2(&pending_value_clone).await;
-                                if let Ok(success_value) = &value {
-                                    self_clone
-                                        .state
-                                        .items
-                                        .upsert_async(
-                                            key_clone.clone(),
-                                            Item::Cached {
-                                                value: success_value.clone(),
-                                                last_access: Instant::now(),
-                                            },
-                                        )
-                                        .await;
-                                    let old_count =
-                                        self_clone.state.count.fetch_add(1, Ordering::Relaxed);
-                                    let new_count = old_count.saturating_add(1);
+                        // Same as `get_or_insert_spawned` above: no `.in_current_span()`,
+                        // because this owner outlives the caller that started it.
+                        tokio::task::spawn(async move {
+                            let value = f2(&pending_value_clone).await;
+                            if let Ok(success_value) = &value {
+                                self_clone
+                                    .state
+                                    .items
+                                    .upsert_async(
+                                        key_clone.clone(),
+                                        Item::Cached {
+                                            value: success_value.clone(),
+                                            last_access: Instant::now(),
+                                        },
+                                    )
+                                    .await;
+                                let old_count =
+                                    self_clone.state.count.fetch_add(1, Ordering::Relaxed);
+                                let new_count = old_count.saturating_add(1);
 
-                                    record_cache_size(self_clone.name, new_count);
+                                record_cache_size(self_clone.name, new_count);
 
-                                    if self_clone
-                                        .capacity
-                                        .is_some_and(|capacity| new_count > capacity)
-                                    {
-                                        self_clone.evict().await;
-                                    }
-                                } else {
-                                    self_clone.state.items.remove_async(&key_clone).await;
+                                if self_clone
+                                    .capacity
+                                    .is_some_and(|capacity| new_count > capacity)
+                                {
+                                    self_clone.evict().await;
                                 }
-                                // `send_replace` instead of `send`: a plain `send`
-                                // fails without storing the value when no waiter
-                                // has subscribed yet, and later subscribers would
-                                // then wait forever.
-                                tx_clone.send_replace(Some(value.clone()));
+                            } else {
+                                self_clone.state.items.remove_async(&key_clone).await;
                             }
-                            .in_current_span(),
-                        );
+                            // `send_replace` instead of `send`: a plain `send`
+                            // fails without storing the value when no waiter
+                            // has subscribed yet, and later subscribers would
+                            // then wait forever.
+                            tx_clone.send_replace(Some(value.clone()));
+                        });
                     }
 
                     Ok(PendingOrFinal::Pending(pending_value))

--- a/golem-common/src/metrics.rs
+++ b/golem-common/src/metrics.rs
@@ -238,6 +238,7 @@ pub mod api {
     use prometheus::{Gauge, HistogramVec, register_gauge, register_histogram_vec};
     use std::fmt::Debug;
     use tracing::{Span, debug, error};
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
 
     lazy_static! {
         static ref API_SUCCESS_SECONDS: HistogramVec = register_histogram_vec!(
@@ -396,26 +397,38 @@ pub mod api {
     impl Drop for RecordedApiRequest {
         fn drop(&mut self) {
             if let Some(start) = self.start_time.take() {
+                // Neither `succeed` nor `fail` ran: the caller went away before the
+                // request produced a result. Not an error status - the server did not
+                // fail - but recorded, because work this request started can outlive
+                // it.
+                self.span.set_attribute("cancelled", true);
                 record_api_failure(self.api_name, self.api_type, "Drop", start.elapsed());
             }
         }
     }
 
+    /// Creates the entry-point span for an inbound gRPC request.
+    ///
+    /// `otel.kind = "server"` marks it as the service's inbound edge, which is what
+    /// lets a trace backend derive the service graph. Without it every span Golem
+    /// emits is exported as `Internal`.
     #[macro_export]
     macro_rules! recorded_grpc_api_request {
         ($api_name:expr,  $($fields:tt)*) => {
             {
-                let span = tracing::span!(tracing::Level::INFO, concat!("gRPC ", $api_name), api = $api_name,  api_type = "grpc", $($fields)*);
+                let span = tracing::span!(tracing::Level::INFO, concat!("gRPC ", $api_name), api = $api_name,  api_type = "grpc", otel.kind = "server", $($fields)*);
                 $crate::metrics::api::RecordedApiRequest::new($api_name, "grpc", span)
             }
         };
     }
 
+    /// Creates the entry-point span for an inbound HTTP request. See
+    /// [`recorded_grpc_api_request!`] for why `otel.kind` is set.
     #[macro_export]
     macro_rules! recorded_http_api_request {
         ($api_name:expr,  $($fields:tt)*) => {
             {
-                let span = tracing::span!(tracing::Level::INFO, concat!("HTTP ", $api_name), api = $api_name,  api_type = "http", $($fields)*);
+                let span = tracing::span!(tracing::Level::INFO, concat!("HTTP ", $api_name), api = $api_name,  api_type = "http", otel.kind = "server", $($fields)*);
                 $crate::metrics::api::RecordedApiRequest::new($api_name, "http", span)
             }
         };
@@ -569,5 +582,79 @@ pub mod db {
         DB_DESERIALIZED_SIZE_BYTES
             .with_label_values(&[db_type, svc_name, entity_name])
             .observe(size as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::{SpanKind, Status};
+    use test_r::test;
+
+    use crate::tracing::test::otel::{exported_spans, named};
+
+    /// Golem's own entry-point spans have to declare `otel.kind`, otherwise every
+    /// span the service emits is exported as `Internal` and a trace backend cannot
+    /// tell which spans are the inbound edges of the service.
+    #[test]
+    fn recorded_grpc_api_request_is_a_server_span() {
+        let spans = exported_spans(|| {
+            let record = crate::recorded_grpc_api_request!("test_api",);
+            drop(record);
+        });
+
+        assert_eq!(named(&spans, "gRPC test_api").span_kind, SpanKind::Server);
+    }
+
+    /// A request that is dropped without `succeed`/`fail` was abandoned by its
+    /// caller. The span has to say so: work the request started can outlive it, and
+    /// a reader seeing a child span run past its parent needs to be able to tell an
+    /// abandoned request from a broken trace.
+    #[test]
+    fn an_abandoned_request_is_marked_cancelled() {
+        let spans = exported_spans(|| {
+            let record = crate::recorded_grpc_api_request!("test_api",);
+            drop(record);
+        });
+
+        let span = named(&spans, "gRPC test_api");
+        assert!(
+            span.attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "cancelled" && kv.value.as_str() == "true"),
+            "expected a cancelled attribute, got {:?}",
+            span.attributes
+        );
+        assert!(
+            !matches!(span.status, Status::Error { .. }),
+            "an abandoned request is not a server error"
+        );
+    }
+
+    #[test]
+    fn a_completed_request_is_not_marked_cancelled() {
+        let spans = exported_spans(|| {
+            let record = crate::recorded_grpc_api_request!("test_api",);
+            record.succeed(());
+        });
+
+        let span = named(&spans, "gRPC test_api");
+        assert!(
+            !span
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "cancelled"),
+            "got {:?}",
+            span.attributes
+        );
+    }
+
+    #[test]
+    fn recorded_http_api_request_is_a_server_span() {
+        let spans = exported_spans(|| {
+            let record = crate::recorded_http_api_request!("test_api",);
+            drop(record);
+        });
+
+        assert_eq!(named(&spans, "HTTP test_api").span_kind, SpanKind::Server);
     }
 }

--- a/golem-common/src/tracing.rs
+++ b/golem-common/src/tracing.rs
@@ -27,7 +27,7 @@ use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracer;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 use tracing_subscriber::fmt::MakeWriter;
@@ -38,6 +38,72 @@ use tracing_subscriber::util::SubscriberInitExt;
 use crate::SafeDisplay;
 use crate::config::env_config_provider;
 use crate::tracing::format::JsonFlattenSpanFormatter;
+
+pub use origin::TraceOrigin;
+
+/// Environment variable holding the OTLP layer's filter.
+const OTLP_FILTER_VAR: &str = "GOLEM_OTLP_FILTER";
+
+/// What [`OTLP_FILTER_VAR`] was called before this filter became trace-only. Still
+/// honoured so an existing deployment keeps working.
+const DEPRECATED_OTLP_FILTER_VAR: &str = "GOLEM_OTLP_LOG";
+
+/// The OTLP filter from the environment, with the variable it came from, so a
+/// caller can report what is actually in force rather than what it assumes.
+///
+/// A variable set to nothing counts as unset, so `GOLEM_OTLP_FILTER=` behaves the
+/// same as leaving it out rather than quietly meaning something else.
+pub fn otlp_filter_from_env() -> Option<(String, &'static str)> {
+    for name in [OTLP_FILTER_VAR, DEPRECATED_OTLP_FILTER_VAR] {
+        if let Some(value) = std::env::var(name).ok().and_then(set_to_something) {
+            return Some((value, name));
+        }
+    }
+    None
+}
+
+/// A variable set to nothing counts as unset, so `GOLEM_OTLP_FILTER=` behaves the
+/// same as leaving it out. Without this a caller's fallback is skipped and it
+/// silently exports nothing.
+fn set_to_something(value: String) -> Option<String> {
+    (!value.trim().is_empty()).then_some(value)
+}
+
+/// Resolves `service.instance.id` from the pod name, falling back to the hostname.
+///
+/// Both are subject to [`set_to_something`]: a downward-API field or a Helm
+/// template can render a variable that is set but empty, and taking that at face
+/// value would both blank the attribute and skip the fallback.
+fn instance_id_from(pod_name: Option<String>, hostname: Option<String>) -> Option<String> {
+    pod_name
+        .and_then(set_to_something)
+        .or_else(|| hostname.and_then(set_to_something))
+}
+
+/// Targets naming a source of telemetry that an operator is likely to want to turn
+/// up or down on its own.
+///
+/// Only sources whose volume is decided by something outside the executor are named
+/// here; everything else keeps its module's target, so the usual `RUST_LOG`
+/// conventions apply and `golem_worker_executor=debug` means what it looks like.
+///
+/// These names are deliberately not module paths. A module path is unguessable from
+/// outside the codebase and changes whenever the code is reorganised, which makes it
+/// a poor thing to put in a deployment. Changing one of these is a breaking change
+/// to the operator-facing contract.
+pub mod target {
+    /// Log output from oplog-processor plugin agents, which is mirrored into the
+    /// server log because it cannot be watched with the CLI. How much of it there
+    /// is, is decided by the plugin, so a long-running invocation can hold a great
+    /// many of these on its span before it finishes.
+    pub const PLUGIN_LOG: &str = "golem::plugin_log";
+
+    /// SQL an agent runs against its own database, emitted per statement and per
+    /// transaction. Nothing to do with the database Golem itself stores state in.
+    pub const AGENT_RDBMS: &str = "golem::agent_rdbms";
+}
+
+mod origin;
 
 pub enum Output {
     Stdout,
@@ -360,7 +426,7 @@ impl Default for OtlpConfig {
 }
 
 pub mod directive {
-    use tracing_subscriber::filter::Directive;
+    use tracing_subscriber::filter::{Directive, LevelFilter};
 
     pub mod default {
         use tracing_subscriber::filter::Directive;
@@ -415,14 +481,30 @@ pub mod directive {
         ]
     }
 
-    /// Directives for the OTLP layer: same as default_deps but also
-    /// enables trace-level for `otel::tracing` target so that spans
-    /// created by `tonic-tracing-opentelemetry` (which uses TRACE level)
-    /// are exported and can propagate trace context across services.
-    pub fn otlp_deps() -> Vec<Directive> {
-        let mut deps = default_deps();
-        deps.push("otel::tracing=trace".parse().unwrap());
-        deps
+    /// The OTLP layer's filter, as an `EnvFilter` spec.
+    ///
+    /// `user` is the raw `GOLEM_OTLP_FILTER` value and is used verbatim when set:
+    /// nothing is merged into it, so a directive means what it says and `info`
+    /// means info everywhere, third-party crates included. Which crates are worth
+    /// quietening differs per service, so that judgement belongs to whoever writes
+    /// the deployment, not here.
+    ///
+    /// Unset means `off`. Exporting needs an endpoint configured
+    /// (`GOLEM__TRACING__OTLP__ENABLED`, `__HOST`, `__PORT`), and this is the
+    /// remaining switch. `off` rather than `error` because this feeds a span sink:
+    /// the spans bounding an operation are `info` and the detail inside them
+    /// `debug`, so anything less verbose than `info` exports nothing at all while
+    /// still paying for the exporter - errors reach a trace as events on an
+    /// operation's span, never as spans of their own.
+    ///
+    /// Directives name crates and modules as usual; the sources worth turning up
+    /// or down on their own also have stable names of their own, in
+    /// [`target`](crate::tracing::target).
+    pub fn otlp_spec(user: Option<&str>) -> String {
+        match user.map(str::trim).filter(|user| !user.is_empty()) {
+            Some(user) => user.to_string(),
+            None => LevelFilter::OFF.to_string(),
+        }
     }
 }
 
@@ -434,7 +516,7 @@ pub mod filter {
 
     pub mod boxed {
         use tracing_subscriber::EnvFilter;
-        use tracing_subscriber::filter::Directive;
+        use tracing_subscriber::filter::{Directive, LevelFilter};
 
         use crate::tracing::directive;
         use crate::tracing::filter::Boxed;
@@ -474,26 +556,25 @@ pub mod filter {
             env_with_directives(directive::default::info(), directive::default_deps())
         }
 
-        /// Filter for the OTLP layer: debug level by default, with
-        /// `otel::tracing=trace` so context-propagation spans are exported.
-        ///
-        /// Unlike the other filters this does **not** read `RUST_LOG`.
-        /// `RUST_LOG` controls console verbosity and is often set to `warn`
-        /// in benchmark/CI runs, which would silently suppress all
-        /// INFO/DEBUG spans from OTLP export.  Instead the OTLP layer
-        /// always starts from `debug` and can be overridden via
-        /// `GOLEM_OTLP_LOG` if needed.
+        /// The OTLP layer's filter, from `GOLEM_OTLP_FILTER`. See
+        /// [`directive::otlp_spec`] for what it accepts and what unset means.
         pub fn default_otlp_env() -> Boxed {
-            let mut builder = EnvFilter::builder()
-                .with_default_directive(directive::default::debug())
-                .with_env_var("GOLEM_OTLP_LOG")
-                .from_env_lossy();
+            otlp_env_or(&LevelFilter::OFF.to_string())
+        }
 
-            for directive in directive::otlp_deps() {
-                builder = builder.add_directive(directive);
-            }
-
-            Box::new(builder)
+        /// As [`default_otlp_env`], but falling back to `default_spec` instead of
+        /// `off` when the environment sets no filter.
+        ///
+        /// For a caller where enabling OTLP is already a deliberate act of its own -
+        /// a `--otlp` flag rather than the service configuration - and where
+        /// exporting nothing would be surprising.
+        pub fn otlp_env_or(default_spec: &str) -> Boxed {
+            let user = crate::tracing::otlp_filter_from_env();
+            let spec = user
+                .as_ref()
+                .map(|(value, _)| directive::otlp_spec(Some(value)))
+                .unwrap_or_else(|| default_spec.to_string());
+            Box::new(EnvFilter::builder().parse_lossy(spec))
         }
     }
 
@@ -503,30 +584,46 @@ pub mod filter {
         use crate::tracing::Output;
         use crate::tracing::filter::{Boxed, boxed};
 
-        /// For OTLP, uses a permissive debug-level filter with
-        /// `otel::tracing=trace` so that context-propagation spans created
-        /// by `tonic-tracing-opentelemetry` (at TRACE level) are always
-        /// exported. For other outputs falls back to the RUST_LOG-based
-        /// env filter.
-        pub const DEFAULT_ENV: fn(Output) -> Boxed = |output| match output {
-            Output::Otlp => boxed::default_otlp_env(),
-            _ => boxed::default_env(),
-        };
+        /// OTLP always reads `GOLEM_OTLP_FILTER`; every other output takes the
+        /// filter the caller chose.
+        ///
+        /// The two are separate because console verbosity and what is worth
+        /// exporting to a trace store are different questions - `RUST_LOG=warn` is
+        /// common in benchmark and CI runs and would otherwise leave no spans at
+        /// all. Routing every constructor through here means that holds whichever
+        /// one a service picked, so `GOLEM_OTLP_FILTER` is the single answer to
+        /// "what is being exported".
+        fn otlp_or(output: Output, other: impl FnOnce() -> Boxed) -> Boxed {
+            match output {
+                Output::Otlp => boxed::default_otlp_env(),
+                _ => other(),
+            }
+        }
+
+        pub const DEFAULT_ENV: fn(Output) -> Boxed = |output| otlp_or(output, boxed::default_env);
 
         pub fn debug_env_with_directives(directives: Vec<Directive>) -> impl Fn(Output) -> Boxed {
-            move |_output| boxed::debug_env_with_directives(directives.clone())
+            move |output| {
+                otlp_or(output, || {
+                    boxed::debug_env_with_directives(directives.clone())
+                })
+            }
         }
 
         pub fn default_debug_env() -> impl Fn(Output) -> Boxed {
-            move |_output| boxed::default_debug_env()
+            move |output| otlp_or(output, boxed::default_debug_env)
         }
 
         pub fn info_env_with_directives(directives: Vec<Directive>) -> impl Fn(Output) -> Boxed {
-            move |_output| boxed::info_env_with_directives(directives.clone())
+            move |output| {
+                otlp_or(output, || {
+                    boxed::info_env_with_directives(directives.clone())
+                })
+            }
         }
 
         pub fn default_info_env() -> impl Fn(Output) -> Boxed {
-            move |_output| boxed::default_info_env()
+            move |output| otlp_or(output, boxed::default_info_env)
         }
     }
 }
@@ -562,9 +659,24 @@ where
             .build()
             .expect("Failed to build OTLP exporter");
 
-        let resource = Resource::builder()
-            .with_service_name(config.otlp.service_name.clone())
-            .build();
+        // Without an instance id every span from a multi-replica deployment looks
+        // the same, and a background tick - which has no request to identify it -
+        // cannot be attributed to a pod at all.
+        let mut resource = Resource::builder().with_service_name(config.otlp.service_name.clone());
+
+        // Set only when it resolves to something: a shared literal would collapse
+        // every replica into one instance, which is worse than the attribute being
+        // absent, and would override whatever the SDK's own env detector found.
+        if let Some(instance_id) = instance_id_from(
+            std::env::var("POD_NAME").ok(),
+            std::env::var("HOSTNAME").ok(),
+        ) {
+            resource = resource.with_attribute(opentelemetry::KeyValue::new(
+                "service.instance.id",
+                instance_id,
+            ));
+        }
+        let resource = resource.build();
 
         let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
             .with_resource(resource)
@@ -636,10 +748,31 @@ where
         })
     });
 
+    let otlp_filter_env = otlp_filter_from_env();
+    if otlp_filter_env.as_ref().map(|(_, name)| *name) == Some(DEPRECATED_OTLP_FILTER_VAR)
+        && !config.dtor_friendly
+    {
+        warn!(
+            "{DEPRECATED_OTLP_FILTER_VAR} is deprecated and will be removed; \
+             set {OTLP_FILTER_VAR} instead. It filters traces, not logs."
+        );
+    }
+
     if !config.dtor_friendly {
         info!(
             // NOTE: intentionally logged as string and not as structured
             tracing_config = serde_json::to_string(&config).expect("cannot serialize log config"),
+            // What `GOLEM_OTLP_FILTER` resolves to, and where it came from, so an
+            // operator seeing no spans can tell whether it is the filter or the
+            // exporter without reading the source. This is the filter in force for
+            // every service binary. It is not, for the one caller that supplies a
+            // fallback spec (`otlp_env_or`, used by the benchmark runner), which
+            // uses its own default when the variable is unset - there this reports
+            // `off` while the layer runs at the fallback.
+            otlp_filter = %directive::otlp_spec(
+                otlp_filter_env.as_ref().map(|(value, _)| value.as_str())
+            ),
+            otlp_filter_from = otlp_filter_env.as_ref().map_or("unset", |(_, name)| *name),
             "Tracing initialized"
         );
     }
@@ -828,7 +961,7 @@ pub(crate) mod format {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     pub fn make_mock_writer<'a>() -> tracing_test::internal::MockWriter<'a> {
         tracing_test::internal::MockWriter::new(tracing_test::internal::global_buf())
     }
@@ -841,6 +974,415 @@ mod test {
                 .to_vec(),
         )
         .unwrap()
+    }
+
+    /// Support for asserting on what the OTLP path actually exports.
+    ///
+    /// Tests here run against a real `tracing-opentelemetry` layer and a real
+    /// `SdkTracerProvider`, because what is being verified is precisely how that
+    /// stack treats parents, links, span kind and span lifetime - a hand-written
+    /// fake would verify nothing.
+    pub(crate) mod otel {
+        use std::sync::{Arc, Mutex};
+
+        use opentelemetry::trace::TracerProvider;
+        use opentelemetry_sdk::error::OTelSdkResult;
+        use opentelemetry_sdk::trace::{
+            SdkTracerProvider, SimpleSpanProcessor, SpanData, SpanExporter,
+        };
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Debug, Clone, Default)]
+        struct CollectingExporter {
+            spans: Arc<Mutex<Vec<SpanData>>>,
+        }
+
+        impl SpanExporter for CollectingExporter {
+            fn export(
+                &self,
+                batch: Vec<SpanData>,
+            ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+                self.spans.lock().unwrap().extend(batch);
+                std::future::ready(Ok(()))
+            }
+        }
+
+        /// Runs `f` under a subscriber whose only layer is a `tracing-opentelemetry`
+        /// layer, and returns the exported spans.
+        ///
+        /// `SimpleSpanProcessor` exports synchronously when a span closes, so every
+        /// span closed inside `f` is collected by the time this returns. A span
+        /// still open at the end of `f` is absent, which is what makes this usable
+        /// for asserting on span lifetime.
+        pub(crate) fn exported_spans(f: impl FnOnce()) -> Vec<SpanData> {
+            let collected: Arc<Mutex<Vec<SpanData>>> = Arc::new(Mutex::new(Vec::new()));
+            let provider = SdkTracerProvider::builder()
+                .with_span_processor(SimpleSpanProcessor::new(CollectingExporter {
+                    spans: collected.clone(),
+                }))
+                .build();
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")));
+
+            tracing::subscriber::with_default(subscriber, f);
+
+            collected.lock().unwrap().clone()
+        }
+
+        /// As [`exported_spans`], but with `filter` applied to the OTLP layer, so
+        /// what reaches the exporter is what the real OTLP layer would export.
+        pub(crate) fn exported_spans_filtered(
+            filter: crate::tracing::filter::Boxed,
+            f: impl FnOnce(),
+        ) -> Vec<SpanData> {
+            use tracing_subscriber::Layer;
+
+            let collected: Arc<Mutex<Vec<SpanData>>> = Arc::new(Mutex::new(Vec::new()));
+            let provider = SdkTracerProvider::builder()
+                .with_span_processor(SimpleSpanProcessor::new(CollectingExporter {
+                    spans: collected.clone(),
+                }))
+                .build();
+            let subscriber = tracing_subscriber::registry().with(
+                tracing_opentelemetry::layer()
+                    .with_tracer(provider.tracer("test"))
+                    .with_filter(filter),
+            );
+
+            tracing::subscriber::with_default(subscriber, f);
+
+            collected.lock().unwrap().clone()
+        }
+
+        pub(crate) fn named<'a>(spans: &'a [SpanData], name: &str) -> &'a SpanData {
+            spans.iter().find(|s| s.name == name).unwrap_or_else(|| {
+                let found: Vec<&str> = spans.iter().map(|s| &*s.name).collect();
+                panic!("no exported span named {name:?}; exported: {found:?}")
+            })
+        }
+    }
+
+    /// Tests for the OTLP layer's filter.
+    mod otlp_spec {
+        use test_r::test;
+        use tracing_subscriber::EnvFilter;
+
+        use crate::tracing::directive::otlp_spec;
+        use crate::tracing::target;
+        use crate::tracing::test::otel::{exported_spans_filtered, named};
+
+        fn exported(user: Option<&str>) -> Vec<String> {
+            let filter = EnvFilter::builder().parse_lossy(otlp_spec(user));
+            let spans = exported_spans_filtered(Box::new(filter), || {
+                tracing::info_span!("golem_operation").in_scope(|| {
+                    tracing::info!(target: target::PLUGIN_LOG, "plugin said something");
+                    tracing::debug!(target: target::AGENT_RDBMS, "select 1");
+                    tracing::info!(target: "hyper::client", "third-party at info");
+                });
+            });
+            spans.iter().map(|s| s.name.to_string()).collect()
+        }
+
+        fn events_on_operation(user: Option<&str>) -> usize {
+            let filter = EnvFilter::builder().parse_lossy(otlp_spec(user));
+            let spans = exported_spans_filtered(Box::new(filter), || {
+                tracing::info_span!("golem_operation").in_scope(|| {
+                    tracing::info!(target: target::PLUGIN_LOG, "plugin said something");
+                    tracing::debug!(target: target::AGENT_RDBMS, "select 1");
+                    tracing::info!(target: "hyper::client", "third-party at info");
+                });
+            });
+            named(&spans, "golem_operation").events.len()
+        }
+
+        /// Exporting already needs an endpoint configured; this is the remaining
+        /// switch, and until it is set nothing is produced.
+        #[test]
+        fn unset_exports_nothing() {
+            assert_eq!(otlp_spec(None), "off");
+            assert!(exported(None).is_empty());
+        }
+
+        #[test]
+        fn blank_is_treated_as_unset() {
+            assert_eq!(otlp_spec(Some("   ")), "off");
+        }
+
+        /// A set-but-empty `POD_NAME` - a downward-API field or Helm template that
+        /// rendered blank - must fall through to the hostname rather than blanking
+        /// the attribute for every replica.
+        #[test]
+        fn a_blank_pod_name_falls_through_to_the_hostname() {
+            use crate::tracing::instance_id_from;
+
+            assert_eq!(
+                instance_id_from(Some("  ".to_string()), Some("node-7".to_string())),
+                Some("node-7".to_string())
+            );
+            assert_eq!(
+                instance_id_from(Some("pod-3".to_string()), Some("node-7".to_string())),
+                Some("pod-3".to_string())
+            );
+            assert_eq!(instance_id_from(Some(String::new()), None), None);
+            assert_eq!(instance_id_from(None, None), None);
+        }
+
+        /// A variable set to nothing must reach callers as absent, not as a filter
+        /// that happens to mean `off` - otherwise `otlp_env_or`'s fallback is
+        /// skipped and a caller that asked for OTLP exports nothing.
+        #[test]
+        fn a_blank_variable_does_not_count_as_set() {
+            use crate::tracing::set_to_something;
+
+            assert_eq!(set_to_something(String::new()), None);
+            assert_eq!(set_to_something("   ".to_string()), None);
+            assert_eq!(
+                set_to_something("info".to_string()),
+                Some("info".to_string())
+            );
+        }
+
+        /// `info` means info, with nothing quietly merged in - including for
+        /// third-party crates, whose noise is the deployment's judgement to make.
+        #[test]
+        fn info_means_info_everywhere() {
+            assert_eq!(otlp_spec(Some("info")), "info");
+            assert_eq!(exported(Some("info")), vec!["golem_operation"]);
+            assert_eq!(
+                events_on_operation(Some("info")),
+                2,
+                "plugin log and the third-party event, but not the debug SQL"
+            );
+        }
+
+        /// The shape a deployment actually writes, quietening what it knows to be
+        /// noisy for that service.
+        #[test]
+        fn a_deployment_can_quieten_what_it_chooses() {
+            assert_eq!(
+                events_on_operation(Some("info,hyper=warn,golem::plugin_log=off")),
+                0
+            );
+        }
+
+        /// Each source can be turned up on its own without raising anything else.
+        #[test]
+        fn a_label_can_be_raised_on_its_own() {
+            assert_eq!(
+                events_on_operation(Some("info,golem::agent_rdbms=debug")),
+                3,
+                "the debug SQL joins the two info events"
+            );
+        }
+
+        /// Quietening the named event sources leaves the operation spans they were
+        /// recorded on, since those are selected by their own module and level.
+        #[test]
+        fn quietening_an_event_source_keeps_the_spans() {
+            assert_eq!(
+                exported(Some("info,golem::plugin_log=off,golem::agent_rdbms=off")),
+                vec!["golem_operation"]
+            );
+        }
+
+        #[test]
+        fn an_unparseable_directive_is_ignored_rather_than_fatal() {
+            let filter = EnvFilter::builder().parse_lossy(otlp_spec(Some("info,not a level")));
+            let spans = exported_spans_filtered(Box::new(filter), || {
+                tracing::info_span!("golem_operation").in_scope(|| {});
+            });
+            named(&spans, "golem_operation");
+        }
+    }
+
+    /// Tests for which filter each output gets.
+    ///
+    /// The dispatch has regressed more than once: a constructor that ignored its
+    /// `Output` silently handed the OTLP layer the `RUST_LOG` filter, so
+    /// `GOLEM_OTLP_FILTER` did nothing and the startup diagnostic reported a filter
+    /// that was not in force.
+    mod output_dispatch {
+        use test_r::test;
+        use tracing_subscriber::filter::LevelFilter;
+
+        use crate::tracing::Output;
+        use crate::tracing::filter::for_all_outputs;
+
+        fn max_level(filter: crate::tracing::filter::Boxed) -> Option<LevelFilter> {
+            use tracing_subscriber::layer::Filter;
+            Filter::<tracing_subscriber::Registry>::max_level_hint(&filter)
+        }
+
+        /// Compared against `default_otlp_env` rather than a fixed level, so this
+        /// holds whatever `GOLEM_OTLP_FILTER` happens to be in the running
+        /// environment - the perf skill tells developers to export it.
+        ///
+        /// A constructor that ignored its `Output` would hand the OTLP layer the
+        /// `RUST_LOG` filter instead, and fail here. Only in the coincidence where
+        /// both filters resolve to the same level would that pass unnoticed, which
+        /// is why this asserts identity with the OTLP filter rather than difference
+        /// from the other one - the latter false-fails on the same coincidence.
+        fn otlp_gets_its_own_filter(make: impl Fn(Output) -> crate::tracing::filter::Boxed) {
+            assert_eq!(
+                max_level(make(Output::Otlp)),
+                max_level(crate::tracing::filter::boxed::default_otlp_env()),
+                "the OTLP layer must take the OTLP filter"
+            );
+        }
+
+        #[test]
+        fn default_env_routes_otlp_separately() {
+            otlp_gets_its_own_filter(for_all_outputs::DEFAULT_ENV);
+        }
+
+        #[test]
+        fn default_debug_env_routes_otlp_separately() {
+            otlp_gets_its_own_filter(for_all_outputs::default_debug_env());
+        }
+
+        #[test]
+        fn default_info_env_routes_otlp_separately() {
+            otlp_gets_its_own_filter(for_all_outputs::default_info_env());
+        }
+
+        #[test]
+        fn env_with_directives_routes_otlp_separately() {
+            otlp_gets_its_own_filter(for_all_outputs::debug_env_with_directives(vec![]));
+            otlp_gets_its_own_filter(for_all_outputs::info_env_with_directives(vec![]));
+        }
+    }
+
+    /// Tests for [`crate::tracing::TraceOrigin`].
+    mod trace_origin {
+        use opentelemetry::trace::SpanId;
+        use test_r::test;
+
+        use crate::tracing::TraceOrigin;
+        use crate::tracing::test::otel::{exported_spans, named};
+
+        /// Work is handed off, so execution is a new trace linked back to whatever
+        /// enqueued it. Per the OpenTelemetry messaging conventions the link lives
+        /// on the consumer span.
+        #[test]
+        fn add_as_link_to_starts_a_new_trace_linked_to_the_captured_span() {
+            let spans = exported_spans(|| {
+                let enqueue = tracing::info_span!("enqueue");
+                let captured = enqueue.in_scope(TraceOrigin::capture_current);
+                // The enqueuing request returns before the work is picked up.
+                drop(enqueue);
+
+                let picked_up = tracing::info_span!(parent: None, "picked_up");
+                captured.add_as_link_to(&picked_up);
+                drop(picked_up);
+            });
+
+            let enqueue = named(&spans, "enqueue");
+            let picked_up = named(&spans, "picked_up");
+
+            assert_ne!(
+                picked_up.span_context.trace_id(),
+                enqueue.span_context.trace_id(),
+                "linked work should be a separate trace"
+            );
+            assert_eq!(
+                picked_up.parent_span_id,
+                SpanId::INVALID,
+                "linked work should be a trace root, not a child"
+            );
+
+            let link_targets: Vec<(_, _)> = picked_up
+                .links
+                .iter()
+                .map(|l| (l.span_context.trace_id(), l.span_context.span_id()))
+                .collect();
+            assert!(
+                link_targets.contains(&(
+                    enqueue.span_context.trace_id(),
+                    enqueue.span_context.span_id()
+                )),
+                "consumer span should link to the enqueuing span; links were {link_targets:?}"
+            );
+        }
+
+        /// Capturing a parent must not keep the captured span open, so that a span
+        /// remembered for later use still closes and exports on its own schedule.
+        #[test]
+        fn capturing_a_parent_does_not_keep_the_captured_span_open() {
+            let mut held: Option<TraceOrigin> = None;
+
+            let spans = exported_spans(|| {
+                let request = tracing::info_span!("request");
+                held = Some(request.in_scope(TraceOrigin::capture_current));
+                drop(request);
+                // `held` is still alive here, as the pending-invocation map holds it
+                // while the invocation waits to be picked up.
+            });
+
+            assert!(held.is_some_and(|parent| !parent.is_empty()));
+            assert_eq!(
+                spans.len(),
+                1,
+                "the captured span must still close and export while its TraceOrigin is held"
+            );
+            assert_eq!(spans[0].name, "request");
+        }
+
+        /// With no active span, or with no OpenTelemetry layer installed, a captured
+        /// parent is empty and applying it changes nothing.
+        #[test]
+        fn an_empty_parent_leaves_the_span_as_a_root() {
+            let empty = TraceOrigin::default();
+            assert!(empty.is_empty());
+
+            let spans = exported_spans(|| {
+                let root = tracing::info_span!(parent: None, "root");
+                empty.add_as_link_to(&root);
+                drop(root);
+            });
+
+            let root = named(&spans, "root");
+            assert_eq!(root.parent_span_id, SpanId::INVALID);
+            assert!(root.links.is_empty());
+        }
+
+        /// Handed-off work is a linked root, not a child - including the invocation
+        /// path where the caller waits for the result, since the worker runs it
+        /// independently and the caller is only notified.
+        #[test]
+        fn related_span_makes_the_work_a_linked_root() {
+            let spans = exported_spans(|| {
+                let caller = tracing::info_span!("caller");
+                let origin = caller.in_scope(TraceOrigin::capture_current);
+
+                let work = crate::related_span!(origin, tracing::Level::INFO, "work");
+                drop(work);
+                drop(caller);
+            });
+
+            let caller = named(&spans, "caller");
+            let work = named(&spans, "work");
+            assert_ne!(
+                work.span_context.trace_id(),
+                caller.span_context.trace_id(),
+                "linked work is the root of its own trace"
+            );
+            assert_eq!(work.parent_span_id, SpanId::INVALID);
+            assert_eq!(work.links.iter().count(), 1);
+            assert_eq!(
+                work.links.iter().next().unwrap().span_context.span_id(),
+                caller.span_context.span_id(),
+                "the link points back at whatever handed the work off"
+            );
+        }
+
+        #[test]
+        fn capture_current_outside_any_span_is_empty() {
+            let mut captured = None;
+            exported_spans(|| {
+                captured = Some(TraceOrigin::capture_current());
+            });
+            assert!(captured.is_some_and(|parent| parent.is_empty()));
+        }
     }
 
     mod json_flatten_span_formatter {

--- a/golem-common/src/tracing/origin.rs
+++ b/golem-common/src/tracing/origin.rs
@@ -1,0 +1,153 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Relating work to whatever handed it off.
+//!
+//! Separate from the subscriber configuration in the parent module: this is a
+//! domain model for span relationships, not tracing setup.
+
+/// Creates a parentless span and links it back to a [`TraceOrigin`], yielding the
+/// span.
+///
+/// The span starts with no parent because it is the root of its own trace; the
+/// link, not a parent, is what ties it to whatever handed the work off.
+#[macro_export]
+macro_rules! related_span {
+    ($origin:expr, $level:expr, $name:expr) => {{
+        let span = ::tracing::span!(parent: None, $level, $name);
+        $origin.add_as_link_to(&span);
+        span
+    }};
+    ($origin:expr, $level:expr, $name:expr, $($fields:tt)*) => {{
+        let span = ::tracing::span!(parent: None, $level, $name, $($fields)*);
+        $origin.add_as_link_to(&span);
+        span
+    }};
+}
+
+/// The span that work running elsewhere came from, holding only that span's
+/// OpenTelemetry [`SpanContext`](opentelemetry::trace::SpanContext) rather than the
+/// span itself.
+///
+/// Use this whenever the origin of an operation has to be remembered across an
+/// asynchronous boundary - an invocation enqueued by one request and executed
+/// after that request returned, for example.
+///
+/// A `tracing::Span` is unsuitable for that: it stays open until every clone of it
+/// is dropped, with the consequences described under *Why background tasks get no
+/// ambient span* below. A captured `SpanContext` is a small fixed-size value that
+/// holds nothing open.
+///
+/// # The work is always linked, never nested
+///
+/// Work reaches this type by being handed off - enqueued, spawned, scheduled - so
+/// the originator does not contain it in time. Even an invocation whose caller
+/// waits for the result is handed to a worker that runs it independently: the
+/// caller learns the outcome from a published event rather than from a return, and
+/// the work continues if the caller goes away. Making such a span a child would
+/// report a span longer than its parent, and often one that started after its
+/// parent finished.
+///
+/// So the relationship is always [`add_as_link_to`](Self::add_as_link_to), which is
+/// the OpenTelemetry messaging conventions' default for correlating a producer with
+/// a consumer. The specification is explicit that a parent is the wrong
+/// relationship when it does not enclose the child, and names a "long running
+/// asynchronous data processing operation that was initiated by one of many fast
+/// incoming requests" as a case for a new linked trace.
+///
+/// # Why background tasks get no ambient span
+///
+/// A span is only exported when it closes, and while it is open
+/// `tracing-opentelemetry` appends an OpenTelemetry event to it for every `tracing`
+/// event recorded inside it, without any bound. A span covering a background loop,
+/// a worker's residency, or a task whose handle a guest owns therefore never
+/// exports, reports a duration unrelated to any request, and retains everything
+/// recorded inside it for as long as the task lives.
+///
+/// So such tasks are spawned with no span, and the bounded operations inside them
+/// span themselves and link back through a `TraceOrigin`. Sites that deliberately
+/// omit a span point here rather than restating this.
+///
+/// # Levels
+///
+/// A span must never be less likely to export than its own children, or the child
+/// is exported with its parent missing. So the outermost span of a background loop
+/// is `info` - it is that loop's whole operation, with nothing enclosing it - and
+/// the detail inside it is `debug`.
+#[derive(Clone, Debug, Default)]
+pub struct TraceOrigin(Option<opentelemetry::trace::SpanContext>);
+
+impl TraceOrigin {
+    /// Captures the currently active span as the origin. Yields an empty origin
+    /// when there is no active span, or when no OTLP layer is installed.
+    ///
+    /// Note that this forces the span's sampling decision, since its span id has to
+    /// be known before it can be recorded as a link.
+    ///
+    /// Only call this where the intended span is *provably* current: inside
+    /// `Span::in_scope`, inside a future already under `.instrument(..)`, or in a
+    /// function whose callers are documented to run under it. A span that merely
+    /// exists further up the call stack is not enough - it may have been exited, and
+    /// a task spawned with `tokio::spawn` never inherits one. When nothing is
+    /// current this returns an empty origin and the link is silently absent, so the
+    /// capture site is the thing to get right.
+    pub fn capture_current() -> Self {
+        use opentelemetry::trace::TraceContextExt;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        let span = tracing::Span::current();
+
+        // `context()` is not cheap: it takes the registry's extensions lock and
+        // forces a sampling decision. A disabled span can never yield a valid
+        // context, so skip all of it - this runs per outgoing host call.
+        if span.is_disabled() {
+            return Self(None);
+        }
+
+        let span_context = span.context().span().span_context().clone();
+        if span_context.is_valid() {
+            Self(Some(span_context))
+        } else {
+            Self(None)
+        }
+    }
+
+    /// An origin with nothing to link to, for work with no in-process originator -
+    /// recovered from durable storage after a restart, for example.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Only the tests need to distinguish an empty origin; production code goes
+    /// through [`add_as_link_to`](Self::add_as_link_to), which no-ops on one.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Records the captured origin as a link on `span`, for work the origin caused
+    /// but does not contain. `span` stays the root of its own trace. Does nothing
+    /// for an empty origin.
+    ///
+    /// The link is recorded on the consuming span and points back at the
+    /// originating one, which is the direction the OpenTelemetry messaging
+    /// conventions prescribe.
+    pub fn add_as_link_to(&self, span: &tracing::Span) {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        if let Some(span_context) = &self.0 {
+            span.add_link(span_context.clone());
+        }
+    }
+}

--- a/golem-test-framework/src/components/jaeger/mod.rs
+++ b/golem-test-framework/src/components/jaeger/mod.rs
@@ -14,7 +14,7 @@
 
 use async_trait::async_trait;
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -38,7 +38,17 @@ pub struct JaegerQueryClient {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct JaegerQueryResponse {
+    /// Jaeger sends `null` rather than `[]` when no trace matched.
+    #[serde(default, deserialize_with = "null_as_empty")]
     pub data: Vec<JaegerTrace>,
+}
+
+fn null_as_empty<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -56,6 +66,11 @@ pub struct JaegerSpan {
     pub span_id: String,
     #[serde(rename = "operationName")]
     pub operation_name: String,
+    /// Span start, in microseconds since the Unix epoch.
+    #[serde(rename = "startTime")]
+    pub start_time: u64,
+    /// Span duration in microseconds.
+    pub duration: u64,
     pub references: Vec<JaegerReference>,
     pub tags: Vec<JaegerTag>,
 }
@@ -158,6 +173,30 @@ impl JaegerTrace {
             .collect()
     }
 
+    /// Returns `(operation_name, parent_operation_name)` for every span that
+    /// escapes its parent's time window - it either started before its parent or
+    /// ended after it.
+    ///
+    /// A span is supposed to represent one operation, and a parent is supposed to
+    /// contain the operations of its children; a child that outlives its parent
+    /// makes critical-path analysis meaningless. Spans whose parent was not
+    /// exported into this trace are skipped, since there is nothing to compare
+    /// against, and linked roots (FOLLOWS_FROM only) are not children at all so
+    /// they are exempt by construction.
+    pub fn spans_outliving_parent(&self) -> Vec<(&str, &str)> {
+        let by_id: HashMap<&str, &JaegerSpan> =
+            self.spans.iter().map(|s| (s.span_id.as_str(), s)).collect();
+
+        self.spans
+            .iter()
+            .filter_map(|span| {
+                let parent = by_id.get(span.parent_span_id()?)?;
+                (span.start_time < parent.start_time || span.end_time() > parent.end_time())
+                    .then_some((span.operation_name.as_str(), parent.operation_name.as_str()))
+            })
+            .collect()
+    }
+
     /// Returns span IDs of spans whose operation name is `"unknown"`.
     pub fn unknown_name_spans(&self) -> Vec<&str> {
         self.spans
@@ -169,9 +208,22 @@ impl JaegerTrace {
 }
 
 impl JaegerSpan {
-    /// Returns the parent span ID from the first CHILD_OF reference, if any.
+    /// Returns the parent span ID from the CHILD_OF reference, if any.
+    ///
+    /// Only CHILD_OF establishes parentage. A span may also carry FOLLOWS_FROM
+    /// references, which is how OpenTelemetry span links are surfaced, and those
+    /// must not be mistaken for a parent - a span whose only reference is
+    /// FOLLOWS_FROM is the root of its own trace.
     pub fn parent_span_id(&self) -> Option<&str> {
-        self.references.first().map(|r| r.span_id.as_str())
+        self.references
+            .iter()
+            .find(|r| r.ref_type == "CHILD_OF")
+            .map(|r| r.span_id.as_str())
+    }
+
+    /// Span end, in microseconds since the Unix epoch.
+    pub fn end_time(&self) -> u64 {
+        self.start_time + self.duration
     }
 
     /// Returns the value of a tag by key, if present.
@@ -182,6 +234,8 @@ impl JaegerSpan {
 
 #[derive(Debug, Clone, Deserialize)]
 struct JaegerServicesResponse {
+    /// Jaeger sends `null` rather than `[]` when it knows of no services yet.
+    #[serde(default, deserialize_with = "null_as_empty")]
     data: Vec<String>,
 }
 
@@ -298,5 +352,137 @@ async fn wait_for_startup(query_url: &str, timeout: Duration) {
             panic!("Failed to verify that Jaeger is running at {query_url}");
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_r::test;
+
+    use super::{JaegerReference, JaegerSpan, JaegerTrace};
+
+    fn span(
+        span_id: &str,
+        name: &str,
+        start_time: u64,
+        duration: u64,
+        references: Vec<JaegerReference>,
+    ) -> JaegerSpan {
+        JaegerSpan {
+            trace_id: "trace".to_string(),
+            span_id: span_id.to_string(),
+            operation_name: name.to_string(),
+            start_time,
+            duration,
+            references,
+            tags: vec![],
+        }
+    }
+
+    fn reference(ref_type: &str, span_id: &str) -> JaegerReference {
+        JaegerReference {
+            ref_type: ref_type.to_string(),
+            trace_id: "trace".to_string(),
+            span_id: span_id.to_string(),
+        }
+    }
+
+    /// A span may carry both a CHILD_OF parent and FOLLOWS_FROM links, and Jaeger
+    /// does not guarantee the order. Only the CHILD_OF reference is the parent.
+    #[test]
+    fn parent_span_id_ignores_non_child_of_references() {
+        let with_link_first = span(
+            "b",
+            "child",
+            0,
+            1,
+            vec![
+                reference("FOLLOWS_FROM", "link"),
+                reference("CHILD_OF", "a"),
+            ],
+        );
+        assert_eq!(with_link_first.parent_span_id(), Some("a"));
+
+        let only_link = span("b", "root", 0, 1, vec![reference("FOLLOWS_FROM", "link")]);
+        assert_eq!(
+            only_link.parent_span_id(),
+            None,
+            "a linked root has no parent"
+        );
+    }
+
+    /// Acceptance criterion: no span may escape its parent's window. A child that
+    /// starts before or ends after its parent means the parent does not actually
+    /// contain the operation it appears to contain.
+    #[test]
+    fn spans_outliving_parent_flags_children_that_escape_their_parent() {
+        let trace = JaegerTrace {
+            trace_id: "trace".to_string(),
+            spans: vec![
+                span("a", "parent", 1_000, 1_000, vec![]),
+                span(
+                    "b",
+                    "contained",
+                    1_100,
+                    500,
+                    vec![reference("CHILD_OF", "a")],
+                ),
+                span(
+                    "c",
+                    "ends_late",
+                    1_500,
+                    2_000,
+                    vec![reference("CHILD_OF", "a")],
+                ),
+                span(
+                    "d",
+                    "starts_early",
+                    500,
+                    200,
+                    vec![reference("CHILD_OF", "a")],
+                ),
+                // A linked root is not a child, so it is exempt.
+                span(
+                    "e",
+                    "linked",
+                    9_000,
+                    9_000,
+                    vec![reference("FOLLOWS_FROM", "a")],
+                ),
+            ],
+        };
+
+        let offenders: Vec<&str> = trace
+            .spans_outliving_parent()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+
+        assert!(offenders.contains(&"ends_late"), "got {offenders:?}");
+        assert!(offenders.contains(&"starts_early"), "got {offenders:?}");
+        assert!(!offenders.contains(&"contained"), "got {offenders:?}");
+        assert!(
+            !offenders.contains(&"linked"),
+            "a linked root is not a child and must not be flagged; got {offenders:?}"
+        );
+    }
+
+    #[test]
+    fn spans_outliving_parent_ignores_parents_outside_the_trace() {
+        let trace = JaegerTrace {
+            trace_id: "trace".to_string(),
+            spans: vec![span(
+                "b",
+                "remote_child",
+                1_000,
+                10_000,
+                vec![reference("CHILD_OF", "not-in-this-trace")],
+            )],
+        };
+
+        assert!(
+            trace.spans_outliving_parent().is_empty(),
+            "cannot compare against a parent that was not exported here"
+        );
     }
 }

--- a/golem-test-framework/src/components/mod.rs
+++ b/golem-test-framework/src/components/mod.rs
@@ -472,6 +472,14 @@ impl EnvVarBuilder {
                 "GOLEM__TRACING__OTLP__SERVICE_NAME".to_string(),
                 service_name.to_string(),
             );
+            // The OTLP layer exports nothing unless its filter is set, and a test
+            // that asked for OTLP wants the spans. An inherited value wins, so a
+            // developer chasing one source can turn it up for the spawned services.
+            let filter = golem_common::tracing::otlp_filter_from_env()
+                .map(|(value, _)| value)
+                .unwrap_or_else(|| "info".to_string());
+            self.env_vars
+                .insert("GOLEM_OTLP_FILTER".to_string(), filter);
             // Increase the BatchSpanProcessor queue size from the default (2048)
             // to avoid dropping spans under high throughput (e.g. benchmarks).
             self.env_vars

--- a/golem-test-framework/src/config/benchmark.rs
+++ b/golem-test-framework/src/config/benchmark.rs
@@ -313,8 +313,10 @@ impl BenchmarkTestDependencies {
                 .use_stderr()
                 .with_otlp(params.otlp, "localhost", 4318, "benchmarks"),
             |output| match output {
+                // `--otlp` is the deliberate act here, so exporting nothing unless a
+                // second variable is also set would just be surprising.
                 golem_common::tracing::Output::Otlp => {
-                    golem_common::tracing::filter::boxed::default_otlp_env()
+                    golem_common::tracing::filter::boxed::otlp_env_or("info")
                 }
                 _ => golem_common::tracing::filter::boxed::env_with_directives(
                     params

--- a/golem-worker-executor/Cargo.toml
+++ b/golem-worker-executor/Cargo.toml
@@ -134,5 +134,6 @@ serde_json = { workspace = true }
 test-r = { workspace = true }
 testcontainers = { workspace = true }
 tokio-tungstenite = { workspace = true }
+tracing-subscriber = { workspace = true }
 tryhard = { workspace = true }
 system-interface = { workspace = true }

--- a/golem-worker-executor/src/durable_host/http/inline_retry.rs
+++ b/golem-worker-executor/src/durable_host/http/inline_retry.rs
@@ -49,12 +49,14 @@ use golem_common::model::oplog::{
     DurableFunctionType, HostRequestHttpRequest, HostResponse, OplogEntry, OplogIndex,
 };
 use golem_common::model::{NamedRetryPolicy, PredicateValue, RetryContext, RetryProperties};
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use http::{HeaderName, HeaderValue};
 use http_body_util::BodyExt;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::Instrument;
+use tracing::{Instrument, Level};
 use wasmtime_wasi::OutputStream;
 use wasmtime_wasi_http::HttpConnectionPool;
 use wasmtime_wasi_http::p2::bindings::http::types as wasi_http_types;
@@ -698,110 +700,107 @@ pub(crate) fn spawn_http_status_retry_after_body_finish<Ctx: crate::workerctx::W
     max_delay: Duration,
     begin_index: OplogIndex,
 ) -> FutureIncomingResponseHandle {
-    wasmtime_wasi::runtime::spawn(
-        async move {
-            let result = original_handle.await;
-            let Ok(Ok(response)) = result else {
-                // No response to evaluate against — publish a definitive non-match
-                // so any consumer waiting on the decision wakes up immediately
-                // (rather than waiting on the sender drop).
-                let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
-                return result;
-            };
+    // No span: this task waits for the guest to finish its outgoing body, so its
+    // duration is decided by guest code rather than by an operation the executor
+    // performs, and it has no bound. See `TraceOrigin`.
+    wasmtime_wasi::runtime::spawn(async move {
+        let result = original_handle.await;
+        let Ok(Ok(response)) = result else {
+            // No response to evaluate against — publish a definitive non-match
+            // so any consumer waiting on the decision wakes up immediately
+            // (rather than waiting on the sender drop).
+            let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
+            return result;
+        };
 
-            if *body_state.borrow() != HttpOutgoingBodyState::Open {
-                let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
-                return Ok(Ok(response));
-            }
+        if *body_state.borrow() != HttpOutgoingBodyState::Open {
+            let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
+            return Ok(Ok(response));
+        }
 
-            let status = response.resp.status().as_u16();
-            let mut properties = RetryContext::http_with_response(
-                &request.method.to_string(),
-                &request.uri,
-                Some(status),
-                "http-status",
-            );
-            if let Some(agent_type) = agent_type {
-                properties.set("agent-type", PredicateValue::Text(agent_type));
-            }
-            properties.set(
-                "is-idempotent",
-                PredicateValue::Boolean(is_http_request_idempotent(
-                    assume_idempotence,
-                    &request.method,
-                )),
-            );
+        let status = response.resp.status().as_u16();
+        let mut properties = RetryContext::http_with_response(
+            &request.method.to_string(),
+            &request.uri,
+            Some(status),
+            "http-status",
+        );
+        if let Some(agent_type) = agent_type {
+            properties.set("agent-type", PredicateValue::Text(agent_type));
+        }
+        properties.set(
+            "is-idempotent",
+            PredicateValue::Boolean(is_http_request_idempotent(
+                assume_idempotence,
+                &request.method,
+            )),
+        );
 
-            let current_retry_policy_state = worker
-                .get_non_detached_last_known_status()
-                .await
-                .current_retry_state
-                .get(&begin_index)
-                .cloned();
-            let mut task_ctx = crate::durable_host::durability::TaskRetryContext {
-                retry_point: begin_index,
-                environment_state_service,
-                environment_id,
-                default_retry_policy,
-                agent_config_retry_policies,
-                runtime_retry_policy_mutations,
-                max_in_function_retry_delay: max_delay,
-                current_retry_policy_state,
-                retry_properties: properties.clone(),
-                worker,
-            };
+        let current_retry_policy_state = worker
+            .get_non_detached_last_known_status()
+            .await
+            .current_retry_state
+            .get(&begin_index)
+            .cloned();
+        let mut task_ctx = crate::durable_host::durability::TaskRetryContext {
+            retry_point: begin_index,
+            environment_state_service,
+            environment_id,
+            default_retry_policy,
+            agent_config_retry_policies,
+            runtime_retry_policy_mutations,
+            max_in_function_retry_delay: max_delay,
+            current_retry_policy_state,
+            retry_properties: properties.clone(),
+            worker,
+        };
 
-            let policies = task_ctx.named_retry_policies().await;
-            match resolve_matching_status_retry_policy(policies, &properties) {
-                Ok(Some(matched)) => {
-                    // Publish the decision *before* waiting for the body to finish.
-                    // Stream write paths can now deterministically observe `Matched`
-                    // via `watch::Receiver::wait_for(...)` instead of polling and
-                    // hoping a single `yield_now()` is enough.
-                    let _ = pending_status_retry_decision
-                        .send(PendingStatusRetryDecision::Matched);
+        let policies = task_ctx.named_retry_policies().await;
+        match resolve_matching_status_retry_policy(policies, &properties) {
+            Ok(Some(matched)) => {
+                // Publish the decision *before* waiting for the body to finish.
+                // Stream write paths can now deterministically observe `Matched`
+                // via `watch::Receiver::wait_for(...)` instead of polling and
+                // hoping a single `yield_now()` is enough.
+                let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::Matched);
+                tracing::debug!(
+                    policy = %matched.name,
+                    status,
+                    uri = %request.uri,
+                    "HTTP status retry matched before request body finished; delaying response readiness"
+                );
+                if wait_for_outgoing_body_finish(&mut body_state).await {
                     tracing::debug!(
                         policy = %matched.name,
                         status,
                         uri = %request.uri,
-                        "HTTP status retry matched before request body finished; delaying response readiness"
+                        "HTTP request body finished after pending status retry match; exposing response to retry path"
                     );
-                    if wait_for_outgoing_body_finish(&mut body_state).await {
-                        tracing::debug!(
-                            policy = %matched.name,
-                            status,
-                            uri = %request.uri,
-                            "HTTP request body finished after pending status retry match; exposing response to retry path"
-                        );
-                    } else {
-                        tracing::debug!(
-                            policy = %matched.name,
-                            status,
-                            uri = %request.uri,
-                            "HTTP request body closed before pending status retry could become replayable"
-                        );
-                    }
-                }
-                Ok(None) => {
-                    let _ = pending_status_retry_decision
-                        .send(PendingStatusRetryDecision::NotMatched);
-                }
-                Err(err) => {
-                    let _ = pending_status_retry_decision
-                        .send(PendingStatusRetryDecision::NotMatched);
-                    tracing::warn!(
-                        ?err,
+                } else {
+                    tracing::debug!(
+                        policy = %matched.name,
                         status,
                         uri = %request.uri,
-                        "Failed evaluating status-code retry policies for pending HTTP status retry"
+                        "HTTP request body closed before pending status retry could become replayable"
                     );
                 }
             }
-
-            Ok(Ok(response))
+            Ok(None) => {
+                let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
+            }
+            Err(err) => {
+                let _ = pending_status_retry_decision.send(PendingStatusRetryDecision::NotMatched);
+                tracing::warn!(
+                    ?err,
+                    status,
+                    uri = %request.uri,
+                    "Failed evaluating status-code retry policies for pending HTTP status retry"
+                );
+            }
         }
-        .in_current_span(),
-    )
+
+        Ok(Ok(response))
+    })
 }
 
 /// Writes a sequence of `BodyChunk`s into an `OutputStream`, respecting
@@ -943,6 +942,26 @@ pub fn spawn_http_request_with_retry<Ctx: crate::workerctx::WorkerCtx>(
     let connect_timeout = config.connect_timeout;
     let first_byte_timeout = config.first_byte_timeout;
     let between_bytes_timeout = config.between_bytes_timeout;
+
+    // The retry task is spawned and outlives the invocation that started it, so it
+    // links back rather than running inside that invocation's span. See `TraceOrigin`.
+    let origin = TraceOrigin::capture_current();
+    let agent_id = worker.agent_id();
+    // Built here, while the request is still borrowable, so nothing is cloned for
+    // it and the fields stay lazy. The root of its own trace, so it has to say
+    // which request is retrying: the agent alone matches every outgoing call that
+    // worker ever made.
+    let retry_span = related_span!(
+        origin,
+        Level::INFO,
+        "http_request_retry",
+        %agent_id,
+        method = %request.method,
+        // Endpoint only: a query string routinely carries credentials, and the full
+        // URL is unbounded cardinality besides. Evaluated lazily by `span!`, so it
+        // costs nothing when the span is disabled.
+        uri = %request.uri.split('?').next().unwrap_or(&request.uri),
+    );
 
     wasmtime_wasi::runtime::spawn(
         async move {
@@ -1137,7 +1156,7 @@ pub fn spawn_http_request_with_retry<Ctx: crate::workerctx::WorkerCtx>(
                 }
             }
         }
-        .in_current_span(),
+        .instrument(retry_span),
     )
 }
 

--- a/golem-worker-executor/src/durable_host/logging/policy.rs
+++ b/golem-worker-executor/src/durable_host/logging/policy.rs
@@ -55,9 +55,14 @@ pub async fn emit_log_event_with_state<Ctx: WorkerCtx>(
         // Oplog processor plugin logs are emitted into the server log because
         // they cannot be easily watched with CLI tools.
         if has_oplog_processor {
+            // Under `target::PLUGIN_LOG` rather than this module: the plugin
+            // decides how much of this there is, so an operator needs to be
+            // able to name it on its own.
+            use golem_common::tracing::target::PLUGIN_LOG;
             match level {
                 LogLevel::Stdout | LogLevel::Debug | LogLevel::Trace => {
                     tracing::debug!(
+                        target: PLUGIN_LOG,
                         plugin_agent = %owned_agent_id,
                         context,
                         "Plugin: {message}"
@@ -65,6 +70,7 @@ pub async fn emit_log_event_with_state<Ctx: WorkerCtx>(
                 }
                 LogLevel::Stderr | LogLevel::Info => {
                     tracing::info!(
+                        target: PLUGIN_LOG,
                         plugin_agent = %owned_agent_id,
                         context,
                         "Plugin: {message}"
@@ -72,6 +78,7 @@ pub async fn emit_log_event_with_state<Ctx: WorkerCtx>(
                 }
                 LogLevel::Warn => {
                     tracing::warn!(
+                        target: PLUGIN_LOG,
                         plugin_agent = %owned_agent_id,
                         context,
                         "Plugin: {message}"
@@ -79,6 +86,7 @@ pub async fn emit_log_event_with_state<Ctx: WorkerCtx>(
                 }
                 LogLevel::Error | LogLevel::Critical => {
                     tracing::error!(
+                        target: PLUGIN_LOG,
                         plugin_agent = %owned_agent_id,
                         context,
                         "Plugin: {message}"

--- a/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
+++ b/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
@@ -54,9 +54,11 @@ use golem_common::model::{
     AgentFingerprint, AgentId, AgentInvocation, IdempotencyKey, NamedRetryPolicy, OplogIndex,
     OwnedAgentId, RetryContext, RetryProperties, ScheduleId, ScheduledAction,
 };
+use golem_common::related_span;
 use golem_common::schema::agent::{AgentMethodSchema, AgentTypeSchema};
 use golem_common::schema::schema_value::SchemaValue;
 use golem_common::serialization::{deserialize, serialize};
+use golem_common::tracing::TraceOrigin;
 use golem_schema::schema::wit::{
     EncodeError, decode_typed_rejecting_quota_with, decode_value_with, encode_value_with,
 };
@@ -67,7 +69,7 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{Instrument, error};
+use tracing::{Instrument, Level, error};
 use wasmtime::component::{Accessor, HasSelf, Resource, ResourceTableError};
 use wasmtime_wasi::runtime::AbortOnDropJoinHandle;
 
@@ -2349,6 +2351,27 @@ fn spawn_rpc_task_with_retry<Ctx: WorkerCtx>(
     let first_dispatch = Arc::new(std::sync::atomic::AtomicBool::new(
         initial_freshness_disposition == InvocationFreshnessDisposition::KnownFresh,
     ));
+
+    // The returned handle is owned by a guest resource, so this task can outlive
+    // the invocation. It links back rather than running inside its span. See
+    // `TraceOrigin`.
+    let origin = TraceOrigin::capture_current();
+    let caller_agent_id = agent_id.clone();
+
+    // Built here, while the values are still borrowable, so nothing is cloned for
+    // it and the fields stay lazy. The root of its own trace, so it has to say
+    // which call is retrying: the caller alone matches every RPC that worker
+    // ever made.
+    let retry_span = related_span!(
+        origin,
+        Level::INFO,
+        "rpc_invoke_retry",
+        agent_id = %caller_agent_id,
+        target_agent_id = %remote_agent_id.agent_id,
+        method = %method_name,
+        idempotency_key = %idempotency_key,
+    );
+
     let invoke = move || {
         let rpc = rpc.clone();
         let remote_agent_id = remote_agent_id.clone();
@@ -2447,7 +2470,7 @@ fn spawn_rpc_task_with_retry<Ctx: WorkerCtx>(
                 Err(RpcTaskError::Host(err)) => Err(err),
             }
         }
-        .in_current_span(),
+        .instrument(retry_span),
     )
 }
 

--- a/golem-worker-executor/src/lib.rs
+++ b/golem-worker-executor/src/lib.rs
@@ -27,6 +27,9 @@ pub mod worker;
 pub mod workerctx;
 
 #[cfg(test)]
+pub mod span_test_support;
+
+#[cfg(test)]
 test_r::enable!();
 
 use self::durable_host::{DurableWorkerCtx, DurableWorkerCtxView};

--- a/golem-worker-executor/src/metrics.rs
+++ b/golem-worker-executor/src/metrics.rs
@@ -71,6 +71,14 @@ const SCHEDULER_LAG_BUCKETS: &[f64; 22] = &[
     10.0, 30.0, 60.0, 300.0, 600.0,
 ];
 
+/// Admission-wait buckets. A worker normally clears admission in milliseconds, but
+/// under memory pressure a single phase can block for minutes, so the tail reaches
+/// well past the scheduler buckets.
+const ADMISSION_WAIT_BUCKETS: &[f64; 18] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0,
+    1800.0, 3600.0,
+];
+
 /// Tick-duration buckets for the scheduler. Values are dense at low latencies
 /// because slow ticks directly add scheduling delay.
 const SCHEDULER_TICK_DURATION_BUCKETS: &[f64; 24] = &[
@@ -291,6 +299,7 @@ pub mod workers {
     use lazy_static::lazy_static;
     use prometheus::core::Number;
     use prometheus::*;
+    use std::time::Duration;
 
     lazy_static! {
         static ref WORKER_EXECUTOR_CALL_TOTAL: CounterVec = register_counter_vec!(
@@ -326,6 +335,13 @@ pub mod workers {
             "worker_waiting_for_memory_count",
             "Workers blocked waiting to acquire a memory permit on this executor",
             &["executor_id"]
+        )
+        .unwrap();
+        pub static ref WORKER_ADMISSION_WAIT_SECONDS: HistogramVec = register_histogram_vec!(
+            "worker_admission_wait_seconds",
+            "Time a starting worker spent blocked in one phase of admission before it could become resident, labelled by phase (resolve_component_charge, concurrency_slot, memory, filesystem_storage). Observed once per phase per worker start. Sum across phases for the total wait; read per phase to see which resource is the constraint. worker_waiting_for_memory_count says how many workers are waiting, this says for how long",
+            &["executor_id", "phase"],
+            crate::metrics::ADMISSION_WAIT_BUCKETS.to_vec()
         )
         .unwrap();
         pub static ref WORKER_STORE_ALIVE_COUNT: GaugeVec = register_gauge_vec!(
@@ -526,6 +542,34 @@ pub mod workers {
         WORKER_STORE_ALIVE_COUNT
             .with_label_values(&[crate::metrics::storage::executor_id()])
             .dec();
+    }
+
+    /// Phases a starting worker waits through before it can become resident. Each is
+    /// a separate blocking acquisition, so recording them apart shows which resource
+    /// a stalled start is actually waiting on.
+    #[derive(Debug, Clone, Copy)]
+    pub enum AdmissionPhase {
+        ResolveComponentCharge,
+        ConcurrencySlot,
+        Memory,
+        FilesystemStorage,
+    }
+
+    impl AdmissionPhase {
+        fn as_str(self) -> &'static str {
+            match self {
+                AdmissionPhase::ResolveComponentCharge => "resolve_component_charge",
+                AdmissionPhase::ConcurrencySlot => "concurrency_slot",
+                AdmissionPhase::Memory => "memory",
+                AdmissionPhase::FilesystemStorage => "filesystem_storage",
+            }
+        }
+    }
+
+    pub fn record_worker_admission_wait(phase: AdmissionPhase, elapsed: Duration) {
+        WORKER_ADMISSION_WAIT_SECONDS
+            .with_label_values(&[crate::metrics::storage::executor_id(), phase.as_str()])
+            .observe(elapsed.as_secs_f64());
     }
 
     pub fn inc_worker_waiting_for_memory() {

--- a/golem-worker-executor/src/services/golem_config.rs
+++ b/golem-worker-executor/src/services/golem_config.rs
@@ -47,9 +47,10 @@ pub struct GolemConfig {
     /// hot paths such as promise and worker status updates from crashing the executor under load.
     #[serde(default = "default_key_value_storage_retry")]
     pub key_value_storage_retry: RetryConfig,
-    /// Retry policy applied to SQL-backed scheduler storage operations when the connection pool
-    /// is briefly exhausted (a pool acquisition timeout). The scheduler background loop panics
-    /// on exhaustion because its `schedule`/`cancel` entry points cannot propagate errors.
+    /// Retry policy applied when scheduling or cancelling hits a briefly exhausted connection
+    /// pool (a pool acquisition timeout). Those two panic once it is exhausted, because their
+    /// entry points return no error for a caller to act on; the tick's own storage calls
+    /// propagate their errors instead.
     #[serde(default = "default_scheduler_storage_retry")]
     pub scheduler_storage_retry: RetryConfig,
     /// Retry policy applied to SQL-backed indexed storage (oplog) operations when the connection

--- a/golem-worker-executor/src/services/oplog/ephemeral.rs
+++ b/golem-worker-executor/src/services/oplog/ephemeral.rs
@@ -34,7 +34,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use tracing::{Instrument, Level, Span, debug, info, span, warn};
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
+use tracing::{Instrument, Level, debug, info, warn};
 
 /// Oplog implementation for ephemeral agents, writing directly to archive layers.
 ///
@@ -171,46 +173,43 @@ impl EphemeralOplog {
         };
 
         let (jobs, mut job_rx) = tokio::sync::mpsc::unbounded_channel::<EphemeralJob>();
-        let actor = tokio::spawn(
-            async move {
-                while let Some(job) = job_rx.recv().await {
-                    match job {
-                        EphemeralJob::Add { entry, done } => {
-                            let idx = state.add(entry).await;
-                            let _ = done.send(idx);
-                        }
-                        EphemeralJob::AddPair {
-                            start,
-                            make_second,
-                            done,
-                        } => {
-                            let first_idx = state.push(start);
-                            let second = make_second(first_idx);
-                            let second_idx = state.push(second);
-                            state.maybe_commit().await;
-                            let _ = done.send((first_idx, second_idx));
-                        }
-                        EphemeralJob::Commit { done } => {
-                            let result = state.commit().await;
-                            let _ = done.send(result);
-                        }
-                        EphemeralJob::CurrentIndex { done } => {
-                            let _ = done.send(state.last_oplog_idx);
-                        }
-                        EphemeralJob::LastAddedNonHintEntry { done } => {
-                            let _ = done.send(state.last_added_non_hint_entry);
-                        }
-                        EphemeralJob::ReadSnapshot { done } => {
-                            let _ = done.send(EphemeralReadSnapshot {
-                                buffer: state.buffer.iter().cloned().collect(),
-                                last_committed_idx: state.last_committed_idx,
-                            });
-                        }
+        let actor = tokio::spawn(async move {
+            while let Some(job) = job_rx.recv().await {
+                match job {
+                    EphemeralJob::Add { entry, done } => {
+                        let idx = state.add(entry).await;
+                        let _ = done.send(idx);
+                    }
+                    EphemeralJob::AddPair {
+                        start,
+                        make_second,
+                        done,
+                    } => {
+                        let first_idx = state.push(start);
+                        let second = make_second(first_idx);
+                        let second_idx = state.push(second);
+                        state.maybe_commit().await;
+                        let _ = done.send((first_idx, second_idx));
+                    }
+                    EphemeralJob::Commit { done } => {
+                        let result = state.commit().await;
+                        let _ = done.send(result);
+                    }
+                    EphemeralJob::CurrentIndex { done } => {
+                        let _ = done.send(state.last_oplog_idx);
+                    }
+                    EphemeralJob::LastAddedNonHintEntry { done } => {
+                        let _ = done.send(state.last_added_non_hint_entry);
+                    }
+                    EphemeralJob::ReadSnapshot { done } => {
+                        let _ = done.send(EphemeralReadSnapshot {
+                            buffer: state.buffer.iter().cloned().collect(),
+                            last_committed_idx: state.last_committed_idx,
+                        });
                     }
                 }
             }
-            .in_current_span(),
-        );
+        });
 
         Self {
             owned_agent_id,
@@ -302,6 +301,7 @@ impl EphemeralOplog {
                     keep_alive: Some(keep_alive),
                     done: done_tx,
                     drain,
+                    transfer_origin: TraceOrigin::capture_current(),
                 })
                 .expect("Failed to enqueue transfer of ephemeral oplog entries");
             // Return true if there are more movable layers that could still hold data
@@ -328,18 +328,11 @@ impl EphemeralOplog {
         rx: UnboundedReceiver<BackgroundTransferMessage>,
         start: tokio::sync::oneshot::Receiver<()>,
     ) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(
-            async move {
-                if start.await.is_ok() {
-                    Self::background_transfer(owned_agent_id, lower, rx).await;
-                }
+        tokio::spawn(async move {
+            if start.await.is_ok() {
+                Self::background_transfer(owned_agent_id, lower, rx).await;
             }
-            .instrument(
-                span!(parent: None, Level::INFO, "Ephemeral oplog background transfer")
-                    .follows_from(Span::current())
-                    .clone(),
-            ),
-        )
+        })
     }
 
     async fn background_transfer(
@@ -355,66 +348,89 @@ impl EphemeralOplog {
                     mut keep_alive,
                     done,
                     drain,
+                    transfer_origin,
                 } => {
-                    if source + 1 >= lower.len().get() {
+                    async {
+                        if source + 1 >= lower.len().get() {
+                            warn!(
+                                "Invalid TransferFromLower source layer {source} — no target layer exists"
+                            );
+                            let _ = keep_alive.take();
+                            if let Some(done) = done {
+                                let _ = done.send(());
+                            }
+                            return;
+                        }
+
+                        info!(
+                            "Transferring oplog entries up to index {last_transferred_idx} of ephemeral oplog layer {source} to the next layer"
+                        );
+                        debug!("Reading entries from ephemeral oplog layer {source}");
+
+                        let source_layer = lower[source].clone();
+                        let target_layer = lower[source + 1].clone();
+
+                        let entries: Vec<_> = source_layer
+                            .read_prefix(last_transferred_idx)
+                            .await
+                            .into_iter()
+                            .collect();
+
+                        match entries.last() {
+                            Some(last_entry) => {
+                                let last_dropped_id = last_entry.0;
+                                let _ = target_layer.append(entries).await;
+                                source_layer.drop_prefix(last_dropped_id).await;
+                            }
+                            None => {
+                                warn!("No entries to transfer from ephemeral oplog layer {source}");
+                            }
+                        }
+
+                        if drain && let Some(oplog) = keep_alive.as_ref() {
+                            let _ = EphemeralOplog::try_archive_background(oplog).await;
+                        }
+
+                        let _ = keep_alive.take();
+                        if let Some(done) = done {
+                            let _ = done.send(());
+                        }
+                    }
+                    .instrument(related_span!(
+                        transfer_origin,
+                        Level::INFO,
+                        "ephemeral_oplog_background_transfer",
+                        agent_id = %owned_agent_id.agent_id,
+                        from = %format!("layer-{source}"),
+                        last_transferred_idx = %last_transferred_idx,
+                    ))
+                    .await;
+                }
+                BackgroundTransferMessage::TransferFromPrimary {
+                    mut keep_alive,
+                    done,
+                    transfer_origin,
+                    ..
+                } => {
+                    async {
+                        // Ephemeral oplogs do not use primary storage — ignore.
                         warn!(
-                            "Invalid TransferFromLower source layer {source} — no target layer exists"
+                            "Unexpected TransferFromPrimary message in ephemeral oplog for {}",
+                            owned_agent_id
                         );
                         let _ = keep_alive.take();
                         if let Some(done) = done {
                             let _ = done.send(());
                         }
-                        continue;
                     }
-
-                    info!(
-                        "Transferring oplog entries up to index {last_transferred_idx} of ephemeral oplog layer {source} to the next layer"
-                    );
-                    debug!("Reading entries from ephemeral oplog layer {source}");
-
-                    let source_layer = lower[source].clone();
-                    let target_layer = lower[source + 1].clone();
-
-                    let entries: Vec<_> = source_layer
-                        .read_prefix(last_transferred_idx)
-                        .await
-                        .into_iter()
-                        .collect();
-
-                    match entries.last() {
-                        Some(last_entry) => {
-                            let last_dropped_id = last_entry.0;
-                            let _ = target_layer.append(entries).await;
-                            source_layer.drop_prefix(last_dropped_id).await;
-                        }
-                        None => {
-                            warn!("No entries to transfer from ephemeral oplog layer {source}");
-                        }
-                    }
-
-                    if drain && let Some(oplog) = keep_alive.as_ref() {
-                        let _ = EphemeralOplog::try_archive_background(oplog).await;
-                    }
-
-                    let _ = keep_alive.take();
-                    if let Some(done) = done {
-                        let _ = done.send(());
-                    }
-                }
-                BackgroundTransferMessage::TransferFromPrimary {
-                    mut keep_alive,
-                    done,
-                    ..
-                } => {
-                    // Ephemeral oplogs do not use primary storage — ignore.
-                    warn!(
-                        "Unexpected TransferFromPrimary message in ephemeral oplog for {}",
-                        owned_agent_id
-                    );
-                    let _ = keep_alive.take();
-                    if let Some(done) = done {
-                        let _ = done.send(());
-                    }
+                    .instrument(related_span!(
+                        transfer_origin,
+                        Level::INFO,
+                        "ephemeral_oplog_background_transfer",
+                        agent_id = %owned_agent_id.agent_id,
+                        from = "primary",
+                    ))
+                    .await;
                 }
             }
         }

--- a/golem-worker-executor/src/services/oplog/multilayer.rs
+++ b/golem-worker-executor/src/services/oplog/multilayer.rs
@@ -35,6 +35,8 @@ use golem_common::model::oplog::{
 };
 use golem_common::model::{AgentId, AgentMetadata, AgentStatusRecord, OwnedAgentId, ScanCursor};
 use golem_common::read_only_lock;
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use nonempty_collections::NEVec;
 use std::cmp::min;
@@ -45,7 +47,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
-use tracing::{Instrument, Level, Span, debug, error, info, span, warn};
+use tracing::{Instrument, Level, debug, error, info, warn};
 
 pub(crate) type TransferFiber = Arc<Mutex<TransferFiberState>>;
 type TransferFibers = Arc<Mutex<HashMap<AgentId, Weak<Mutex<TransferFiberState>>>>>;
@@ -909,26 +911,19 @@ impl MultiLayerOplog {
             &result.transfer_fiber,
         );
         let (start_tx, start_rx) = tokio::sync::oneshot::channel();
-        let transfer_fiber = tokio::spawn(
-            async move {
-                if start_rx.await.is_ok() {
-                    Self::background_transfer(
-                        owned_agent_id,
-                        agent_mode,
-                        Arc::downgrade(&result_oplog),
-                        lower,
-                        multi_layer_oplog_service.clone(),
-                        rx,
-                    )
-                    .await;
-                }
+        let transfer_fiber = tokio::spawn(async move {
+            if start_rx.await.is_ok() {
+                Self::background_transfer(
+                    owned_agent_id,
+                    agent_mode,
+                    Arc::downgrade(&result_oplog),
+                    lower,
+                    multi_layer_oplog_service.clone(),
+                    rx,
+                )
+                .await;
             }
-            .instrument(
-                span!(parent: None, Level::INFO, "Oplog background transfer")
-                    .follows_from(Span::current())
-                    .clone(),
-            ),
-        );
+        });
         result
             .set_background_transfer(start_tx, transfer_fiber)
             .await;
@@ -956,31 +951,43 @@ impl MultiLayerOplog {
                     last_transferred_idx,
                     mut keep_alive,
                     done,
+                    transfer_origin,
                 } => {
-                    info!(
-                        "Transferring oplog entries up to index {last_transferred_idx} of the primary oplog to the next layer"
-                    );
-                    debug!("Reading entries from the primary oplog");
-
-                    if let Some(primary) = primary.upgrade() {
-                        let transfer = BackgroundTransferFromPrimary::new(
-                            owned_agent_id.clone(),
-                            agent_mode,
-                            last_transferred_idx,
-                            multi_layer_oplog_service.clone(),
-                            primary.clone(),
-                            lower.clone(),
+                    async {
+                        info!(
+                            "Transferring oplog entries up to index {last_transferred_idx} of the primary oplog to the next layer"
                         );
-                        let result = transfer.run().await;
-                        if let Err(error) = result {
-                            error!("Failed to transfer entries from the primary oplog: {error}");
-                        }
-                        let _ = keep_alive.take();
+                        debug!("Reading entries from the primary oplog");
 
-                        if let Some(done) = done {
-                            done.send(()).unwrap()
+                        if let Some(primary) = primary.upgrade() {
+                            let transfer = BackgroundTransferFromPrimary::new(
+                                owned_agent_id.clone(),
+                                agent_mode,
+                                last_transferred_idx,
+                                multi_layer_oplog_service.clone(),
+                                primary.clone(),
+                                lower.clone(),
+                            );
+                            let result = transfer.run().await;
+                            if let Err(error) = result {
+                                error!("Failed to transfer entries from the primary oplog: {error}");
+                            }
+                            let _ = keep_alive.take();
+
+                            if let Some(done) = done {
+                                done.send(()).unwrap()
+                            }
                         }
                     }
+                    .instrument(related_span!(
+                        transfer_origin,
+                        Level::INFO,
+                        "oplog_background_transfer",
+                        agent_id = %owned_agent_id.agent_id,
+                        from = "primary",
+                        last_transferred_idx = %last_transferred_idx,
+                    ))
+                    .await;
                 }
                 TransferFromLower {
                     source,
@@ -988,27 +995,41 @@ impl MultiLayerOplog {
                     mut keep_alive,
                     done,
                     drain: _,
+                    transfer_origin,
                 } => {
-                    info!(
-                        "Transferring oplog entries up to index {last_transferred_idx} of oplog layer {source} to the next layer"
-                    );
-                    debug!("Reading entries from oplog layer {source}");
+                    async {
+                        info!(
+                            "Transferring oplog entries up to index {last_transferred_idx} of oplog layer {source} to the next layer"
+                        );
+                        debug!("Reading entries from oplog layer {source}");
 
-                    let transfer = BackgroundTransferBetweenLowers::new(
-                        source,
-                        last_transferred_idx,
-                        lower.clone(),
-                    );
-                    let result = transfer.run().await;
+                        let transfer = BackgroundTransferBetweenLowers::new(
+                            source,
+                            last_transferred_idx,
+                            lower.clone(),
+                        );
+                        let result = transfer.run().await;
 
-                    if let Err(error) = result {
-                        error!("Failed to transfer entries from oplog layer {source}: {error}");
+                        if let Err(error) = result {
+                            error!("Failed to transfer entries from oplog layer {source}: {error}");
+                        }
+                        let _ = keep_alive.take();
+
+                        if let Some(done) = done {
+                            done.send(()).unwrap()
+                        }
                     }
-                    let _ = keep_alive.take();
-
-                    if let Some(done) = done {
-                        done.send(()).unwrap()
-                    }
+                    .instrument(related_span!(
+                        transfer_origin,
+                        Level::INFO,
+                        "oplog_background_transfer",
+                        agent_id = %owned_agent_id.agent_id,
+                        // A string in both arms: the same field name typed
+                        // differently per call site conflicts in a typed store.
+                        from = %format!("layer-{source}"),
+                        last_transferred_idx = %last_transferred_idx,
+                    ))
+                    .await;
                 }
             }
         }
@@ -1038,6 +1059,7 @@ impl MultiLayerOplog {
                     last_transferred_idx: this.primary.current_oplog_index().await,
                     keep_alive: Some(this.clone()),
                     done: done_tx,
+                    transfer_origin: TraceOrigin::capture_current(),
                 })
                 .expect("Failed to enqueue transfer of primary oplog entries");
 
@@ -1068,6 +1090,7 @@ impl MultiLayerOplog {
                         keep_alive: Some(this.clone()),
                         done: done_tx,
                         drain: false,
+                        transfer_origin: TraceOrigin::capture_current(),
                     })
                     .expect("Failed to enqueue transfer of primary oplog entries");
 
@@ -1137,6 +1160,7 @@ impl Oplog for MultiLayerOplog {
                 last_transferred_idx: last_committed_idx,
                 keep_alive: None,
                 done: None,
+                transfer_origin: TraceOrigin::capture_current(),
             });
             self.last_transfer_point.set(last_committed_idx);
         }
@@ -1270,6 +1294,7 @@ pub enum BackgroundTransferMessage {
         last_transferred_idx: OplogIndex,
         keep_alive: Option<Arc<dyn Oplog>>,
         done: Option<Sender<()>>,
+        transfer_origin: TraceOrigin,
     },
     TransferFromLower {
         source: usize,
@@ -1277,6 +1302,7 @@ pub enum BackgroundTransferMessage {
         keep_alive: Option<Arc<dyn Oplog>>,
         done: Option<Sender<()>>,
         drain: bool,
+        transfer_origin: TraceOrigin,
     },
 }
 
@@ -1369,6 +1395,7 @@ impl OplogArchive for WrappedOplogArchive {
                     keep_alive: None,
                     done: None,
                     drain: false,
+                    transfer_origin: TraceOrigin::capture_current(),
                 });
                 // Resetting the counter, otherwise it would trigger additional transfers until the background process finishes
                 self.entry_count.store(0, Ordering::Release);

--- a/golem-worker-executor/src/services/oplog/plugin.rs
+++ b/golem-worker-executor/src/services/oplog/plugin.rs
@@ -44,6 +44,8 @@ use golem_common::model::{
     OwnedAgentId, ScanCursor, ShardId,
 };
 use golem_common::read_only_lock;
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use golem_service_base::error::worker_executor::WorkerExecutorError;
 use golem_service_base::model::auth::AuthCtx;
 use golem_service_base::model::component::Component;
@@ -900,6 +902,11 @@ impl ForwardingOplog {
             state
         };
 
+        // Captured here, where the caller's context is still current: each flush
+        // tick links back to it rather than running inside it.
+        let flush_origin = TraceOrigin::capture_current();
+        let agent_id = initial_worker_metadata.agent_id.clone();
+
         let mut state = ForwardingOplogState {
             buffer: VecDeque::new(),
             buffer_start_idx: last_oplog_idx.next(),
@@ -919,85 +926,106 @@ impl ForwardingOplog {
         };
 
         let (jobs, mut job_rx) = tokio::sync::mpsc::unbounded_channel::<ForwardingJob>();
-        let actor = tokio::spawn(
-            async move {
-                while let Some(job) = job_rx.recv().await {
-                    match job {
-                        ForwardingJob::Add { entry, done } => {
-                            state.buffer.push_back(entry.clone());
+        let actor = tokio::spawn(async move {
+            while let Some(job) = job_rx.recv().await {
+                match job {
+                    ForwardingJob::Add { entry, done } => {
+                        state.buffer.push_back(entry.clone());
+                        state.last_oplog_idx = state.last_oplog_idx.next();
+                        let idx = state.inner.add(entry).await;
+                        let _ = done.send(idx);
+                    }
+                    ForwardingJob::AddPair {
+                        start,
+                        make_second,
+                        done,
+                    } => {
+                        // The `Start` will be appended at the next index; this wrapper tracks
+                        // `last_oplog_idx` in lockstep with the inner oplog, so the predicted
+                        // index matches the one the inner oplog assigns.
+                        let first_idx = state.last_oplog_idx.next();
+                        let second = make_second(first_idx);
+                        state.buffer.push_back(start.clone());
+                        state.last_oplog_idx = state.last_oplog_idx.next();
+                        state.buffer.push_back(second.clone());
+                        state.last_oplog_idx = state.last_oplog_idx.next();
+                        let result = state.inner.add_pair(start, Box::new(move |_| second)).await;
+                        let _ = done.send(result);
+                    }
+                    ForwardingJob::AddStart {
+                        serialized_request,
+                        build_start,
+                        done,
+                    } => {
+                        // The `Start` entry is built deep in the leaf from the reserved payload
+                        // reference, so — unlike `Add`/`AddPair` — it is mirrored into the
+                        // buffer only after the delegation returns it.
+                        let result = state
+                            .inner
+                            .add_start_with_reserved_raw_payload(serialized_request, build_start)
+                            .await;
+                        if let Ok(ordered) = &result {
+                            state.buffer.push_back(ordered.entry.clone());
                             state.last_oplog_idx = state.last_oplog_idx.next();
-                            let idx = state.inner.add(entry).await;
-                            let _ = done.send(idx);
                         }
-                        ForwardingJob::AddPair {
-                            start,
-                            make_second,
-                            done,
-                        } => {
-                            // The `Start` will be appended at the next index; this wrapper tracks
-                            // `last_oplog_idx` in lockstep with the inner oplog, so the predicted
-                            // index matches the one the inner oplog assigns.
-                            let first_idx = state.last_oplog_idx.next();
-                            let second = make_second(first_idx);
-                            state.buffer.push_back(start.clone());
-                            state.last_oplog_idx = state.last_oplog_idx.next();
-                            state.buffer.push_back(second.clone());
-                            state.last_oplog_idx = state.last_oplog_idx.next();
-                            let result =
-                                state.inner.add_pair(start, Box::new(move |_| second)).await;
-                            let _ = done.send(result);
+                        let _ = done.send(result);
+                    }
+                    ForwardingJob::Commit { level, done } => {
+                        let mut result = state.inner.commit(level).await;
+                        // Update last_committed_idx from committed entries
+                        if let Some(max_idx) = result.keys().max()
+                            && *max_idx > state.last_committed_idx
+                        {
+                            state.last_committed_idx = *max_idx;
                         }
-                        ForwardingJob::AddStart {
-                            serialized_request,
-                            build_start,
-                            done,
-                        } => {
-                            // The `Start` entry is built deep in the leaf from the reserved payload
-                            // reference, so — unlike `Add`/`AddPair` — it is mirrored into the
-                            // buffer only after the delegation returns it.
-                            let result = state
-                                .inner
-                                .add_start_with_reserved_raw_payload(
-                                    serialized_request,
-                                    build_start,
-                                )
+                        state.commit_count += 1;
+                        if state.commit_count >= max_commit_count {
+                            // Spanned inside the threshold check, not around the commit:
+                            // this arm runs per oplog commit, the flush only every
+                            // `max_commit_count` of them. The actor has no ambient span,
+                            // so without this the flush would be untraceable.
+                            //
+                            // Named apart from the periodic `oplog_forwarding_flush` so the
+                            // two triggers stay distinguishable in a trace backend. The link
+                            // points at the worker's startup rather than at the commit that
+                            // tripped the threshold: the actor receives commits over a
+                            // channel, so the committing invocation's context is not
+                            // available here.
+                            state
+                                .try_flush()
+                                .instrument(related_span!(
+                                    flush_origin,
+                                    tracing::Level::INFO,
+                                    "oplog_forwarding_threshold_flush",
+                                    agent_id = %agent_id
+                                ))
                                 .await;
-                            if let Ok(ordered) = &result {
-                                state.buffer.push_back(ordered.entry.clone());
-                                state.last_oplog_idx = state.last_oplog_idx.next();
-                            }
-                            let _ = done.send(result);
                         }
-                        ForwardingJob::Commit { level, done } => {
-                            let mut result = state.inner.commit(level).await;
-                            // Update last_committed_idx from committed entries
-                            if let Some(max_idx) = result.keys().max()
-                                && *max_idx > state.last_committed_idx
-                            {
-                                state.last_committed_idx = *max_idx;
-                            }
-                            state.commit_count += 1;
-                            if state.commit_count >= max_commit_count {
-                                state.try_flush().await;
-                            }
-                            // Merge entries committed directly to inner during flush
-                            // so the Worker folds them into AgentStatusRecord
-                            result.append(&mut state.pending_direct_commits);
-                            let _ = done.send(result);
-                        }
-                        ForwardingJob::SetWorkerEventService { service, done } => {
-                            state.worker_event_service = Some(service);
-                            let _ = done.send(());
-                        }
-                        ForwardingJob::Tick => {
+                        // Merge entries committed directly to inner during flush
+                        // so the Worker folds them into AgentStatusRecord
+                        result.append(&mut state.pending_direct_commits);
+                        let _ = done.send(result);
+                    }
+                    ForwardingJob::SetWorkerEventService { service, done } => {
+                        state.worker_event_service = Some(service);
+                        let _ = done.send(());
+                    }
+                    ForwardingJob::Tick => {
+                        async {
                             state.try_locality_recovery().await;
                             state.try_flush().await;
                         }
+                        .instrument(related_span!(
+                            flush_origin,
+                            tracing::Level::INFO,
+                            "oplog_forwarding_flush",
+                            agent_id = %agent_id
+                        ))
+                        .await;
                     }
                 }
             }
-            .in_current_span(),
-        );
+        });
 
         let timer = tokio::spawn({
             let jobs = jobs.clone();
@@ -1009,7 +1037,6 @@ impl ForwardingOplog {
                     }
                 }
             }
-            .in_current_span()
         });
         Self {
             inner,
@@ -1480,6 +1507,17 @@ impl ForwardingOplogState {
                 let environment_id = metadata.environment_id;
                 let caller_account_id = metadata.created_by;
                 let target_clone = target_agent_id.clone();
+                // The task polls on after this flush returned, so it links back to
+                // the flush rather than running inside its span. See `TraceOrigin`.
+                let monitor_span = related_span!(
+                    TraceOrigin::capture_current(),
+                    tracing::Level::INFO,
+                    "oplog_plugin_batch_monitor",
+                    agent_id = %metadata.agent_id,
+                    grant_id = %grant_id,
+                    batch_start = %batch_start,
+                    batch_end = %batch_end
+                );
                 let monitor = tokio::spawn(
                     async move {
                         // Poll until the invocation completes, with a timeout
@@ -1534,7 +1572,7 @@ impl ForwardingOplogState {
                             }
                         }
                     }
-                    .in_current_span(),
+                    .instrument(monitor_span),
                 );
                 self.monitor_tasks.push(monitor.into());
             }

--- a/golem-worker-executor/src/services/quota.rs
+++ b/golem-worker-executor/src/services/quota.rs
@@ -471,26 +471,22 @@ impl GrpcQuotaService {
         renewal_interval: Duration,
     ) {
         let svc_weak = Arc::downgrade(self);
-        tokio::spawn(
-            async move {
-                loop {
-                    tokio::select! {
-                        _ = shutdown_token.cancelled() => break,
-                        _ = tokio::time::sleep(renewal_interval) => {}
-                    }
-                    let svc = match svc_weak.upgrade() {
-                        Some(s) => s,
-                        None => {
-                            info!("QuotaService was dropped, stopping renewal loop");
-                            break;
-                        }
-                    };
-                    svc.renew_all().await;
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => break,
+                    _ = tokio::time::sleep(renewal_interval) => {}
                 }
+                let svc = match svc_weak.upgrade() {
+                    Some(s) => s,
+                    None => {
+                        info!("QuotaService was dropped, stopping renewal loop");
+                        break;
+                    }
+                };
+                svc.renew_all().await;
             }
-            .instrument(info_span!("Quota renewal loop"))
-            .instrument(tracing::Span::current()),
-        );
+        });
     }
 
     async fn get_slot(&self, key: &ResourceKey) -> Option<Arc<LeaseEntry>> {
@@ -741,221 +737,227 @@ impl GrpcQuotaService {
         }
     }
 
+    /// Performs one renewal pass, spanned per pass rather than per loop: a span
+    /// wrapping the loop would never close, so it would never be exported.
     async fn renew_all(&self) {
-        // phase 1: collect live and dead slots
-        let mut entries_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
-        let mut leases_to_release: Vec<TrackedLease> = Vec::new();
+        async {
+            // phase 1: collect live and dead slots
+            let mut entries_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
+            let mut leases_to_release: Vec<TrackedLease> = Vec::new();
 
-        self.state
-            .retain_async(|key, entry| {
-                let is_dead = entry.interest.lock().unwrap().strong_count() == 0;
-                if is_dead {
-                    // Try to take the lease for release; skip if inner is locked.
-                    if let Ok(mut inner) = entry.inner.try_lock() {
-                        leases_to_release.push(inner.take_lease());
-                        false
+            self.state
+                .retain_async(|key, entry| {
+                    let is_dead = entry.interest.lock().unwrap().strong_count() == 0;
+                    if is_dead {
+                        // Try to take the lease for release; skip if inner is locked.
+                        if let Ok(mut inner) = entry.inner.try_lock() {
+                            leases_to_release.push(inner.take_lease());
+                            false
+                        } else {
+                            // Inner is locked — keep for next pass.
+                            true
+                        }
                     } else {
-                        // Inner is locked — keep for next pass.
+                        entries_to_renew.push((key.clone(), entry.clone()));
                         true
                     }
-                } else {
-                    entries_to_renew.push((key.clone(), entry.clone()));
-                    true
-                }
-            })
-            .await;
+                })
+                .await;
 
-        // phase 2: release dead leases
-        if !leases_to_release.is_empty() {
-            debug!("releasing {} unneeded leases", leases_to_release.len());
-        }
+            // phase 2: release dead leases
+            if !leases_to_release.is_empty() {
+                debug!("releasing {} unneeded leases", leases_to_release.len());
+            }
 
-        for lease in leases_to_release {
-            self.try_release_lease_if_needed(lease).await;
-        }
+            for lease in leases_to_release {
+                self.try_release_lease_if_needed(lease).await;
+            }
 
-        // phase 3: renew live leases before they expire.
-        // Bounded leases are batched; unlimited leases are re-acquired individually.
-        let mut bounded_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
-        let mut unlimited_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
+            // phase 3: renew live leases before they expire.
+            // Bounded leases are batched; unlimited leases are re-acquired individually.
+            let mut bounded_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
+            let mut unlimited_to_renew: Vec<(ResourceKey, Arc<LeaseEntry>)> = Vec::new();
 
-        for (key, slot_mutex) in &entries_to_renew {
-            let slot = slot_mutex.inner.lock().await;
-            match &slot.lease {
-                TrackedLease::Bounded(b) => {
-                    if (b.expires_at - Utc::now()).to_std().unwrap_or_default()
-                        >= self.renewal_threshold
-                    {
-                        continue; // Plenty of time left — skip until closer to expiry.
+            for (key, slot_mutex) in &entries_to_renew {
+                let slot = slot_mutex.inner.lock().await;
+                match &slot.lease {
+                    TrackedLease::Bounded(b) => {
+                        if (b.expires_at - Utc::now()).to_std().unwrap_or_default()
+                            >= self.renewal_threshold
+                        {
+                            continue; // Plenty of time left — skip until closer to expiry.
+                        }
+                        bounded_to_renew.push((key.clone(), slot_mutex.clone()));
                     }
-                    bounded_to_renew.push((key.clone(), slot_mutex.clone()));
-                }
-                TrackedLease::Unlimited(u) => {
-                    if (u.expires_at - Utc::now()).to_std().unwrap_or_default()
-                        >= self.renewal_threshold
-                    {
-                        continue;
+                    TrackedLease::Unlimited(u) => {
+                        if (u.expires_at - Utc::now()).to_std().unwrap_or_default()
+                            >= self.renewal_threshold
+                        {
+                            continue;
+                        }
+                        unlimited_to_renew.push((key.clone(), slot_mutex.clone()));
                     }
-                    unlimited_to_renew.push((key.clone(), slot_mutex.clone()));
-                }
-                TrackedLease::Lost => continue,
-            }
-        }
-
-        // Batch-renew all bounded leases in one RPC.
-        // Lock all slots first, hold the locks across the RPC, then apply
-        // results. This prevents concurrent try_reserve/commit/notify_demand
-        // from modifying state between when we snapshot it and when we write
-        // the new allocation back.
-        if !bounded_to_renew.is_empty() {
-            let mut locked: Vec<(ResourceKey, tokio::sync::MutexGuard<LeaseInner>)> =
-                Vec::with_capacity(bounded_to_renew.len());
-            for (key, entry) in &bounded_to_renew {
-                locked.push((key.clone(), entry.inner.lock().await));
-            }
-
-            let mut batch: Vec<BatchRenewalEntry> = Vec::with_capacity(locked.len());
-            for (_, slot) in &locked {
-                if let TrackedLease::Bounded(b) = &slot.lease {
-                    batch.push(BatchRenewalEntry {
-                        resource_definition_id: b.resource_definition_id,
-                        epoch: b.epoch.0,
-                        unused: b.remaining,
-                        pending_reservations: slot
-                            .waiters
-                            .iter()
-                            .map(|w| PendingReservation {
-                                amount: w.amount,
-                                priority: w.priority(),
-                            })
-                            .collect(),
-                    });
+                    TrackedLease::Lost => continue,
                 }
             }
 
-            let rpc_result = self.client.batch_renew_quota_leases(self.port, batch).await;
+            // Batch-renew all bounded leases in one RPC.
+            // Lock all slots first, hold the locks across the RPC, then apply
+            // results. This prevents concurrent try_reserve/commit/notify_demand
+            // from modifying state between when we snapshot it and when we write
+            // the new allocation back.
+            if !bounded_to_renew.is_empty() {
+                let mut locked: Vec<(ResourceKey, tokio::sync::MutexGuard<LeaseInner>)> =
+                    Vec::with_capacity(bounded_to_renew.len());
+                for (key, entry) in &bounded_to_renew {
+                    locked.push((key.clone(), entry.inner.lock().await));
+                }
 
-            match rpc_result {
-                Ok(results) => {
-                    for ((key, mut slot), result) in locked.into_iter().zip(results) {
-                        let (expires_at, resource_definition_id) =
-                            if let TrackedLease::Bounded(b) = &slot.lease {
-                                (b.expires_at, b.resource_definition_id)
-                            } else {
-                                continue;
-                            };
-                        match result {
-                            Ok(new_lease) => {
-                                if let QuotaLease::Bounded {
-                                    allocation,
-                                    total_available_amount,
-                                    ..
-                                } = &new_lease
-                                {
-                                    debug!(
-                                        resource_definition_id = %resource_definition_id,
+                let mut batch: Vec<BatchRenewalEntry> = Vec::with_capacity(locked.len());
+                for (_, slot) in &locked {
+                    if let TrackedLease::Bounded(b) = &slot.lease {
+                        batch.push(BatchRenewalEntry {
+                            resource_definition_id: b.resource_definition_id,
+                            epoch: b.epoch.0,
+                            unused: b.remaining,
+                            pending_reservations: slot
+                                .waiters
+                                .iter()
+                                .map(|w| PendingReservation {
+                                    amount: w.amount,
+                                    priority: w.priority(),
+                                })
+                                .collect(),
+                        });
+                    }
+                }
+
+                let rpc_result = self.client.batch_renew_quota_leases(self.port, batch).await;
+
+                match rpc_result {
+                    Ok(results) => {
+                        for ((key, mut slot), result) in locked.into_iter().zip(results) {
+                            let (expires_at, resource_definition_id) =
+                                if let TrackedLease::Bounded(b) = &slot.lease {
+                                    (b.expires_at, b.resource_definition_id)
+                                } else {
+                                    continue;
+                                };
+                            match result {
+                                Ok(new_lease) => {
+                                    if let QuotaLease::Bounded {
                                         allocation,
-                                        total_available = total_available_amount,
-                                        waiters = slot.waiters.len(),
-                                        "renew_all: received new allocation"
-                                    );
+                                        total_available_amount,
+                                        ..
+                                    } = &new_lease
+                                    {
+                                        debug!(
+                                            resource_definition_id = %resource_definition_id,
+                                            allocation,
+                                            total_available = total_available_amount,
+                                            waiters = slot.waiters.len(),
+                                            "renew_all: received new allocation"
+                                        );
+                                    }
+                                    slot.lease = Self::from_quota_lease(&new_lease);
+                                    self.process_waiters(&mut slot, &key);
                                 }
-                                slot.lease = Self::from_quota_lease(&new_lease);
-                                self.process_waiters(&mut slot, &key);
-                            }
-                            Err(QuotaError::LeaseNotFound(_) | QuotaError::StaleEpoch(_)) => {
-                                tracing::warn!(
-                                    resource_definition_id = %resource_definition_id,
-                                    "Lease lost during batch renewal"
-                                );
-                                slot.lease = TrackedLease::Lost;
-                            }
-                            Err(err) => {
-                                tracing::error!(
-                                    resource_definition_id = %resource_definition_id,
-                                    error = %err,
-                                    "Failed to renew bounded quota lease in batch"
-                                );
-                                if Utc::now() >= expires_at {
+                                Err(QuotaError::LeaseNotFound(_) | QuotaError::StaleEpoch(_)) => {
+                                    tracing::warn!(
+                                        resource_definition_id = %resource_definition_id,
+                                        "Lease lost during batch renewal"
+                                    );
                                     slot.lease = TrackedLease::Lost;
+                                }
+                                Err(err) => {
+                                    tracing::error!(
+                                        resource_definition_id = %resource_definition_id,
+                                        error = %err,
+                                        "Failed to renew bounded quota lease in batch"
+                                    );
+                                    if Utc::now() >= expires_at {
+                                        slot.lease = TrackedLease::Lost;
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                Err(err) => {
-                    tracing::error!(error = %err, "batch_renew_quota_leases failed entirely");
+                    Err(err) => {
+                        tracing::error!(error = %err, "batch_renew_quota_leases failed entirely");
+                    }
                 }
             }
-        }
 
-        // Renew unlimited leases individually
-        for (key, slot_mutex) in &unlimited_to_renew {
-            let (environment_id, resource_name) = key;
-            let mut slot = slot_mutex.inner.lock().await;
-            if let TrackedLease::Unlimited(u) = &slot.lease {
-                let expires_at = u.expires_at;
+            // Renew unlimited leases individually
+            for (key, slot_mutex) in &unlimited_to_renew {
+                let (environment_id, resource_name) = key;
+                let mut slot = slot_mutex.inner.lock().await;
+                if let TrackedLease::Unlimited(u) = &slot.lease {
+                    let expires_at = u.expires_at;
+                    match self
+                        .client
+                        .acquire_quota_lease(*environment_id, resource_name.clone(), self.port)
+                        .await
+                    {
+                        Ok(new_lease) => {
+                            slot.lease = Self::from_quota_lease(&new_lease);
+                            self.process_waiters(&mut slot, key);
+                        }
+                        Err(err) => {
+                            tracing::error!(error = %err, "Failed to renew unlimited quota lease");
+                            if Utc::now() >= expires_at {
+                                slot.lease = TrackedLease::Lost;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // phase 4: re-acquire all Lost leases that still have live interest.
+            // Waiters are kept in place and served once a new lease arrives.
+            // If re-acquire fails we leave the entry as Lost and retry next loop.
+            for (key, slot_mutex) in &entries_to_renew {
+                let (environment_id, resource_name) = key;
+                let is_lost = matches!(slot_mutex.inner.lock().await.lease, TrackedLease::Lost);
+                if !is_lost {
+                    continue;
+                }
+
+                debug!("trying to reacquire lost lease {environment_id}/{resource_name}");
+
                 match self
                     .client
                     .acquire_quota_lease(*environment_id, resource_name.clone(), self.port)
                     .await
                 {
                     Ok(new_lease) => {
-                        slot.lease = Self::from_quota_lease(&new_lease);
-                        self.process_waiters(&mut slot, key);
-                    }
-                    Err(err) => {
-                        tracing::error!(error = %err, "Failed to renew unlimited quota lease");
-                        if Utc::now() >= expires_at {
-                            slot.lease = TrackedLease::Lost;
+                        let mut slot = slot_mutex.inner.lock().await;
+                        // Only update if still Lost — another concurrent path won't exist
+                        // given the single renewal task, but guard defensively.
+                        if matches!(slot.lease, TrackedLease::Lost) {
+                            tracing::info!(
+                                environment_id = %environment_id,
+                                resource_name = %resource_name,
+                                "Re-acquired lost lease"
+                            );
+                            slot.lease = Self::from_quota_lease(&new_lease);
+                            self.process_waiters(&mut slot, key);
                         }
                     }
-                }
-            }
-        }
-
-        // phase 4: re-acquire all Lost leases that still have live interest.
-        // Waiters are kept in place and served once a new lease arrives.
-        // If re-acquire fails we leave the entry as Lost and retry next loop.
-        for (key, slot_mutex) in &entries_to_renew {
-            let (environment_id, resource_name) = key;
-            let is_lost = matches!(slot_mutex.inner.lock().await.lease, TrackedLease::Lost);
-            if !is_lost {
-                continue;
-            }
-
-            debug!("trying to reacquire lost lease {environment_id}/{resource_name}");
-
-            match self
-                .client
-                .acquire_quota_lease(*environment_id, resource_name.clone(), self.port)
-                .await
-            {
-                Ok(new_lease) => {
-                    let mut slot = slot_mutex.inner.lock().await;
-                    // Only update if still Lost — another concurrent path won't exist
-                    // given the single renewal task, but guard defensively.
-                    if matches!(slot.lease, TrackedLease::Lost) {
-                        tracing::info!(
+                    Err(err) => {
+                        tracing::warn!(
                             environment_id = %environment_id,
                             resource_name = %resource_name,
-                            "Re-acquired lost lease"
+                            error = %err,
+                            "Re-acquire of lost lease failed, will retry next loop"
                         );
-                        slot.lease = Self::from_quota_lease(&new_lease);
-                        self.process_waiters(&mut slot, key);
+                        // Leave as Lost — the next renewal cycle will try again.
                     }
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        environment_id = %environment_id,
-                        resource_name = %resource_name,
-                        error = %err,
-                        "Re-acquire of lost lease failed, will retry next loop"
-                    );
-                    // Leave as Lost — the next renewal cycle will try again.
                 }
             }
         }
+        .instrument(info_span!("quota_renewal"))
+        .await
     }
 
     async fn try_release_lease_if_needed(&self, tracked_lease: TrackedLease) {
@@ -1407,6 +1409,18 @@ mod tests {
             Duration::from_millis(200),
             Duration::from_secs(60),
         )
+    }
+
+    /// One span per renewal pass, not one for the lifetime of the renewal loop.
+    #[test]
+    async fn renew_all_records_one_closed_span_per_pass() {
+        let svc = make_service(MockShardManager::new());
+
+        let recorder = crate::span_test_support::record_spans();
+        svc.renew_all().await;
+
+        recorder.assert_closed_span("quota_renewal");
+        recorder.assert_all_closed();
     }
 
     #[test]

--- a/golem-worker-executor/src/services/rdbms/ignite/client_rdbms.rs
+++ b/golem-worker-executor/src/services/rdbms/ignite/client_rdbms.rs
@@ -464,6 +464,7 @@ impl Rdbms<IgniteType> for IgniteRdbms {
         DbValue: 'async_trait,
     {
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             pool_key = key.to_string(),
             "ignite execute: {statement}, params: {}",
             params.len()
@@ -492,6 +493,7 @@ impl Rdbms<IgniteType> for IgniteRdbms {
         DbValue: 'async_trait,
     {
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             pool_key = key.to_string(),
             "ignite query_stream: {statement}, params: {}",
             params.len()
@@ -525,6 +527,7 @@ impl Rdbms<IgniteType> for IgniteRdbms {
         DbValue: 'async_trait,
     {
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             pool_key = key.to_string(),
             "ignite query: {statement}, params: {}",
             params.len()
@@ -543,7 +546,7 @@ impl Rdbms<IgniteType> for IgniteRdbms {
         key: &RdbmsPoolKey,
         worker_id: &AgentId,
     ) -> Result<Arc<dyn DbTransaction<IgniteType> + Send + Sync>, RdbmsError> {
-        debug!(pool_key = key.to_string(), "ignite begin_transaction");
+        debug!(target: golem_common::tracing::target::AGENT_RDBMS, pool_key = key.to_string(), "ignite begin_transaction");
         let client = self.get_or_create_client(key, worker_id).await?;
         let tx = client.begin_transaction().await.map_err(|e| {
             error!(

--- a/golem-worker-executor/src/services/rdbms/sqlx_common.rs
+++ b/golem-worker-executor/src/services/rdbms/sqlx_common.rs
@@ -217,6 +217,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             "execute - statement: {}, params count: {}",
@@ -255,6 +256,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             "query stream - statement: {}, params count: {}",
@@ -301,6 +303,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             "query - statement: {}, params count: {}",
@@ -334,6 +337,7 @@ where
     ) -> Result<Arc<dyn DbTransaction<T> + Send + Sync>, RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             "begin transaction",
@@ -367,6 +371,7 @@ where
     ) -> Result<RdbmsTransactionStatus, RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             transaction_id = transaction_id.to_string(),
@@ -400,6 +405,7 @@ where
     ) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = key.to_string(),
             transaction_id = transaction_id.to_string(),
@@ -657,6 +663,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -693,6 +700,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -728,6 +736,7 @@ where
     {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -759,6 +768,7 @@ where
     async fn pre_commit(&self) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -783,6 +793,7 @@ where
     async fn pre_rollback(&self) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -807,6 +818,7 @@ where
     async fn commit(&self) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -837,6 +849,7 @@ where
     async fn rollback(&self) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -867,6 +880,7 @@ where
     async fn rollback_if_open(&self) -> Result<(), RdbmsError> {
         let start = Instant::now();
         debug!(
+            target: golem_common::tracing::target::AGENT_RDBMS,
             rdbms_type = self.rdbms_type.to_string(),
             pool_key = self.pool_key.to_string(),
             transaction_id = self.transaction_id.to_string(),
@@ -982,7 +996,7 @@ where
     DbRow<T::DbValue>: for<'a> TryFrom<&'a DB::Row, Error = String>,
 {
     async fn get_columns(&self) -> Result<Vec<T::DbColumn>, RdbmsError> {
-        debug!(rdbms_type = self.rdbms_type.to_string(), "get columns");
+        debug!(target: golem_common::tracing::target::AGENT_RDBMS, rdbms_type = self.rdbms_type.to_string(), "get columns");
         Ok(self.columns.clone())
     }
 
@@ -990,6 +1004,7 @@ where
         let mut rows = self.first_rows.lock().await;
         if rows.is_some() {
             debug!(
+                target: golem_common::tracing::target::AGENT_RDBMS,
                 rdbms_type = self.rdbms_type.to_string(),
                 "get next - initial"
             );
@@ -997,7 +1012,7 @@ where
             *rows = None;
             Ok(result)
         } else {
-            debug!(rdbms_type = self.rdbms_type.to_string(), "get next");
+            debug!(target: golem_common::tracing::target::AGENT_RDBMS, rdbms_type = self.rdbms_type.to_string(), "get next");
             let mut stream = self.row_stream.lock().await;
             let next = stream.next().await;
 

--- a/golem-worker-executor/src/services/resource_limits.rs
+++ b/golem-worker-executor/src/services/resource_limits.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
-use tracing::{Instrument, Level, error, span};
+use tracing::{Instrument, error, info_span};
 
 #[derive(Debug)]
 pub struct AtomicResourceEntry {
@@ -433,31 +433,28 @@ impl ResourceLimitsGrpc {
         let svc_weak = Arc::downgrade(&svc);
 
         // Background task for batch updates
-        tokio::spawn(
-            async move {
-                let mut tick = tokio::time::interval(batch_update_interval);
-                let refresh_threshold_secs = limit_refresh_interval.as_secs() as i64;
-                loop {
-                    tokio::select! {
-                        _ = shutdown_token.cancelled() => {
-                            break;
-                        }
-                        _ = tick.tick() => {}
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(batch_update_interval);
+            let refresh_threshold_secs = limit_refresh_interval.as_secs() as i64;
+            loop {
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        break;
                     }
-
-                    let svc_arc = match svc_weak.upgrade() {
-                        Some(s) => s,
-                        None => {
-                            // service itself was dropped, we can exit
-                            break;
-                        }
-                    };
-
-                    svc_arc.send_batch(refresh_threshold_secs).await;
+                    _ = tick.tick() => {}
                 }
+
+                let svc_arc = match svc_weak.upgrade() {
+                    Some(s) => s,
+                    None => {
+                        // service itself was dropped, we can exit
+                        break;
+                    }
+                };
+
+                svc_arc.send_batch(refresh_threshold_secs).await;
             }
-            .instrument(span!(parent: None, Level::INFO, "Resource limits batch updates")),
-        );
+        });
 
         svc
     }
@@ -490,158 +487,162 @@ impl ResourceLimitsGrpc {
     /// failure, resets in-flight deltas for active accounts so they are not
     /// double-counted next cycle; stale idle accounts are retried next tick.
     async fn send_batch(&self, refresh_threshold_secs: i64) {
-        // Fuel and call usage need batch-interval freshness. Storage-only usage stays local until
-        // the limit refresh interval to avoid expensive registry limit queries every minute.
-        let mut updates: HashMap<AccountId, ResourceUsageUpdate> = HashMap::new();
+        async {
+            // Fuel and call usage need batch-interval freshness. Storage-only usage stays local until
+            // the limit refresh interval to avoid expensive registry limit queries every minute.
+            let mut updates: HashMap<AccountId, ResourceUsageUpdate> = HashMap::new();
 
-        self.entries
-            .iter_async(|k, cell| {
-                if let Some(entry) = cell.get() {
-                    let fuel_delta = entry.delta.swap(0, Ordering::AcqRel);
-                    // Move unsynced call counts into the syncing bucket for this batch.
-                    let http_count = entry.unsynced_http_calls.swap(0, Ordering::AcqRel);
-                    let rpc_count = entry.unsynced_rpc_calls.swap(0, Ordering::AcqRel);
-                    let active = fuel_delta != 0 || http_count > 0 || rpc_count > 0;
-                    let stale = entry.secs_since_last_refresh() >= refresh_threshold_secs;
+            self.entries
+                .iter_async(|k, cell| {
+                    if let Some(entry) = cell.get() {
+                        let fuel_delta = entry.delta.swap(0, Ordering::AcqRel);
+                        // Move unsynced call counts into the syncing bucket for this batch.
+                        let http_count = entry.unsynced_http_calls.swap(0, Ordering::AcqRel);
+                        let rpc_count = entry.unsynced_rpc_calls.swap(0, Ordering::AcqRel);
+                        let active = fuel_delta != 0 || http_count > 0 || rpc_count > 0;
+                        let stale = entry.secs_since_last_refresh() >= refresh_threshold_secs;
 
-                    if active || stale {
-                        // Integrate the meters only when this batch will actually ship an
-                        // update. Neither `active` nor `stale` depends on storage, and
-                        // un-integrated byte-nanoseconds stay in the meter's own state until
-                        // the next flush or its `Drop`, so nothing is lost by deferring —
-                        // storage-only accounts simply settle on the limit refresh interval
-                        // instead of every batch tick.
-                        entry.flush_storage_meters(Instant::now());
-                        let durable_storage_byte_seconds_delta =
-                            entry.durable_byte_seconds_delta.swap(0, Ordering::AcqRel);
-                        let ephemeral_storage_byte_seconds_delta =
-                            entry.ephemeral_byte_seconds_delta.swap(0, Ordering::AcqRel);
-                        if http_count > 0 {
+                        if active || stale {
+                            // Integrate the meters only when this batch will actually ship an
+                            // update. Neither `active` nor `stale` depends on storage, and
+                            // un-integrated byte-nanoseconds stay in the meter's own state until
+                            // the next flush or its `Drop`, so nothing is lost by deferring —
+                            // storage-only accounts simply settle on the limit refresh interval
+                            // instead of every batch tick.
+                            entry.flush_storage_meters(Instant::now());
+                            let durable_storage_byte_seconds_delta =
+                                entry.durable_byte_seconds_delta.swap(0, Ordering::AcqRel);
+                            let ephemeral_storage_byte_seconds_delta =
+                                entry.ephemeral_byte_seconds_delta.swap(0, Ordering::AcqRel);
+                            if http_count > 0 {
+                                entry
+                                    .syncing_http_calls
+                                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |c| {
+                                        Some(c.saturating_add(http_count))
+                                    })
+                                    .ok();
+                            }
+                            if rpc_count > 0 {
+                                entry
+                                    .syncing_rpc_calls
+                                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |c| {
+                                        Some(c.saturating_add(rpc_count))
+                                    })
+                                    .ok();
+                            }
+
                             entry
-                                .syncing_http_calls
-                                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |c| {
-                                    Some(c.saturating_add(http_count))
+                                .in_flight_delta
+                                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |d| {
+                                    Some(d.saturating_add(fuel_delta))
                                 })
                                 .ok();
+                            updates.insert(
+                                *k,
+                                ResourceUsageUpdate {
+                                    fuel_delta,
+                                    http_call_count_delta: http_count,
+                                    rpc_call_count_delta: rpc_count,
+                                    durable_storage_byte_seconds_delta,
+                                    ephemeral_storage_byte_seconds_delta,
+                                },
+                            );
                         }
-                        if rpc_count > 0 {
-                            entry
-                                .syncing_rpc_calls
-                                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |c| {
-                                    Some(c.saturating_add(rpc_count))
-                                })
-                                .ok();
-                        }
-
-                        entry
-                            .in_flight_delta
-                            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |d| {
-                                Some(d.saturating_add(fuel_delta))
-                            })
-                            .ok();
-                        updates.insert(
-                            *k,
-                            ResourceUsageUpdate {
-                                fuel_delta,
-                                http_call_count_delta: http_count,
-                                rpc_call_count_delta: rpc_count,
-                                durable_storage_byte_seconds_delta,
-                                ephemeral_storage_byte_seconds_delta,
-                            },
-                        );
                     }
-                }
-                true
-            })
-            .await;
-
-        if updates.is_empty() {
-            return;
-        }
-
-        tracing::debug!(
-            "Sending batch: {} fuel, {} durable storage, {} ephemeral storage, {} http, {} rpc, {} stale idle account(s)",
-            updates.values().filter(|u| u.fuel_delta != 0).count(),
-            updates
-                .values()
-                .filter(|u| u.durable_storage_byte_seconds_delta != 0)
-                .count(),
-            updates
-                .values()
-                .filter(|u| u.ephemeral_storage_byte_seconds_delta != 0)
-                .count(),
-            updates
-                .values()
-                .filter(|u| u.http_call_count_delta > 0)
-                .count(),
-            updates
-                .values()
-                .filter(|u| u.rpc_call_count_delta > 0)
-                .count(),
-            updates
-                .values()
-                .filter(|u| {
-                    u.fuel_delta == 0
-                        && u.durable_storage_byte_seconds_delta == 0
-                        && u.ephemeral_storage_byte_seconds_delta == 0
-                        && u.http_call_count_delta == 0
-                        && u.rpc_call_count_delta == 0
+                    true
                 })
-                .count(),
-        );
+                .await;
 
-        // Send resource usage batch. The response refreshes all account limits
-        // (fuel, memory, disk, per-invocation caps, and monthly call budgets)
-        // for every account in `updates`.
-        match self
-            .client
-            .batch_update_resource_usage(updates.clone())
-            .await
-        {
-            Ok(updated_limits) => {
-                for (account_id, update) in &updates {
-                    let durable = update.durable_storage_byte_seconds_delta;
-                    let ephemeral = update.ephemeral_storage_byte_seconds_delta;
-                    if durable == 0 && ephemeral == 0 {
-                        continue;
-                    }
-
-                    let account_id = account_id.to_string();
-                    if durable > 0 {
-                        record_storage_byte_seconds(&account_id, AgentMode::Durable, durable);
-                    }
-                    if ephemeral > 0 {
-                        record_storage_byte_seconds(&account_id, AgentMode::Ephemeral, ephemeral);
-                    }
-                }
-                for (account_id, resource_limits) in updated_limits.0 {
-                    self.update_last_known_limits(account_id, resource_limits)
-                        .await;
-                }
+            if updates.is_empty() {
+                return;
             }
-            Err(err) => {
-                record_resource_usage_batch_update_failure();
-                error!("Failed to send batched resource usage updates: {}", err);
-                for (account_id, update) in &updates {
-                    if update.fuel_delta != 0
-                        || update.durable_storage_byte_seconds_delta != 0
-                        || update.ephemeral_storage_byte_seconds_delta != 0
-                        || update.http_call_count_delta > 0
-                        || update.rpc_call_count_delta > 0
-                    {
-                        error!(
-                            "Lost resource usage updates for account {account_id}: fuel_delta={}, durable_storage_byte_seconds_delta={}, ephemeral_storage_byte_seconds_delta={}, http_call_count_delta={}, rpc_call_count_delta={}",
-                            update.fuel_delta,
-                            update.durable_storage_byte_seconds_delta,
-                            update.ephemeral_storage_byte_seconds_delta,
-                            update.http_call_count_delta,
-                            update.rpc_call_count_delta,
-                        );
-                        self.reset_in_flight_delta(*account_id).await;
+
+            tracing::debug!(
+                "Sending batch: {} fuel, {} durable storage, {} ephemeral storage, {} http, {} rpc, {} stale idle account(s)",
+                updates.values().filter(|u| u.fuel_delta != 0).count(),
+                updates
+                    .values()
+                    .filter(|u| u.durable_storage_byte_seconds_delta != 0)
+                    .count(),
+                updates
+                    .values()
+                    .filter(|u| u.ephemeral_storage_byte_seconds_delta != 0)
+                    .count(),
+                updates
+                    .values()
+                    .filter(|u| u.http_call_count_delta > 0)
+                    .count(),
+                updates
+                    .values()
+                    .filter(|u| u.rpc_call_count_delta > 0)
+                    .count(),
+                updates
+                    .values()
+                    .filter(|u| {
+                        u.fuel_delta == 0
+                            && u.durable_storage_byte_seconds_delta == 0
+                            && u.ephemeral_storage_byte_seconds_delta == 0
+                            && u.http_call_count_delta == 0
+                            && u.rpc_call_count_delta == 0
+                    })
+                    .count(),
+            );
+
+            // Send resource usage batch. The response refreshes all account limits
+            // (fuel, memory, disk, per-invocation caps, and monthly call budgets)
+            // for every account in `updates`.
+            match self
+                .client
+                .batch_update_resource_usage(updates.clone())
+                .await
+            {
+                Ok(updated_limits) => {
+                    for (account_id, update) in &updates {
+                        let durable = update.durable_storage_byte_seconds_delta;
+                        let ephemeral = update.ephemeral_storage_byte_seconds_delta;
+                        if durable == 0 && ephemeral == 0 {
+                            continue;
+                        }
+
+                        let account_id = account_id.to_string();
+                        if durable > 0 {
+                            record_storage_byte_seconds(&account_id, AgentMode::Durable, durable);
+                        }
+                        if ephemeral > 0 {
+                            record_storage_byte_seconds(&account_id, AgentMode::Ephemeral, ephemeral);
+                        }
+                    }
+                    for (account_id, resource_limits) in updated_limits.0 {
+                        self.update_last_known_limits(account_id, resource_limits)
+                            .await;
+                    }
+                }
+                Err(err) => {
+                    record_resource_usage_batch_update_failure();
+                    error!("Failed to send batched resource usage updates: {}", err);
+                    for (account_id, update) in &updates {
+                        if update.fuel_delta != 0
+                            || update.durable_storage_byte_seconds_delta != 0
+                            || update.ephemeral_storage_byte_seconds_delta != 0
+                            || update.http_call_count_delta > 0
+                            || update.rpc_call_count_delta > 0
+                        {
+                            error!(
+                                "Lost resource usage updates for account {account_id}: fuel_delta={}, durable_storage_byte_seconds_delta={}, ephemeral_storage_byte_seconds_delta={}, http_call_count_delta={}, rpc_call_count_delta={}",
+                                update.fuel_delta,
+                                update.durable_storage_byte_seconds_delta,
+                                update.ephemeral_storage_byte_seconds_delta,
+                                update.http_call_count_delta,
+                                update.rpc_call_count_delta,
+                            );
+                            self.reset_in_flight_delta(*account_id).await;
+                        }
                     }
                 }
             }
         }
+        .instrument(info_span!("resource_limits_batch_update"))
+        .await
     }
 
     async fn update_last_known_limits(
@@ -1791,6 +1792,36 @@ mod tests {
 
         let result = svc.initialize_account(account_id()).await;
         assert!(result.is_err());
+    }
+
+    /// One span per tick, not one for the lifetime of the batch loop.
+    #[test]
+    async fn send_batch_records_one_closed_span_when_it_sends_a_batch() {
+        let mock = Arc::new(MockRegistryService::new(1000, 512));
+        let svc = make_grpc(mock);
+        let entry = svc.initialize_account(account_id()).await.unwrap();
+        entry.borrow_fuel(300);
+
+        let recorder = crate::span_test_support::record_spans();
+        svc.send_batch(NO_IDLE_REFRESH_THRESHOLD_SECS).await;
+
+        recorder.assert_closed_span("resource_limits_batch_update");
+        recorder.assert_all_closed();
+    }
+
+    /// An idle tick is still spanned: discovering that there is nothing to send is
+    /// itself work that can fail, and events recorded outside a span never reach
+    /// the trace.
+    #[test]
+    async fn send_batch_records_one_closed_span_when_there_is_nothing_to_send() {
+        let mock = Arc::new(MockRegistryService::new(1000, 512));
+        let svc = make_grpc(mock);
+        let _ = svc.initialize_account(account_id()).await.unwrap();
+
+        let recorder = crate::span_test_support::record_spans();
+        svc.send_batch(NO_IDLE_REFRESH_THRESHOLD_SECS).await;
+
+        recorder.assert_closed_span("resource_limits_batch_update");
     }
 
     #[test]

--- a/golem-worker-executor/src/services/scheduler.rs
+++ b/golem-worker-executor/src/services/scheduler.rs
@@ -45,7 +45,7 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, Level, debug, error, info, span, warn};
+use tracing::{Instrument, Level, debug, debug_span, error, info, info_span, span, warn};
 
 #[async_trait]
 pub trait SchedulerService: Send + Sync {
@@ -199,35 +199,31 @@ impl SchedulerServiceDefault {
         let svc = Arc::new(svc);
         let background_handle = {
             let svc_weak = Arc::downgrade(&svc);
-            tokio::spawn(
-                async move {
-                    loop {
-                        tokio::select! {
-                            _ = shutdown_token.cancelled() => {
-                                info!("Shutdown requested, stopping scheduler background loop");
-                                break;
-                            }
-                            _ = tokio::time::sleep(process_interval) => {}
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            info!("Shutdown requested, stopping scheduler background loop");
+                            break;
                         }
-                        let svc = match svc_weak.upgrade() {
-                            Some(s) => s,
-                            None => {
-                                info!("Scheduler service dropped, stopping background loop");
-                                break;
-                            }
-                        };
-                        if svc.shard_service.is_ready() {
-                            let r = svc.process(Utc::now()).await;
-                            if let Err(err) = r {
-                                error!(err, "Error in scheduler background task");
-                            }
-                        } else {
-                            warn!("Skipping schedule, shard service is not ready")
+                        _ = tokio::time::sleep(process_interval) => {}
+                    }
+                    let svc = match svc_weak.upgrade() {
+                        Some(s) => s,
+                        None => {
+                            info!("Scheduler service dropped, stopping background loop");
+                            break;
                         }
+                    };
+                    if svc.shard_service.is_ready() {
+                        // A failed tick is logged inside `process`, where its span is
+                        // still open.
+                        let _ = svc.process(Utc::now()).await;
+                    } else {
+                        warn!("Skipping schedule, shard service is not ready")
                     }
                 }
-                .instrument(span!(parent: None, Level::INFO, "Scheduler loop")),
-            )
+            })
         };
         *svc.background_handle.lock().unwrap() = Some(background_handle);
 
@@ -269,45 +265,66 @@ impl SchedulerServiceDefault {
         }
     }
 
+    /// Performs one scheduler tick, spanned per tick rather than per loop: a span
+    /// wrapping the loop would never close, so it would never be exported.
     async fn process(&self, now: DateTime<Utc>) -> Result<(), String> {
-        let tick_start = std::time::Instant::now();
-        let assignment = self
-            .shard_service
-            .current_assignment()
-            .map_err(|err| err.to_string())?;
+        async {
+            let result = async {
+                let tick_start = std::time::Instant::now();
+                let assignment = self
+                    .shard_service
+                    .current_assignment()
+                    .map_err(|err| err.to_string())?;
 
-        for _ in 0..self.max_batches_per_tick {
-            let claimed = self
-                .scheduler_storage
-                .claim_due(now, &assignment, self.claim_batch_size, self.lease_ttl)
-                .await?;
+                for _ in 0..self.max_batches_per_tick {
+                    let claimed = self
+                        .scheduler_storage
+                        .claim_due(now, &assignment, self.claim_batch_size, self.lease_ttl)
+                        .instrument(debug_span!("scheduler_storage_claim_due"))
+                        .await?;
 
-            let claimed_count = claimed.len();
-            crate::metrics::scheduler::set_scheduler_queue_depth(claimed_count);
-            if claimed.is_empty() {
-                break;
+                    let claimed_count = claimed.len();
+                    crate::metrics::scheduler::set_scheduler_queue_depth(claimed_count);
+                    if claimed.is_empty() {
+                        break;
+                    }
+
+                    self.process_claimed_actions(claimed, now).await?;
+
+                    if claimed_count < self.claim_batch_size as usize {
+                        break;
+                    }
+                }
+
+                match self
+                    .scheduler_storage
+                    .count_due(Utc::now(), &assignment)
+                    .instrument(debug_span!("scheduler_storage_count_due"))
+                    .await
+                {
+                    Ok(backlog) => {
+                        crate::metrics::scheduler::set_scheduler_due_action_backlog_after_tick(
+                            backlog,
+                        )
+                    }
+                    Err(error) => {
+                        warn!(%error, "Failed to count due scheduled actions after tick")
+                    }
+                }
+
+                crate::metrics::scheduler::record_scheduler_tick_duration(tick_start.elapsed());
+                Ok(())
             }
-
-            self.process_claimed_actions(claimed, now).await?;
-
-            if claimed_count < self.claim_batch_size as usize {
-                break;
+            .await;
+            // Logged inside the span, so a failed tick is visible in the trace and
+            // not only in the logs.
+            if let Err(error) = &result {
+                error!(error, "Scheduler tick failed");
             }
+            result
         }
-
-        match self
-            .scheduler_storage
-            .count_due(Utc::now(), &assignment)
-            .await
-        {
-            Ok(backlog) => {
-                crate::metrics::scheduler::set_scheduler_due_action_backlog_after_tick(backlog)
-            }
-            Err(error) => warn!(error, "Failed to count due scheduled actions after tick"),
-        }
-
-        crate::metrics::scheduler::record_scheduler_tick_duration(tick_start.elapsed());
-        Ok(())
+        .instrument(info_span!("scheduler_tick"))
+        .await
     }
 
     async fn process_claimed_actions(
@@ -451,9 +468,9 @@ impl SchedulerServiceDefault {
                         // TODO: this is probably redundant with the wakeup in PromiseService. check and fix
                         {
                             let span = span!(
-                                Level::INFO,
-                                "scheduler",
-                                agent_id = owned_agent_id.agent_id.to_string()
+                                Level::DEBUG,
+                                "scheduler_activate_worker",
+                                agent_id = %owned_agent_id.agent_id
                             );
 
                             self.worker_access
@@ -1142,7 +1159,7 @@ mod tests {
             &self,
             now: DateTime<Utc>,
             assignment: &ShardAssignment,
-        ) -> Result<u64, String> {
+        ) -> Result<u64, SchedulerStorageError> {
             self.inner.count_due(now, assignment).await
         }
 
@@ -1216,7 +1233,7 @@ mod tests {
             &self,
             now: DateTime<Utc>,
             assignment: &ShardAssignment,
-        ) -> Result<u64, String> {
+        ) -> Result<u64, SchedulerStorageError> {
             self.inner.count_due(now, assignment).await
         }
 
@@ -1329,6 +1346,22 @@ mod tests {
             invocation_context: InvocationContextStack::fresh(),
             principal: Principal::anonymous(),
         }
+    }
+
+    /// The scheduler's span must cover one tick, not the whole background loop. A
+    /// loop-lifetime span never closes, so it is never exported and it retains
+    /// every event recorded inside it for as long as the process runs.
+    #[test]
+    async fn process_records_one_closed_span_per_tick() {
+        let storage = Arc::new(InMemorySchedulerStorage::new());
+        let promise_service = create_promise_service_mock();
+        let svc = create_scheduler(storage, promise_service).await;
+
+        let recorder = crate::span_test_support::record_spans();
+        svc.process(Utc::now()).await.unwrap();
+
+        recorder.assert_closed_span("scheduler_tick");
+        recorder.assert_all_closed();
     }
 
     #[test]

--- a/golem-worker-executor/src/span_test_support.rs
+++ b/golem-worker-executor/src/span_test_support.rs
@@ -1,0 +1,131 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test support for asserting on span lifetime.
+//!
+//! A span covers one operation and closes when that operation finishes. A span
+//! wrapped around a background loop instead of around the work the loop performs
+//! never closes, so it is never exported, and `tracing-opentelemetry` retains an
+//! OpenTelemetry event on it for every `tracing` event recorded inside it for as
+//! long as the process runs.
+//!
+//! [`record_spans`] installs a recording subscriber for the current thread, so a
+//! test can assert that calling an operation produces exactly one span for that
+//! operation and that the span is closed by the time the call returns.
+//!
+//! The subscriber is thread-local. Work the test `await`s directly is recorded,
+//! because `test_r` drives each test future with `block_on` on a single thread;
+//! work handed to `tokio::spawn` is not. That asymmetry is deliberate - it forces
+//! the operation under test to be reachable directly rather than only through a
+//! spawned background loop.
+
+use std::sync::{Arc, Mutex};
+
+use tracing::span::{Attributes, Id};
+use tracing::subscriber::DefaultGuard;
+use tracing::{Subscriber, subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{Layer, Registry};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordedSpan {
+    name: &'static str,
+    /// Whether the span had closed by the time it was inspected. A span that is
+    /// still open cannot have been exported.
+    closed: bool,
+}
+
+#[derive(Clone, Default)]
+struct RecordingLayer {
+    spans: Arc<Mutex<Vec<(Id, RecordedSpan)>>>,
+}
+
+impl<S> Layer<S> for RecordingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, _ctx: Context<'_, S>) {
+        self.spans.lock().unwrap().push((
+            id.clone(),
+            RecordedSpan {
+                name: attrs.metadata().name(),
+                closed: false,
+            },
+        ));
+    }
+
+    fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
+        let mut spans = self.spans.lock().unwrap();
+        if let Some((_, span)) = spans.iter_mut().find(|(sid, _)| *sid == id) {
+            span.closed = true;
+        }
+    }
+}
+
+/// Records spans created on the current thread until dropped.
+pub struct SpanRecorder {
+    layer: RecordingLayer,
+    _guard: DefaultGuard,
+}
+
+/// Installs a span-recording subscriber for the current thread. Recording stops
+/// when the returned [`SpanRecorder`] is dropped.
+pub fn record_spans() -> SpanRecorder {
+    let layer = RecordingLayer::default();
+    let guard = subscriber::set_default(Registry::default().with(layer.clone()));
+    SpanRecorder {
+        layer,
+        _guard: guard,
+    }
+}
+
+impl SpanRecorder {
+    /// Spans created so far, in creation order.
+    fn spans(&self) -> Vec<RecordedSpan> {
+        self.layer
+            .spans
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, span)| span.clone())
+            .collect()
+    }
+
+    /// Asserts that exactly one span named `name` was created and that it closed.
+    pub fn assert_closed_span(&self, name: &str) {
+        let spans = self.spans();
+        let matching: Vec<&RecordedSpan> = spans.iter().filter(|s| s.name == name).collect();
+        let recorded: Vec<&str> = spans.iter().map(|s| s.name).collect();
+
+        assert_eq!(
+            matching.len(),
+            1,
+            "expected exactly one span named {name:?}, found {}; recorded: {recorded:?}",
+            matching.len()
+        );
+        assert!(
+            matching[0].closed,
+            "span {name:?} was still open when the operation returned; a span that never \
+             closes is never exported and retains every event recorded inside it"
+        );
+    }
+
+    /// Asserts every recorded span has closed.
+    pub fn assert_all_closed(&self) {
+        let spans = self.spans();
+        let open: Vec<&str> = spans.iter().filter(|s| !s.closed).map(|s| s.name).collect();
+        assert!(open.is_empty(), "spans left open: {open:?}");
+    }
+}

--- a/golem-worker-executor/src/storage/scheduler/memory.rs
+++ b/golem-worker-executor/src/storage/scheduler/memory.rs
@@ -124,7 +124,7 @@ impl SchedulerStorage for InMemorySchedulerStorage {
         &self,
         now: DateTime<Utc>,
         assignment: &ShardAssignment,
-    ) -> Result<u64, String> {
+    ) -> Result<u64, SchedulerStorageError> {
         let now_ms = datetime_to_millis(now);
         Ok(self
             .entries

--- a/golem-worker-executor/src/storage/scheduler/mod.rs
+++ b/golem-worker-executor/src/storage/scheduler/mod.rs
@@ -48,12 +48,6 @@ pub enum SchedulerStorageError {
     Other(String),
 }
 
-impl SchedulerStorageError {
-    pub fn is_retriable(&self) -> bool {
-        matches!(self, SchedulerStorageError::Transient(_))
-    }
-}
-
 impl Display for SchedulerStorageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -113,7 +107,7 @@ pub trait SchedulerStorage: Debug {
         &self,
         now: DateTime<Utc>,
         assignment: &ShardAssignment,
-    ) -> Result<u64, String>;
+    ) -> Result<u64, SchedulerStorageError>;
 
     async fn extend_lease(
         &self,

--- a/golem-worker-executor/src/storage/scheduler/postgres.rs
+++ b/golem-worker-executor/src/storage/scheduler/postgres.rs
@@ -19,7 +19,6 @@ use super::{
 use crate::services::golem_config::SchedulerStoragePostgresConfig;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use golem_common::SafeDisplay;
 use golem_common::model::{ScheduleId, ScheduledAction, ShardAssignment, ShardId};
 use golem_common::serialization::{deserialize, serialize};
 use golem_service_base::db::postgres::PostgresPool;
@@ -181,7 +180,7 @@ impl SchedulerStorage for PostgresSchedulerStorage {
         &self,
         now: DateTime<Utc>,
         assignment: &ShardAssignment,
-    ) -> Result<u64, String> {
+    ) -> Result<u64, SchedulerStorageError> {
         if assignment.shard_ids.is_empty() {
             return Ok(0);
         }
@@ -202,7 +201,7 @@ impl SchedulerStorage for PostgresSchedulerStorage {
             .fetch_one_as(query)
             .await
             .map(|(count,)| count as u64)
-            .map_err(|err| err.to_safe_string())
+            .map_err(SchedulerStorageError::from)
     }
 
     async fn extend_lease(

--- a/golem-worker-executor/src/storage/scheduler/sqlite.rs
+++ b/golem-worker-executor/src/storage/scheduler/sqlite.rs
@@ -19,7 +19,6 @@ use super::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
-use golem_common::SafeDisplay;
 use golem_common::config::DbSqliteConfig;
 use golem_common::model::{ScheduleId, ScheduledAction, ShardAssignment, ShardId};
 use golem_common::serialization::{deserialize, serialize};
@@ -192,7 +191,7 @@ impl SchedulerStorage for SqliteSchedulerStorage {
         &self,
         now: DateTime<Utc>,
         assignment: &ShardAssignment,
-    ) -> Result<u64, String> {
+    ) -> Result<u64, SchedulerStorageError> {
         if assignment.shard_ids.is_empty() {
             return Ok(0);
         }
@@ -218,7 +217,7 @@ impl SchedulerStorage for SqliteSchedulerStorage {
             .fetch_one_as(query)
             .await
             .map(|(count,)| count as u64)
-            .map_err(|err| err.to_safe_string())
+            .map_err(SchedulerStorageError::from)
     }
 
     async fn extend_lease(

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -23,7 +23,7 @@ use crate::worker::invocation::{
 use crate::worker::status_checkpointer;
 use crate::worker::{
     FinalWorkerState, PendingWorkerInterrupt, QueuedWorkerInvocation, RetryDecision, RunningWorker,
-    Worker, WorkerCommand, WorkerInterruptState,
+    Worker, WorkerCommand, WorkerInterruptState, WorkerTrace,
 };
 use crate::workerctx::{PublicWorkerIo, UpdateManagement, WorkerCtx};
 use anyhow::anyhow;
@@ -47,6 +47,8 @@ use golem_service_base::error::worker_executor::{InterruptKind, WorkerExecutorEr
 use golem_service_base::model::GetFileSystemNodeResult;
 
 use golem_common::model::agent::structural_format::format_structural_typed;
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use std::collections::VecDeque;
 use std::ops::DerefMut;
 use std::sync::Arc;
@@ -55,9 +57,28 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::task::JoinHandle;
-use tracing::{Instrument, Level, Span, debug, error, span, warn};
+use tracing::{Instrument, Level, debug, error, span, warn};
 use wasmtime::Store;
 use wasmtime::component::Instance;
+
+/// Span for one bounded phase of a worker's lifecycle.
+///
+/// The loop itself has no span (see `TraceOrigin`), so each phase span carries the
+/// agent fields itself and links back to the worker's startup, keeping one worker's
+/// phases navigable from each other.
+///
+/// Requires `owned_agent_id` and `worker_trace` fields on `$this`.
+macro_rules! agent_phase_span {
+    ($this:expr, $name:expr) => {
+        related_span!(
+            $this.worker_trace.startup_origin,
+            Level::INFO,
+            $name,
+            agent_id = %$this.owned_agent_id.agent_id,
+            agent_type = %$this.worker_trace.agent_type,
+        )
+    };
+}
 
 /// Context of a running worker's invocation loop
 pub struct InvocationLoop<Ctx: WorkerCtx> {
@@ -76,6 +97,8 @@ pub struct InvocationLoop<Ctx: WorkerCtx> {
     /// `ResumeReplay` is not represented in the internal queue, so we track it
     /// explicitly to avoid evicting a worker that is blocked waking up for it.
     pub resume_replay_pending: Arc<AtomicBool>,
+    /// What this worker's phase spans link back to, and the fields they carry.
+    pub worker_trace: WorkerTrace,
 }
 
 /// Outcome of creating the worker instance for one iteration of the invocation loop.
@@ -109,11 +132,10 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
     /// - Suspending the worker
     /// - Process the retry decision
     pub async fn run(&mut self) {
+        let agent_id = self.owned_agent_id.agent_id.clone();
         let mut deferred_wakeups = VecDeque::new();
 
         'outer: loop {
-            debug!("Invocation queue loop creating the instance");
-
             let (instance, store) = match self.create_instance().await {
                 CreateInstanceResult::Created { instance, store } => (instance, store),
                 CreateInstanceResult::Interrupted(kind) => {
@@ -159,14 +181,13 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                 }
             };
 
-            debug!("Invocation queue loop preparing the instance");
-
             let mut final_decision = self.recover_instance_state(&instance, &store).await;
             let mut final_interrupt = None;
             let mut cleanup_ephemeral_worker = false;
 
             if let Some((kind, decision)) = self.pending_interrupt().await {
                 debug!(
+                    %agent_id,
                     ?decision,
                     "Invocation queue loop interrupted after recovery"
                 );
@@ -190,6 +211,7 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                     idle_snapshot_task: None,
                     concurrent_agent_permit: &mut self.concurrent_agent_permit,
                     resume_replay_pending: self.resume_replay_pending.clone(),
+                    worker_trace: self.worker_trace.clone(),
                     deferred_wakeups: &mut deferred_wakeups,
                 };
 
@@ -213,7 +235,10 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
 
             match final_decision {
                 None | Some(RetryDecision::None) => {
-                    debug!("Invocation queue loop notifying parent about being stopped");
+                    debug!(
+                        %agent_id,
+                        "Invocation queue loop notifying parent about being stopped"
+                    );
                     self.stop_unloaded(
                         cleanup_ephemeral_worker.then(super::inactive_ephemeral_agent_error),
                     )
@@ -227,41 +252,49 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                 Some(RetryDecision::TryStop(ts)) => {
                     if ts < *self.parent.last_resume_request.lock().await {
                         debug!(
+                            %agent_id,
                             "Suspend request ignored because there was a resume request since it"
                         );
                         continue;
                     } else {
-                        debug!("Invocation queue loop notifying parent about being stopped");
+                        debug!(
+                            %agent_id,
+                            "Invocation queue loop notifying parent about being stopped"
+                        );
                         self.stop_unloaded(None).await;
                         break;
                     }
                 }
                 Some(RetryDecision::Immediate) => {
-                    debug!("Invocation queue loop triggering restart immediately");
+                    debug!(%agent_id, "Invocation queue loop triggering restart immediately");
                     continue;
                 }
                 Some(RetryDecision::Delayed(delay)) => {
-                    debug!("Invocation queue loop sleeping for {delay:?} for delayed restart");
+                    debug!(
+                        %agent_id,
+                        ?delay,
+                        "Invocation queue loop sleeping for a delayed restart"
+                    );
                     let sleep = tokio::time::sleep(delay);
                     tokio::pin!(sleep);
                     loop {
                         tokio::select! {
                             _ = &mut sleep => {
-                                debug!("Invocation queue loop restarting after delay");
+                                debug!(%agent_id, "Invocation queue loop restarting after delay");
                                 continue 'outer;
                             }
                             command = self.receiver.recv() => {
                                 let command = match command {
                                     Some(command) => command,
                                     None => {
-                                        debug!("Invocation queue loop command channel closed during delayed retry");
+                                        debug!(%agent_id, "Invocation queue loop command channel closed during delayed retry");
                                         self.stop_unloaded(None).await;
                                         break 'outer;
                                     }
                                 };
 
                                 if let Some((kind, decision)) = self.pending_interrupt().await {
-                                    debug!(?decision, "Invocation queue loop interrupted during delayed retry");
+                                    debug!(%agent_id, ?decision, "Invocation queue loop interrupted during delayed retry");
                                     if !matches!(kind, InterruptKind::Restart | InterruptKind::Jump) {
                                         self.record_retry_interrupt_failure(&store, kind).await;
                                     }
@@ -286,12 +319,12 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                                         continue;
                                     }
                                     WorkerCommand::WorkAvailable => {
-                                        debug!("Invocation queue loop woke up during delayed retry");
+                                        debug!(%agent_id, "Invocation queue loop woke up during delayed retry");
                                         Self::defer_wakeup(&mut deferred_wakeups, WorkerCommand::WorkAvailable);
                                         continue 'outer;
                                     }
                                     WorkerCommand::ResumeReplay => {
-                                        debug!("Invocation queue loop woke up for resume replay during delayed retry");
+                                        debug!(%agent_id, "Invocation queue loop woke up for resume replay during delayed retry");
                                         Self::defer_wakeup(&mut deferred_wakeups, WorkerCommand::ResumeReplay);
                                         continue 'outer;
                                     }
@@ -303,7 +336,9 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                 Some(RetryDecision::ReacquirePermits) => {
                     let delay = get_delay(self.parent.oom_retry_config(), self.oom_retry_count);
                     debug!(
-                        "Invocation queue loop dropping memory permits and triggering restart with a delay of {delay:?}"
+                        %agent_id,
+                        ?delay,
+                        "Invocation queue loop dropping memory permits and triggering restart"
                     );
                     let _ = Worker::restart_on_oom(
                         self.parent.clone(),
@@ -358,45 +393,50 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
 
     /// Create the worker instance and publish an event about it
     async fn create_instance(&self) -> CreateInstanceResult<Ctx> {
-        match RunningWorker::create_instance(self.parent.clone()).await {
-            Ok((instance, store)) => {
-                self.parent.events().publish(Event::WorkerLoaded {
-                    agent_id: self.owned_agent_id.agent_id(),
-                    result: Ok(()),
-                });
-                CreateInstanceResult::Created { instance, store }
-            }
-            // Wasm executing during instantiation was interrupted (e.g. suspended by the fuel
-            // check in the epoch deadline callback). The worker exists — its metadata and
-            // `Create` oplog entry are already persisted — so this is not a creation failure:
-            // creation waiters are released successfully and the caller parks or restarts the
-            // worker like any other interrupt.
-            Err(WorkerExecutorError::Interrupted { kind }) => {
-                debug!("Worker instantiation interrupted: {kind:?}");
-                self.parent.events().publish(Event::WorkerLoaded {
-                    agent_id: self.owned_agent_id.agent_id(),
-                    result: Ok(()),
-                });
-                CreateInstanceResult::Interrupted(kind)
-            }
-            Err(err) => {
-                warn!("Failed to start the worker: {err}");
-                self.parent.events().publish(Event::WorkerLoaded {
-                    agent_id: self.owned_agent_id.agent_id(),
-                    result: Err(err.clone()),
-                });
-                self.parent
-                    .stop_internal(
-                        true,
-                        Some(err.clone()),
-                        FinalWorkerState::Unloaded {
-                            startup_failure: Some(err),
-                        },
-                    )
-                    .await;
-                CreateInstanceResult::Failed
+        async {
+            debug!("Creating the worker instance");
+            match RunningWorker::create_instance(self.parent.clone()).await {
+                Ok((instance, store)) => {
+                    self.parent.events().publish(Event::WorkerLoaded {
+                        agent_id: self.owned_agent_id.agent_id(),
+                        result: Ok(()),
+                    });
+                    CreateInstanceResult::Created { instance, store }
+                }
+                // Wasm executing during instantiation was interrupted (e.g. suspended by the fuel
+                // check in the epoch deadline callback). The worker exists — its metadata and
+                // `Create` oplog entry are already persisted — so this is not a creation failure:
+                // creation waiters are released successfully and the caller parks or restarts the
+                // worker like any other interrupt.
+                Err(WorkerExecutorError::Interrupted { kind }) => {
+                    debug!("Worker instantiation interrupted: {kind:?}");
+                    self.parent.events().publish(Event::WorkerLoaded {
+                        agent_id: self.owned_agent_id.agent_id(),
+                        result: Ok(()),
+                    });
+                    CreateInstanceResult::Interrupted(kind)
+                }
+                Err(err) => {
+                    warn!("Failed to start the worker: {err}");
+                    self.parent.events().publish(Event::WorkerLoaded {
+                        agent_id: self.owned_agent_id.agent_id(),
+                        result: Err(err.clone()),
+                    });
+                    self.parent
+                        .stop_internal(
+                            true,
+                            Some(err.clone()),
+                            FinalWorkerState::Unloaded {
+                                startup_failure: Some(err),
+                            },
+                        )
+                        .await;
+                    CreateInstanceResult::Failed
+                }
             }
         }
+        .instrument(agent_phase_span!(self, "create_instance"))
+        .await
     }
 
     /// Prepares the instance for running by recovering its persisted state
@@ -407,70 +447,75 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
         instance: &Instance,
         store: &Mutex<Store<Ctx>>,
     ) -> Option<RetryDecision> {
-        let mut store = store.lock().await;
+        async {
+            debug!("Preparing the worker instance");
+            let mut store = store.lock().await;
 
-        store.data().set_suspended();
+            store.data().set_suspended();
 
-        let span = span!(
-            Level::INFO,
-            "invocation",
-            agent_id = %self.owned_agent_id.agent_id,
-            agent_type = self.parent
-                .parsed_agent_id
-                .as_ref()
-                .map(|id| id.agent_type.to_string())
-                .unwrap_or_else(|| "-".to_string()),
-        );
-        let prepare_result =
-            Ctx::prepare_instance(&self.owned_agent_id.agent_id, instance, &mut *store)
-                .instrument(span)
-                .await;
-
-        match prepare_result {
-            Ok(decision) => {
-                debug!("Recovery decision from prepare_instance: {decision:?}");
-                decision
-            }
-            Err(err) => {
-                warn!("Failed to start the worker: {err}");
-                store.data().set_suspended();
-
-                self.parent
-                    .stop_internal(
-                        true,
-                        Some(err.clone()),
-                        FinalWorkerState::Unloaded {
-                            startup_failure: Some(err),
-                        },
-                    )
+            let span = span!(
+                Level::INFO,
+                "invocation",
+                agent_id = %self.owned_agent_id.agent_id,
+                agent_type = %self.worker_trace.agent_type,
+            );
+            let prepare_result =
+                Ctx::prepare_instance(&self.owned_agent_id.agent_id, instance, &mut *store)
+                    .instrument(span)
                     .await;
-                Some(RetryDecision::None) // early return, we can't retry this
+
+            match prepare_result {
+                Ok(decision) => {
+                    debug!("Recovery decision from prepare_instance: {decision:?}");
+                    decision
+                }
+                Err(err) => {
+                    warn!("Failed to start the worker: {err}");
+                    store.data().set_suspended();
+
+                    self.parent
+                        .stop_internal(
+                            true,
+                            Some(err.clone()),
+                            FinalWorkerState::Unloaded {
+                                startup_failure: Some(err),
+                            },
+                        )
+                        .await;
+                    Some(RetryDecision::None) // early return, we can't retry this
+                }
             }
         }
+        .instrument(agent_phase_span!(self, "recover_instance_state"))
+        .await
     }
 
     /// Suspends the worker after the invocation loop exited
     async fn suspend_worker(&self, store: &Mutex<Store<Ctx>>) {
-        // Marking the worker as suspended
-        store.lock().await.data().set_suspended();
+        async {
+            // Marking the worker as suspended
+            store.lock().await.data().set_suspended();
 
-        // Making sure all pending commits are flushed
-        // Make sure all pending commits are done
-        let worker = store.lock().await.data().get_public_state().worker();
-        worker
-            .commit_oplog_and_update_state(CommitLevel::Always)
-            .await;
+            // Making sure all pending commits are flushed
+            // Make sure all pending commits are done
+            let worker = store.lock().await.data().get_public_state().worker();
+            worker
+                .commit_oplog_and_update_state(CommitLevel::Always)
+                .await;
 
-        // The worker is going idle; persist its cached status synchronously now instead of leaving
-        // it for the next background sweep, so reads of an idle worker see an up-to-date blob.
-        worker.force_flush_status().await;
+            // The worker is going idle; persist its cached status synchronously now instead of leaving
+            // it for the next background sweep, so reads of an idle worker see an up-to-date blob.
+            worker.force_flush_status().await;
 
-        // Idle is a structurally clean boundary (the invocation loop has exited and committed, so
-        // no jumpable region is open): write a throttled clean status checkpoint so a later
-        // jump-induced recompute can fold forward from here.
-        worker
-            .checkpoint_status(status_checkpointer::CheckpointReason::Idle)
-            .await;
+            // Idle is a structurally clean boundary (the invocation loop has exited and committed, so
+            // no jumpable region is open): write a throttled clean status checkpoint so a later
+            // jump-induced recompute can fold forward from here.
+            worker
+                .checkpoint_status(status_checkpointer::CheckpointReason::Idle)
+                .await;
+        }
+        .instrument(agent_phase_span!(self, "suspend_worker"))
+        .await
     }
 }
 
@@ -491,6 +536,8 @@ struct InnerInvocationLoop<'a, Ctx: WorkerCtx> {
     concurrent_agent_permit: &'a mut Option<crate::services::active_workers::ConcurrentAgentPermit>,
     resume_replay_pending: Arc<AtomicBool>,
     deferred_wakeups: &'a mut VecDeque<WorkerCommand>,
+    /// What this worker's phase spans link back to, and the fields they carry.
+    worker_trace: WorkerTrace,
 }
 
 impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
@@ -509,7 +556,8 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     ///
     /// The outer loop should either break or use the returned retry decision after the inner loop quits.
     pub async fn run(&mut self) -> InnerInvocationLoopResult {
-        debug!("Invocation queue loop started");
+        let agent_id = self.owned_agent_id.agent_id.clone();
+        debug!(%agent_id, "Invocation queue loop started");
 
         let mut final_decision = None;
         let mut final_interrupt = None;
@@ -641,7 +689,7 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     /// Called when the agent enters idle state. No-op if already released.
     fn release_concurrent_agent_permit(&mut self) {
         if let Some(permit) = self.concurrent_agent_permit.take() {
-            debug!("Releasing concurrent-agent permit (entering idle)");
+            debug!(agent_id = %self.owned_agent_id.agent_id, "Releasing concurrent-agent permit (entering idle)");
             drop(permit);
         }
     }
@@ -652,10 +700,15 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     /// that just finished goes to the back of the queue.
     async fn acquire_concurrent_agent_permit(&mut self) {
         if self.concurrent_agent_permit.is_none() {
+            let span = agent_phase_span!(self, "acquire_concurrent_agent_permit");
             let agent_id = self.owned_agent_id.agent_id();
             let registered_concurrent_account = self.parent.registered_concurrent_account.clone();
-            debug!("Re-acquiring concurrent-agent permit (waking from idle)");
-            let permit = registered_concurrent_account.acquire(agent_id).await;
+            let permit = async {
+                debug!("Re-acquiring concurrent-agent permit (waking from idle)");
+                registered_concurrent_account.acquire(agent_id).await
+            }
+            .instrument(span)
+            .await;
             *self.concurrent_agent_permit = Some(permit);
         }
     }
@@ -672,7 +725,7 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                 result = &mut *task => {
                     if let Err(err) = result {
                         if !err.is_cancelled() {
-                            warn!("Idle snapshot timer failed: {err}");
+                            warn!(agent_id = %self.owned_agent_id.agent_id, "Idle snapshot timer failed: {err}");
                         }
                         return self.receiver.recv().await;
                     }
@@ -714,14 +767,20 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
             // Then, try to process a pending invocation
             if let Some(pending_invocation) = status.pending_invocations.first() {
                 let idempotency_key = pending_invocation.idempotency_key();
-                let invocation_span = if let Some(idempotency_key) = idempotency_key {
-                    let spans = self.parent.external_invocation_spans.read().await;
-                    spans.get(idempotency_key).cloned()
-                } else {
-                    None
+                let origin = match idempotency_key {
+                    Some(idempotency_key) => self
+                        .parent
+                        .external_invocation_origins
+                        .read()
+                        .await
+                        .get(idempotency_key)
+                        .cloned(),
+                    None => None,
                 };
 
-                let invocation_span = invocation_span.unwrap_or(Span::current());
+                // An invocation with no recorded origin was enqueued in an earlier
+                // process, so there is nothing in-process to relate it to.
+                let origin = origin.unwrap_or_else(TraceOrigin::none);
 
                 // The status record only stores a lightweight reference to the pending invocation;
                 // hydrate the full invocation (including its payload) from the oplog before running.
@@ -732,10 +791,36 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                 {
                     Ok(invocation) => invocation,
                     Err(error) => {
-                        warn!("Failed to hydrate pending invocation from oplog: {error}");
+                        warn!(
+                            agent_id = %self.owned_agent_id.agent_id,
+                            "Failed to hydrate pending invocation from oplog: {error}"
+                        );
                         break CommandOutcome::BreakInnerLoop(RetryDecision::Immediate);
                     }
                 };
+
+                // The span for picking work off the queue and running it: the root
+                // of its own trace, linked back to whatever enqueued the work.
+                // `otel.kind = consumer` is what the OpenTelemetry messaging
+                // conventions prescribe for processing work a producer handed off.
+                let pickup_span = related_span!(
+                    origin,
+                    Level::INFO,
+                    "invocation_queue_pickup",
+                    agent_id = %self.owned_agent_id.agent_id,
+                    agent_type = %self.worker_trace.agent_type,
+                    // The root of the execution's own trace, so it has to say which
+                    // invocation it is: the link points back at the producer, but
+                    // this key is what a search can join the two traces on. Left
+                    // unset rather than empty when there is none, so a search for
+                    // one key cannot collide with every keyless pickup.
+                    idempotency_key = tracing::field::Empty,
+                    otel.kind = "consumer",
+                );
+
+                if let Some(idempotency_key) = idempotency_key {
+                    pickup_span.record("idempotency_key", tracing::field::display(idempotency_key));
+                }
 
                 let outcome = async {
                     let mut store = self.store.lock().await;
@@ -745,11 +830,9 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                         instance: self.instance,
                         store: store.deref_mut(),
                     };
-                    invocation
-                        .external_invocation(timestamped_invocation, &invocation_span)
-                        .await
+                    invocation.external_invocation(timestamped_invocation).await
                 }
-                .instrument(span!(parent: &invocation_span, Level::INFO, "invocation_queue_pickup"))
+                .instrument(pickup_span)
                 .await;
 
                 match outcome {
@@ -850,29 +933,33 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     /// Returns `CommandOutcome` if this fails and the invocation loop should be stopped.
     /// Otherwise, it returns the new retry decision to be used by the outer invocation loop.
     async fn resume_replay(&self) -> CommandOutcome {
-        let mut store = self.store.lock().await;
+        async {
+            let mut store = self.store.lock().await;
 
-        let resume_replay_result = Ctx::resume_replay(&mut *store, self.instance, true).await;
+            let resume_replay_result = Ctx::resume_replay(&mut *store, self.instance, true).await;
 
-        match resume_replay_result {
-            Ok(None) => CommandOutcome::Continue,
-            Ok(Some(decision)) => CommandOutcome::BreakInnerLoop(decision),
-            Err(err) => {
-                warn!("Failed to resume replay: {err}");
-                store.data().set_suspended();
+            match resume_replay_result {
+                Ok(None) => CommandOutcome::Continue,
+                Ok(Some(decision)) => CommandOutcome::BreakInnerLoop(decision),
+                Err(err) => {
+                    warn!("Failed to resume replay: {err}");
+                    store.data().set_suspended();
 
-                self.parent
-                    .stop_internal(
-                        true,
-                        Some(err.clone()),
-                        FinalWorkerState::Unloaded {
-                            startup_failure: Some(err),
-                        },
-                    )
-                    .await;
-                CommandOutcome::BreakOuterLoop
+                    self.parent
+                        .stop_internal(
+                            true,
+                            Some(err.clone()),
+                            FinalWorkerState::Unloaded {
+                                startup_failure: Some(err),
+                            },
+                        )
+                        .await;
+                    CommandOutcome::BreakOuterLoop
+                }
             }
         }
+        .instrument(agent_phase_span!(self, "resume_replay"))
+        .await
     }
 
     /// Performs a queued invocation on the worker
@@ -949,11 +1036,7 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
     /// Process an external queued worker invocation - this is either an exported function invocation
     /// or a manual update request (which involves invoking the exported save-snapshot functions, so
     /// it is a special case of the exported function invocation).
-    async fn external_invocation(
-        &mut self,
-        inner: TimestampedAgentInvocation,
-        invocation_span: &Span,
-    ) -> CommandOutcome {
+    async fn external_invocation(&mut self, inner: TimestampedAgentInvocation) -> CommandOutcome {
         match inner.invocation {
             AgentInvocation::ManualUpdate { target_revision } => {
                 self.manual_update(target_revision).await
@@ -965,7 +1048,7 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
                         invocation_results.contains_key(idempotency_key)
                     };
                     if !has_result {
-                        self.invoke_agent(invocation, invocation_span).await
+                        self.invoke_agent(invocation).await
                     } else {
                         debug!(
                             "Skipping enqueued invocation with idempotency key {idempotency_key} as it already has a result"
@@ -973,18 +1056,14 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
                         CommandOutcome::Continue
                     }
                 } else {
-                    self.invoke_agent(invocation, invocation_span).await
+                    self.invoke_agent(invocation).await
                 }
             }
         }
     }
 
     /// Invokes an agent function on the worker
-    async fn invoke_agent(
-        &mut self,
-        invocation: AgentInvocation,
-        invocation_span: &Span,
-    ) -> CommandOutcome {
+    async fn invoke_agent(&mut self, invocation: AgentInvocation) -> CommandOutcome {
         let display_name = invocation.display_name();
         let invocation_context = invocation.invocation_context();
         let idempotency_key = invocation
@@ -993,15 +1072,10 @@ impl<Ctx: WorkerCtx> Invocation<'_, Ctx> {
             .unwrap_or_else(IdempotencyKey::fresh);
 
         let span = span!(
-            parent: invocation_span,
             Level::INFO,
             "invocation",
             agent_id = %self.owned_agent_id.agent_id,
-            agent_type = self.parent
-                .parsed_agent_id
-                .as_ref()
-                .map(|id| id.agent_type.to_string())
-                .unwrap_or_else(|| "-".to_string()),
+            agent_type = self.parent.agent_type_label(),
             %idempotency_key,
             function = display_name
         );

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -27,6 +27,7 @@ use self::agent_config::{
 };
 use crate::durable_host::{agent_effective_surface_from_component_metadata, recover_stderr_logs};
 use crate::metrics::storage::record_filesystem_pool_released;
+use crate::metrics::workers::AdmissionPhase;
 use crate::model::{AgentConfig, ExecutionStatus, LookupResult, ReadFileResult, TrapType};
 use crate::services::active_workers::{
     FilesystemStoragePermit, HeldComponentCharge, MemoryGrant, RegisteredConcurrentAccount,
@@ -81,6 +82,8 @@ use golem_common::model::{
 };
 use golem_common::one_shot::OneShotEvent;
 use golem_common::read_only_lock;
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use golem_service_base::error::worker_executor::{
     GolemSpecificWasmTrap, InterruptKind, WorkerExecutorError,
 };
@@ -94,7 +97,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex, MutexGuard, RwLock};
 use tokio::task::JoinHandle;
-use tracing::{Instrument, Level, Span, debug, info, span, warn};
+use tracing::{Instrument, Level, debug, info, span, warn};
 use uuid::Uuid;
 use wasmtime::component::Instance;
 use wasmtime::{Store, UpdateDeadline};
@@ -250,7 +253,14 @@ pub struct Worker<Ctx: WorkerCtx> {
     deps: All<Ctx>,
 
     queue: Arc<RwLock<VecDeque<QueuedWorkerInvocation>>>,
-    external_invocation_spans: Arc<RwLock<HashMap<IdempotencyKey, Span>>>,
+    /// How each not-yet-completed external invocation should be related to the
+    /// trace of whatever enqueued it, so the invocation loop can attach the
+    /// invocation's spans correctly when it picks the work up.
+    ///
+    /// Holds captured origins rather than `tracing::Span`s: a durable invocation can
+    /// be picked up long after the request that enqueued it returned. See
+    /// [`TraceOrigin`].
+    external_invocation_origins: Arc<RwLock<HashMap<IdempotencyKey, TraceOrigin>>>,
 
     invocation_results: Arc<RwLock<HashMap<IdempotencyKey, InvocationResult>>>,
     ephemeral_invocation: StdMutex<EphemeralInvocationState>,
@@ -327,6 +337,23 @@ impl<Ctx: WorkerCtx> UsesAllDeps for Worker<Ctx> {
 }
 
 impl<Ctx: WorkerCtx> Worker<Ctx> {
+    /// Builds the span context this worker's phase spans share.
+    fn trace(&self, startup_origin: TraceOrigin) -> WorkerTrace {
+        WorkerTrace {
+            startup_origin,
+            agent_type: self.agent_type_label(),
+        }
+    }
+
+    /// The agent type as a span field value, `-` for an agent id that could not be
+    /// parsed into one. Shared so every span labels it the same way.
+    pub(crate) fn agent_type_label(&self) -> String {
+        self.parsed_agent_id
+            .as_ref()
+            .map(|id| id.agent_type.to_string())
+            .unwrap_or_else(|| "-".to_string())
+    }
+
     pub(crate) async fn remove_from_active_workers(&self) {
         self.deps
             .active_workers()
@@ -572,20 +599,17 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
         let current_status_snapshot = current_status.load_full();
         let metrics_status = Arc::new(WorkerStatusMetric::new(current_status_snapshot.status));
-        let initial_pending_invocations = current_status_snapshot.pending_invocations.clone();
         let initial_invocation_results = current_status_snapshot.invocation_results.clone();
         let last_oplog_idx = current_status_snapshot.oplog_idx;
         drop(current_status_snapshot);
 
-        let mut spans_map = HashMap::new();
-        for inv in initial_pending_invocations {
-            if let Some(idempotency_key) = inv.idempotency_key() {
-                spans_map.insert(idempotency_key.clone(), Span::current());
-            }
-        }
-
+        // Invocations already pending when this worker is loaded were enqueued by
+        // an earlier request, possibly in an earlier process, so there is no
+        // in-process originator to relate them to. They start with no origin rather
+        // than being attributed to whichever request happened to trigger the load,
+        // which is neither their true origin nor a span that outlives them.
         let queue = Arc::new(RwLock::new(VecDeque::new()));
-        let external_invocation_spans = Arc::new(RwLock::new(spans_map));
+        let external_invocation_origins = Arc::new(RwLock::new(HashMap::new()));
 
         let invocation_results = Arc::new(RwLock::new(HashMap::from_iter(
             initial_invocation_results.iter().map(|(key, oplog_idx)| {
@@ -675,7 +699,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             )),
             deps: all_deps,
             queue,
-            external_invocation_spans,
+            external_invocation_origins,
             invocation_results,
             ephemeral_invocation: StdMutex::new(if reconstructed_ephemeral {
                 EphemeralInvocationState::Accepted(None)
@@ -1074,12 +1098,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self: Arc<Self>,
         invocation: AgentInvocation,
     ) -> Result<ResultOrSubscription, WorkerExecutorError> {
-        let idempotency_key = invocation
-            .idempotency_key()
-            .ok_or_else(|| {
-                WorkerExecutorError::invalid_request("Invocation has no idempotency key")
-            })?
-            .clone();
+        let idempotency_key = Self::require_idempotency_key(&invocation)?;
 
         // Classification uses the in-memory component snapshot - no metadata
         // fetch on the hot path.
@@ -1146,7 +1165,12 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         };
 
         let output = async { self.lookup_invocation_result(&idempotency_key).await }
-            .instrument(span!(Level::INFO, "lookup_invocation_result"))
+            .instrument(span!(
+                Level::INFO,
+                "lookup_invocation_result",
+                agent_id = %self.owned_agent_id.agent_id,
+                idempotency_key = %idempotency_key,
+            ))
             .await;
         let (result, enqueue_epoch) = match output {
             LookupResult::Complete(output) => (ResultOrSubscription::Finished(output), None),
@@ -1220,12 +1244,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self: Arc<Self>,
         invocation: AgentInvocation,
     ) -> Result<AgentInvocationOutput, WorkerExecutorError> {
-        let idempotency_key = invocation
-            .idempotency_key()
-            .ok_or_else(|| {
-                WorkerExecutorError::invalid_request("Invocation has no idempotency key")
-            })?
-            .clone();
+        let idempotency_key = Self::require_idempotency_key(&invocation)?;
 
         // Fast path: read-only Await coalescing.
         //
@@ -1246,7 +1265,17 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         let lookup_for_coalesce = if let Some(ro) = self.read_only_context_for(&invocation)
             && !is_no_cache(&ro.cfg.cache_policy)
         {
-            Some((ro, self.lookup_invocation_result(&idempotency_key).await))
+            Some((
+                ro,
+                async { self.lookup_invocation_result(&idempotency_key).await }
+                    .instrument(span!(
+                        Level::INFO,
+                        "lookup_invocation_result",
+                        agent_id = %self.owned_agent_id.agent_id,
+                        idempotency_key = %idempotency_key,
+                    ))
+                    .await,
+            ))
         } else {
             None
         };
@@ -1352,24 +1381,59 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             let worker = self.clone();
             let invocation_for_closure = invocation;
             let idem_for_closure = idempotency_key.clone();
-            let entry_result = self
-                .read_only_cache
-                .get_or_insert_simple_spawned(&key, move || async move {
-                    let output = Worker::invoke_and_await_uncoalesced(
-                        worker,
-                        invocation_for_closure,
-                        idem_for_closure,
-                    )
-                    .await?;
-                    if !matches!(output.result, AgentInvocationResult::AgentMethod { .. }) {
-                        // Defensive: only `AgentMethod` outputs are cacheable.
-                        return Err(WorkerExecutorError::unknown(
-                            "read-only invocation produced a non-AgentMethod result",
-                        ));
-                    }
-                    Ok(build_read_only_cache_entry(&ro_for_closure, output))
-                })
-                .await;
+
+            // The owner future is spawned and deliberately survives this caller, so
+            // it cannot run inside the caller's span - that would hold the gRPC span
+            // open for the whole invocation. It links back instead, so the coalesced
+            // execution is still reachable from the request that started it.
+            //
+            // Captured before the wait span rather than inside it, unlike
+            // `enqueue_worker_invocation_with_effect`: N callers coalesce onto one
+            // execution, so linking to any one
+            // caller's wait would pick an arbitrary winner. The request that owns the
+            // execution is the honest originator.
+            let origin = TraceOrigin::capture_current();
+            let owner_agent_id = self.owned_agent_id.agent_id.clone();
+            let owner_idempotency_key = idempotency_key.clone();
+
+            let entry_result = async {
+                self.read_only_cache
+                    .get_or_insert_simple_spawned(&key, move || {
+                        let span = related_span!(
+                            origin,
+                            Level::INFO,
+                            "read_only_invocation",
+                            agent_id = %owner_agent_id,
+                            idempotency_key = %owner_idempotency_key,
+                        );
+                        async move {
+                            let output = Worker::invoke_and_await_uncoalesced(
+                                worker,
+                                invocation_for_closure,
+                                idem_for_closure,
+                            )
+                            .await?;
+                            if !matches!(output.result, AgentInvocationResult::AgentMethod { .. }) {
+                                // Defensive: only `AgentMethod` outputs are cacheable.
+                                return Err(WorkerExecutorError::unknown(
+                                    "read-only invocation produced a non-AgentMethod result",
+                                ));
+                            }
+                            Ok(build_read_only_cache_entry(&ro_for_closure, output))
+                        }
+                        .instrument(span)
+                    })
+                    .await
+            }
+            // The caller's own share: however long it waits for the coalesced
+            // execution, whether or not it is the one that owns it.
+            .instrument(span!(
+                Level::INFO,
+                "wait_for_read_only_invocation",
+                agent_id = %self.owned_agent_id.agent_id,
+                idempotency_key = %idempotency_key,
+            ))
+            .await;
 
             // Stale-populate guard: if the epoch bumped while the owner ran,
             // the entry we just inserted is keyed on the old epoch and is
@@ -1414,11 +1478,21 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
                 debug!("Waiting for idempotency key to complete",);
 
+                // The caller's honest share of the work: the execution runs in the
+                // worker's own trace, linked from here, and only its outcome comes
+                // back. This span measures the waiting, which is what the request
+                // actually spent its time on.
+
                 let result = async {
                     self.wait_for_invocation_result(&idempotency_key, subscription)
                         .await
                 }
-                .instrument(span!(Level::INFO, "wait_for_invocation_result"))
+                .instrument(span!(
+                    Level::INFO,
+                    "wait_for_invocation_result",
+                    agent_id = %self.owned_agent_id.agent_id,
+                    idempotency_key = %idempotency_key,
+                ))
                 .await;
 
                 match result {
@@ -1439,6 +1513,14 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 }
             }
         }
+    }
+
+    fn require_idempotency_key(
+        invocation: &AgentInvocation,
+    ) -> Result<IdempotencyKey, WorkerExecutorError> {
+        invocation.idempotency_key().cloned().ok_or_else(|| {
+            WorkerExecutorError::invalid_request("Invocation has no idempotency key")
+        })
     }
 
     /// Enqueue attempting an update.
@@ -1560,11 +1642,24 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 result: Ok(output.clone()),
             },
         );
+        // `drop` before taking `origins`: `fail_pending_invocations` locks
+        // origins -> invocation_results, so holding `map` here would invert that
+        // order and can deadlock. Not a scope tidy-up.
+        drop(map);
+        self.external_invocation_origins.write().await.remove(key);
         debug!("Stored invocation success for {key}");
+        self.publish_completion(key, Ok(output));
+    }
+
+    fn publish_completion(
+        &self,
+        key: &IdempotencyKey,
+        result: Result<AgentInvocationOutput, WorkerExecutorError>,
+    ) {
         self.events().publish(Event::InvocationCompleted {
             agent_id: self.owned_agent_id.agent_id(),
             idempotency_key: key.clone(),
-            result: Ok(output),
+            result,
         });
     }
 
@@ -1586,12 +1681,15 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 },
             );
             if let Some(golem_error) = &golem_error {
-                self.events().publish(Event::InvocationCompleted {
-                    agent_id: self.owned_agent_id.agent_id(),
-                    idempotency_key: key.clone(),
-                    result: Err(golem_error.clone()),
-                });
+                self.publish_completion(key, Err(golem_error.clone()));
             }
+        }
+        // See `store_invocation_success`: origins must not be taken while
+        // `invocation_results` is held.
+        drop(map);
+        let mut origins = self.external_invocation_origins.write().await;
+        for key in &keys_to_fail {
+            origins.remove(key);
         }
     }
 
@@ -2102,6 +2200,24 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         invocation: AgentInvocation,
         read_only_cache_effect: read_only_cache::InvocationEffect,
     ) -> Result<Option<u64>, WorkerExecutorError> {
+        // Carried on the span so the two sides of the hand-off share a searchable
+        // key: the execution runs in its own trace, linked rather than nested, so
+        // `idempotency_key` is what joins them. Left unset rather than empty when
+        // there is none, so a search for one key cannot collide with every
+        // keyless enqueue.
+        let span = span!(
+            Level::INFO,
+            "enqueue_invocation",
+            agent_id = %self.owned_agent_id.agent_id,
+            idempotency_key = tracing::field::Empty,
+            // Pairs with the `consumer` span the invocation loop creates when it
+            // picks the work up.
+            otel.kind = "producer"
+        );
+        if let Some(idempotency_key) = invocation.idempotency_key() {
+            span.record("idempotency_key", tracing::field::display(idempotency_key));
+        }
+
         async {
             self.accept_ephemeral_invocation(&invocation)?;
             let instance_guard = self.lock_non_stopping_worker().await;
@@ -2170,10 +2286,19 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 .await;
 
             if let Some(idempotency_key) = timestamped_invocation.invocation.idempotency_key() {
-                self.external_invocation_spans
+                // Captured here, inside the producer span, because a consumer links
+                // back to the *creation context* of the work rather than to wherever
+                // the caller happened to call from.
+                // Captured before taking the lock: `capture_current` reaches into the
+                // tracing registry, which has no business happening inside this map's
+                // critical section. Same-worker enqueues are already serialized by the
+                // instance guard held above, so this keeps the critical section
+                // minimal rather than fixing measurable contention.
+                let origin = TraceOrigin::capture_current();
+                self.external_invocation_origins
                     .write()
                     .await
-                    .insert(idempotency_key.clone(), Span::current());
+                    .insert(idempotency_key.clone(), origin);
             }
 
             if let WorkerInstance::Running(running) = &*instance_guard {
@@ -2184,7 +2309,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
             Ok(read_only_epoch_snapshot)
         }
-        .instrument(span!(Level::INFO, "enqueue_invocation"))
+        .instrument(span)
         .await
     }
 
@@ -2905,7 +3030,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     async fn fail_pending_invocations(&self, error: WorkerExecutorError) {
         let queued_items = self.queue.write().await.drain(..).collect::<VecDeque<_>>();
-        let mut spans_map = self.external_invocation_spans.write().await;
+        let mut origins = self.external_invocation_origins.write().await;
 
         // Publishing the provided initialization error to all queued internal operations
         for item in queued_items {
@@ -2951,13 +3076,8 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                     }),
                 },
             );
-            self.events().publish(Event::InvocationCompleted {
-                agent_id: self.owned_agent_id.agent_id(),
-                idempotency_key: idempotency_key.clone(),
-                result: Err(error.clone()),
-            });
-            // Clean up the span entry
-            spans_map.remove(idempotency_key);
+            self.publish_completion(idempotency_key, Err(error.clone()));
+            origins.remove(idempotency_key);
         }
     }
 
@@ -3329,6 +3449,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         concurrent_agent_permit: crate::services::active_workers::ConcurrentAgentPermit,
         oom_retry_count: u32,
         start_attempt: Uuid,
+        worker_trace: WorkerTrace,
     ) {
         let mut instance_guard = this.instance.lock().await;
         match &*instance_guard {
@@ -3343,6 +3464,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                     component_charge,
                     concurrent_agent_permit,
                     oom_retry_count,
+                    worker_trace,
                 )
                 .await;
                 if let Some(sp) = filesystem_storage_permit {
@@ -3512,6 +3634,17 @@ impl WorkerInstance {
     }
 }
 
+/// What a resident worker's phase spans need in order to be traceable: the startup
+/// they link back to, and the agent fields they carry.
+///
+/// Built while the worker is admitted and passed to the loop rather than captured
+/// there, because the loop task has no ambient span by design.
+#[derive(Debug, Clone)]
+pub struct WorkerTrace {
+    pub startup_origin: TraceOrigin,
+    pub agent_type: String,
+}
+
 #[derive(Debug)]
 struct WaitingWorker {
     handle: Option<JoinHandle<()>>,
@@ -3525,132 +3658,163 @@ impl WaitingWorker {
         filesystem_storage_requirement: u64,
         oom_retry_count: u32,
     ) -> Self {
-        let span = span!(
-            parent: None,
-            Level::INFO,
-            "waiting-for-permits",
-            agent_id = parent.owned_agent_id.agent_id.to_string(),
-            agent_type = parent
-                .parsed_agent_id
-                .as_ref()
-                .map(|id| id.agent_type.to_string())
-                .unwrap_or_else(|| "-".to_string()),
-        );
-        span.follows_from(Span::current());
+        let worker_trace = parent.trace(TraceOrigin::capture_current());
 
         let start_attempt = Uuid::new_v4();
 
-        let handle = tokio::task::spawn(
-            async move {
-                let agent_id = parent.owned_agent_id.agent_id();
-                let registered_concurrent_account = parent.registered_concurrent_account.clone();
+        let handle = tokio::task::spawn(async move {
+            let agent_id = parent.owned_agent_id.agent_id();
+            let registered_concurrent_account = parent.registered_concurrent_account.clone();
 
-                // Determine the component's compiled-module size before acquiring
-                // the per-account concurrency slot (and before reserving memory),
-                // so the worker's memory and its module are admitted together (the
-                // module is reserved first, then the memory admission accounts for
-                // it). The module is charged once per resident component and shared
-                // by all its workers.
-                //
-                // Charges the pending-update target revision when one is queued
-                // (matching what create_instance loads); only a non-existent
-                // target falls back to the current revision, and transient
-                // resolution failures are retried rather than wedging the worker
-                // in WaitingForPermit or under-reserving against the old revision.
-                //
-                // This resolution is read-only and holds no permits, so it is done
-                // before acquiring the concurrent-agent permit: its retry loop must
-                // not hold one of the account's active-agent slots while the worker
-                // is not yet running, otherwise a single worker whose target
-                // metadata is transiently unavailable could block unrelated workers
-                // of the same account from starting.
-                let (component_id, component_revision, component_module_bytes) =
-                    parent.startup_component_charge_requirement().await;
+            // Determine the component's compiled-module size before acquiring
+            // the per-account concurrency slot (and before reserving memory),
+            // so the worker's memory and its module are admitted together (the
+            // module is reserved first, then the memory admission accounts for
+            // it). The module is charged once per resident component and shared
+            // by all its workers.
+            //
+            // Charges the pending-update target revision when one is queued
+            // (matching what create_instance loads); only a non-existent
+            // target falls back to the current revision, and transient
+            // resolution failures are retried rather than wedging the worker
+            // in WaitingForPermit or under-reserving against the old revision.
+            //
+            // This resolution is read-only and holds no permits, so it is done
+            // before acquiring the concurrent-agent permit: its retry loop must
+            // not hold one of the account's active-agent slots while the worker
+            // is not yet running, otherwise a single worker whose target
+            // metadata is transiently unavailable could block unrelated workers
+            // of the same account from starting.
+            // Not spanned: this retries on a 500ms delay and logs once per attempt,
+            // so a span covering the whole call would accumulate two events a second
+            // for as long as resolution keeps failing, and never close to export
+            // them. The retry events stay in the logs, and how long the wait took
+            // is recorded as a metric rather than a span.
+            let phase_start = std::time::Instant::now();
+            let (component_id, component_revision, component_module_bytes) =
+                parent.startup_component_charge_requirement().await;
+            crate::metrics::workers::record_worker_admission_wait(
+                AdmissionPhase::ResolveComponentCharge,
+                phase_start.elapsed(),
+            );
 
-                let concurrent_agent_permit = registered_concurrent_account.acquire(agent_id).await;
+            let phase_start = std::time::Instant::now();
+            let concurrent_agent_permit = registered_concurrent_account
+                .acquire(agent_id.clone())
+                .instrument(related_span!(
+                    worker_trace.startup_origin,
+                    Level::INFO,
+                    "acquire_concurrent_agent_slot",
+                    %agent_id,
+                    agent_type = %worker_trace.agent_type
+                ))
+                .await;
+            crate::metrics::workers::record_worker_admission_wait(
+                AdmissionPhase::ConcurrencySlot,
+                phase_start.elapsed(),
+            );
 
-                // `memory_grant` and `component_charge` own their reservations
-                // from here on: held as locals until the worker becomes resident
-                // (when they move into the RunningWorker) or this task ends/aborts
-                // (when dropping them returns the reservations to the gate). This
-                // is what makes a start cancelled mid-flight — e.g. the worker
-                // being deleted while still waiting for its remaining permits —
-                // release rather than leak its grant and module charge.
-                //
-                // Admission is not gated while waiting for a per-account
-                // concurrency slot above; otherwise one account could exhaust the
-                // memory headroom with workers that are not allowed to run yet.
-                let (memory_grant, component_charge) = parent
+            // `memory_grant` and `component_charge` own their reservations
+            // from here on: held as locals until the worker becomes resident
+            // (when they move into the RunningWorker) or this task ends/aborts
+            // (when dropping them returns the reservations to the gate). This
+            // is what makes a start cancelled mid-flight — e.g. the worker
+            // being deleted while still waiting for its remaining permits —
+            // release rather than leak its grant and module charge.
+            //
+            // Admission is not gated while waiting for a per-account
+            // concurrency slot above; otherwise one account could exhaust the
+            // memory headroom with workers that are not allowed to run yet.
+            let phase_start = std::time::Instant::now();
+            let (memory_grant, component_charge) = parent
+                .active_workers()
+                .acquire_with_component_charge(
+                    memory_requirement,
+                    component_id,
+                    component_revision,
+                    component_module_bytes,
+                )
+                // Not spanned, for the same reason as the charge resolution above:
+                // `acquire_memory` retries on the same 500ms delay and logs once per
+                // attempt. Its duration is recorded as a metric instead.
+                .await;
+            crate::metrics::workers::record_worker_admission_wait(
+                AdmissionPhase::Memory,
+                phase_start.elapsed(),
+            );
+            // Pre-acquire storage permits for this restart.
+            //
+            // We need to acquire `filesystem_storage_requirement + desired_extra` total:
+            // - `filesystem_storage_requirement`: bytes to hold as the pre-acquired permit
+            //   for replay (mirrors what the worker held before being evicted).
+            //   The old RunningWorker already returned these bytes to the pool
+            //   when it dropped, so the pool likely already has them — the
+            //   blocking acquire will find them without needing to evict anyone.
+            // - `desired_extra`: bytes for the write that triggered NodeOutOfFilesystemStorage.
+            //   The pool may not have these yet, so the blocking acquire will
+            //   evict idle workers only for the missing portion.
+            //
+            // After acquiring, we release `desired_extra` back to the pool so
+            // it is available for the pending write to re-acquire at runtime.
+            //
+            // Example: prior writes = 3 KB, failing write needs 1 KB extra.
+            //   Old RunningWorker drops → 3 KB returned to pool.
+            //   acquire_bytes = 4 KB. Pool has 3 KB → 1 KB gap → evict 1 KB.
+            //   Hold 3 KB as filesystem_storage_permit, release 1 KB → pool has 1 KB free.
+            //   Pending write re-acquires 1 KB → succeeds.
+            let desired_extra = parent
+                .desired_extra_filesystem_storage
+                .load(Ordering::Relaxed);
+            let acquire_bytes = filesystem_storage_requirement + desired_extra;
+            let filesystem_storage_permit = if acquire_bytes > 0 {
+                let phase_start = std::time::Instant::now();
+                let mut permit = parent
                     .active_workers()
-                    .acquire_with_component_charge(
-                        memory_requirement,
-                        component_id,
-                        component_revision,
-                        component_module_bytes,
-                    )
+                    .acquire_filesystem_storage(acquire_bytes)
+                    .instrument(related_span!(
+                        worker_trace.startup_origin,
+                        Level::INFO,
+                        "acquire_filesystem_storage",
+                        %agent_id,
+                        agent_type = %worker_trace.agent_type
+                    ))
                     .await;
-                // Pre-acquire storage permits for this restart.
-                //
-                // We need to acquire `filesystem_storage_requirement + desired_extra` total:
-                // - `filesystem_storage_requirement`: bytes to hold as the pre-acquired permit
-                //   for replay (mirrors what the worker held before being evicted).
-                //   The old RunningWorker already returned these bytes to the pool
-                //   when it dropped, so the pool likely already has them — the
-                //   blocking acquire will find them without needing to evict anyone.
-                // - `desired_extra`: bytes for the write that triggered NodeOutOfFilesystemStorage.
-                //   The pool may not have these yet, so the blocking acquire will
-                //   evict idle workers only for the missing portion.
-                //
-                // After acquiring, we release `desired_extra` back to the pool so
-                // it is available for the pending write to re-acquire at runtime.
-                //
-                // Example: prior writes = 3 KB, failing write needs 1 KB extra.
-                //   Old RunningWorker drops → 3 KB returned to pool.
-                //   acquire_bytes = 4 KB. Pool has 3 KB → 1 KB gap → evict 1 KB.
-                //   Hold 3 KB as filesystem_storage_permit, release 1 KB → pool has 1 KB free.
-                //   Pending write re-acquires 1 KB → succeeds.
-                let desired_extra = parent
-                    .desired_extra_filesystem_storage
-                    .load(Ordering::Relaxed);
-                let acquire_bytes = filesystem_storage_requirement + desired_extra;
-                let filesystem_storage_permit = if acquire_bytes > 0 {
-                    let mut permit = parent
-                        .active_workers()
-                        .acquire_filesystem_storage(acquire_bytes)
-                        .await;
-                    // Release the `desired_extra` portion back to the pool.
-                    if desired_extra > 0 {
-                        let extra_permits =
-                            crate::services::active_workers::bytes_to_filesystem_storage_permits(
-                                desired_extra,
-                            ) as usize;
-                        if let Some(extra) = permit.split(extra_permits) {
-                            drop(extra); // returns to semaphore
-                        }
+                crate::metrics::workers::record_worker_admission_wait(
+                    AdmissionPhase::FilesystemStorage,
+                    phase_start.elapsed(),
+                );
+                // Release the `desired_extra` portion back to the pool.
+                if desired_extra > 0 {
+                    let extra_permits =
+                        crate::services::active_workers::bytes_to_filesystem_storage_permits(
+                            desired_extra,
+                        ) as usize;
+                    if let Some(extra) = permit.split(extra_permits) {
+                        drop(extra); // returns to semaphore
                     }
-                    if permit.num_permits() > 0 {
-                        Some(permit)
-                    } else {
-                        None
-                    }
+                }
+                if permit.num_permits() > 0 {
+                    Some(permit)
                 } else {
                     None
-                };
-                debug!("Attempting to start worker after acquiring enough permits");
-                Worker::start_waiting_worker(
-                    parent,
-                    memory_grant,
-                    component_charge,
-                    filesystem_storage_permit,
-                    concurrent_agent_permit,
-                    oom_retry_count,
-                    start_attempt,
-                )
-                .await;
-                // If we do not start the worker here we will drop the permits here, which will release them to the host.
-            }
-            .instrument(span),
-        );
+                }
+            } else {
+                None
+            };
+            debug!("Attempting to start worker after acquiring enough permits");
+            Worker::start_waiting_worker(
+                parent,
+                memory_grant,
+                component_charge,
+                filesystem_storage_permit,
+                concurrent_agent_permit,
+                oom_retry_count,
+                start_attempt,
+                worker_trace,
+            )
+            .await;
+            // If we do not start the worker here we will drop the permits here, which will release them to the host.
+        });
 
         WaitingWorker {
             handle: Some(handle),
@@ -3801,6 +3965,7 @@ impl RunningWorker {
         component_charge: WorkerComponentCharge,
         concurrent_agent_permit: crate::services::active_workers::ConcurrentAgentPermit,
         oom_retry_count: u32,
+        worker_trace: WorkerTrace,
     ) -> Self {
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
         sender.send(WorkerCommand::WorkAvailable).unwrap();
@@ -3814,35 +3979,21 @@ impl RunningWorker {
         let resume_replay_pending = Arc::new(AtomicBool::new(false));
         let resume_replay_pending_clone = resume_replay_pending.clone();
 
-        let span = span!(
-            parent: None,
-            Level::INFO,
-            "invocation-loop",
-            agent_id = parent.owned_agent_id.agent_id.to_string(),
-            agent_type = parent
-                .parsed_agent_id
-                .as_ref()
-                .map(|id| id.agent_type.to_string())
-                .unwrap_or_else(|| "-".to_string()),
-        );
-        let handle = tokio::task::spawn(
-            async move {
-                RunningWorker::invocation_loop(
-                    receiver,
-                    active_clone,
-                    owned_agent_id_clone,
-                    parent,
-                    waiting_for_command_clone,
-                    interrupt_signal_clone,
-                    oom_retry_count,
-                    concurrent_agent_permit,
-                    resume_replay_pending_clone,
-                )
-                .instrument(span)
-                .await;
-            }
-            .in_current_span(),
-        );
+        let handle = tokio::task::spawn(async move {
+            RunningWorker::invocation_loop(
+                receiver,
+                active_clone,
+                owned_agent_id_clone,
+                parent,
+                waiting_for_command_clone,
+                interrupt_signal_clone,
+                oom_retry_count,
+                concurrent_agent_permit,
+                resume_replay_pending_clone,
+                worker_trace,
+            )
+            .await;
+        });
 
         RunningWorker {
             handle: Some(handle),
@@ -4153,6 +4304,7 @@ impl RunningWorker {
         oom_retry_count: u32,
         concurrent_agent_permit: crate::services::active_workers::ConcurrentAgentPermit,
         resume_replay_pending: Arc<AtomicBool>,
+        worker_trace: WorkerTrace,
     ) {
         let mut invocation_loop = InvocationLoop {
             receiver,
@@ -4164,6 +4316,7 @@ impl RunningWorker {
             oom_retry_count,
             concurrent_agent_permit: Some(concurrent_agent_permit),
             resume_replay_pending,
+            worker_trace,
         };
         invocation_loop.run().await;
     }

--- a/golem-worker-executor/src/worker/state_actor.rs
+++ b/golem-worker-executor/src/worker/state_actor.rs
@@ -64,7 +64,7 @@ use golem_common::model::{AgentStatus, AgentStatusRecord, OwnedAgentId, Schedule
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Mutex, mpsc, oneshot};
-use tracing::{Instrument, debug, warn};
+use tracing::{debug, warn};
 
 /// Handle to the worker-state actor's two job queues. Owned by [`Worker`]; dropping it aborts
 /// both tasks.
@@ -173,58 +173,53 @@ impl<Ctx: WorkerCtx> WorkerStateActor<Ctx> {
         };
 
         let (status_jobs, mut status_rx) = mpsc::unbounded_channel::<StatusJob>();
-        let status_task = tokio::spawn(
-            async move {
-                while let Some(job) = status_rx.recv().await {
-                    match job {
-                        StatusJob::CommitAndUpdateState { level, done } => {
-                            let changed = state.commit_and_update_state(level).await;
-                            let index = state.oplog.current_oplog_index().await;
-                            let _ = done.send((index, changed));
-                        }
-                        StatusJob::NonDetachedStatus { done } => {
-                            let status = if state.detached.load(Ordering::Acquire) {
-                                None
-                            } else {
-                                Some(state.last_known_status.load_full().as_ref().clone())
-                            };
-                            let _ = done.send(status);
-                        }
-                        StatusJob::Reattach { done } => {
-                            state.reattach().await;
-                            let _ = done.send(());
-                        }
+        let status_task = tokio::spawn(async move {
+            while let Some(job) = status_rx.recv().await {
+                match job {
+                    StatusJob::CommitAndUpdateState { level, done } => {
+                        let changed = state.commit_and_update_state(level).await;
+                        let index = state.oplog.current_oplog_index().await;
+                        let _ = done.send((index, changed));
+                    }
+                    StatusJob::NonDetachedStatus { done } => {
+                        let status = if state.detached.load(Ordering::Acquire) {
+                            None
+                        } else {
+                            Some(state.last_known_status.load_full().as_ref().clone())
+                        };
+                        let _ = done.send(status);
+                    }
+                    StatusJob::Reattach { done } => {
+                        state.reattach().await;
+                        let _ = done.send(());
                     }
                 }
             }
-            .in_current_span(),
-        );
+        });
 
         let (lifecycle_jobs, mut lifecycle_rx) = mpsc::unbounded_channel::<LifecycleJob<Ctx>>();
-        let lifecycle_task = tokio::spawn(
-            async move {
-                while let Some(job) = lifecycle_rx.recv().await {
-                    match job {
-                        LifecycleJob::NotifyStatusChanged => {
-                            let instance_guard = instance.lock().await;
-                            if let WorkerInstance::Running(running) = &*instance_guard {
-                                let _ = running.sender.send(WorkerCommand::InternalStatusChanged);
-                            }
+        let lifecycle_task = tokio::spawn(async move {
+            while let Some(job) = lifecycle_rx.recv().await {
+                match job {
+                    LifecycleJob::NotifyStatusChanged => {
+                        let instance_guard = instance.lock().await;
+                        if let WorkerInstance::Running(running) = &*instance_guard {
+                            let _ = running.sender.send(WorkerCommand::InternalStatusChanged);
                         }
-                        LifecycleJob::GrowMemory { worker, delta } => {
-                            worker.add_to_oplog(OplogEntry::grow_memory(delta)).await;
-                            if let Err(error) = worker.increase_memory(delta).await {
-                                warn!(
-                                    "Failed to acquire {delta} bytes of additional memory: {error}; restarting the worker after releasing its memory permits"
-                                );
-                                worker.interrupt_for_permit_reacquire().await;
-                            }
+                    }
+                    LifecycleJob::GrowMemory { worker, delta } => {
+                        worker.add_to_oplog(OplogEntry::grow_memory(delta)).await;
+                        if let Err(error) = worker.increase_memory(delta).await {
+                            warn!(
+                                agent_id = %worker.owned_agent_id.agent_id,
+                                "Failed to acquire {delta} bytes of additional memory: {error}; restarting the worker after releasing its memory permits"
+                            );
+                            worker.interrupt_for_permit_reacquire().await;
                         }
                     }
                 }
             }
-            .in_current_span(),
-        );
+        });
 
         Self {
             status_jobs,
@@ -339,7 +334,7 @@ impl<Ctx: WorkerCtx> StatusState<Ctx> {
             } else {
                 // The status can no longer be incrementally computed by adding the new oplog entries, instead a full reload needs to be performed.
                 // This can happen during a revert or a snapshot update for example.
-                debug!("Detaching worker_status from oplog");
+                debug!(agent_id = %self.owned_agent_id.agent_id, "Detaching worker_status from oplog");
                 self.detached.store(true, Ordering::Release);
                 // The in-memory status is no longer authoritative, and after reattach it will be
                 // recomputed from scratch, so the persisted baseline can no longer be trusted: the
@@ -356,7 +351,10 @@ impl<Ctx: WorkerCtx> StatusState<Ctx> {
         self.commit_and_update_state(CommitLevel::Always).await;
 
         if self.detached.load(Ordering::Relaxed) {
-            debug!("Worker status was detached from oplog, recomputing it");
+            debug!(
+                agent_id = %self.owned_agent_id.agent_id,
+                "Worker status was detached from oplog, recomputing it"
+            );
 
             // The in-memory status is no longer foldable (a jump deleted its index, or a revert
             // moved the oplog behind it), so we recompute. Prefer folding forward from the clean
@@ -385,7 +383,10 @@ impl<Ctx: WorkerCtx> StatusState<Ctx> {
             // immediately consistent rather than waiting for the next background sweep. Best-effort:
             // a failure is logged/metered and re-queued inside `flush`.
             if let Err(err) = self.status_flusher.flush(FlushReason::Forced).await {
-                debug!("Forced status flush on reattach failed (will retry in background): {err}");
+                debug!(
+                    agent_id = %self.owned_agent_id.agent_id,
+                    "Forced status flush on reattach failed (will retry in background): {err}"
+                );
             }
         }
     }

--- a/golem-worker-executor/src/worker/status_flusher.rs
+++ b/golem-worker-executor/src/worker/status_flusher.rs
@@ -45,7 +45,7 @@ use futures::StreamExt;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, Level, debug, error, span};
+use tracing::{Instrument, debug, error, info_span};
 
 use golem_common::model::{AgentStatusRecord, OwnedAgentId};
 
@@ -321,31 +321,28 @@ impl AgentStatusFlushQueue {
         });
 
         let weak = Arc::downgrade(&queue);
-        let handle = tokio::spawn(
-            async move {
-                loop {
-                    tokio::select! {
-                        _ = shutdown_token.cancelled() => {
-                            debug!("Shutdown requested, draining agent status flush queue once before stopping");
-                            // Best-effort final drain so a graceful shutdown leaves the cache as
-                            // fresh as possible. Not required for correctness (the oplog is the
-                            // source of truth and a cold load re-folds), but avoids an avoidable
-                            // re-fold on next load of every dirty worker.
-                            if let Some(queue) = weak.upgrade() {
-                                queue.sweep().await;
-                            }
-                            break;
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        debug!("Shutdown requested, draining agent status flush queue once before stopping");
+                        // Best-effort final drain so a graceful shutdown leaves the cache as
+                        // fresh as possible. Not required for correctness (the oplog is the
+                        // source of truth and a cold load re-folds), but avoids an avoidable
+                        // re-fold on next load of every dirty worker.
+                        if let Some(queue) = weak.upgrade() {
+                            queue.sweep().await;
                         }
-                        _ = tokio::time::sleep(interval) => {}
+                        break;
                     }
-                    match weak.upgrade() {
-                        Some(queue) => queue.sweep().await,
-                        None => break,
-                    }
+                    _ = tokio::time::sleep(interval) => {}
+                }
+                match weak.upgrade() {
+                    Some(queue) => queue.sweep().await,
+                    None => break,
                 }
             }
-            .instrument(span!(parent: None, Level::INFO, "Agent status flush sweeper")),
-        );
+        });
         *queue.background_handle.lock().unwrap() = Some(handle);
         queue
     }
@@ -359,23 +356,27 @@ impl AgentStatusFlushQueue {
     /// Drains all currently-dirty flushers and flushes them with bounded concurrency. Entries
     /// enqueued while a sweep is running are picked up by the next tick.
     async fn sweep(&self) {
-        let entries: Vec<Weak<AgentStatusFlusher>> = {
-            let mut dirty = self.dirty.lock().unwrap();
-            dirty.drain().map(|(_, weak)| weak).collect()
-        };
-        if entries.is_empty() {
-            return;
-        }
+        async {
+            let entries: Vec<Weak<AgentStatusFlusher>> = {
+                let mut dirty = self.dirty.lock().unwrap();
+                dirty.drain().map(|(_, weak)| weak).collect()
+            };
+            if entries.is_empty() {
+                return;
+            }
 
-        futures::stream::iter(entries)
-            .for_each_concurrent(self.max_concurrency, |weak| async move {
-                if let Some(flusher) = weak.upgrade() {
-                    // Failures are logged, metered and re-queued inside `flush`; nothing more to do
-                    // here (the next sweep will retry).
-                    let _ = flusher.flush(FlushReason::Background).await;
-                }
-            })
-            .await;
+            futures::stream::iter(entries)
+                .for_each_concurrent(self.max_concurrency, |weak| async move {
+                    if let Some(flusher) = weak.upgrade() {
+                        // Failures are logged, metered and re-queued inside `flush`; nothing more to do
+                        // here (the next sweep will retry).
+                        let _ = flusher.flush(FlushReason::Background).await;
+                    }
+                })
+                .await;
+        }
+        .instrument(info_span!("agent_status_flush_sweep"))
+        .await
     }
 
     #[cfg(test)]
@@ -550,6 +551,37 @@ mod tests {
     fn test_queue() -> Arc<AgentStatusFlushQueue> {
         // Long interval so the background sweeper never fires; tests drive `sweep` manually.
         AgentStatusFlushQueue::new(Duration::from_secs(3600), 16, CancellationToken::new())
+    }
+
+    /// One span per sweep, not one for the lifetime of the sweeper.
+    #[test]
+    async fn sweep_records_one_closed_span_when_it_has_work() {
+        let ws = MockWorkerService::arc();
+        let queue = test_queue();
+        let (flusher, current, _) = make_flusher(false, true, ws.clone(), queue.clone());
+
+        current.store(Arc::new(status(AgentStatus::Running, 1)));
+        flusher.mark_dirty();
+
+        let recorder = crate::span_test_support::record_spans();
+        queue.sweep().await;
+
+        recorder.assert_closed_span("agent_status_flush_sweep");
+        recorder.assert_all_closed();
+    }
+
+    /// An idle sweep is still spanned, so that every tick of the sweeper is
+    /// represented the same way.
+    #[test]
+    async fn sweep_records_one_closed_span_when_nothing_is_dirty() {
+        let ws = MockWorkerService::arc();
+        let queue = test_queue();
+        let (_flusher, _current, _) = make_flusher(false, true, ws.clone(), queue.clone());
+
+        let recorder = crate::span_test_support::record_spans();
+        queue.sweep().await;
+
+        recorder.assert_closed_span("agent_status_flush_sweep");
     }
 
     #[test]

--- a/golem-worker-service/src/api/worker.rs
+++ b/golem-worker-service/src/api/worker.rs
@@ -1043,11 +1043,15 @@ impl WorkerApi {
             .connect_to_worker(component_id.0, agent_name.0, token.0.secret())
             .await?;
 
-        let upgraded: BoxWebSocketUpgraded = websocket.on_upgrade(Box::new(|socket_stream| {
+        // The stream captured this when it was built, inside the request span.
+        let origin = worker_stream.origin();
+
+        let upgraded: BoxWebSocketUpgraded = websocket.on_upgrade(Box::new(move |socket_stream| {
             Box::pin(async move {
                 let (sink, stream) = socket_stream.split();
                 let _ = proxy_worker_connection(
                     agent_id,
+                    origin,
                     worker_stream,
                     sink,
                     stream,

--- a/golem-worker-service/src/service/worker/connect.rs
+++ b/golem-worker-service/src/service/worker/connect.rs
@@ -18,6 +18,7 @@ use futures::{Stream, StreamExt};
 use golem_api_grpc::proto::golem::worker::LogEvent;
 use golem_common::model::AgentId;
 use golem_common::model::account::AccountId;
+use golem_common::tracing::TraceOrigin;
 use std::sync::Arc;
 use tonic::Status;
 
@@ -26,6 +27,10 @@ pub struct ConnectWorkerStream {
     agent_id: AgentId,
     account_id: AccountId,
     limit_service: Arc<dyn LimitService>,
+    /// The request that opened this connection. Carried on the stream so that work
+    /// outliving the request - the websocket proxy - can link back to it without the
+    /// caller having to know where the span was still current.
+    origin: TraceOrigin,
 }
 
 impl ConnectWorkerStream {
@@ -40,7 +45,18 @@ impl ConnectWorkerStream {
             agent_id,
             account_id,
             limit_service,
+            // Captured here rather than at any use site: this constructor is only
+            // reached from `WorkerService::connect`, which the API layer runs under
+            // the `connect_worker` request span, so that span is current exactly
+            // here. See `TraceOrigin::capture_current` for the rule.
+            origin: TraceOrigin::capture_current(),
         }
+    }
+
+    /// The request this connection was opened by, for linking longer-lived work back
+    /// to it.
+    pub fn origin(&self) -> TraceOrigin {
+        self.origin.clone()
     }
 }
 

--- a/golem-worker-service/src/service/worker/connect_proxy.rs
+++ b/golem-worker-service/src/service/worker/connect_proxy.rs
@@ -20,86 +20,105 @@ use std::{
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use golem_api_grpc::proto::golem::worker::LogEvent;
 use golem_common::model::{AgentEvent, AgentId};
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 use poem::web::websocket::Message;
 use tonic::Status;
-use tracing::{error, info};
+use tracing::{Instrument, Level, error, info};
 
 /// Proxies a worker connection, listening for either connection to close. Websocket sink will be closed at the end.
 ///
+/// origin: the request that opened this connection, to link the proxy's span back to
 /// keep_alive_interval: Interval at which Ping messages are sent
 /// max_pong_timeout: Maximum time to wait for a Pong message before considering the connection dead
-#[tracing::instrument(skip_all, fields(agent_id = agent_id.to_string()))]
+// The proxy runs for the connection's whole life - hours, for a `connect` websocket -
+// so it is the root of its own trace, linked to the request that opened it rather than
+// nested under it. The origin has to be captured by the caller: poem drives the upgrade
+// callback from a bare `tokio::spawn`, so by the time this runs there is no current
+// span left to capture.
 pub async fn proxy_worker_connection(
     agent_id: AgentId,
+    origin: TraceOrigin,
     mut worker_stream: impl Stream<Item = Result<LogEvent, Status>> + Unpin,
     websocket_sender: impl Sink<Message, Error = IoError> + Unpin,
     websocket_receiver: impl Stream<Item = IoResult<Message>> + Unpin,
     keep_alive_interval: Duration,
     max_pong_timeout: Duration,
 ) -> Result<(), ConnectProxyError> {
-    info!("Proxying worker connection");
-
-    let mut websocket = keep_alive::WebSocketKeepAlive::from_sink_and_stream(
-        websocket_receiver,
-        websocket_sender,
-        keep_alive_interval,
-        max_pong_timeout,
+    let span = related_span!(
+        origin,
+        Level::INFO,
+        "proxy_worker_connection",
+        agent_id = %agent_id
     );
 
-    let result = loop {
-        tokio::select! {
-            // WebSocket is cancellation safe.
-            // https://github.com/snapview/tokio-tungstenite/issues/167
-            websocket_message = websocket.next() => {
-                match websocket_message {
-                    Some(Ok(Message::Close(payload))) => {
-                        info!(
-                            close_code=payload.as_ref().map(|p| u16::from(p.0)),
-                            close_message=payload.as_ref().map(|p| &p.1),
-                            "Client closed WebSocket connection",
-                        );
-                        break Ok(());
-                    }
-                    Some(Err(error)) => {
-                        let error: ConnectProxyError = error.into();
-                        info!(error=error.to_string(), "Received WebSocket Error");
-                        break Err(error);
-                    },
-                    Some(Ok(_)) => {
-                    }
-                    None => {
-                        info!("WebSocket connection closed");
-                        break Ok(());
-                    }
-                }
-            },
+    async move {
+        info!("Proxying worker connection");
 
-            worker_message = worker_stream.next() => {
-                if let Some(message) = worker_message {
-                    if let Err(error) = forward_worker_message(message, &mut websocket).await {
-                        info!(error=error.to_string(), "Error forwarding message to WebSocket client");
-                        break Err(error)
-
-                    }
-                } else {
-                    info!("Worker stream ended");
-                    break Ok(());
-                }
-            },
-        }
-    };
-
-    info!("Closing websocket connection");
-    if let Err(error) = websocket.close().await {
-        error!(
-            error = error.to_string(),
-            "Error closing WebSocket connection"
+        let mut websocket = keep_alive::WebSocketKeepAlive::from_sink_and_stream(
+            websocket_receiver,
+            websocket_sender,
+            keep_alive_interval,
+            max_pong_timeout,
         );
-    } else {
-        info!("WebSocket connection successfully closed");
-    }
 
-    result
+        let result = loop {
+            tokio::select! {
+                // WebSocket is cancellation safe.
+                // https://github.com/snapview/tokio-tungstenite/issues/167
+                websocket_message = websocket.next() => {
+                    match websocket_message {
+                        Some(Ok(Message::Close(payload))) => {
+                            info!(
+                                close_code=payload.as_ref().map(|p| u16::from(p.0)),
+                                close_message=payload.as_ref().map(|p| &p.1),
+                                "Client closed WebSocket connection",
+                            );
+                            break Ok(());
+                        }
+                        Some(Err(error)) => {
+                            let error: ConnectProxyError = error.into();
+                            info!(error=error.to_string(), "Received WebSocket Error");
+                            break Err(error);
+                        },
+                        Some(Ok(_)) => {
+                        }
+                        None => {
+                            info!("WebSocket connection closed");
+                            break Ok(());
+                        }
+                    }
+                },
+
+                worker_message = worker_stream.next() => {
+                    if let Some(message) = worker_message {
+                        if let Err(error) = forward_worker_message(message, &mut websocket).await {
+                            info!(error=error.to_string(), "Error forwarding message to WebSocket client");
+                            break Err(error)
+
+                        }
+                    } else {
+                        info!("Worker stream ended");
+                        break Ok(());
+                    }
+                },
+            }
+        };
+
+        info!("Closing websocket connection");
+        if let Err(error) = websocket.close().await {
+            error!(
+                error = error.to_string(),
+                "Error closing WebSocket connection"
+            );
+        } else {
+            info!("WebSocket connection successfully closed");
+        }
+
+        result
+    }
+    .instrument(span)
+    .await
 }
 
 async fn forward_worker_message<E>(

--- a/golem-worker-service/src/service/worker/worker_stream.rs
+++ b/golem-worker-service/src/service/worker/worker_stream.rs
@@ -21,11 +21,13 @@ use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tonic::{Status, Streaming};
-use tracing::{Instrument, error};
+use tracing::{Instrument, Level, error};
 
 use golem_common::metrics::api::{
     record_closed_grpc_api_active_stream, record_new_grpc_api_active_stream,
 };
+use golem_common::related_span;
+use golem_common::tracing::TraceOrigin;
 
 pub struct WorkerStream<T> {
     receiver: mpsc::Receiver<Result<T, Status>>,
@@ -41,6 +43,16 @@ impl<T: Send + 'static> WorkerStream<T> {
 
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
+
+        // The pump lives as long as the stream does - a `connect` websocket can stay
+        // open for hours - so it links back to the request that opened it rather than
+        // running inside its span, which would keep that span open just as long.
+        //
+        // `new` is reached from `WorkerService::connect` and from the file-read path
+        // (`get_file_contents`), both of which the API layer runs under a request
+        // span, so a span is current here. See `TraceOrigin::capture_current` for the
+        // rule.
+        let origin = TraceOrigin::capture_current();
 
         tokio::spawn(
             async move {
@@ -70,7 +82,7 @@ impl<T: Send + 'static> WorkerStream<T> {
                 drop(sender);
                 record_closed_grpc_api_active_stream();
             }
-            .in_current_span(),
+            .instrument(related_span!(origin, Level::INFO, "worker_stream_pump")),
         );
 
         Self { receiver, cancel }

--- a/integration-tests/tests/otlp_plugin.rs
+++ b/integration-tests/tests/otlp_plugin.rs
@@ -173,6 +173,15 @@ async fn otlp_basic_trace_export(
         "Found spans with ERROR status: {errors:?}"
     );
 
+    // A span must not escape its parent's time window. A child that outlives its
+    // parent means the parent does not contain the operation it appears to
+    // contain, which makes critical-path analysis meaningless.
+    let outliving = trace.spans_outliving_parent();
+    assert!(
+        outliving.is_empty(),
+        "Found spans outliving their parent (child, parent): {outliving:?}"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Scope spans to the operation they measure, instead of a worker's, a loop's, or a connection's lifetime.
- Relate handed-off work to its originator by an OpenTelemetry link rather than by nesting.
- Set `otel.kind` on entry-point, producer and consumer spans.
- Make the OTLP layer's filter a plain `RUST_LOG`-style filter under `GOLEM_OTLP_FILTER`, with stable target names for the two high-volume sources.
- Record how long each worker admission phase blocks, as `worker_admission_wait_seconds`.

Spans modelled residency rather than work. A worker's span covered its whole time resident, the scheduler's covered its loop, an actor task inherited whatever span its constructor happened to run under, and a websocket proxy's covered the connection. Those spans stay open for as long as the thing they name exists, which has three consequences: `tracing-opentelemetry` never exports them, they accumulate an OpenTelemetry event for every `tracing` event recorded inside them — the SDK applies `max_events_per_span` only at close, keeping the first N — and their children report durations longer than the request that appears to contain them. A trace showed `get_or_create_worker` running for 3m26s inside a 1.76s gRPC call, and executor RSS reached 11 GB, at which point OOM began failing worker admission.

## Behavior

Every span covers one bounded operation. Background loops — the scheduler, quota renewal, resource-limit batching, agent status flushing, oplog transfer and forwarding — span each tick rather than the loop, so a span always closes and its events are bounded by one iteration. Worker residency and the invocation loop have no span at all; the phases inside them span themselves. A worker's admission waits are spanned one at a time, and each records its duration to `worker_admission_wait_seconds`, labelled by phase, so a stalled start says which resource it is waiting on.

Work that is handed off is related to its originator by a link, never by parent-child nesting. This includes the synchronous invoke-and-await path: the caller enqueues an invocation and waits on a published event rather than a return, and the work continues if the caller goes away, so the caller does not contain it in time. The caller keeps its own span for the time it spends waiting, and the execution is the root of its own trace, linked back to the producer span. `otel.kind` is `server` on gRPC and HTTP entry points, and `producer`/`consumer` on the enqueue and pickup pair, following the OpenTelemetry messaging conventions.

The same applies wherever a task outlives the request that started it. Read-only invocation coalescing runs a whole agent invocation as its cache owner, which by design survives the caller — it now links back as `read_only_invocation` instead of holding the `invoke_and_await` gRPC span open for the invocation's duration. In `golem-worker-service`, the gRPC stream pump and the websocket proxy each link back to the request that opened the connection rather than running inside its span, which previously kept that span open for the connection's life — hours, for a `connect` websocket. A connection carries its own origin, captured where the request span is provably current, so no caller has to know where to capture it.

Origins are carried as captured span contexts rather than `tracing::Span` handles, so remembering where an invocation came from no longer holds a span open until it completes, and the map that holds them is emptied as invocations complete rather than growing for the worker's residency.

`GOLEM_OTLP_FILTER` sets the OTLP layer's filter in `RUST_LOG` syntax, and is used exactly as written — nothing is merged into it, so `info` means info everywhere including third-party crates, and quietening a crate is the deployment's judgement to make. Unset means `off`: exporting already requires `GOLEM__TRACING__OTLP__ENABLED`, `__HOST` and `__PORT`, and this is the remaining switch. Levels below `info` export nothing, because the spans bounding an operation are `info` and an error reaches a trace as an event on a span rather than as a span of its own. `GOLEM_OTLP_LOG` is still honoured, with a warning naming the replacement. The filter in force, and the variable it came from, are logged at startup.

Two sources whose volume is decided outside the executor have stable target names, so they can be tuned without naming a Rust module path: `golem::plugin_log` for log output from oplog-processor plugin agents, and `golem::agent_rdbms` for SQL an agent runs against its own database. Everything else keeps its module's target, so ordinary `RUST_LOG` conventions apply.

## Notes

- A trace no longer contains both services for any invocation path. Handed-off work is a linked root by design, which is the representation the OpenTelemetry messaging conventions prescribe for a producer and consumer; the link is what ties the two traces together, and both sides carry `idempotency_key` to join on.
- The websocket proxy span still covers a connection rather than an operation. It closes at disconnect so it does export, but at `debug` the keep-alive ping log accumulates on it. Bounding it properly means per-message spans or reworking `WebSocketKeepAlive`'s hand-written `poll_next`, which belongs in its own change.
- The startup `otlp_filter` diagnostic reports what `GOLEM_OTLP_FILTER` resolves to. That is the filter in force for every service binary, but not for the benchmark runner, which supplies its own fallback spec when the variable is unset.
- Flat RSS over a long run and the absence of OOM-induced admission failures are runtime properties and are not asserted in CI.
- Benchmark trace volume is not comparable across this change: the runner previously exported at `debug` with directives merged in, and now exports at `info`.
