### PR TITLE
Fix behavior parity issues between various rpc clients

### DIFF
--- a/cli/golem-cli/src/bridge_gen/moonbit/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/moonbit/mod.rs
@@ -99,6 +99,7 @@ const RESERVED_PARAM_NAMES: &[&str] = &[
     "configuration",
     "parameters",
     "response",
+    "decoded",
     "result",
     "value",
     "v",
@@ -1070,23 +1071,25 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
 
         self.write_guest_constructors(writer, &client, &agent_type_name)?;
 
-        writer.line(format!(
-            "pub fn {client}::get_agent_id(self : {client}) -> String raise @common.AgentError {{"
-        ));
-        writer.indent();
-        writer.line("self.client.get_agent_id()");
-        writer.dedent();
-        writer.line("}");
-        writer.blank();
+        if self.agent_type.mode == AgentMode::Durable {
+            writer.line(format!(
+                "pub fn {client}::get_agent_id(self : {client}) -> String raise @common.AgentError {{"
+            ));
+            writer.indent();
+            writer.line("self.client.get_agent_id()");
+            writer.dedent();
+            writer.line("}");
+            writer.blank();
 
-        writer.line(format!(
-            "pub fn {client}::phantom_id(self : {client}) -> @types.Uuid? {{"
-        ));
-        writer.indent();
-        writer.line("self.client.phantom_id()");
-        writer.dedent();
-        writer.line("}");
-        writer.blank();
+            writer.line(format!(
+                "pub fn {client}::phantom_id(self : {client}) -> @types.Uuid? {{"
+            ));
+            writer.indent();
+            writer.line("self.client.phantom_id()");
+            writer.dedent();
+            writer.line("}");
+            writer.blank();
+        }
 
         writer.line(format!("pub fn {client}::drop(self : {client}) -> Unit {{"));
         writer.indent();
@@ -1178,16 +1181,18 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
             None,
             None,
         )?;
-        self.write_guest_constructor(
-            writer,
-            client,
-            agent_type_name,
-            "get_phantom",
-            &append_param("phantom_id : @types.Uuid", &param_decls),
-            &input,
-            Some("phantom_id"),
-            None,
-        )?;
+        if self.agent_type.mode == AgentMode::Durable {
+            self.write_guest_constructor(
+                writer,
+                client,
+                agent_type_name,
+                "get_phantom",
+                &append_param("phantom_id : @types.Uuid", &param_decls),
+                &input,
+                Some("phantom_id"),
+                None,
+            )?;
+        }
 
         let configs = self.local_configs();
         if configs.is_empty() {
@@ -1233,19 +1238,21 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
             None,
             Some((&configs, &config_names)),
         )?;
-        self.write_guest_constructor(
-            writer,
-            client,
-            agent_type_name,
-            "get_phantom_with_config",
-            &append_param(
-                &config_decls,
-                &append_param("phantom_id : @types.Uuid", &param_decls),
-            ),
-            &input,
-            Some("phantom_id"),
-            Some((&configs, &config_names)),
-        )?;
+        if self.agent_type.mode == AgentMode::Durable {
+            self.write_guest_constructor(
+                writer,
+                client,
+                agent_type_name,
+                "get_phantom_with_config",
+                &append_param(
+                    &config_decls,
+                    &append_param("phantom_id : @types.Uuid", &param_decls),
+                ),
+                &input,
+                Some("phantom_id"),
+                Some((&configs, &config_names)),
+            )?;
+        }
         Ok(())
     }
 
@@ -1276,8 +1283,13 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
         if configs.is_some() {
             args.push("agent_config".to_string());
         }
+        let runtime_constructor = match (self.agent_type.mode, name) {
+            (AgentMode::Ephemeral, "new_phantom") => "ephemeral",
+            (AgentMode::Ephemeral, "new_phantom_with_config") => "ephemeral_with_config",
+            _ => name,
+        };
         writer.line(format!(
-            "let client = @rpc.AgentClient::{name}({})",
+            "let client = @rpc.AgentClient::{runtime_constructor}({})",
             args.join(", ")
         ));
         writer.line("{ client, }");
@@ -1400,20 +1412,39 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
         let self_decls = prepend_self_decl(client, &param_decls);
         let (ret_ty, decode) = self.output_return(&method.output_schema)?;
         let decode = decode.map(guest_codec_source);
+        let ephemeral = self.agent_type.mode == AgentMode::Ephemeral;
+        let await_ret_ty = if ephemeral {
+            format!("@rpc.InvocationResult[{ret_ty}]")
+        } else {
+            ret_ty.clone()
+        };
 
         writer.line(format!(
-            "pub async fn {client}::{base}(self : {self_decls}) -> {ret_ty} {{"
+            "pub async fn {client}::{base}(self : {self_decls}) -> {await_ret_ty} {{"
         ));
         writer.indent();
         self.write_guest_invocation_input(writer, &method.input_schema, "input", &method.name)?;
         match decode {
+            None if ephemeral => {
+                writer.line(format!(
+                    "let response = self.client.invoke_and_await({method_name}, input)"
+                ));
+                writer.line("{ metadata: response.metadata, value: () }");
+            }
             None => writer.line(format!(
                 "let _ = self.client.invoke_and_await({method_name}, input)"
             )),
             Some(decode) => {
-                writer.line(format!(
-                    "match self.client.invoke_and_await({method_name}, input).value {{"
-                ));
+                if ephemeral {
+                    writer.line(format!(
+                        "let response = self.client.invoke_and_await({method_name}, input)"
+                    ));
+                    writer.line("match response.value {");
+                } else {
+                    writer.line(format!(
+                        "match self.client.invoke_and_await({method_name}, input).value {{"
+                    ));
+                }
                 writer.indent();
                 writer.line("Some(tree) => {");
                 writer.indent();
@@ -1425,7 +1456,11 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
                 ));
                 writer.dedent();
                 writer.line("}");
-                writer.line(format!("{decode} catch {{"));
+                if ephemeral {
+                    writer.line(format!("let decoded = {decode} catch {{"));
+                } else {
+                    writer.line(format!("{decode} catch {{"));
+                }
                 writer.indent();
                 writer.line(format!(
                     "error => raise @common.AgentError::InvalidType({} + repr(error))",
@@ -1433,6 +1468,9 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
                 ));
                 writer.dedent();
                 writer.line("}");
+                if ephemeral {
+                    writer.line("{ metadata: response.metadata, value: decoded }");
+                }
                 writer.dedent();
                 writer.line("}");
                 writer.line(format!(
@@ -1447,38 +1485,69 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
         writer.line("}");
         writer.blank();
 
+        let trigger_ret_ty = if ephemeral {
+            "@rpc.InvocationMetadata"
+        } else {
+            "Unit"
+        };
         writer.line(format!(
-            "pub fn {client}::trigger_{base}(self : {self_decls}) -> Unit raise @common.AgentError {{"
+            "pub fn {client}::trigger_{base}(self : {self_decls}) -> {trigger_ret_ty} raise @common.AgentError {{"
         ));
         writer.indent();
         self.write_guest_invocation_input(writer, &method.input_schema, "input", &method.name)?;
-        writer.line(format!("let _ = self.client.invoke({method_name}, input)"));
+        if ephemeral {
+            writer.line(format!("self.client.invoke({method_name}, input)"));
+        } else {
+            writer.line(format!("let _ = self.client.invoke({method_name}, input)"));
+        }
         writer.dedent();
         writer.line("}");
         writer.blank();
 
         let schedule_decls = prepend_param("scheduled_at : @systemClock.Instant", &param_decls);
         let schedule_self_decls = prepend_self_decl(client, &schedule_decls);
+        let schedule_ret_ty = if ephemeral {
+            "@rpc.ScheduledInvocationReceipt"
+        } else {
+            "Unit"
+        };
         writer.line(format!(
-            "pub fn {client}::schedule_{base}(self : {schedule_self_decls}) -> Unit raise @common.AgentError {{"
+            "pub fn {client}::schedule_{base}(self : {schedule_self_decls}) -> {schedule_ret_ty} raise @common.AgentError {{"
         ));
         writer.indent();
         self.write_guest_invocation_input(writer, &method.input_schema, "input", &method.name)?;
-        writer.line(format!(
-            "let _ = self.client.schedule_invocation(scheduled_at, {method_name}, input)"
-        ));
+        if ephemeral {
+            writer.line(format!(
+                "self.client.schedule_invocation(scheduled_at, {method_name}, input)"
+            ));
+        } else {
+            writer.line(format!(
+                "let _ = self.client.schedule_invocation(scheduled_at, {method_name}, input)"
+            ));
+        }
         writer.dedent();
         writer.line("}");
         writer.blank();
 
+        let schedule_cancelable_ret_ty = if ephemeral {
+            "@rpc.CancelableScheduledInvocationReceipt"
+        } else {
+            "@agentHost.CancellationToken"
+        };
         writer.line(format!(
-            "pub fn {client}::schedule_cancelable_{base}(self : {schedule_self_decls}) -> @agentHost.CancellationToken raise @common.AgentError {{"
+            "pub fn {client}::schedule_cancelable_{base}(self : {schedule_self_decls}) -> {schedule_cancelable_ret_ty} raise @common.AgentError {{"
         ));
         writer.indent();
         self.write_guest_invocation_input(writer, &method.input_schema, "input", &method.name)?;
-        writer.line(format!(
-            "self.client.schedule_cancelable_invocation(scheduled_at, {method_name}, input).cancellation_token"
-        ));
+        if ephemeral {
+            writer.line(format!(
+                "self.client.schedule_cancelable_invocation(scheduled_at, {method_name}, input)"
+            ));
+        } else {
+            writer.line(format!(
+                "self.client.schedule_cancelable_invocation(scheduled_at, {method_name}, input).cancellation_token"
+            ));
+        }
         writer.dedent();
         writer.line("}");
         writer.blank();
@@ -2143,18 +2212,21 @@ fn guest_decode_unstructured_binary(value : @model.SchemaValue, allowed : Array[
             if self.agent_type.mode == AgentMode::Ephemeral {
                 used.remove("get");
                 used.remove("get_with_config");
+                used.remove("get_phantom");
+                used.remove("get_phantom_with_config");
             }
             if self.local_configs().is_empty() {
                 used.remove("get_with_config");
                 used.remove("get_phantom_with_config");
                 used.remove("new_phantom_with_config");
             }
-            used.extend(
-                ["drop", "get_agent_id", "phantom_id"]
-                    .into_iter()
-                    .map(str::to_string),
-            );
+            used.insert("drop".to_string());
             if self.agent_type.mode == AgentMode::Durable {
+                used.extend(
+                    ["get_agent_id", "phantom_id"]
+                        .into_iter()
+                        .map(str::to_string),
+                );
                 used.insert("scoped".to_string());
             }
         }

--- a/cli/golem-cli/src/bridge_gen/scala/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/scala/mod.rs
@@ -211,6 +211,8 @@ const RESERVED_PARAM_NAMES: &[&str] = &[
     "configValue",
 ];
 
+const GUEST_RESERVED_PARAM_NAMES: &[&str] = &["__invocation", "__decoded"];
+
 /// Member names a generated named type cannot use for a case-class field or a
 /// companion case object / case class, because they would clash with (or fail
 /// to override) a synthesized case-class member or an inherited
@@ -820,32 +822,35 @@ impl ScalaBridgeGenerator {
                 .map(|m| remote_method_class_name(&m.name))
                 .collect(),
         );
+        let mut reserved_method_names = vec![
+            "agentTypeName",
+            "toString",
+            "hashCode",
+            "equals",
+            "getClass",
+            "isInstanceOf",
+            "asInstanceOf",
+            "notify",
+            "notifyAll",
+            "wait",
+            "clone",
+            "finalize",
+            "synchronized",
+            "##",
+            "==",
+            "!=",
+            "eq",
+            "ne",
+        ];
+        if self.agent_type.mode == AgentMode::Durable {
+            reserved_method_names.push("agentId");
+        }
         let method_val_names = unique_idents_with_reserved(
             methods
                 .iter()
                 .map(|m| to_scala_term_ident(&m.name, self.same_language))
                 .collect(),
-            &[
-                "agentId",
-                "agentTypeName",
-                "toString",
-                "hashCode",
-                "equals",
-                "getClass",
-                "isInstanceOf",
-                "asInstanceOf",
-                "notify",
-                "notifyAll",
-                "wait",
-                "clone",
-                "finalize",
-                "synchronized",
-                "##",
-                "==",
-                "!=",
-                "eq",
-                "ne",
-            ],
+            &reserved_method_names,
         );
         for (method, class_name) in methods.iter().zip(&method_class_names) {
             self.write_guest_remote_method_class(writer, class_name, method)?;
@@ -894,51 +899,118 @@ impl ScalaBridgeGenerator {
         writer.blank();
 
         let (ret_ty, decode_block) = self.guest_output_return(&method.output_schema)?;
-        writer.line(format!("def apply({param_decls}): {FUTURE}[{ret_ty}] = {{"));
-        writer.indent();
-        writer.line(format!(
-            "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
-        ));
-        writer.line(format!(
-            "resolved.asyncInvokeAndAwait({method_name_lit}, parameters).map {{ __result =>"
-        ));
-        writer.indent();
-        writer.line(decode_block.clone());
-        writer.dedent();
-        writer.line("}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue)");
-        writer.dedent();
-        writer.line("}");
+        let ephemeral = self.agent_type.mode == AgentMode::Ephemeral;
+        if ephemeral {
+            writer.line(format!(
+                "def apply({param_decls}): {FUTURE}[{GUEST_RUNTIME_PKG}.runtime.rpc.InvocationResult[{ret_ty}]] = {{"
+            ));
+            writer.indent();
+            writer.line(format!(
+                "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
+            ));
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.invokeAndAwaitWithMetadata({method_name_lit}, parameters)).map {{ __response =>"
+            ));
+            writer.indent();
+            writer.line("val __result = __response.value");
+            writer.line("val __decoded = {");
+            writer.indent();
+            writer.line(decode_block.clone());
+            writer.dedent();
+            writer.line("}");
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.runtime.rpc.InvocationResult(__response.metadata, __decoded)"
+            ));
+            writer.dedent();
+            writer.line("}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue)");
+            writer.dedent();
+            writer.line("}");
+        } else {
+            writer.line(format!("def apply({param_decls}): {FUTURE}[{ret_ty}] = {{"));
+            writer.indent();
+            writer.line(format!(
+                "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
+            ));
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.invokeAndAwait({method_name_lit}, parameters)).map {{ __result =>"
+            ));
+            writer.indent();
+            writer.line(decode_block.clone());
+            writer.dedent();
+            writer.line("}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue)");
+            writer.dedent();
+            writer.line("}");
+        }
         writer.blank();
 
-        writer.line(format!(
-            "def cancelable({param_decls}): ({FUTURE}[{ret_ty}], {GUEST_RUNTIME_PKG}.runtime.rpc.CancellationToken) = {{"
-        ));
-        writer.indent();
-        writer.line(format!(
-            "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
-        ));
-        writer.line(format!(
-            "val (__future, __token) = resolved.cancelableAsyncInvokeAndAwait({method_name_lit}, parameters)"
-        ));
-        writer.line("(__future.map { __result =>");
-        writer.indent();
-        writer.line(decode_block.clone());
-        writer.dedent();
-        writer.line(
-            "}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue), __token)",
-        );
-        writer.dedent();
-        writer.line("}");
+        if ephemeral {
+            writer.line(format!(
+                "def cancelable({param_decls}): _root_.scala.Either[{STRING}, {GUEST_RUNTIME_PKG}.runtime.rpc.CancelableAsyncInvocation[{ret_ty}]] = {{"
+            ));
+            writer.indent();
+            writer.line(format!(
+                "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
+            ));
+            writer.line(format!(
+                "resolved.cancelableAsyncInvokeAndAwaitWithMetadata({method_name_lit}, parameters).map {{ __invocation =>"
+            ));
+            writer.indent();
+            writer.line("val __future = __invocation.result.map { __result =>");
+            writer.indent();
+            writer.line(decode_block.clone());
+            writer.dedent();
+            writer.line("}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue)");
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.runtime.rpc.CancelableAsyncInvocation(__invocation.metadata, __future, __invocation.cancellationToken)"
+            ));
+            writer.dedent();
+            writer.line("}");
+            writer.dedent();
+            writer.line("}");
+        } else {
+            writer.line(format!(
+                "def cancelable({param_decls}): ({FUTURE}[{ret_ty}], {GUEST_RUNTIME_PKG}.runtime.rpc.CancellationToken) = {{"
+            ));
+            writer.indent();
+            writer.line(format!(
+                "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
+            ));
+            writer.line(format!(
+                "val (__future, __token) = resolved.cancelableAsyncInvokeAndAwait({method_name_lit}, parameters)"
+            ));
+            writer.line("(__future.map { __result =>");
+            writer.indent();
+            writer.line(decode_block.clone());
+            writer.dedent();
+            writer.line(
+                "}(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue), __token)",
+            );
+            writer.dedent();
+            writer.line("}");
+        }
         writer.blank();
 
-        writer.line(format!("def trigger({param_decls}): {FUTURE}[{UNIT}] = {{"));
+        let trigger_result = if ephemeral {
+            format!("{GUEST_RUNTIME_PKG}.runtime.rpc.InvocationReceipt")
+        } else {
+            UNIT.to_string()
+        };
+        writer.line(format!(
+            "def trigger({param_decls}): {FUTURE}[{trigger_result}] = {{"
+        ));
         writer.indent();
         writer.line(format!(
             "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
         ));
-        writer.line(format!(
-            "_root_.golem.FutureInterop.fromEither(resolved.invoke({method_name_lit}, parameters))"
-        ));
+        if ephemeral {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.invokeWithMetadata({method_name_lit}, parameters).map({GUEST_RUNTIME_PKG}.runtime.rpc.InvocationReceipt.apply))"
+            ));
+        } else {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.invoke({method_name_lit}, parameters))"
+            ));
+        }
         writer.dedent();
         writer.line("}");
         writer.blank();
@@ -948,30 +1020,52 @@ impl ScalaBridgeGenerator {
         } else {
             format!("{param_decls}, when: {GUEST_DATETIME}")
         };
+        let schedule_result = if ephemeral {
+            format!("{GUEST_RUNTIME_PKG}.runtime.rpc.InvocationReceipt")
+        } else {
+            UNIT.to_string()
+        };
         writer.line(format!(
-            "def scheduleAt({schedule_decls}): {FUTURE}[{UNIT}] = {{"
+            "def scheduleAt({schedule_decls}): {FUTURE}[{schedule_result}] = {{"
         ));
         writer.indent();
         writer.line(format!(
             "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
         ));
-        writer.line(format!(
-            "_root_.golem.FutureInterop.fromEither(resolved.scheduleInvocation(when, {method_name_lit}, parameters))"
-        ));
+        if ephemeral {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.scheduleInvocationWithMetadata(when, {method_name_lit}, parameters))"
+            ));
+        } else {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.scheduleInvocation(when, {method_name_lit}, parameters))"
+            ));
+        }
         writer.dedent();
         writer.line("}");
         writer.blank();
 
+        let schedule_cancelable_result = if ephemeral {
+            format!("{GUEST_RUNTIME_PKG}.runtime.rpc.CancelableInvocationReceipt")
+        } else {
+            format!("{GUEST_RUNTIME_PKG}.runtime.rpc.CancellationToken")
+        };
         writer.line(format!(
-            "def scheduleCancelableAt({schedule_decls}): {FUTURE}[{GUEST_RUNTIME_PKG}.runtime.rpc.CancellationToken] = {{"
+            "def scheduleCancelableAt({schedule_decls}): {FUTURE}[{schedule_cancelable_result}] = {{"
         ));
         writer.indent();
         writer.line(format!(
             "val parameters = {GUEST_CODEC}.encodeValue(methodParameters({invoke_args}))"
         ));
-        writer.line(format!(
-            "_root_.golem.FutureInterop.fromEither(resolved.scheduleCancelableInvocation(when, {method_name_lit}, parameters))"
-        ));
+        if ephemeral {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.scheduleCancelableInvocationWithMetadata(when, {method_name_lit}, parameters))"
+            ));
+        } else {
+            writer.line(format!(
+                "{GUEST_RUNTIME_PKG}.FutureInterop.fromEither(resolved.scheduleCancelableInvocation(when, {method_name_lit}, parameters))"
+            ));
+        }
         writer.dedent();
         writer.line("}");
 
@@ -989,7 +1083,9 @@ impl ScalaBridgeGenerator {
     ) {
         writer.line(format!("trait {remote_name} {{"));
         writer.indent();
-        writer.line(format!("def agentId: {GUEST_AGENT_ID}"));
+        if self.agent_type.mode == AgentMode::Durable {
+            writer.line(format!("def agentId: {GUEST_AGENT_ID}"));
+        }
         writer.line(format!("def agentTypeName: {STRING}"));
         for (val_name, class_name) in method_val_names.iter().zip(method_class_names) {
             writer.line(format!("val {val_name}: {class_name}"));
@@ -1002,7 +1098,9 @@ impl ScalaBridgeGenerator {
             "private def bindRemote(resolved: {GUEST_REMOTE_AGENT_CLIENT}): {remote_name} = new {remote_name} {{"
         ));
         writer.indent();
-        writer.line(format!("def agentId: {GUEST_AGENT_ID} = resolved.agentId"));
+        if self.agent_type.mode == AgentMode::Durable {
+            writer.line(format!("def agentId: {GUEST_AGENT_ID} = resolved.agentId"));
+        }
         writer.line(format!(
             "def agentTypeName: {STRING} = resolved.agentTypeName"
         ));
@@ -1055,9 +1153,7 @@ impl ScalaBridgeGenerator {
         writer.blank();
 
         if self.agent_type.mode == AgentMode::Durable {
-            writer.line(format!(
-                "def get({param_decls}): {FUTURE}[{remote_name}] = {{"
-            ));
+            writer.line(format!("def get({param_decls}): {remote_name} = {{"));
             writer.indent();
             self.write_guest_resolve_body(writer, &invoke_args, "_root_.scala.None", LIST_EMPTY);
             writer.dedent();
@@ -1065,33 +1161,41 @@ impl ScalaBridgeGenerator {
             writer.blank();
         }
 
-        let phantom_decls = if param_decls.is_empty() {
-            format!("phantom: {GUEST_UUID}")
-        } else {
-            format!("{param_decls}, phantom: {GUEST_UUID}")
-        };
-        writer.line(format!(
-            "def getPhantom({phantom_decls}): {FUTURE}[{remote_name}] = {{"
-        ));
-        writer.indent();
-        self.write_guest_resolve_body(
-            writer,
-            &invoke_args,
-            "_root_.scala.Some(phantom)",
-            LIST_EMPTY,
-        );
-        writer.dedent();
-        writer.line("}");
-        writer.blank();
+        if self.agent_type.mode == AgentMode::Durable {
+            let phantom_decls = if param_decls.is_empty() {
+                format!("phantom: {GUEST_UUID}")
+            } else {
+                format!("{param_decls}, phantom: {GUEST_UUID}")
+            };
+            writer.line(format!(
+                "def getPhantom({phantom_decls}): {remote_name} = {{"
+            ));
+            writer.indent();
+            self.write_guest_resolve_body(
+                writer,
+                &invoke_args,
+                "_root_.scala.Some(phantom)",
+                LIST_EMPTY,
+            );
+            writer.dedent();
+            writer.line("}");
+            writer.blank();
 
-        let new_phantom_args = if invoke_args.is_empty() {
-            format!("{GUEST_UUID}.random()")
+            let new_phantom_args = if invoke_args.is_empty() {
+                "_root_.golem.HostApi.generateIdempotencyKey()".to_string()
+            } else {
+                format!("{invoke_args}, _root_.golem.HostApi.generateIdempotencyKey()")
+            };
+            writer.line(format!(
+                "def newPhantom({param_decls}): {remote_name} = getPhantom({new_phantom_args})"
+            ));
         } else {
-            format!("{invoke_args}, {GUEST_UUID}.random()")
-        };
-        writer.line(format!(
-            "def newPhantom({param_decls}): {FUTURE}[{remote_name}] = getPhantom({new_phantom_args})"
-        ));
+            writer.line(format!("def newPhantom({param_decls}): {remote_name} = {{"));
+            writer.indent();
+            self.write_guest_resolve_body(writer, &invoke_args, "_root_.scala.None", LIST_EMPTY);
+            writer.dedent();
+            writer.line("}");
+        }
 
         if !local_configs.is_empty() {
             let with_config_decls = |extra: &str| {
@@ -1105,7 +1209,7 @@ impl ScalaBridgeGenerator {
             if self.agent_type.mode == AgentMode::Durable {
                 writer.blank();
                 writer.line(format!(
-                    "def getWithConfig({}): {FUTURE}[{remote_name}] = {{",
+                    "def getWithConfig({}): {remote_name} = {{",
                     with_config_decls("")
                 ));
                 writer.indent();
@@ -1120,35 +1224,37 @@ impl ScalaBridgeGenerator {
                 writer.line("}");
             }
 
-            writer.blank();
-            writer.line(format!(
-                "def getPhantomWithConfig({}): {FUTURE}[{remote_name}] = {{",
-                with_config_decls(&format!("phantom: {GUEST_UUID}"))
-            ));
-            writer.indent();
-            self.write_guest_config_list(writer, &config_param_names, &local_configs)?;
-            self.write_guest_resolve_body(
-                writer,
-                &invoke_args,
-                "_root_.scala.Some(phantom)",
-                "agentConfig",
-            );
-            writer.dedent();
-            writer.line("}");
+            if self.agent_type.mode == AgentMode::Durable {
+                writer.blank();
+                writer.line(format!(
+                    "def getPhantomWithConfig({}): {remote_name} = {{",
+                    with_config_decls(&format!("phantom: {GUEST_UUID}"))
+                ));
+                writer.indent();
+                self.write_guest_config_list(writer, &config_param_names, &local_configs)?;
+                self.write_guest_resolve_body(
+                    writer,
+                    &invoke_args,
+                    "_root_.scala.Some(phantom)",
+                    "agentConfig",
+                );
+                writer.dedent();
+                writer.line("}");
+            }
 
             writer.blank();
             writer.line(format!(
-                "def newPhantomWithConfig({}): {FUTURE}[{remote_name}] = {{",
+                "def newPhantomWithConfig({}): {remote_name} = {{",
                 with_config_decls("")
             ));
             writer.indent();
             self.write_guest_config_list(writer, &config_param_names, &local_configs)?;
-            self.write_guest_resolve_body(
-                writer,
-                &invoke_args,
-                &format!("_root_.scala.Some({GUEST_UUID}.random())"),
-                "agentConfig",
-            );
+            let phantom = if self.agent_type.mode == AgentMode::Durable {
+                "_root_.scala.Some(_root_.golem.HostApi.generateIdempotencyKey())"
+            } else {
+                "_root_.scala.None"
+            };
+            self.write_guest_resolve_body(writer, &invoke_args, phantom, "agentConfig");
             writer.dedent();
             writer.line("}");
         }
@@ -1223,8 +1329,15 @@ impl ScalaBridgeGenerator {
             "val constructorPayload = {GUEST_CODEC}.encodeValue(constructorParameters({invoke_args}))"
         ));
         writer.line(format!(
-            "_root_.golem.FutureInterop.fromEither({GUEST_REMOTE_AGENT_CLIENT}.resolve(agentTypeName, constructorPayload, {phantom_expr}, {config_expr})).map(bindRemote)(_root_.scala.scalajs.concurrent.JSExecutionContext.Implicits.queue)"
+            "{GUEST_REMOTE_AGENT_CLIENT}.resolve(agentTypeName, constructorPayload, {phantom_expr}, {config_expr}) match {{"
         ));
+        writer.indent();
+        writer.line("case _root_.scala.Right(resolved) => bindRemote(resolved)");
+        writer.line(
+            "case _root_.scala.Left(err) => throw _root_.scala.scalajs.js.JavaScriptException(err)",
+        );
+        writer.dedent();
+        writer.line("}");
     }
 
     fn guest_output_return(&self, output: &OutputSchema) -> anyhow::Result<(String, String)> {
@@ -2016,6 +2129,9 @@ impl ScalaBridgeGenerator {
     fn input_param_field_idents(&self, fields: &[&NamedField]) -> Vec<String> {
         let mut reserved: Vec<String> =
             RESERVED_PARAM_NAMES.iter().map(|s| s.to_string()).collect();
+        if self.mode == ScalaBridgeMode::GuestWasmRpc {
+            reserved.extend(GUEST_RESERVED_PARAM_NAMES.iter().map(|s| s.to_string()));
+        }
         for i in 0..fields.len() {
             reserved.push(format!("f{i}"));
         }
@@ -3483,7 +3599,7 @@ mod tests {
         assert!(client_source.contains("_root_.golem.schema.SchemaValue.StringValue(message)"));
         assert!(client_source.contains("_root_.golem.runtime.rpc.SchemaRpcCodec.encodeValue"));
         assert!(client_source.contains("_root_.golem.runtime.rpc.RemoteAgentClient.resolve"));
-        assert!(client_source.contains("resolved.asyncInvokeAndAwait"));
+        assert!(client_source.contains("resolved.invokeAndAwait"));
         assert!(client_source.contains("def cancelable("));
         assert!(client_source.contains("resolved.cancelableAsyncInvokeAndAwait"));
         assert!(client_source.contains("def scheduleCancelableAt("));

--- a/cli/golem-cli/src/bridge_gen/scala/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/scala/mod.rs
@@ -3568,6 +3568,7 @@ mod tests {
         let target_path =
             Utf8PathBuf::from_path_buf(dir.path().join("alpha-agent-guest-client")).unwrap();
         let mut agent_type = minimal_agent_type("AlphaAgent");
+        agent_type.mode = AgentMode::Durable;
         agent_type.source_language = "scala".to_string();
         agent_type.methods.push(AgentMethodSchema {
             name: "echo".to_string(),
@@ -3653,6 +3654,7 @@ mod tests {
         let target_path =
             Utf8PathBuf::from_path_buf(dir.path().join("alpha-agent-guest-client")).unwrap();
         let mut agent_type = minimal_agent_type("AlphaAgent");
+        agent_type.mode = AgentMode::Durable;
         agent_type.source_language = "scala".to_string();
         agent_type.methods.push(AgentMethodSchema {
             name: "echo".to_string(),

--- a/cli/golem-cli/src/bridge_gen/typescript/mod.rs
+++ b/cli/golem-cli/src/bridge_gen/typescript/mod.rs
@@ -922,9 +922,9 @@ impl TypeScriptBridgeGenerator {
             "ReturnType<base.RemoteAgentHandle['scheduleCancelable']>"
         };
         let schedule_result = if ephemeral {
-            "ReturnType<base.RemoteAgentHandle['scheduleWithMetadata']>"
+            "ReturnType<base.RemoteAgentHandle['scheduleCancelableWithMetadata']>"
         } else {
-            "void"
+            "ReturnType<base.RemoteAgentHandle['scheduleCancelable']>"
         };
         let await_call = if ephemeral {
             format!(
@@ -949,10 +949,10 @@ impl TypeScriptBridgeGenerator {
         };
         let schedule_call = if ephemeral {
             format!(
-                "return this.resolved.scheduleWithMetadata(at, {method_name}, __encode(__args));"
+                "return this.resolved.scheduleCancelableWithMetadata(at, {method_name}, __encode(__args));"
             )
         } else {
-            format!("this.resolved.schedule(at, {method_name}, __encode(__args));")
+            format!("return this.resolved.scheduleCancelable(at, {method_name}, __encode(__args));")
         };
         writer.write_doc(&method.description);
         writer.write_line(formatdoc! {"

--- a/cli/golem-cli/tests/bridge_gen/moonbit.rs
+++ b/cli/golem-cli/tests/bridge_gen/moonbit.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::bridge_gen::fixtures::{
-    agent, def, field, method, multi_agent_wrapper_2_types, named_field, ref_to,
+    agent, def, field, local_config, method, multi_agent_wrapper_2_types, named_field, ref_to,
     single_agent_wrapper_types, variant_case,
 };
 use crate::bridge_gen::type_naming::test_type_naming;
@@ -811,23 +811,56 @@ fn guest_mode_accepts_numeric_agent_type_names() {
 
 #[test]
 fn ephemeral_guest_client_omits_get_and_scoped() {
-    let guest = generate_without_check(
-        agent(
-            "EphemeralAgent",
-            "moonbit",
-            vec![],
-            vec![method("ping", vec![], None)],
-            vec![],
-            AgentMode::Ephemeral,
-        ),
-        MoonBitBridgeMode::GuestWasmRpc,
+    let mut agent_type = agent(
+        "EphemeralAgent",
+        "moonbit",
+        vec![],
+        vec![
+            method("ping", vec![], None),
+            method(
+                "echo",
+                vec![field("message", SchemaType::string())],
+                Some(SchemaType::string()),
+            ),
+        ],
+        vec![],
+        AgentMode::Ephemeral,
     );
+    agent_type.config = vec![local_config(vec!["region"], SchemaType::string())];
+    let guest = generate_without_check(agent_type, MoonBitBridgeMode::GuestWasmRpc);
     let source = std::fs::read_to_string(guest.path().join("client/client.mbt")).unwrap();
 
     assert!(!source.contains("pub fn EphemeralAgentClient::get("));
     assert!(!source.contains("pub fn[T] EphemeralAgentClient::scoped("));
     assert!(source.contains("pub fn EphemeralAgentClient::new_phantom("));
-    assert!(source.contains("pub fn EphemeralAgentClient::get_phantom("));
+    assert!(!source.contains("pub fn EphemeralAgentClient::get_phantom("));
+    assert!(!source.contains("pub fn EphemeralAgentClient::get_agent_id("));
+    assert!(!source.contains("pub fn EphemeralAgentClient::phantom_id("));
+    assert!(source.contains("@rpc.AgentClient::ephemeral("));
+    assert!(source.contains("@rpc.AgentClient::ephemeral_with_config("));
+    assert!(source.contains("-> @rpc.InvocationResult[Unit]"));
+    assert!(source.contains("-> @rpc.InvocationResult[String]"));
+    assert!(source.contains("-> @rpc.InvocationMetadata"));
+    assert!(source.contains("-> @rpc.ScheduledInvocationReceipt"));
+    assert!(source.contains("-> @rpc.CancelableScheduledInvocationReceipt"));
+    assert!(source.contains("{ metadata: response.metadata, value: () }"));
+    assert!(source.contains("let decoded ="));
+    assert!(source.contains("{ metadata: response.metadata, value: decoded }"));
+
+    let output = std::process::Command::new("moon")
+        .arg("-C")
+        .arg(guest.path())
+        .arg("check")
+        .arg("--target")
+        .arg("wasm")
+        .output()
+        .expect("failed to run moon; is it installed?");
+    assert!(
+        output.status.success(),
+        "guest moon check failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]

--- a/cli/golem-cli/tests/bridge_gen/scala.rs
+++ b/cli/golem-cli/tests/bridge_gen/scala.rs
@@ -346,6 +346,50 @@ fn generated_project_layout_is_correct() {
     assert!(build_sbt.contains("counter-agent-client"));
 }
 
+/// Guest-only implementation temporaries must not rename public parameters in
+/// the external REST generator.
+#[test]
+fn guest_only_temporary_parameter_names_are_mode_scoped() {
+    let agent_type = agent(
+        "ExternalAgent",
+        "scala",
+        vec![],
+        vec![method(
+            "echo",
+            vec![
+                field("__decoded", SchemaType::string()),
+                field("__invocation", SchemaType::string()),
+            ],
+            Some(SchemaType::string()),
+        )],
+        vec![],
+        AgentMode::Durable,
+    );
+    let pkg = GeneratedPackage::new(agent_type.clone());
+    let client_path = pkg
+        .package_dir()
+        .join("src/main/scala/golem/bridge/client/external_agent/ExternalAgentClient.scala");
+    let client = std::fs::read_to_string(client_path).unwrap();
+
+    assert!(
+        client.contains(
+            "def apply(__decoded: _root_.scala.Predef.String, __invocation: _root_.scala.Predef.String)"
+        ),
+        "ExternalRest public parameters were renamed:\n{client}"
+    );
+
+    let guest = GeneratedPackage::new_with_mode(agent_type, ScalaBridgeMode::GuestWasmRpc);
+    let guest_client = std::fs::read_to_string(
+        guest
+            .package_dir()
+            .join("src/main/scala/golem/bridge/client/external_agent/ExternalAgentClient.scala"),
+    )
+    .unwrap();
+    assert!(guest_client.contains(
+        "def apply(__decoded_2: _root_.scala.Predef.String, __invocation_2: _root_.scala.Predef.String)"
+    ));
+}
+
 /// Guest Scala bridge projects skip embedding the external REST runtime and
 /// depend on the Scala SDK's guest runtime instead, so the generated client must
 /// not refer to the external-only `golem.bridge.runtime` package.
@@ -385,7 +429,7 @@ fn guest_wasm_rpc_does_not_emit_external_rest_runtime_references() {
 
 /// Guest agent bridges expose the Scala SDK RPC surface: constructors resolve
 /// remote agents through `RemoteAgentClient`, methods invoke Wasm RPC via
-/// `asyncInvokeAndAwait`, and the generated Scala.js build is ready for a real
+/// `invokeAndAwait`, and the generated Scala.js build is ready for a real
 /// compile once the in-tree Scala SDK has been published locally.
 #[test]
 fn guest_agent_client_surface_targets_scala_sdk_rpc() {
@@ -415,7 +459,7 @@ fn guest_agent_client_surface_targets_scala_sdk_rpc() {
     assert!(client_source.contains("_root_.scala.Either"));
     assert!(client_source.contains("CounterAgentRemote"));
     assert!(client_source.contains("_root_.golem.runtime.rpc.RemoteAgentClient.resolve"));
-    assert!(client_source.contains("resolved.asyncInvokeAndAwait"));
+    assert!(client_source.contains("resolved.invokeAndAwait"));
     assert!(client_source.contains("resolved.cancelableAsyncInvokeAndAwait"));
     assert!(client_source.contains("_root_.golem.runtime.rpc.CancellationToken"));
     assert!(client_source.contains("_root_.golem.runtime.rpc.SchemaRpcCodec.encodeValue"));
@@ -432,21 +476,23 @@ fn guest_agent_client_surface_targets_scala_sdk_rpc() {
     compile_guest_if_enabled(dir.as_path());
 }
 
-/// Ephemeral guest agents omit the parameter-addressable `get` constructor, but
-/// still expose phantom constructors. Constructor errors are surfaced as
-/// `Either[String, …]`, not thrown futures, because guest RPC resolution is
-/// synchronous at the SDK boundary.
+/// Ephemeral guest agents expose a local metadata-bearing proxy without a fixed
+/// phantom identity, matching the SDK-generated client.
 #[test]
-fn guest_ephemeral_agent_omits_get_and_returns_either_constructors() {
+fn guest_ephemeral_agent_uses_per_invocation_identity() {
     let pkg = GeneratedPackage::new_with_mode(
-        agent(
-            "EphemeralAgent",
-            "scala",
-            vec![field("name", SchemaType::string())],
-            vec![method("ping", vec![], None)],
-            vec![],
-            AgentMode::Ephemeral,
-        ),
+        {
+            let mut agent_type = agent(
+                "EphemeralAgent",
+                "scala",
+                vec![field("name", SchemaType::string())],
+                vec![method("ping", vec![], None)],
+                vec![],
+                AgentMode::Ephemeral,
+            );
+            agent_type.config = vec![local_config(vec!["region"], SchemaType::string())];
+            agent_type
+        },
         ScalaBridgeMode::GuestWasmRpc,
     );
     let dir = pkg.package_dir();
@@ -459,11 +505,58 @@ fn guest_ephemeral_agent_omits_get_and_returns_either_constructors() {
         !client_source.contains("def get("),
         "ephemeral guest agent must not expose get:\n{client_source}"
     );
-    assert!(client_source.contains("def getPhantom(name: _root_.scala.Predef.String"));
-    assert!(client_source.contains("phantom: _root_.golem.Uuid"));
+    assert!(!client_source.contains("def getPhantom("));
     assert!(client_source.contains("def newPhantom(name: _root_.scala.Predef.String)"));
-    assert!(client_source.contains("_root_.scala.Either"));
+    assert!(client_source.contains("def newPhantomWithConfig("));
+    assert!(client_source.contains("constructorPayload, _root_.scala.None, agentConfig"));
+    assert!(!client_source.contains("Future[EphemeralAgentRemote]"));
+    assert!(!client_source.contains("generateIdempotencyKey"));
+    assert!(!client_source.contains("def agentId:"));
+    assert!(client_source.contains("_root_.golem.runtime.rpc.InvocationResult[_root_.scala.Unit]"));
+    assert!(
+        client_source
+            .contains("_root_.golem.runtime.rpc.CancelableAsyncInvocation[_root_.scala.Unit]")
+    );
+    assert!(client_source.contains("resolved.invokeAndAwaitWithMetadata("));
+    assert!(client_source.contains("resolved.invokeWithMetadata("));
+    assert!(client_source.contains("resolved.scheduleInvocationWithMetadata("));
+    assert!(client_source.contains("resolved.scheduleCancelableInvocationWithMetadata("));
     assert!(client_source.contains("EphemeralAgentRemote"));
+
+    compile_guest_if_enabled(dir.as_path());
+}
+
+#[test]
+fn guest_durable_phantom_constructors_use_replay_safe_identity() {
+    let pkg = GeneratedPackage::new_with_mode(
+        {
+            let mut agent_type = agent(
+                "DurableAgent",
+                "scala",
+                vec![field("name", SchemaType::string())],
+                vec![method("ping", vec![], None)],
+                vec![],
+                AgentMode::Durable,
+            );
+            agent_type.config = vec![local_config(vec!["region"], SchemaType::string())];
+            agent_type
+        },
+        ScalaBridgeMode::GuestWasmRpc,
+    );
+    let dir = pkg.package_dir();
+    let client_source = std::fs::read_to_string(
+        dir.join("src/main/scala/golem/bridge/client/durable_agent/DurableAgentClient.scala"),
+    )
+    .unwrap();
+
+    assert!(
+        client_source.contains("getPhantom(name, _root_.golem.HostApi.generateIdempotencyKey())")
+    );
+    assert!(
+        client_source.contains("_root_.scala.Some(_root_.golem.HostApi.generateIdempotencyKey())")
+    );
+    assert!(client_source.contains("_root_.scala.Some(phantom)"));
+    assert!(!client_source.contains("_root_.golem.Uuid.random()"));
 
     compile_guest_if_enabled(dir.as_path());
 }

--- a/cli/golem-cli/tests/bridge_gen/typescript.rs
+++ b/cli/golem-cli/tests/bridge_gen/typescript.rs
@@ -537,7 +537,8 @@ fn guest_durable_generation_uses_sdk_runtime_surface() {
     assert!(source.contains("invokeAndAwait("));
     assert!(source.contains("abortable(signal: AbortSignal"));
     assert!(source.contains("this.resolved.invoke("));
-    assert!(source.contains("this.resolved.schedule("));
+    assert!(!source.contains("this.resolved.schedule("));
+    assert!(source.contains("return this.resolved.scheduleCancelable("));
     assert!(source.contains("this.resolved.scheduleCancelable("));
     assert!(source.contains("base.typedSchemaValueFromJson("));
     assert!(source.contains("reachable-config"));
@@ -757,7 +758,7 @@ fn guest_ephemeral_generation_uses_metadata_runtime_calls() {
     assert!(!source.contains("static getPhantom("));
     assert!(source.contains("invokeAndAwaitWithMetadata("));
     assert!(source.contains("invokeWithMetadata("));
-    assert!(source.contains("scheduleWithMetadata("));
+    assert!(!source.contains("scheduleWithMetadata("));
     assert!(source.contains("scheduleCancelableWithMetadata("));
     assert!(source.contains("const phantomId = undefined;"));
     assert!(!source.contains("base.Uuid.generate()"));

--- a/sdks/scala/core/js/src/main/scala/golem/runtime/rpc/RemoteAgentClient.scala
+++ b/sdks/scala/core/js/src/main/scala/golem/runtime/rpc/RemoteAgentClient.scala
@@ -47,14 +47,38 @@ final case class RemoteAgentClient(
   ): Future[Option[JsSchemaValueTree]] =
     rpc.asyncInvokeAndAwait(functionName, input)
 
+  def invokeAndAwaitWithMetadata(
+    functionName: String,
+    input: JsSchemaValueTree
+  ): Either[String, InvocationResult[Option[JsSchemaValueTree]]] =
+    rpc.invokeAndAwaitWithMetadata(functionName, input)
+
   def cancelableAsyncInvokeAndAwait(
     functionName: String,
     input: JsSchemaValueTree
   ): (Future[Option[JsSchemaValueTree]], CancellationToken) =
     rpc.cancelableAsyncInvokeAndAwait(functionName, input)
 
+  def cancelableAsyncInvokeAndAwaitWithMetadata(
+    functionName: String,
+    input: JsSchemaValueTree
+  ): Either[String, CancelableAsyncInvocation[Option[JsSchemaValueTree]]] =
+    rpc.asyncInvokeAndAwaitWithMetadata(functionName, input).map { invocation =>
+      CancelableAsyncInvocation(
+        invocation.metadata,
+        invocation.result,
+        invocation.cancellationToken
+      )
+    }
+
   def invoke(functionName: String, input: JsSchemaValueTree): Either[String, Unit] =
     rpc.invoke(functionName, input)
+
+  def invokeWithMetadata(
+    functionName: String,
+    input: JsSchemaValueTree
+  ): Either[String, InvocationMetadata] =
+    rpc.invokeWithMetadata(functionName, input)
 
   def scheduleInvocation(
     datetime: Datetime,
@@ -63,12 +87,26 @@ final case class RemoteAgentClient(
   ): Either[String, Unit] =
     rpc.scheduleInvocation(datetime, functionName, input)
 
+  def scheduleInvocationWithMetadata(
+    datetime: Datetime,
+    functionName: String,
+    input: JsSchemaValueTree
+  ): Either[String, InvocationReceipt] =
+    rpc.scheduleInvocationWithMetadata(datetime, functionName, input)
+
   def scheduleCancelableInvocation(
     datetime: Datetime,
     functionName: String,
     input: JsSchemaValueTree
   ): Either[String, CancellationToken] =
     rpc.scheduleCancelableInvocation(datetime, functionName, input)
+
+  def scheduleCancelableInvocationWithMetadata(
+    datetime: Datetime,
+    functionName: String,
+    input: JsSchemaValueTree
+  ): Either[String, CancelableInvocationReceipt] =
+    rpc.scheduleCancelableInvocationWithMetadata(datetime, functionName, input)
 }
 
 object RemoteAgentClient {


### PR DESCRIPTION
Resolves GOL-322

- TypeScript scheduling now returns the same cancellation token/metadata receipt as SDK-generated clients
- Scala durable phantoms use replay-safe idempotency keys; ephemeral clients preserve invocation metadata and expose no fixed identity constructors, RPC methods.
- MoonBit ephemeral clients now use the SDK’s ephemeral runtime constructors and metadata-bearing return types constructors, methods.
- Rust agent clients and all tool-client generators were audited and already matched, so they remain unchanged.

External bridges are not affected (out of scope)