### PR TITLE
Reduce default workspace dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,17 +780,23 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
  "http 1.4.0",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tracing",
 ]
@@ -936,7 +942,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1205,16 +1211,16 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-named-pipe",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -3168,13 +3174,13 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "redis-protocol",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "semver",
  "serde_json",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -3549,7 +3555,7 @@ dependencies = [
  "poem",
  "prometheus",
  "rlimit",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "sqlx",
@@ -3631,7 +3637,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-retry",
- "rustls",
+ "rustls 0.23.37",
  "semver",
  "serde",
  "serde_derive",
@@ -3804,7 +3810,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "prometheus",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "test-r",
  "thiserror 2.0.18",
@@ -3840,7 +3846,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "prometheus",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tempfile",
@@ -3901,7 +3907,7 @@ dependencies = [
  "heck",
  "http 1.4.0",
  "humantime-serde",
- "hyper",
+ "hyper 1.9.0",
  "include_dir",
  "indoc",
  "itertools 0.14.0",
@@ -3921,7 +3927,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.2",
- "rustls",
+ "rustls 0.23.37",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -4102,7 +4108,7 @@ dependencies = [
  "kube",
  "prometheus",
  "prost-types",
- "rustls",
+ "rustls 0.23.37",
  "scc",
  "serde",
  "sqlx",
@@ -4221,7 +4227,7 @@ dependencies = [
  "http-body-util",
  "humansize",
  "humantime-serde",
- "hyper",
+ "hyper 1.9.0",
  "ignite-v2-client",
  "include_dir",
  "itertools 0.14.0",
@@ -4243,7 +4249,7 @@ dependencies = [
  "redis",
  "regex",
  "ringbuf",
- "rustls",
+ "rustls 0.23.37",
  "scc",
  "serde",
  "serde_json",
@@ -4294,7 +4300,7 @@ dependencies = [
  "golem-worker-executor",
  "prometheus",
  "regex",
- "rustls",
+ "rustls 0.23.37",
  "scc",
  "serde",
  "serde_json",
@@ -4340,7 +4346,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "humantime-serde",
- "hyper",
+ "hyper 1.9.0",
  "include_dir",
  "indexmap 2.14.0",
  "mime",
@@ -4362,7 +4368,7 @@ dependencies = [
  "rmcp",
  "rsa",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pemfile",
  "scc",
  "serde",
@@ -4417,6 +4423,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -4696,6 +4721,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -4704,7 +4753,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4726,13 +4775,13 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.4.0",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -4743,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4753,19 +4802,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -4776,7 +4840,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4795,7 +4859,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4816,7 +4880,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5003,12 +5067,12 @@ dependencies = [
  "futures",
  "ignite-client-derive",
  "num-bigint",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
  "uuid",
@@ -5502,16 +5566,16 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-http-proxy",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -7000,7 +7064,7 @@ dependencies = [
  "headers",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "mime",
  "multer",
@@ -7596,7 +7660,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
@@ -7617,7 +7681,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7992,22 +8056,22 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -8029,12 +8093,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
@@ -8043,7 +8107,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -8051,7 +8115,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -8089,7 +8153,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "http 1.4.0",
- "hyper",
+ "hyper 1.9.0",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "retry-policies",
@@ -8348,6 +8412,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -8357,7 +8433,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -8417,10 +8493,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8432,6 +8508,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -8579,6 +8665,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sdd"
@@ -9153,7 +9249,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "sha2",
@@ -9878,11 +9974,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -9906,10 +10012,10 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -10090,11 +10196,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -10102,7 +10208,7 @@ dependencies = [
  "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -10186,7 +10292,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.9.0",
  "opentelemetry 0.30.0",
  "pin-project-lite",
  "tonic 0.13.1",
@@ -10537,7 +10643,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -10703,7 +10809,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -11469,12 +11575,12 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
- "rustls",
+ "rustls 0.23.37",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,20 +675,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
- "p256 0.11.1",
  "percent-encoding",
- "ring",
  "sha2",
- "subtle",
  "time",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -785,23 +780,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.9.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tracing",
 ]
@@ -947,7 +936,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1046,12 +1035,6 @@ dependencies = [
  "libc",
  "nix 0.23.2",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1222,16 +1205,16 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-named-pipe",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -2260,18 +2243,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array 0.14.9",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -2508,16 +2479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -2759,28 +2720,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -2789,8 +2738,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -2830,41 +2779,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
- "ff 0.12.1",
- "generic-array 0.14.9",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest",
- "ff 0.13.1",
+ "ff",
  "generic-array 0.14.9",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -3070,16 +2999,6 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
@@ -3264,13 +3183,13 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "redis-protocol",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "semver",
  "serde_json",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -3645,7 +3564,7 @@ dependencies = [
  "poem",
  "prometheus",
  "rlimit",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "sqlx",
@@ -3749,7 +3668,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.25.0",
+ "tokio-tungstenite",
  "toml 0.9.12+spec-1.1.0",
  "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
@@ -3902,7 +3821,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "prometheus",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "test-r",
  "thiserror 2.0.18",
@@ -3938,7 +3857,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "prometheus",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -3946,7 +3865,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.25.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tonic 0.14.5",
  "tonic-tracing-opentelemetry",
@@ -3984,8 +3903,6 @@ dependencies = [
  "assert2",
  "async-trait",
  "async_zip",
- "aws-config",
- "aws-sdk-s3",
  "bigdecimal",
  "blake3",
  "bytes",
@@ -4001,7 +3918,7 @@ dependencies = [
  "heck",
  "http 1.4.0",
  "humantime-serde",
- "hyper 1.9.0",
+ "hyper",
  "include_dir",
  "indoc",
  "itertools 0.14.0",
@@ -4021,7 +3938,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.2",
- "rustls 0.23.37",
+ "rustls",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -4202,7 +4119,7 @@ dependencies = [
  "kube",
  "prometheus",
  "prost-types",
- "rustls 0.23.37",
+ "rustls",
  "scc",
  "serde",
  "sqlx",
@@ -4262,7 +4179,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.25.0",
+ "tokio-tungstenite",
  "tonic 0.14.5",
  "tracing",
  "tracing-core",
@@ -4321,7 +4238,7 @@ dependencies = [
  "http-body-util",
  "humansize",
  "humantime-serde",
- "hyper 1.9.0",
+ "hyper",
  "ignite-v2-client",
  "include_dir",
  "itertools 0.14.0",
@@ -4343,7 +4260,7 @@ dependencies = [
  "redis",
  "regex",
  "ringbuf",
- "rustls 0.23.37",
+ "rustls",
  "scc",
  "serde",
  "serde_json",
@@ -4356,7 +4273,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.25.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tonic 0.14.5",
  "tonic-health",
@@ -4394,7 +4311,7 @@ dependencies = [
  "golem-worker-executor",
  "prometheus",
  "regex",
- "rustls 0.23.37",
+ "rustls",
  "scc",
  "serde",
  "serde_json",
@@ -4440,7 +4357,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "humantime-serde",
- "hyper 1.9.0",
+ "hyper",
  "include_dir",
  "indexmap 2.14.0",
  "mime",
@@ -4462,7 +4379,7 @@ dependencies = [
  "rmcp",
  "rsa",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
  "scc",
  "serde",
@@ -4510,43 +4427,13 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -4826,30 +4713,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -4858,7 +4721,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4880,13 +4743,13 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.4.0",
- "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -4897,7 +4760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4907,34 +4770,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -4945,7 +4793,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4964,7 +4812,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4985,7 +4833,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5172,12 +5020,12 @@ dependencies = [
  "futures",
  "ignite-client-derive",
  "num-bigint",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "uuid",
@@ -5314,7 +5162,7 @@ dependencies = [
  "test-r",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.25.0",
+ "tokio-tungstenite",
  "tracing",
  "tracing-opentelemetry",
  "url",
@@ -5671,16 +5519,16 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-http-proxy",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -6608,7 +6456,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "oauth2",
- "p256 0.13.2",
+ "p256",
  "p384",
  "rand 0.8.5",
  "rsa",
@@ -6842,23 +6690,12 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2",
 ]
@@ -6869,8 +6706,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2",
 ]
@@ -7166,19 +7003,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -7187,8 +7014,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -7245,7 +7072,7 @@ dependencies = [
  "headers",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "mime",
  "multer",
@@ -7274,7 +7101,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.27.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower 0.4.13",
  "tracing",
@@ -7482,7 +7309,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -7841,7 +7668,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
@@ -7862,7 +7689,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -8237,22 +8064,22 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -8274,12 +8101,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -8288,7 +8115,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -8296,7 +8123,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -8334,7 +8161,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "retry-policies",
@@ -8369,17 +8196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
  "rand 0.9.2",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
 ]
 
 [[package]]
@@ -8520,10 +8336,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -8604,18 +8420,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -8625,7 +8429,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -8685,10 +8489,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8700,16 +8504,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -8859,16 +8653,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sdd"
 version = "4.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8893,28 +8677,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array 0.14.9",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array 0.14.9",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -9261,16 +9031,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -9416,22 +9176,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -9475,7 +9225,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -10210,21 +9960,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -10242,28 +9982,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28562dd8aea311048ed1ab9372a6b9a59977e1b308afb87c985c1f2b3206938"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tungstenite 0.25.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
- "tungstenite 0.27.0",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -10442,11 +10170,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -10454,7 +10182,7 @@ dependencies = [
  "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -10538,7 +10266,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper",
  "opentelemetry 0.30.0",
  "pin-project-lite",
  "tonic 0.13.1",
@@ -10879,25 +10607,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326eb16466ed89221beef69dbc94f517ee888bae959895472133924a25f7070e"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "native-tls",
- "rand 0.8.5",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
@@ -10907,6 +10616,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
@@ -11072,7 +10782,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -11838,12 +11548,12 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,21 +3133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3634,9 +3619,6 @@ dependencies = [
  "lenient_bool",
  "log",
  "minijinja",
- "native-tls",
- "openssl",
- "openssl-sys",
  "phf 0.11.3",
  "portable-pty",
  "pretty_assertions",
@@ -3649,6 +3631,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-retry",
+ "rustls",
  "semver",
  "serde",
  "serde_derive",
@@ -6107,23 +6090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6473,32 +6439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6509,18 +6449,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -9949,16 +9877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9988,10 +9906,12 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -10616,8 +10536,9 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,6 @@ mimalloc = "0.1.52"
 minijinja = "2.7.0"
 
 nanoid = "0.4.0"
-native-tls = "=0.2.13"
 nondestructive = "0.0.26"
 nonempty-collections = "1.2.1"
 nonzero_ext = "0.3.0"
@@ -176,8 +175,6 @@ num-traits = "0.2.19"
 once_cell = "1.21.0"
 openapiv3 = "=2.0.0"
 openidconnect = "4.0.1"
-openssl = "=0.10.73"
-openssl-sys = "=0.9.109"
 opentelemetry = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0" }
 opentelemetry-prometheus-text-exporter = "=0.2.0"
@@ -260,7 +257,7 @@ tokio-metrics = { version = "0.5.0", features = ["metrics-rs-integration"] }
 tokio-postgres = "0.7.13"
 tokio-rustls = { version = "0.26.2" }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-tungstenite = { version = "0.27.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-webpki-roots"] }
 tokio-util = "0.7.13"
 toml = "0.9.5"
 toml_edit = "0.23.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = "0.1.87"
 async_zip = { version = "0.0.17", features = ["tokio", "tokio-fs", "deflate"] }
 auditable-serde = "0.8.0"
 aws-config = "1.5.10"
-aws-sdk-s3 = "1.65.0"
+aws-sdk-s3 = { version = "1.65.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
 backtrace-on-stack-overflow = "0.3.0"
 axum = { version = "0.8", features = ["multipart"] }
 axum-jrpc = "0.9.0"
@@ -237,7 +237,7 @@ shell-words = "1.1.0"
 shlex = "1.3.0"
 similar = "2.7.0"
 spdx = "0.10.8"
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "sqlite", "postgres", "mysql", "uuid", "migrate", "chrono", "json", "bigdecimal", "mac_address", "bit-vec", "ipnetwork", ] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls", "sqlite", "postgres", "mysql", "uuid", "migrate", "derive", "chrono", "json", "bigdecimal", "mac_address", "bit-vec", "ipnetwork", ] }
 sqlx-core = { version = "0.8" }
 strip-ansi-escapes = "0.2.0"
 strum = "0.27.1"
@@ -260,7 +260,7 @@ tokio-metrics = { version = "0.5.0", features = ["metrics-rs-integration"] }
 tokio-postgres = "0.7.13"
 tokio-rustls = { version = "0.26.2" }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-tungstenite = { version = "0.25.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.27.0", features = ["native-tls"] }
 tokio-util = "0.7.13"
 toml = "0.9.5"
 toml_edit = "0.23.3"
@@ -327,6 +327,11 @@ wasmtime-wizer = { git = "https://github.com/golemcloud/wasmtime.git", branch = 
 
 [profile.dev]
 panic = "abort"
+debug = "line-tables-only"
+
+[profile.full-debug]
+inherits = "dev"
+debug = "full"
 
 # Build the Cranelift/regalloc codegen crates (the ones Wasmtime runs to compile
 # wasm -> native) at opt-level 3 even in debug builds. A debug-built Cranelift is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = "0.1.87"
 async_zip = { version = "0.0.17", features = ["tokio", "tokio-fs", "deflate"] }
 auditable-serde = "0.8.0"
 aws-config = "1.5.10"
-aws-sdk-s3 = { version = "1.65.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { version = "1.65.0", default-features = false, features = ["default-https-client", "rt-tokio", "rustls"] }
 backtrace-on-stack-overflow = "0.3.0"
 axum = { version = "0.8", features = ["multipart"] }
 axum-jrpc = "0.9.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -261,6 +261,12 @@ private = true
 condition = { env_not_set = ["CI"] }
 run_task = [{ name = ["build-registry-service"] }]
 
+[tasks.build-shard-manager-kubernetes]
+private = true
+dependencies = ["build-bins-non-ci"]
+command = "cargo"
+args = ["build", "-p", "golem-shard-manager", "--features", "kubernetes"]
+
 [tasks.build-release-full]
 dependencies = [
     "wit",
@@ -273,6 +279,8 @@ args = [
     "--release",
     "--exclude",
     "integration-tests",
+    "--features",
+    "golem-shard-manager/kubernetes",
 ]
 
 [tasks.build-release]
@@ -302,6 +310,8 @@ args = [
     "integration-tests",
     "--exclude",
     "golem",
+    "--features",
+    "golem-shard-manager/kubernetes",
 ]
 
 [tasks.build-release-override-linux-amd64]
@@ -318,6 +328,8 @@ args = [
     "integration-tests",
     "--exclude",
     "golem",
+    "--features",
+    "golem-shard-manager/kubernetes",
 ]
 
 [tasks.build-release-override-linux-arm64]
@@ -335,6 +347,8 @@ args = [
     "integration-tests",
     "--exclude",
     "golem",
+    "--features",
+    "golem-shard-manager/kubernetes",
 ]
 
 [tasks.build-sdk-ts]
@@ -1124,7 +1138,7 @@ script = { file = "./local-run/start.sh" }
 
 [tasks.generate-configs]
 description = "Generates default and example config files"
-dependencies = ["build-bins-non-ci"]
+dependencies = ["build-shard-manager-kubernetes"]
 
 script = '''
 export RUST_BACKTRACE=1

--- a/cli/golem-cli/Cargo.toml
+++ b/cli/golem-cli/Cargo.toml
@@ -67,7 +67,6 @@ itertools = { workspace = true }
 jsonschema = { workspace = true }
 lenient_bool = { workspace = true }
 minijinja = { workspace = true }
-native-tls = { workspace = true }
 phf = { workspace = true }
 portable-pty = { workspace = true }
 prettyplease = { workspace = true }
@@ -77,6 +76,7 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -119,10 +119,6 @@ wasm-rquickjs = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
-
-[target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
-openssl = { workspace = true }
-openssl-sys = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }

--- a/cli/golem-cli/src/command_handler/agent/stream.rs
+++ b/cli/golem-cli/src/command_handler/agent/stream.rs
@@ -414,8 +414,7 @@ impl AgentConnection {
                 }
             }
             Message::Binary(data) => {
-                let parsed: serde_json::Result<AgentEvent> =
-                    serde_json::from_slice(data.as_slice());
+                let parsed: serde_json::Result<AgentEvent> = serde_json::from_slice(data.as_ref());
                 match parsed {
                     Ok(parsed) => Some(parsed),
                     Err(err) => {

--- a/cli/golem-cli/src/command_handler/agent/stream.rs
+++ b/cli/golem-cli/src/command_handler/agent/stream.rs
@@ -24,7 +24,10 @@ use futures_util::{SinkExt, StreamExt, TryStreamExt, future, pin_mut};
 use golem_common::model::auth::TokenSecret;
 use golem_common::model::component::ComponentId;
 use golem_common::model::{AgentEvent, AgentId, IdempotencyKey, LogLevel, Timestamp};
-use native_tls::TlsConnector;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -40,6 +43,46 @@ use tokio_tungstenite::{
 use tracing::{debug, error, info, trace};
 use url::Url;
 use uuid::Uuid;
+
+#[derive(Debug)]
+struct InsecureServerCertVerifier {
+    signature_algorithms: WebPkiSupportedAlgorithms,
+}
+
+impl ServerCertVerifier for InsecureServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.signature_algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.signature_algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.signature_algorithms.supported_schemes()
+    }
+}
 
 pub struct AgentConnection {
     request: Request,
@@ -184,12 +227,16 @@ impl AgentConnection {
         }
 
         let connector = if allow_insecure {
-            Some(Connector::NativeTls(
-                TlsConnector::builder()
-                    .danger_accept_invalid_certs(true)
-                    .danger_accept_invalid_hostnames(true)
-                    .build()?,
-            ))
+            let provider = Arc::new(rustls::crypto::ring::default_provider());
+            let verifier = InsecureServerCertVerifier {
+                signature_algorithms: provider.signature_verification_algorithms,
+            };
+            let tls_config = rustls::ClientConfig::builder_with_provider(provider)
+                .with_safe_default_protocol_versions()?
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(verifier))
+                .with_no_client_auth();
+            Some(Connector::Rustls(Arc::new(tls_config)))
         } else {
             None
         };
@@ -208,9 +255,7 @@ impl AgentConnection {
             interval.tick().await;
 
             let ping_result = write
-                .send(Message::Ping(
-                    Bytes::from(cnt.to_ne_bytes().to_vec()).into(),
-                ))
+                .send(Message::Ping(Bytes::from(cnt.to_ne_bytes().to_vec())))
                 .await
                 .context("Failed to send ping");
 

--- a/golem-debugging-service/tests/debug_mode/debug_worker_executor.rs
+++ b/golem-debugging-service/tests/debug_mode/debug_worker_executor.rs
@@ -12,7 +12,6 @@ use tokio::net::TcpStream;
 use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::protocol::frame::Utf8Payload;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 pub type DebugServiceClient = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -55,9 +54,7 @@ impl DebugWorkerExecutorClient {
         let id = Id::Str(uuid.to_string());
 
         self.write_msg
-            .send(Message::Text(Utf8Payload::from(serde_json::to_string(
-                &jrpc_request,
-            )?)))
+            .send(Message::Text(serde_json::to_string(&jrpc_request)?.into()))
             .await?;
 
         Ok(id)

--- a/golem-registry-service/Cargo.toml
+++ b/golem-registry-service/Cargo.toml
@@ -27,8 +27,6 @@ anyhow = { workspace = true }
 applying = { workspace = true }
 async-trait = { workspace = true }
 async_zip = { workspace = true, features = ["tokio", "tokio-fs", "deflate"] }
-aws-config = { workspace = true }
-aws-sdk-s3 = { workspace = true }
 bigdecimal = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }

--- a/golem-shard-manager/Cargo.toml
+++ b/golem-shard-manager/Cargo.toml
@@ -65,5 +65,5 @@ uuid = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-default = ["kubernetes"]
+default = []
 kubernetes = ["dep:kube", "dep:k8s-openapi"]

--- a/golem-shard-manager/src/config.rs
+++ b/golem-shard-manager/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "kubernetes")]
 use crate::config::HealthCheckMode::K8s;
 use golem_common::SafeDisplay;
 use golem_common::config::{
@@ -121,19 +122,27 @@ impl Default for ShardManagerConfig {
 
 impl HasConfigExamples<ShardManagerConfig> for ShardManagerConfig {
     fn examples() -> Vec<ConfigExample<ShardManagerConfig>> {
-        vec![(
-            "with k8s healthcheck",
-            Self {
-                health_check: HealthCheckConfig {
-                    delay: Duration::from_secs(1),
-                    mode: K8s(HealthCheckK8sConfig {
-                        namespace: "namespace".to_string(),
-                    }),
-                    silent: false,
+        #[cfg(feature = "kubernetes")]
+        {
+            vec![(
+                "with k8s healthcheck",
+                Self {
+                    health_check: HealthCheckConfig {
+                        delay: Duration::from_secs(1),
+                        mode: K8s(HealthCheckK8sConfig {
+                            namespace: "namespace".to_string(),
+                        }),
+                        silent: false,
+                    },
+                    ..Self::default()
                 },
-                ..Self::default()
-            },
-        )]
+            )]
+        }
+
+        #[cfg(not(feature = "kubernetes"))]
+        {
+            Vec::new()
+        }
     }
 }
 

--- a/golem-shard-manager/src/lib.rs
+++ b/golem-shard-manager/src/lib.rs
@@ -20,7 +20,9 @@ mod registry_event_subscriber;
 pub(crate) mod sharding;
 
 use self::grpc::ShardManagerServiceImpl;
-use crate::config::{HealthCheckK8sConfig, HealthCheckMode};
+#[cfg(feature = "kubernetes")]
+use crate::config::HealthCheckK8sConfig;
+use crate::config::HealthCheckMode;
 use crate::quota::{DbQuotaRepo, GrpcResourceDefinitionFetcher, QuotaService};
 use crate::registry_event_subscriber::ShardManagerRegistryInvalidationHandler;
 use crate::sharding::healthcheck::GrpcHealthCheck;

--- a/golem-shard-manager/src/sharding/error.rs
+++ b/golem-shard-manager/src/sharding/error.rs
@@ -70,16 +70,22 @@ pub enum HealthCheckError {
     GrpcTransportError(#[source] tonic::transport::Error),
     #[error("gRPC: {0}")]
     GrpcOther(&'static str),
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: connect error: {0}")]
     K8sConnectError(#[source] kube::Error),
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: pod not found")]
     K8sPodNotFound,
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: pod terminated")]
     K8sPodTerminated,
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: pod is not ready")]
     K8sPodNotReady,
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: no pod status")]
     K8sNoPodStatus,
+    #[cfg(feature = "kubernetes")]
     #[error("K8s: no pod name")]
     K8sNoPodName,
 }
@@ -90,11 +96,17 @@ impl IsRetriableError for HealthCheckError {
             HealthCheckError::GrpcError(status) => status.is_retriable(),
             HealthCheckError::GrpcTransportError(_) => true,
             HealthCheckError::GrpcOther(_) => true,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sConnectError(_) => true,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sPodNotFound => false,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sPodTerminated => false,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sPodNotReady => true,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sNoPodStatus => true,
+            #[cfg(feature = "kubernetes")]
             HealthCheckError::K8sNoPodName => false,
         }
     }

--- a/golem-test-framework/Cargo.toml
+++ b/golem-test-framework/Cargo.toml
@@ -50,7 +50,7 @@ testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-tokio-tungstenite = { workspace = true, features = ["native-tls"] }
+tokio-tungstenite = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }

--- a/golem-test-framework/src/config/dsl_impl.rs
+++ b/golem-test-framework/src/config/dsl_impl.rs
@@ -69,7 +69,6 @@ use tokio::fs::File;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::protocol::frame::Payload;
 use tokio_tungstenite::{Connector, MaybeTlsStream, WebSocketStream};
 use tracing::trace;
 use uuid::Uuid;
@@ -1114,7 +1113,7 @@ impl HttpWorkerLogEventStream {
             loop {
                 interval.tick().await;
                 match write
-                    .send(Message::Ping(Payload::from(PING_HELLO.as_bytes())))
+                    .send(Message::Ping(PING_HELLO.as_bytes().to_vec().into()))
                     .await
                 {
                     Ok(_) => {}
@@ -1142,7 +1141,7 @@ impl WorkerLogEventStream for HttpWorkerLogEventStream {
                     }
                     Message::Binary(payload) => {
                         return Ok(Some(
-                            serde_json::from_slice::<AgentEvent>(payload.as_slice())?
+                            serde_json::from_slice::<AgentEvent>(payload.as_ref())?
                                 .try_into()
                                 .map_err(|error: String| anyhow!(error))?,
                         ));

--- a/golem-worker-executor/src/durable_host/websocket/client.rs
+++ b/golem-worker-executor/src/durable_host/websocket/client.rs
@@ -940,7 +940,7 @@ fn to_tungstenite_message(message: Message) -> tungstenite::Message {
 fn to_user_message(msg: tungstenite::Message) -> Result<Option<Message>, Error> {
     match msg {
         tungstenite::Message::Text(text) => Ok(Some(Message::Text(text.as_str().to_owned()))),
-        tungstenite::Message::Binary(data) => Ok(Some(Message::Binary(data.as_slice().to_vec()))),
+        tungstenite::Message::Binary(data) => Ok(Some(Message::Binary(data.as_ref().to_vec()))),
         tungstenite::Message::Close(frame) => {
             let (code, reason) = match frame {
                 Some(frame) => (frame.code.into(), frame.reason.to_string()),


### PR DESCRIPTION
## Summary

- use line-table-only debug information for the default development profile and add an opt-in `full-debug` profile
- make Kubernetes support in the shard manager opt-in while keeping it enabled in release and config-generation builds
- narrow SQLx and AWS S3 feature sets to the functionality Golem uses
- unify `tokio-tungstenite` on 0.27 and use Rustls for WebSocket connections, including the CLI's insecure-development mode
- remove unused direct AWS and OpenSSL dependencies

The normal workspace dependency graph decreases from 868 to 813 package versions, and the lockfile decreases from 1110 to 1081 package entries.

## Validation

- `cargo make fix`
- `cargo check -p golem-shard-manager --no-default-features`
- `cargo check -p golem-shard-manager --features kubernetes`
- `cargo check -p golem-worker-executor -p golem-cli -p golem-registry-service`
- `cargo check --tests -p golem-worker-executor -p golem-debugging-service -p golem-test-framework`
- `cargo check -p golem-service-base --tests`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo make build` compiled the workspace but failed while linking all targets because the orb's 64 GiB filesystem filled up; targeted builds and checks above passed.
