### PR TITLE
Fix P3 response bodies created without persistence

### DIFF
--- a/golem-worker-executor/src/durable_host/concurrent/call.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/call.rs
@@ -1332,6 +1332,17 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
         self.start_idx
     }
 
+    /// Whether resources produced by this call must retain their own durable lifecycle after the
+    /// call returns. This uses the call's initiation-time state rather than ambient worker state,
+    /// which may change while a returned resource remains live.
+    pub fn persistence_enabled(&self) -> bool {
+        self.retry
+            .durable_execution_state()
+            .snapshotting_mode
+            .is_none()
+            && self.execution_scope.persistence_level != PersistenceLevel::PersistNothing
+    }
+
     /// The index returned by `begin_durable_function`: the durable scope `Start` for a
     /// non-idempotent `WriteRemote` / `WriteRemoteBatched(None)`, or the pre-call index otherwise.
     /// Used by call sites that derive a stable identifier from that index (e.g. the idempotency-key

--- a/golem-worker-executor/src/durable_host/p3/http/response_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/response_body.rs
@@ -20,7 +20,7 @@ use super::serialization::{deserialize_headers, serialize_headers};
 use super::*;
 use crate::durable_host::concurrent::{
     AccessClaimOptions, CallHandle, Cancellable, CompletionDelivery, DeferredCallReplayOutcome,
-    DropEvent, NotCancellable,
+    DropEvent, NotCancellable, finish_span_in_memory,
 };
 use crate::durable_host::durability::{
     AsyncRetryDecision, DurabilityHost, DurableCallTrapContext, HostFailureKind,
@@ -95,6 +95,16 @@ pub(crate) struct OpenP3HttpResponseState {
     /// an empty placeholder body: the first live body read must re-issue the
     /// recorded request (via `resend`) to obtain a real body.
     pub(crate) body_is_placeholder: bool,
+    /// The response body inherits the persistence policy of the send that created it. A
+    /// pass-through body never starts durable consume-body calls, even if it is read after the
+    /// ambient worker persistence level has been restored.
+    pub(crate) body_mode: P3HttpResponseBodyMode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum P3HttpResponseBodyMode {
+    Durable,
+    Passthrough,
 }
 
 /// The send's `outgoing-http-request` invocation-context span together with
@@ -1629,6 +1639,30 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostResponseWithStore<U> for Dura
             let mut store_ctx = store.as_context_mut();
             let ctx = durable_worker_ctx::<Ctx, U>(store_ctx.data_mut());
             ctx.state.open_p3_http_responses.remove(&res.rep())
+        };
+
+        let response_state = match response_state {
+            None => {
+                let http_store =
+                    Access::<U, WasiHttp>::new(store.as_context_mut(), wasi_http_view::<Ctx, U>);
+                return <WasiHttp as types::HostResponseWithStore<U>>::consume_body(
+                    http_store, res, fut,
+                );
+            }
+            Some(state) if state.body_mode == P3HttpResponseBodyMode::Passthrough => {
+                {
+                    let mut store_ctx = store.as_context_mut();
+                    let ctx = durable_worker_ctx::<Ctx, U>(store_ctx.data_mut());
+                    finish_span_in_memory(ctx, &state.span.span_id)
+                        .map_err(wasmtime::Error::from)?;
+                }
+                let http_store =
+                    Access::<U, WasiHttp>::new(store.as_context_mut(), wasi_http_view::<Ctx, U>);
+                return <WasiHttp as types::HostResponseWithStore<U>>::consume_body(
+                    http_store, res, fut,
+                );
+            }
+            Some(state) => Some(state),
         };
 
         // Delegate to the built-in implementation to wire `fut` into the body's

--- a/golem-worker-executor/src/durable_host/p3/http/send.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/send.rs
@@ -195,6 +195,11 @@ where
     .await
     .map_err(HttpError::trap)?;
     let send_start_index = handle.start_index();
+    let response_body_mode = if handle.persistence_enabled() {
+        P3HttpResponseBodyMode::Durable
+    } else {
+        P3HttpResponseBodyMode::Passthrough
+    };
 
     let span = store
         .with(|mut access| {
@@ -300,6 +305,7 @@ where
                                     durable_body: None,
                                 }),
                                 body_is_placeholder: true,
+                                body_mode: response_body_mode,
                             },
                         );
                         // Spawns the demand-gated transmission recorder
@@ -717,6 +723,7 @@ where
                         durable_body: Some(physical.body.clone()),
                     }),
                     body_is_placeholder: false,
+                    body_mode: response_body_mode,
                 },
             );
             // Spawns the demand-gated transmission recorder at a

--- a/golem-worker-executor/tests/wasi.rs
+++ b/golem-worker-executor/tests/wasi.rs
@@ -4869,6 +4869,72 @@ async fn oplog_replay_after_streaming_http_read(
     Ok(())
 }
 
+#[test]
+#[tracing::instrument]
+#[timeout("1m")]
+async fn p3_stream_created_in_persist_nothing_stays_non_durable(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    use golem_common::data_value;
+    use golem_common::model::oplog::{OplogIndex, PublicOplogEntry};
+
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let (port, server) = streaming_chunk_server(3, Duration::from_millis(5)).await;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+    let agent_id = agent_id!("StreamingClient");
+    let worker_id = executor
+        .start_agent_with(
+            &component.id,
+            agent_id.clone(),
+            HashMap::from([("PORT".to_string(), port.to_string())]),
+            Vec::new(),
+        )
+        .await?;
+
+    let result = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "streaming_http_read_with_persist_nothing",
+            data_value!(),
+        )
+        .await?
+        .into_typed::<String>()?;
+    assert_eq!(result, "chunk-0\nchunk-1\nchunk-2\n");
+
+    let oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    let start_names = oplog.iter().filter_map(|entry| match &entry.entry {
+        PublicOplogEntry::Start(params) => Some(params.function_name.as_str()),
+        _ => None,
+    });
+    let (body_calls, custom_poll_calls) = start_names.fold((0, 0), |counts, name| {
+        (
+            counts.0 + usize::from(name == "http::types::response::consume-body"),
+            counts.1 + usize::from(name == "test::non-durable-http-stream-poll"),
+        )
+    });
+    assert_eq!(
+        body_calls, 0,
+        "the pass-through body must not open a durable scope"
+    );
+    assert!(
+        custom_poll_calls >= 2,
+        "logical stream polls outside PersistNothing must remain durable"
+    );
+
+    executor.check_oplog_is_queryable(&worker_id).await?;
+    server.abort();
+    Ok(())
+}
+
 /// A transient mid-body failure of a streaming HTTP response must route
 /// through worker-level retry and re-issue the recorded request instead of
 /// surfacing a truncated body to the guest.

--- a/test-components/http-tests/src/streaming_client.rs
+++ b/test-components/http-tests/src/streaming_client.rs
@@ -1,11 +1,15 @@
 use futures_concurrency::prelude::*;
-use golem_rust::{agent_definition, agent_implementation};
+use golem_rust::durability::{Durability, DurableFunctionType};
+use golem_rust::{
+    PersistenceLevel, agent_definition, agent_implementation, with_persistence_level_async,
+};
 
 #[agent_definition]
 pub trait StreamingClient {
     fn new() -> Self;
 
     async fn streaming_http_read(&self) -> String;
+    async fn streaming_http_read_with_persist_nothing(&self) -> String;
     async fn parallel_streaming_http_reads(&self, n: u64) -> String;
     async fn raw_streaming_http_read(&self) -> String;
     async fn parallel_raw_streaming_http_reads(&self, n: u64) -> String;
@@ -24,6 +28,13 @@ impl StreamingClient for StreamingClientImpl {
 
     async fn streaming_http_read(&self) -> String {
         match send_streaming_request().await {
+            Ok(s) => s,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    async fn streaming_http_read_with_persist_nothing(&self) -> String {
+        match send_non_durable_streaming_request().await {
             Ok(s) => s,
             Err(e) => format!("Error: {e}"),
         }
@@ -129,6 +140,49 @@ async fn send_streaming_request() -> Result<String, String> {
     let mut result: Vec<u8> = Vec::new();
     while let Some(chunk) = stream.chunk().await {
         result.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(result).map_err(|e| e.to_string())
+}
+
+async fn send_non_durable_streaming_request() -> Result<String, String> {
+    let port = std::env::var("PORT").expect("Requires a PORT env var set");
+    let stream_durability = Durability::<bool, String>::new(
+        "test",
+        "non-durable-http-stream",
+        DurableFunctionType::WriteRemote,
+    );
+    let response = with_persistence_level_async(PersistenceLevel::PersistNothing, || async {
+        wasi_fetch::Client::new()
+            .get(&format!("http://localhost:{port}/streaming-chunks"))
+            .send()
+            .await
+    })
+    .await
+    .map_err(|e| format!("{e:?}"))?;
+    stream_durability.persist_infallible((), true);
+
+    let mut stream = response.into_body();
+    let mut result = Vec::new();
+    loop {
+        let poll_durability = Durability::<Option<Vec<u8>>, String>::new(
+            "test",
+            "non-durable-http-stream-poll",
+            DurableFunctionType::ReadRemote,
+        );
+        let chunk = if poll_durability.is_live() {
+            let chunk = with_persistence_level_async(PersistenceLevel::PersistNothing, || async {
+                stream.chunk().await.map(|chunk| chunk.to_vec())
+            })
+            .await;
+            poll_durability.persist_infallible((), chunk)
+        } else {
+            poll_durability.replay_infallible()
+        };
+        match chunk {
+            Some(chunk) => result.extend_from_slice(&chunk),
+            None => break,
+        }
     }
 
     String::from_utf8(result).map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary

A P3 HTTP send begun under `PersistNothing` must pass that initiation-time policy to the response body. Without it, `response::consume-body` starts a long-lived durable host call after the ambient persistence level has returned to `Smart`; restoring `Smart` between golem-ai stream polls then traps with:

> Cannot change oplog persistence level: durable host calls are still in flight

This change records the send's initiation-time persistence policy on the response. Durable sends retain durable response-body behavior, while `PersistNothing` sends use pass-through body handling. This preserves golem-ai's logical stream-event replay and restart semantics.

Motivating integration case: golemcloud/golem-ai#128.

## Verification

Previously verified in the source orb (not rerun during publication):

- Focused regression `p3_stream_created_in_persist_nothing_stays_non_durable` passed.
- Existing `oplog_replay_after_streaming_http_read` passed.
- `cargo check -p golem-worker-executor --lib` passed.
- golem-ai LLM/Ollama checks passed.
- Formatting and diff checks passed.
