### PR TITLE
Support running nightly benchmarks in Amp orbs

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+amp orb services ensure

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+packages=(
+    build-essential
+    clang
+    cmake
+    curl
+    docker.io
+    jq
+    libssl-dev
+    lld
+    pkg-config
+    protobuf-compiler
+    redis-server
+    xz-utils
+)
+
+missing_packages=()
+for package in "${packages[@]}"; do
+    if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q 'ok installed'; then
+        missing_packages+=("$package")
+    fi
+done
+
+if ((${#missing_packages[@]})); then
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing_packages[@]}"
+fi
+
+if ! command -v rustup >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
+
+rustup update stable --no-self-update
+rustup default stable
+rustup target add wasm32-wasip1 wasm32-wasip2
+
+if ! command -v cargo-binstall >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSfL \
+        https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+fi
+
+if ! cargo make --version 2>/dev/null | grep -q 'cargo-make 0.37.24'; then
+    cargo install --force --locked cargo-make --version 0.37.24
+fi
+
+node_version="24.19.0"
+node_home="/opt/node24"
+if [[ ! -x "$node_home/bin/node" ]] || [[ "$($node_home/bin/node --version)" != "v$node_version" ]]; then
+    node_archive="$(mktemp)"
+    curl -sSfL \
+        "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.xz" \
+        -o "$node_archive"
+    sudo rm -rf "$node_home" "/opt/node-v${node_version}-linux-x64"
+    sudo tar xJf "$node_archive" -C /opt
+    sudo mv "/opt/node-v${node_version}-linux-x64" "$node_home"
+    rm -f "$node_archive"
+fi
+export PATH="$node_home/bin:$PATH"
+
+if ! pnpm --version 2>/dev/null | grep -q '^11\.22\.0$'; then
+    sudo "$node_home/bin/npm" install --global pnpm@11.22.0
+fi
+
+if [[ ! -f /opt/wasi-sdk/VERSION ]] || ! grep -q '^25\.0$' /opt/wasi-sdk/VERSION; then
+    wasi_archive="$(mktemp)"
+    curl -sSfL \
+        https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz \
+        -o "$wasi_archive"
+    sudo rm -rf /opt/wasi-sdk /opt/wasi-sdk-25.0-x86_64-linux
+    sudo tar xzf "$wasi_archive" -C /opt
+    sudo mv /opt/wasi-sdk-25.0-x86_64-linux /opt/wasi-sdk
+    rm -f "$wasi_archive"
+fi
+
+if ! wasm-rquickjs --version 2>/dev/null | grep -q '0.4.1'; then
+    cargo binstall --force --locked wasm-rquickjs-cli@0.4.1
+fi
+
+if ! cargo component --version 2>/dev/null | grep -q '0.21.1'; then
+    cargo binstall --force cargo-component@0.21.1
+fi
+
+profile_marker="# Golem Amp orb toolchain"
+touch "$HOME/.bash_profile"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
+    cat >> "$HOME/.bash_profile" <<'EOF'
+
+# Golem Amp orb toolchain
+export PATH="/opt/node24/bin:$HOME/.cargo/bin:$PATH"
+export WASI_SDK_VERSION=25
+export WASI_SDK_PATH=/opt/wasi-sdk
+export WASM_RQUICKJS_VERSION=0.4.1
+EOF
+fi
+
+amp orb services ensure

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,8 @@
+services:
+  docker-daemon:
+    command: >-
+      sudo dockerd
+      --host=unix:///var/run/docker.sock
+      --host=tcp://127.0.0.1:$PORT
+      --storage-driver=vfs
+      --group user

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ proptest-regressions/
 
 # locally kept custom dev files
 /.local/
+/tmp/
 
 # IDEs
 .idea/

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1517,10 +1517,45 @@ rm -rf build-out
 
 [tasks.build-benchmark-components]
 description = "Builds only the benchmark test WASM components"
-dependencies = ["build", "build-sdk-ts"]
+dependencies = ["wit", "build-sdk-ts"]
+script_runner = "@duckscript"
 script = '''
+golem_cli = get_env GOLEM_CLI
+golem_cli_empty = is_empty ${golem_cli}
+if ${golem_cli_empty}
+    exec --fail-on-error cargo build --release -p golem-cli --bin golem-cli
+    golem_cli = set "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/release/golem-cli"
+    set_env GOLEM_CLI ${golem_cli}
+end
 cd test-components
-./build-components.sh benchmarks
+exec --fail-on-error ./build-components.sh benchmarks
+'''
+
+[tasks.run-benchmark-suite-orb]
+description = "Builds and runs the nightly spawned benchmark suite in an Amp orb"
+script_runner = "@duckscript"
+env = { CI = "true", CARGO_INCREMENTAL = "false", WASI_SDK_VERSION = "25", WASI_SDK_PATH = "/opt/wasi-sdk", WASM_RQUICKJS_VERSION = "0.4.1" }
+script = '''
+exec --fail-on-error docker info
+exec --fail-on-error cargo make --profile ci build-release
+golem_cli = set "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/release/golem-cli"
+set_env GOLEM_CLI ${golem_cli}
+exec --fail-on-error cargo make build-benchmark-components
+
+results = get_env GOLEM_BENCHMARK_RESULTS_PATH
+results_empty = is_empty ${results}
+if ${results_empty}
+    mkdir tmp
+    results = set "tmp/orb-benchmark-results.json"
+end
+
+registry_http_port = get_env GOLEM_BENCHMARK_REGISTRY_HTTP_PORT
+registry_http_port_empty = is_empty ${registry_http_port}
+if ${registry_http_port_empty}
+    registry_http_port = set "18081"
+end
+
+exec --fail-on-error cargo run --profile benchmarks -p integration-tests --bin benchmarks -- --primary-only suite --save-to-json ${results} integration-tests/benchmark_suites/ci.yaml spawned --registry-service-http-port ${registry_http_port}
 '''
 
 [tasks.clean-test-components]

--- a/test-components/build-components.sh
+++ b/test-components/build-components.sh
@@ -132,7 +132,10 @@ resolve_target_dir() {
 
 REPO_ROOT="$(cd "${TEST_COMP_DIR:-$(pwd)}/.." && pwd)"
 TARGET_DIR="$(resolve_target_dir "$REPO_ROOT")"
-GOLEM_CLI="${TARGET_DIR}/debug/golem-cli"
+GOLEM_CLI="${GOLEM_CLI:-${TARGET_DIR}/debug/golem-cli}"
+if [[ "$GOLEM_CLI" != /* ]]; then
+  GOLEM_CLI="${REPO_ROOT}/${GOLEM_CLI}"
+fi
 
 should_clean() {
   [ "$clean_only" = true ] || [ "$rebuild" = true ]


### PR DESCRIPTION
## Summary

- make `build-benchmark-components` build only the release `golem-cli` it needs instead of the full debug workspace
- add `cargo make run-benchmark-suite-orb` to reproduce the nightly spawned suite with `--primary-only`, local JSON output, and an orb-safe registry port
- provision the benchmark toolchain through Amp's setup/resume lifecycle and run Docker as a supervised orb service

The orb task writes to `tmp/orb-benchmark-results.json` by default. `GOLEM_BENCHMARK_RESULTS_PATH` and `GOLEM_BENCHMARK_REGISTRY_HTTP_PORT` can override the result path and registry port. It does not access or modify `golemcloud/benchmark-results`.

## Why

The old benchmark component task depended on `cargo make build`, which creates a full debug workspace build and exhausted the fixed orb disk. Amp also reserves the workflow's default registry port 8081, so the orb task defaults to 18081.

## Validation

- full spawned `integration-tests/benchmark_suites/ci.yaml` suite with `--primary-only`: passed (28m45s)
- `cargo make --profile ci build-release`: passed (11m08s in final task smoke run)
- `GOLEM_CLI=target/release/golem-cli cargo make build-benchmark-components`: passed (2.44s warm; no full debug workspace build)
- `.agents/setup`: passed twice and completed in 1.58s warm
- `.agents/resume`: passed in 0.70s
- supervised Docker cold start and socket access: passed
- shell syntax and `git diff --check`: passed

The complete orb task was additionally exercised through release build, component build, spawned backend startup, and active benchmark execution. The full suite had already been completed with the same underlying commands, so the duplicate task run was stopped after that smoke coverage.
