### PR TITLE
Add runner metadata to benchmark results

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -51,7 +51,18 @@ jobs:
           path: benchmark-results
 
       - name: Run benchmark suite
-        run: cargo run --profile benchmarks -p integration-tests --bin benchmarks '--' --primary-only suite --add-to-json benchmark-results/results/results.json integration-tests/benchmark_suites/ci.yaml spawned
+        run: |
+          cargo run --profile benchmarks -p integration-tests --bin benchmarks '--' \
+            --primary-only \
+            suite \
+            --add-to-json benchmark-results/results/results.json \
+            --runner-id github-actions-blacksmith-32vcpu \
+            --runner-label "GitHub Actions (Blacksmith 32 vCPU)" \
+            --source-repository "$GITHUB_REPOSITORY" \
+            --source-commit-sha "$GITHUB_SHA" \
+            --source-ref "$GITHUB_REF" \
+            integration-tests/benchmark_suites/ci.yaml \
+            spawned
 
       - name: Commit results
         run: |

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1555,7 +1555,35 @@ if ${registry_http_port_empty}
     registry_http_port = set "18081"
 end
 
-exec --fail-on-error cargo run --profile benchmarks -p integration-tests --bin benchmarks -- --primary-only suite --save-to-json ${results} integration-tests/benchmark_suites/ci.yaml spawned --registry-service-http-port ${registry_http_port}
+runner_id = get_env GOLEM_BENCHMARK_RUNNER_ID
+runner_id_empty = is_empty ${runner_id}
+if ${runner_id_empty}
+    runner_id = set "amp-orb-a1.xxlarge"
+end
+
+runner_label = get_env GOLEM_BENCHMARK_RUNNER_LABEL
+runner_label_empty = is_empty ${runner_label}
+if ${runner_label_empty}
+    runner_label = set "Amp orb (a1.xxlarge)"
+end
+
+source_commit_result = exec git rev-parse HEAD
+source_commit_ok = eq ${source_commit_result.code} 0
+if not ${source_commit_ok}
+    echo ${source_commit_result.stderr}
+    trigger_error "Failed to determine source commit"
+end
+source_commit = trim ${source_commit_result.stdout}
+
+source_ref_result = exec git rev-parse --symbolic-full-name HEAD
+source_ref_ok = eq ${source_ref_result.code} 0
+if not ${source_ref_ok}
+    echo ${source_ref_result.stderr}
+    trigger_error "Failed to determine source ref"
+end
+source_ref = trim ${source_ref_result.stdout}
+
+exec --fail-on-error cargo run --profile benchmarks -p integration-tests --bin benchmarks -- --primary-only suite --save-to-json ${results} --runner-id ${runner_id} --runner-label ${runner_label} --source-repository golemcloud/golem --source-commit-sha ${source_commit} --source-ref ${source_ref} integration-tests/benchmark_suites/ci.yaml spawned --registry-service-http-port ${registry_http_port}
 '''
 
 [tasks.clean-test-components]

--- a/golem-test-framework/src/benchmark/config.rs
+++ b/golem-test-framework/src/benchmark/config.rs
@@ -65,6 +65,26 @@ pub enum BenchmarkConfig {
         #[arg(long)]
         add_to_json: Option<PathBuf>,
 
+        /// Stable identifier for the runner hardware class
+        #[arg(long)]
+        runner_id: Option<String>,
+
+        /// Human-readable runner name
+        #[arg(long, requires = "runner_id")]
+        runner_label: Option<String>,
+
+        /// Source repository in owner/name form
+        #[arg(long)]
+        source_repository: Option<String>,
+
+        /// Source commit SHA
+        #[arg(long)]
+        source_commit_sha: Option<String>,
+
+        /// Source ref, such as refs/heads/main
+        #[arg(long)]
+        source_ref: Option<String>,
+
         #[command(subcommand)]
         mode: TestMode,
     },
@@ -241,5 +261,70 @@ mod cloud_mode_smoke {
         for r in &runs {
             assert_eq!(r.cluster_size, 0);
         }
+    }
+}
+
+#[cfg(test)]
+mod metadata_cli {
+    use super::*;
+    use clap::Parser;
+    use test_r::test;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(subcommand)]
+        config: BenchmarkConfig,
+    }
+
+    #[test]
+    fn suite_accepts_runner_and_source_metadata() {
+        let cli = Cli::try_parse_from([
+            "test",
+            "suite",
+            "--runner-id",
+            "amp-orb-a1.xxlarge",
+            "--runner-label",
+            "Amp orb (a1.xxlarge)",
+            "--source-repository",
+            "golemcloud/golem",
+            "--source-commit-sha",
+            "0123456789abcdef",
+            "--source-ref",
+            "refs/heads/main",
+            "suite.yaml",
+            "spawned",
+        ])
+        .unwrap();
+
+        let BenchmarkConfig::Suite {
+            runner_id,
+            runner_label,
+            source_repository,
+            source_commit_sha,
+            source_ref,
+            ..
+        } = cli.config
+        else {
+            panic!("expected suite configuration");
+        };
+        assert_eq!(runner_id.as_deref(), Some("amp-orb-a1.xxlarge"));
+        assert_eq!(runner_label.as_deref(), Some("Amp orb (a1.xxlarge)"));
+        assert_eq!(source_repository.as_deref(), Some("golemcloud/golem"));
+        assert_eq!(source_commit_sha.as_deref(), Some("0123456789abcdef"));
+        assert_eq!(source_ref.as_deref(), Some("refs/heads/main"));
+    }
+
+    #[test]
+    fn runner_label_requires_runner_id() {
+        let result = Cli::try_parse_from([
+            "test",
+            "suite",
+            "--runner-label",
+            "Amp orb",
+            "suite.yaml",
+            "spawned",
+        ]);
+
+        assert!(result.is_err());
     }
 }

--- a/golem-test-framework/src/benchmark/mod.rs
+++ b/golem-test-framework/src/benchmark/mod.rs
@@ -16,7 +16,10 @@ mod config;
 mod results;
 
 pub use config::{BenchmarkConfig, BenchmarkSuite, BenchmarkSuiteItem, RunConfig};
-pub use results::{BenchmarkResult, BenchmarkRunResult, BenchmarkSuiteResult, ResultKey};
+pub use results::{
+    BenchmarkResult, BenchmarkRunResult, BenchmarkRunner, BenchmarkSource, BenchmarkSuiteResult,
+    ResultKey,
+};
 
 use crate::config::benchmark::TestMode;
 use async_trait::async_trait;

--- a/golem-test-framework/src/benchmark/results.rs
+++ b/golem-test-framework/src/benchmark/results.rs
@@ -490,11 +490,33 @@ pub struct BenchmarkSuiteResultCollection {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BenchmarkRunner {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BenchmarkSource {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub repository: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub commit_sha: Option<String>,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none", default)]
+    pub source_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BenchmarkSuiteResult {
     pub suite: String,
     pub environment: String,
     pub version: String,
     pub timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub runner: Option<BenchmarkRunner>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub source: Option<BenchmarkSource>,
     /// Suite-level run-id. Set in cloud mode to `bench-{run_id}` to allow
     /// cross-run correlation and garbage collection of orphaned state.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -534,6 +556,8 @@ impl BenchmarkSuiteResult {
             environment,
             version: golem_common::golem_version().to_string(),
             timestamp: Utc::now(),
+            runner: None,
+            source: None,
             run_id: None,
             results: vec![],
         }
@@ -747,5 +771,69 @@ impl BenchmarkRunResult {
             let results = self.count_results.entry(key.clone()).or_default();
             results.add_iteration(&counts);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_r::test;
+
+    fn suite_result() -> BenchmarkSuiteResult {
+        BenchmarkSuiteResult {
+            suite: "CI".to_string(),
+            environment: "test environment".to_string(),
+            version: "0.0.0".to_string(),
+            timestamp: Utc::now(),
+            runner: None,
+            source: None,
+            run_id: None,
+            results: vec![],
+        }
+    }
+
+    #[test]
+    fn legacy_suite_result_deserializes_without_metadata() {
+        let result: BenchmarkSuiteResult = serde_json::from_value(serde_json::json!({
+            "suite": "CI",
+            "environment": "test environment",
+            "version": "0.0.0",
+            "timestamp": "2026-08-19T00:00:00Z",
+            "results": []
+        }))
+        .unwrap();
+
+        assert_eq!(result.runner, None);
+        assert_eq!(result.source, None);
+    }
+
+    #[test]
+    fn appending_preserves_runner_and_source_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("results.json");
+        let mut existing = suite_result();
+        existing.runner = Some(BenchmarkRunner {
+            id: "amp-orb-a1.xxlarge".to_string(),
+            label: Some("Amp orb (a1.xxlarge)".to_string()),
+        });
+        existing.source = Some(BenchmarkSource {
+            repository: Some("golemcloud/golem".to_string()),
+            commit_sha: Some("0123456789abcdef".to_string()),
+            source_ref: Some("refs/heads/main".to_string()),
+        });
+        existing.save_to_json(&path).unwrap();
+
+        suite_result().add_to_json(&path).unwrap();
+
+        let raw = std::fs::read_to_string(path).unwrap();
+        let collection: BenchmarkSuiteResultCollection = serde_json::from_str(&raw).unwrap();
+        assert_eq!(collection.runs.len(), 2);
+        assert_eq!(collection.runs[0], existing);
+        assert_eq!(collection.runs[1].runner, None);
+        assert_eq!(collection.runs[1].source, None);
+        assert!(raw.contains("\"commitSha\""));
+        assert!(raw.contains("\"ref\""));
+        assert!(!raw.contains("\"commit_sha\""));
+        assert!(!raw.contains("\"source_ref\""));
     }
 }

--- a/integration-tests/src/benchmarks/all.rs
+++ b/integration-tests/src/benchmarks/all.rs
@@ -20,8 +20,8 @@ use golem_common::model::application::{ApplicationCreation, ApplicationName};
 use golem_common::model::environment::{EnvironmentCreation, EnvironmentName};
 use golem_common::{agent_id, data_value};
 use golem_test_framework::benchmark::{
-    Benchmark, BenchmarkApi, BenchmarkConfig, BenchmarkResult, BenchmarkSuite, BenchmarkSuiteItem,
-    BenchmarkSuiteResult,
+    Benchmark, BenchmarkApi, BenchmarkConfig, BenchmarkResult, BenchmarkRunner, BenchmarkSource,
+    BenchmarkSuite, BenchmarkSuiteItem, BenchmarkSuiteResult,
 };
 use golem_test_framework::config::benchmark::{TestMode, cloud_bench_run_id};
 use golem_test_framework::config::{
@@ -190,6 +190,11 @@ async fn main() {
             path,
             save_to_json,
             add_to_json,
+            runner_id,
+            runner_label,
+            source_repository,
+            source_commit_sha,
+            source_ref,
             ..
         } => {
             info!("Reading benchmark suite from {path:?}");
@@ -216,6 +221,17 @@ async fn main() {
             .await;
 
             let mut suite_result = BenchmarkSuiteResult::new(&suite.name);
+            suite_result.runner = runner_id.as_ref().map(|id| BenchmarkRunner {
+                id: id.clone(),
+                label: runner_label.clone(),
+            });
+            if source_repository.is_some() || source_commit_sha.is_some() || source_ref.is_some() {
+                suite_result.source = Some(BenchmarkSource {
+                    repository: source_repository.clone(),
+                    commit_sha: source_commit_sha.clone(),
+                    source_ref: source_ref.clone(),
+                });
+            }
             for benchmark in suite.benchmarks {
                 info!("Running {benchmark:?}");
 


### PR DESCRIPTION
## Summary

- add optional runner and source metadata to benchmark suite JSON while preserving compatibility with legacy results
- tag nightly GitHub Actions results as Blacksmith 32 vCPU and Amp orb results as a1.xxlarge
- include the source repository, commit SHA, and ref in both benchmark producer paths
- add CLI parsing and JSON append/serialization coverage

The corresponding multi-runner reader/UI support is already available in `golemcloud/benchmark-results`.

## Validation

- `cargo test -p golem-test-framework --lib benchmark::`
- `cargo check -p integration-tests --bin benchmarks`
- `cargo make fix`
- `cargo make --print-steps run-benchmark-suite-orb`
