### PR TITLE
Analyze nightly Amp orb benchmark regressions

### DIFF
--- a/integration-tests/benchmark_suites/orb-nightly.md
+++ b/integration-tests/benchmark_suites/orb-nightly.md
@@ -6,9 +6,10 @@ The production entry point for the nightly spawned benchmark and publication flo
 cargo make run-and-publish-benchmark-suite-orb
 ```
 
-It builds and runs all primary benchmarks in `ci.yaml`, keeps timestamped JSON and log artifacts
-under `tmp/`, and then uses the validated publisher from `golemcloud/benchmark-results` to append
-and push exactly that run.
+It builds and runs all primary benchmarks in `ci.yaml`, keeps timestamped result, analysis, and log
+artifacts under `tmp/`, and then uses the validated publisher from `golemcloud/benchmark-results`
+to append and push exactly that run. The analysis compares the run only with prior runs from the
+same runner and suite.
 Failed or partial runs are never published. Publishing is idempotent, and non-fast-forward races
 are retried from a fresh `benchmark-results` checkout.
 
@@ -22,7 +23,29 @@ The Amp schedule is intentionally only a trigger. Its durable prompt is:
 
 > Verify the tracked worktree is clean, fast-forward `main` to `origin/main`, run
 > `cargo make run-and-publish-benchmark-suite-orb`, and report the source SHA, duration, artifact
-> paths, and published benchmark-results commit. Do not publish failed or partial runs.
+> paths, and published benchmark-results commit. Follow the regression response policy in
+> `integration-tests/benchmark_suites/orb-nightly.md`. Do not publish failed or partial runs.
+
+## Regression response
+
+The generated analysis has one of these statuses:
+
+- `insufficient-baseline`: report how many baseline runs exist, but do not alert.
+- `no-candidates`: report that no suspicious regression was found, but do not alert.
+- `candidates-found`: inspect the listed measurements and investigate the Golem commits between
+  `previous.commitSha` and `latest.commitSha` before deciding whether to alert.
+
+For each candidate, inspect the commit subjects and diffs for changes on the benchmark's execution
+path. Distinguish direct evidence from inference, consider whether infrastructure-wide movement or
+a benchmark definition change better explains the result, and avoid naming a commit solely because
+it falls in the commit range. Send a warning only when the benchmark-level movement remains
+suspicious after that review. Do not send the same run timestamp twice from this scheduled thread.
+
+Send warnings to `#golem-dev-internal` through `SLACK_BENCHMARK_WEBHOOK_URL`. Include the affected
+benchmarks and percentage changes, links to the previous and latest Golem commits, the suspected
+cause and confidence, and a link to <https://golemcloud.github.io/benchmark-results/>. Never print
+or otherwise expose the webhook URL. If no commit is a credible cause, say that explicitly rather
+than inventing one.
 
 For recovery testing or an idempotent publication retry, set `GOLEM_BENCHMARK_RESULTS_INPUT` to an
 existing JSON artifact. The artifact must match the current commit and ref. The repository URL,

--- a/integration-tests/benchmark_suites/orb-nightly.md
+++ b/integration-tests/benchmark_suites/orb-nightly.md
@@ -8,8 +8,8 @@ cargo make run-and-publish-benchmark-suite-orb
 
 It builds and runs all primary benchmarks in `ci.yaml`, keeps timestamped result, analysis, and log
 artifacts under `tmp/`, and then uses the validated publisher from `golemcloud/benchmark-results`
-to append and push exactly that run. The analysis compares the run only with prior runs from the
-same runner and suite.
+to append and push exactly that run. The analysis compares the run with the immediately preceding
+run from the same runner and suite.
 Failed or partial runs are never published. Publishing is idempotent, and non-fast-forward races
 are retried from a fresh `benchmark-results` checkout.
 
@@ -33,16 +33,15 @@ The Amp schedule is intentionally only a trigger. Its durable prompt is:
 
 The generated analysis has one of these statuses:
 
-- `insufficient-baseline`: report how many baseline runs exist, but do not alert.
+- `no-previous-run`: report that comparison starts with the next run, but do not alert.
 - `no-candidates`: report that no suspicious regression was found, but do not alert.
 - `candidates-found`: inspect the listed measurements and investigate the Golem commits between
-  `previous.commitSha` and `latest.commitSha` before deciding whether to alert.
+  `previous.commitSha` and `latest.commitSha`, then send one consolidated warning.
 
 For each candidate, inspect the commit subjects and diffs for changes on the benchmark's execution
 path. Distinguish direct evidence from inference, consider whether infrastructure-wide movement or
 a benchmark definition change better explains the result, and avoid naming a commit solely because
-it falls in the commit range. Send a warning only when the benchmark-level movement remains
-suspicious after that review. Do not send the same run timestamp twice from this scheduled thread.
+it falls in the commit range. Do not send the same run timestamp twice from this scheduled thread.
 
 Send warnings to `#golem-dev-internal` through `SLACK_BENCHMARK_WEBHOOK_URL`. Include the affected
 benchmarks and percentage changes, links to the previous and latest Golem commits, the suspected

--- a/integration-tests/benchmark_suites/orb-nightly.md
+++ b/integration-tests/benchmark_suites/orb-nightly.md
@@ -38,6 +38,9 @@ The generated analysis has one of these statuses:
 - `candidates-found`: inspect the listed measurements and investigate the Golem commits between
   `previous.commitSha` and `latest.commitSha`, then send one consolidated warning.
 
+A candidate can be a single duration series, such as one language and invocation path for one
+throughput configuration. Do not require movement across the rest of that benchmark before warning.
+
 For each candidate, inspect the commit subjects and diffs for changes on the benchmark's execution
 path. Distinguish direct evidence from inference, consider whether infrastructure-wide movement or
 a benchmark definition change better explains the result, and avoid naming a commit solely because

--- a/integration-tests/benchmark_suites/orb-nightly.md
+++ b/integration-tests/benchmark_suites/orb-nightly.md
@@ -19,6 +19,9 @@ It must be a dedicated, narrowly scoped GitHub token with contents write access 
 `golemcloud/benchmark-results`; rotate it according to the workspace credential policy. An
 interactive run can instead use the orb's existing GitHub credential.
 
+Regression warnings require `SLACK_BENCHMARK_WEBHOOK_URL` as an Amp project secret. Use a Slack
+incoming webhook restricted to `#golem-dev-internal`, and never store the URL in the repository.
+
 The Amp schedule is intentionally only a trigger. Its durable prompt is:
 
 > Verify the tracked worktree is clean, fast-forward `main` to `origin/main`, run

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -31,6 +31,7 @@ artifact_dir="$(realpath "$artifact_dir")"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 results="$artifact_dir/orb-benchmark-results-${timestamp}-${source_commit:0:12}.json"
 log="$artifact_dir/orb-benchmark-${timestamp}-${source_commit:0:12}.log"
+analysis="$artifact_dir/orb-benchmark-analysis-${timestamp}-${source_commit:0:12}.json"
 
 restore_generated_files() {
     git restore -- "${generated_files[@]}"
@@ -46,6 +47,7 @@ trap cleanup EXIT
 
 if [[ -n "${GOLEM_BENCHMARK_RESULTS_INPUT:-}" ]]; then
     results="$(realpath "$GOLEM_BENCHMARK_RESULTS_INPUT")"
+    analysis="$artifact_dir/orb-benchmark-analysis-retry-${source_commit:0:12}.json"
     echo "Using existing benchmark artifact $results"
 else
     amp orb services ensure
@@ -78,6 +80,7 @@ if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
     git status --short >&2
     exit 1
 fi
+run_timestamp="$(jq -er '.runs | select(length == 1) | .[0].timestamp' "$results")"
 
 if [[ -n "${BENCHMARK_RESULTS_TOKEN:-}" ]]; then
     authorization="$(printf 'x-access-token:%s' "$BENCHMARK_RESULTS_TOKEN" | base64 -w0)"
@@ -117,8 +120,16 @@ for attempt in 1 2 3; do
             echo "Published commit $published_commit is not on remote master" >&2
             exit 1
         fi
+        node "$publish_root/scripts/analyze-regressions.mjs" \
+            "$publish_root/results/results.json" \
+            --runner "$runner_id" \
+            --suite CI \
+            --timestamp "$run_timestamp" \
+            --output "$analysis"
+        jq -e '.status != "run-not-found" and .status != "no-runs"' "$analysis" >/dev/null
         echo "Published benchmark results at $published_commit"
         echo "Results: $results"
+        echo "Analysis: $analysis"
         [[ -f "$log" ]] && echo "Log: $log"
         exit 0
     fi

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -80,7 +80,17 @@ if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
     git status --short >&2
     exit 1
 fi
-run_timestamp="$(jq -er '.runs | select(length == 1) | .[0].timestamp' "$results")"
+run_timestamp="$(jq -er \
+    --arg runner "$runner_id" \
+    --arg commit "$source_commit" \
+    --arg ref "$source_ref" \
+    '.runs | select(length == 1) | .[0]
+        | select(.suite == "CI")
+        | select(.runner.id == $runner)
+        | select(.source.repository == "golemcloud/golem")
+        | select(.source.commitSha == $commit and .source.ref == $ref)
+        | .timestamp' \
+    "$results")"
 
 if [[ -n "${BENCHMARK_RESULTS_TOKEN:-}" ]]; then
     authorization="$(printf 'x-access-token:%s' "$BENCHMARK_RESULTS_TOKEN" | base64 -w0)"

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -80,17 +80,20 @@ if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
     git status --short >&2
     exit 1
 fi
-run_timestamp="$(jq -er \
-    --arg runner "$runner_id" \
-    --arg commit "$source_commit" \
-    --arg ref "$source_ref" \
-    '.runs | select(length == 1) | .[0]
-        | select(.suite == "CI")
-        | select(.runner.id == $runner)
-        | select(.source.repository == "golemcloud/golem")
-        | select(.source.commitSha == $commit and .source.ref == $ref)
-        | .timestamp' \
-    "$results")"
+if ! run_timestamp="$(jq -er \
+        --arg runner "$runner_id" \
+        --arg commit "$source_commit" \
+        --arg ref "$source_ref" \
+        '.runs | select(length == 1) | .[0]
+            | select(.suite == "CI")
+            | select(.runner.id == $runner)
+            | select(.source.repository == "golemcloud/golem")
+            | select(.source.commitSha == $commit and .source.ref == $ref)
+            | .timestamp' \
+        "$results")"; then
+    echo "Benchmark artifact does not match the current runner, commit, and ref" >&2
+    exit 1
+fi
 
 if [[ -n "${BENCHMARK_RESULTS_TOKEN:-}" ]]; then
     authorization="$(printf 'x-access-token:%s' "$BENCHMARK_RESULTS_TOKEN" | base64 -w0)"


### PR DESCRIPTION
## Summary

- analyze the exact benchmark run published by the nightly Amp orb workflow
- validate reused benchmark artifacts against runner, commit, and ref before publication
- save a timestamped machine-readable regression-analysis artifact
- document immediate per-series alerts, commit-range correlation, and consolidated Slack warnings

The comparison is deliberately simple and fast: today's Amp run is compared with yesterday's matching Amp run, and any exact duration series that is at least 20% slower is a candidate. An isolated language or invocation path therefore alerts without requiring other series in the benchmark to regress.

## Dependency

Depends on golemcloud/benchmark-results#5, which supplies the analyzer invoked by this orchestration. Merge that PR first.

## Validation

- `cargo make fix` (passed in 23m34s)
- `bash -n integration-tests/benchmark_suites/run_orb_nightly.sh`
- `git diff --check`
- local bare-remote end-to-end publication plus exact-run analysis
- mismatched artifact identity rejection

A subsequent full `cargo make build` compiled for about 24 minutes, then exhausted this orb's fixed 64 GiB filesystem while compiling `wasm-rquickjs`/Cranelift (`No space left on device`). This was an environment-capacity failure, not a source error.