### PR TITLE
Answer callers whose agent moved, and stop retries duplicating their work

### DIFF
--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// `store_component_with` in `dsl_impl.rs` is an instrumented async fn whose
+// layout needs more depth than rustc's default of 128. On rustc 1.98 the
+// observed minimum is 129; 256 matches `golem-worker-executor/tests/lib.rs`.
+#![recursion_limit = "256"]
+
 pub mod agent_deployments_service;
 pub mod component_service;
 pub mod component_writer;

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -54,7 +54,8 @@ use golem_common::model::retry_policy::NamedRetryPolicy;
 use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto};
 use golem_common::model::{
     AgentFilter, AgentId, AgentInvocation, AgentInvocationOutput, AgentStatusRecord,
-    IdempotencyKey, OplogIndex, OwnedAgentId, RdbmsPoolKey, RetryConfig, TransactionId,
+    IdempotencyKey, OplogIndex, OwnedAgentId, RdbmsPoolKey, RetryConfig, ShardAssignment, ShardId,
+    TransactionId,
 };
 use golem_service_base::clients::registry::RegistryService;
 use golem_service_base::config::{BlobStorageConfig, LocalFileSystemBlobStorageConfig};
@@ -123,7 +124,7 @@ use golem_worker_executor::services::resource_limits::{
 };
 use golem_worker_executor::services::rpc::{Rpc, RpcDemand, RpcError as ServiceRpcError};
 use golem_worker_executor::services::scheduler::SchedulerService;
-use golem_worker_executor::services::shard::ShardService;
+use golem_worker_executor::services::shard::{ShardService, ShardServiceDefault};
 use golem_worker_executor::services::worker::WorkerService;
 use golem_worker_executor::services::worker_enumeration::WorkerEnumerationService;
 use golem_worker_executor::services::worker_event::WorkerEventService;
@@ -144,8 +145,9 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::runtime::Handle;
@@ -503,6 +505,7 @@ type WrapBlobStoreServiceFn =
     dyn Fn(Arc<dyn BlobStoreService>) -> Arc<dyn BlobStoreService> + Send + Sync;
 type WrapRpcFn = dyn Fn(Arc<dyn Rpc>) -> Arc<dyn Rpc> + Send + Sync;
 type CreateDirectInvocationAuthFn = dyn Fn() -> Arc<dyn DirectInvocationAuthService> + Send + Sync;
+type WrapShardServiceFn = dyn Fn(Arc<dyn ShardService>) -> Arc<dyn ShardService> + Send + Sync;
 
 #[derive(Clone, Default)]
 pub struct TestExecutorOverrides {
@@ -510,6 +513,11 @@ pub struct TestExecutorOverrides {
     pub wrap_key_value_service: Option<Arc<WrapKeyValueServiceFn>>,
     pub wrap_blob_store_service: Option<Arc<WrapBlobStoreServiceFn>>,
     pub wrap_rpc: Option<Arc<WrapRpcFn>>,
+    /// Wraps the executor's `ShardService`, so a test can observe or fake which
+    /// agents this executor owns. Everything that gates on ownership reads it,
+    /// including the periodic re-check a caller parked in
+    /// `Worker::wait_for_invocation_result` runs.
+    pub wrap_shard_service: Option<Arc<WrapShardServiceFn>>,
     pub create_direct_invocation_auth: Option<Arc<CreateDirectInvocationAuthFn>>,
     /// Named retry policies that the executor's `EnvironmentStateService`
     /// should expose to running agents (mirrors `retryPolicyDefaults` in
@@ -1415,6 +1423,16 @@ impl Bootstrap<TestWorkerCtx> for TestServerBootstrap {
                 &golem_config.agent_status_flush,
                 shutdown_token,
             )),
+        }
+    }
+
+    fn create_shard_service(&self) -> Arc<dyn ShardService> {
+        let shard_service: Arc<dyn ShardService> = Arc::new(ShardServiceDefault::new());
+
+        if let Some(wrap) = &self.overrides.wrap_shard_service {
+            wrap(shard_service)
+        } else {
+            shard_service
         }
     }
 
@@ -2413,6 +2431,201 @@ impl AdditionalTestDeps {
 
         *inner.entry_async(entry).await.or_default().get_mut() += 1;
     }
+}
+
+/// What a [`FakeOwnership`] has been told to report, and what it has reported.
+///
+/// Private: tests drive it through [`OwnershipControls`], which keeps the
+/// atomics and the channel ends out of the test body.
+struct FakeOwnershipState {
+    /// Fail every check the way an executor whose shard assignment has not
+    /// arrived yet fails, with the `Unknown` that `sharding_not_ready_error`
+    /// produces. That must never be read as "the agent moved".
+    assignment_missing: AtomicBool,
+    /// Make the next check announce itself, wait, and only then report that the
+    /// agent is not ours.
+    hold_next_check: AtomicBool,
+    assignment_missing_reports: AtomicUsize,
+    agent_moved_reports: AtomicUsize,
+    at_the_gate: SyncSender<()>,
+    release: Mutex<Receiver<()>>,
+}
+
+/// A [`ShardService`] that reports what a test has told it to report, and
+/// otherwise tells the truth.
+///
+/// Blocking inside `check_worker` is the point of the paused mode. The method is
+/// synchronous, so a wrapper that waits there holds a parked caller's ownership
+/// re-check open mid-flight, which is the only way a test can land an invocation
+/// result inside the window that re-check has to cope with.
+struct FakeOwnership {
+    inner: Arc<dyn ShardService>,
+    state: Arc<FakeOwnershipState>,
+}
+
+impl ShardService for FakeOwnership {
+    fn check_worker(&self, agent_id: &AgentId) -> Result<(), WorkerExecutorError> {
+        if self.state.assignment_missing.load(Ordering::SeqCst) {
+            self.state
+                .assignment_missing_reports
+                .fetch_add(1, Ordering::SeqCst);
+            return Err(WorkerExecutorError::Unknown {
+                details: "Sharding is not ready".to_string(),
+            });
+        }
+
+        // Taken, not read, so concurrent checks from other calls fall straight
+        // through to the truth while this one is held at the gate.
+        if self.state.hold_next_check.swap(false, Ordering::SeqCst) {
+            let _ = self.state.at_the_gate.send(());
+            // `check_worker` is sync and is called from async code, so waiting
+            // here occupies a runtime worker. `block_in_place` hands the worker
+            // back rather than starving a small runtime: without it this
+            // deadlocks whenever tokio has a single worker thread.
+            tokio::task::block_in_place(|| {
+                let _ = self
+                    .state
+                    .release
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(Duration::from_secs(60));
+            });
+            // Counted from the verdict rather than beside it, so the count says
+            // what was actually reported. A fake that quietly started reporting
+            // "still ours" would otherwise leave its tests passing vacuously.
+            let verdict = Err(WorkerExecutorError::invalid_shard_id(
+                ShardId::new(0),
+                HashSet::new(),
+            ));
+            if verdict.is_err() {
+                self.state
+                    .agent_moved_reports
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+            return verdict;
+        }
+
+        self.inner.check_worker(agent_id)
+    }
+
+    fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    fn assign_shards(&self, shard_ids: &HashSet<ShardId>) -> Result<(), WorkerExecutorError> {
+        self.inner.assign_shards(shard_ids)
+    }
+
+    fn register(&self, number_of_shards: usize, shard_ids: &HashSet<ShardId>) {
+        self.inner.register(number_of_shards, shard_ids)
+    }
+
+    fn revoke_shards(&self, shard_ids: &HashSet<ShardId>) -> Result<(), WorkerExecutorError> {
+        self.inner.revoke_shards(shard_ids)
+    }
+
+    fn set_shard_assignment(
+        &self,
+        number_of_shards: usize,
+        shard_ids: &HashSet<ShardId>,
+    ) -> Result<(), WorkerExecutorError> {
+        self.inner.set_shard_assignment(number_of_shards, shard_ids)
+    }
+
+    fn current_assignment(&self) -> Result<ShardAssignment, WorkerExecutorError> {
+        self.inner.current_assignment()
+    }
+
+    fn try_get_current_assignment(&self) -> Option<ShardAssignment> {
+        self.inner.try_get_current_assignment()
+    }
+}
+
+/// A test's handle on a [`FakeOwnership`]: what it should report, when to hold
+/// a check open, and what it has reported so far.
+pub struct OwnershipControls {
+    state: Arc<FakeOwnershipState>,
+    gate_reached: Receiver<()>,
+    release: SyncSender<()>,
+}
+
+impl OwnershipControls {
+    /// Report every ownership check the way an executor whose shard assignment
+    /// has not arrived reports it. Lasts until [`Self::stop_pretending`].
+    pub fn pretend_the_assignment_is_missing(&self) {
+        self.state.assignment_missing.store(true, Ordering::SeqCst);
+    }
+
+    pub fn stop_pretending(&self) {
+        self.state.assignment_missing.store(false, Ordering::SeqCst);
+    }
+
+    /// Hold the next ownership check open, and return once one has arrived.
+    ///
+    /// The waiting happens inside the fake's synchronous `check_worker`, which
+    /// is the only way to pause a parked caller's re-check mid-flight and land
+    /// something behind it. Nothing is held after this returns until
+    /// [`Self::release_the_held_check`] is called.
+    pub async fn hold_the_next_check(&self) -> anyhow::Result<()> {
+        self.state.hold_next_check.store(true, Ordering::SeqCst);
+        tokio::task::block_in_place(|| self.gate_reached.recv_timeout(Duration::from_secs(30)))
+            .map_err(|_| anyhow::anyhow!("no ownership check arrived within 30s"))?;
+        Ok(())
+    }
+
+    pub fn release_the_held_check(&self) -> anyhow::Result<()> {
+        self.release
+            .send(())
+            .map_err(|_| anyhow::anyhow!("the held ownership check stopped waiting"))
+    }
+
+    /// How many checks have been failed as "assignment not here yet". A test
+    /// asserts on this so it cannot quietly pass against an executor that never
+    /// had the fake installed at all.
+    pub fn assignment_missing_reports(&self) -> usize {
+        self.state.assignment_missing_reports.load(Ordering::SeqCst)
+    }
+
+    /// How many checks have reported that the agent has moved away.
+    pub fn agent_moved_reports(&self) -> usize {
+        self.state.agent_moved_reports.load(Ordering::SeqCst)
+    }
+}
+
+/// Builds overrides that put a [`FakeOwnership`] in front of the real shard
+/// service, plus the controls for it.
+pub fn fake_ownership() -> (TestExecutorOverrides, OwnershipControls) {
+    let (at_the_gate, gate_reached) = sync_channel(1);
+    let (release, released) = sync_channel(1);
+
+    let state = Arc::new(FakeOwnershipState {
+        assignment_missing: AtomicBool::new(false),
+        hold_next_check: AtomicBool::new(false),
+        assignment_missing_reports: AtomicUsize::new(0),
+        agent_moved_reports: AtomicUsize::new(0),
+        at_the_gate,
+        release: Mutex::new(released),
+    });
+
+    let for_closure = state.clone();
+    let overrides = TestExecutorOverrides {
+        wrap_shard_service: Some(Arc::new(move |inner| {
+            Arc::new(FakeOwnership {
+                inner,
+                state: for_closure.clone(),
+            })
+        })),
+        ..Default::default()
+    };
+
+    (
+        overrides,
+        OwnershipControls {
+            state,
+            gate_reached,
+            release,
+        },
+    )
 }
 
 pub struct FailingKeyValueService {

--- a/golem-worker-executor/src/lib.rs
+++ b/golem-worker-executor/src/lib.rs
@@ -190,6 +190,13 @@ pub trait Bootstrap<Ctx: WorkerCtx> {
         Arc::new(crate::services::shard_manager::GrpcShardManagerService::new(shard_manager_client))
     }
 
+    /// Overridable so a test can watch or fake shard ownership. Everything that
+    /// gates on ownership goes through this one service, including the periodic
+    /// re-check a caller parked in `Worker::wait_for_invocation_result` runs.
+    fn create_shard_service(&self) -> Arc<dyn ShardService> {
+        Arc::new(ShardServiceDefault::new())
+    }
+
     fn create_quota_service(
         &self,
         shard_manager_client: Arc<dyn golem_service_base::clients::shard_manager::ShardManager>,
@@ -739,7 +746,7 @@ pub async fn create_worker_executor_impl<
     );
     let golem_config = Arc::new(golem_config);
 
-    let shard_service = Arc::new(ShardServiceDefault::new());
+    let shard_service = bootstrap.create_shard_service();
 
     let mut oplog_archives: Vec<Arc<dyn OplogArchiveService>> = Vec::new();
     for idx in 1..golem_config.oplog.indexed_storage_layers {

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -122,6 +122,15 @@ enum TargetChargeAction {
     Retry,
 }
 
+/// How often a caller parked in [`Worker::wait_for_invocation_result`] re-checks
+/// that this executor still owns the agent it is waiting for.
+///
+/// Reached only when the wait is otherwise idle. A tick that finds the agent
+/// still owned costs one set lookup for the ownership check, then re-enters the
+/// loop and re-runs `lookup_invocation_result`, which clones the agent's last
+/// known status. Cheap, but not free, so this is not a millisecond knob.
+pub const INVOCATION_OWNERSHIP_RECHECK_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Classifies a `get_metadata(target)` result into the startup charge action,
 /// preserving the invariant that admission charges the target revision whenever
 /// `create_instance` can still load it. Only a definitely-absent target
@@ -1847,24 +1856,73 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         key: &IdempotencyKey,
         mut subscription: EventsSubscription,
     ) -> Result<LookupResult, RecvError> {
+        // A deadline, so how often the check runs is a property of the check
+        // rather than of how often this loop happens to restart. Both `continue`
+        // paths below re-enter it, and a sleep started fresh each time would
+        // measure the interval from the last restart instead of running every
+        // interval. Reaching that today needs a receiver falling
+        // `invocation_result_broadcast_capacity` events behind over and over,
+        // which is remote enough that this is insurance rather than a fix, but
+        // it costs a single `Instant`.
+        let mut next_ownership_check =
+            tokio::time::Instant::now() + INVOCATION_OWNERSHIP_RECHECK_INTERVAL;
+
         loop {
             match self.lookup_invocation_result(key).await {
                 LookupResult::Interrupted => break Ok(LookupResult::Interrupted),
                 LookupResult::New | LookupResult::Pending => {
-                    let wait_result = subscription
-                        .wait_for(|event| match event {
-                            Event::InvocationCompleted {
-                                agent_id,
-                                idempotency_key,
-                                result,
-                            } if *agent_id == self.owned_agent_id.agent_id
-                                && idempotency_key == key =>
+                    let waiting = subscription.wait_for(|event| match event {
+                        Event::InvocationCompleted {
+                            agent_id,
+                            idempotency_key,
+                            result,
+                        } if *agent_id == self.owned_agent_id.agent_id
+                            && idempotency_key == key =>
+                        {
+                            Some(LookupResult::Complete(result.clone()))
+                        }
+                        _ => None,
+                    });
+
+                    let wait_result = tokio::select! {
+                        biased;
+                        result = waiting => result,
+                        () = tokio::time::sleep_until(next_ownership_check) => {
+                            next_ownership_check = tokio::time::Instant::now()
+                                + INVOCATION_OWNERSHIP_RECHECK_INTERVAL;
+
+                            // An agent whose shard has moved is resumed by whoever owns
+                            // it now, and its `InvocationCompleted` is published on that
+                            // executor's bus. Nothing will ever arrive on ours, and the
+                            // only other way out of this loop is the result turning up in
+                            // this `Worker`'s own memory, which it never will either. So
+                            // hand the caller the error that makes worker-service
+                            // invalidate its routing table and retry against the new
+                            // owner, rather than leave it to find out by timing out.
+                            //
+                            // Only `InvalidShardId` ends the wait. An executor whose
+                            // shard assignment is not set yet fails this check too, with
+                            // an `Unknown` from `sharding_not_ready_error`, and that one
+                            // has to fall through and keep waiting: an assignment is on
+                            // its way, and the agent may well still be ours.
+                            if let Err(error @ WorkerExecutorError::InvalidShardId { .. }) =
+                                self.shard_service().check_worker(&self.owned_agent_id.agent_id)
                             {
-                                Some(LookupResult::Complete(result.clone()))
+                                // The invocation can have finished while we were deciding
+                                // that. `store_invocation_success` fills `invocation_results`
+                                // before it publishes, so the result is already readable
+                                // here, and a real result always beats a reroute.
+                                match self.lookup_invocation_result(key).await {
+                                    LookupResult::New | LookupResult::Pending => {
+                                        debug!("Agent is no longer owned by this executor, ending the wait for its invocation result");
+                                        break Ok(LookupResult::Complete(Err(error)));
+                                    }
+                                    settled => break Ok(settled),
+                                }
                             }
-                            _ => None,
-                        })
-                        .await;
+                            continue;
+                        }
+                    };
                     match wait_result {
                         Ok(result) => break Ok(result),
                         Err(RecvError::Lagged(_)) => {

--- a/golem-worker-executor/tests/api.rs
+++ b/golem-worker-executor/tests/api.rs
@@ -16,6 +16,7 @@ use crate::Tracing;
 use anyhow::anyhow;
 use axum::Router;
 use axum::routing::get;
+use golem_api_grpc::proto::golem::workerexecutor::v1::{AssignShardsRequest, RevokeShardsRequest};
 use golem_common::model::account::AccountId;
 use golem_common::model::agent::{
     ComponentModelElementValue, DataValue, ElementValue, ElementValues,
@@ -25,7 +26,7 @@ use golem_common::model::oplog::OplogIndex;
 use golem_common::model::worker::AgentMetadataDto;
 use golem_common::model::{
     AgentFilter, AgentId, AgentStatus, FilterComparator, IdempotencyKey, PromiseId, RetryConfig,
-    ScanCursor, StringFilterComparator,
+    ScanCursor, ShardId, StringFilterComparator,
 };
 use golem_common::{agent_id, data_value, phantom_agent_id};
 use golem_service_base::error::worker_executor::WorkerExecutorError;
@@ -35,9 +36,10 @@ use golem_wasm::analysis::analysed_type;
 use golem_wasm::analysis::wit_parser::{SharedAnalysedTypeResolve, TypeName, TypeOwner};
 use golem_wasm::{IntoValue, Record};
 use golem_wasm::{IntoValueAndType, Value, ValueAndType};
+use golem_worker_executor::worker::INVOCATION_OWNERSHIP_RECHECK_INTERVAL;
 use golem_worker_executor_test_utils::{
     LastUniqueId, PrecompiledComponent, TestContext, TestExecutorOverrides, TestWorkerExecutor,
-    WorkerExecutorTestDependencies, start, start_customized, start_with_overrides,
+    WorkerExecutorTestDependencies, fake_ownership, start, start_customized, start_with_overrides,
     start_with_redis_storage,
 };
 use pretty_assertions::assert_eq;
@@ -603,6 +605,377 @@ async fn promise(
         Value::Option(Some(Box::new(Value::List(vec![Value::U8(42)]))))
     );
     Ok(())
+}
+
+/// Control for [`a_caller_is_answered_when_its_agents_shard_is_taken_away`].
+///
+/// An agent's shard leaves this executor and comes straight back, and the
+/// promise it is parked on is then completed here. What this pins, and the test
+/// below cannot, is that revoking a shard interrupts the agents on it with
+/// `InterruptKind::Restart`, and that interrupt on its own does not strand the
+/// caller. So the test below is measuring the handoff and not the interrupt.
+///
+/// It does *not* prove the `select!` is cancel-safe, though it did have to stop
+/// claiming that twice. Only the `wait_for` future is dropped on a tick;
+/// `EventsSubscription` keeps the same `broadcast::Receiver`, which holds its
+/// cursor and buffers anything published while no `recv()` is pending. Nothing
+/// is rebuilt, so nothing can be lost, and no test here could tell you
+/// otherwise: the promise below is completed at a moment uncorrelated with the
+/// tick, so a genuinely lossy variant would pass this almost every time.
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn a_caller_is_answered_when_its_agents_shard_comes_back(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("host_api_tests")] host_api_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let parked = park_a_caller_on_a_promise(
+        &executor,
+        &context,
+        host_api_tests,
+        "promise-shard-returned",
+    )
+    .await?;
+
+    info!("Revoking the shard, then handing it straight back");
+
+    revoke_shard_zero(&executor).await?;
+    assign_shard_zero(&executor).await?;
+
+    // Sit here long enough for the caller's ownership re-check to run several
+    // times before the result exists, so the answer has to survive the re-check
+    // firing repeatedly and finding nothing wrong.
+    sleep(INVOCATION_OWNERSHIP_RECHECK_INTERVAL * 3).await;
+
+    parked.complete_the_promise(&executor, vec![42]).await?;
+
+    let value = parked
+        .value_within(
+            Duration::from_secs(30),
+            "caller was not answered even though the shard came back and the promise \
+             was completed on this executor",
+        )
+        .await?;
+    assert_eq!(value, Value::List(vec![Value::U8(42)]));
+    Ok(())
+}
+
+/// An executor that loses an agent must answer anyone still awaiting it.
+///
+/// [`Worker::wait_for_invocation_result`] can end in exactly two ways: the
+/// result turns up in this `Worker`'s in-memory state, or an
+/// `Event::InvocationCompleted` lands on *this executor's* event bus. Once the
+/// agent belongs to a different executor, neither can happen here - the work is
+/// finished over there, on a bus this caller does not subscribe to. There is no
+/// timeout and no ownership re-check, so the caller waits for as long as it is
+/// willing to. Chaos scenario S11 (GOL-377) measured that as the client's own
+/// timeout, 120s, on an executor that was never killed and whose transport was
+/// never disturbed, so nothing below the application layer had anything to
+/// notice.
+///
+/// What it should get is an error of the `InvalidShardId` family, which is
+/// already what worker-service needs to invalidate its routing table and retry
+/// against the new owner. That path exists and works; nothing used to reach it.
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn a_caller_is_answered_when_its_agents_shard_is_taken_away(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("host_api_tests")] host_api_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let parked =
+        park_a_caller_on_a_promise(&executor, &context, host_api_tests, "promise-shard-taken")
+            .await?;
+
+    info!("Revoking the shard that owns the suspended agent, for good");
+
+    revoke_shard_zero(&executor).await?;
+
+    // The agent is somebody else's now. Whatever this executor does about that,
+    // the caller holding an open invoke_and_await has to be told something: an
+    // error it can retry against the new owner is fine, silence is not.
+    // Four turns of INVOCATION_OWNERSHIP_RECHECK_INTERVAL, which is 5s. Left
+    // absolute on purpose: a bound derived from that constant would stretch
+    // along with it, and this test has to stay red when it is neutralised.
+    let answer = parked
+        .answer_within(
+            Duration::from_secs(20),
+            "caller parked in invoke_and_await was never answered, although this \
+             executor no longer owns the agent and can never finish the call",
+        )
+        .await?;
+    info!(result = ?answer, "caller was answered");
+
+    let error =
+        answer.expect_err("nobody completed the promise, so the only honest answer is an error");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("InvalidShardId"),
+        "the caller has to be told the shard moved, because that is what makes \
+         worker-service invalidate its routing table and retry against the new \
+         owner; instead it got: {rendered}"
+    );
+    Ok(())
+}
+
+/// The test executor runs `ShardManagerServiceSingleShard`, so every agent in
+/// these tests lives on shard 0. Moving that one shard moves all of them.
+async fn revoke_shard_zero(executor: &TestWorkerExecutor) -> anyhow::Result<()> {
+    executor
+        .client
+        .clone()
+        .revoke_shards(RevokeShardsRequest {
+            shard_ids: vec![ShardId::new(0).into()],
+        })
+        .await?;
+    Ok(())
+}
+
+/// A result that lands while ownership is being checked must still win.
+///
+/// The check and the completion are not ordered against each other. If the
+/// check comes back "not ours" a moment after the invocation finished here, the
+/// caller has to be handed its result rather than sent to a new owner that
+/// would run the work a second time. Mutation testing is what found this:
+/// deleting the re-poll from the timer arm left every other test green.
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn a_result_that_lands_while_ownership_is_being_checked_still_reaches_the_caller(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("host_api_tests")] host_api_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let (overrides, controls) = fake_ownership();
+    let executor = start_with_overrides(deps, &context, overrides).await?;
+
+    let parked =
+        park_a_caller_on_a_promise(&executor, &context, host_api_tests, "promise-check-race")
+            .await?;
+
+    controls.hold_the_next_check().await?;
+
+    info!("Ownership check is held open; landing the result behind it");
+
+    parked.complete_the_promise(&executor, vec![42]).await?;
+    executor
+        .wait_for_status(&parked.agent_id, AgentStatus::Idle, Duration::from_secs(20))
+        .await?;
+
+    // Only now does the held check report that the agent is not ours. The
+    // result is already sitting in the agent's invocation results.
+    controls.release_the_held_check()?;
+
+    let value = parked
+        .value_within(
+            Duration::from_secs(20),
+            "caller was never answered, although its result had already landed",
+        )
+        .await?;
+    assert_eq!(value, Value::List(vec![Value::U8(42)]));
+
+    // Without this the test also passes when the held check reports that the
+    // agent is still ours, which exercises none of the code it is aimed at.
+    assert_eq!(
+        controls.agent_moved_reports(),
+        1,
+        "the caller's re-check should have been told exactly once that the agent had moved"
+    );
+    Ok(())
+}
+
+/// An executor that does not know its shards yet has not lost the agent.
+///
+/// `check_worker` fails in that state too, with the `Unknown` that
+/// `sharding_not_ready_error` produces, and only `InvalidShardId` means the
+/// agent has moved. Treating any failure as a move would fail callers during
+/// startup and rebalance windows, when an assignment is simply on its way.
+#[test]
+#[tracing::instrument]
+#[timeout("2m")]
+async fn a_caller_is_not_given_up_on_while_the_shard_assignment_is_missing(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("host_api_tests")] host_api_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let (overrides, controls) = fake_ownership();
+    let executor = start_with_overrides(deps, &context, overrides).await?;
+
+    let parked =
+        park_a_caller_on_a_promise(&executor, &context, host_api_tests, "promise-not-ready")
+            .await?;
+
+    info!("Reporting no shard assignment for long enough to span several re-checks");
+
+    controls.pretend_the_assignment_is_missing();
+    sleep(INVOCATION_OWNERSHIP_RECHECK_INTERVAL * 2 + Duration::from_secs(1)).await;
+    controls.stop_pretending();
+
+    // Both bounds earn their place. Without the lower one this passes against an
+    // executor that never had the fake installed and reported nothing at all.
+    // Without the upper one it passes just as happily when the re-check stops
+    // being paced and spins: dropping the deadline reset in
+    // `wait_for_invocation_result` turns these two checks into millions, and
+    // every other assertion in this file is blind to that.
+    let checks = controls.assignment_missing_reports();
+    assert!(
+        (2..=5).contains(&checks),
+        "expected a handful of re-checks across an 11s window while the assignment \
+         was missing, got {checks}"
+    );
+
+    parked.complete_the_promise(&executor, vec![42]).await?;
+
+    let value = parked
+        .value_within(
+            Duration::from_secs(30),
+            "caller was given up on while this executor merely did not know its \
+             shards yet",
+        )
+        .await?;
+    assert_eq!(value, Value::List(vec![Value::U8(42)]));
+    Ok(())
+}
+
+/// Hands shard 0 back, so the agents on it are this executor's again.
+async fn assign_shard_zero(executor: &TestWorkerExecutor) -> anyhow::Result<()> {
+    executor
+        .client
+        .clone()
+        .assign_shards(AssignShardsRequest {
+            shard_ids: vec![ShardId::new(0).into()],
+        })
+        .await?;
+    Ok(())
+}
+
+/// Starts an agent, opens an `invoke_and_await` against it, and returns once
+/// that call is parked on a promise.
+///
+/// The returned fiber is the caller. It is deliberately left running: every test
+/// using this asks what the executor does to a caller it has stopped being able
+/// to answer.
+async fn park_a_caller_on_a_promise(
+    executor: &TestWorkerExecutor,
+    context: &TestContext,
+    host_api_tests: &PrecompiledComponent,
+    agent_name: &str,
+) -> anyhow::Result<ParkedCaller> {
+    let component = executor
+        .component_dep(&context.default_environment_id, host_api_tests)
+        .store()
+        .await?;
+
+    let agent_id = agent_id!("GolemHostApi", agent_name);
+    let worker_id = executor
+        .start_agent(&component.id, agent_id.clone())
+        .await?;
+
+    let promise_id_value = executor
+        .invoke_and_await_agent(&component, &agent_id, "create_promise", data_value!())
+        .await?
+        .into_return_value()
+        .ok_or_else(|| anyhow!("expected return value"))?;
+
+    let promise_data = DataValue::Tuple(ElementValues {
+        elements: vec![ElementValue::ComponentModel(ComponentModelElementValue {
+            value: ValueAndType::new(promise_id_value.clone(), PromiseId::get_type()),
+        })],
+    });
+
+    let executor_clone = executor.clone();
+    let component_clone = component.clone();
+    let agent_id_clone = agent_id.clone();
+    let fiber = tokio::spawn(
+        async move {
+            executor_clone
+                .invoke_and_await_agent(
+                    &component_clone,
+                    &agent_id_clone,
+                    "await_promise",
+                    promise_data,
+                )
+                .await
+        }
+        .in_current_span(),
+    );
+
+    executor
+        .wait_for_status(&worker_id, AgentStatus::Suspended, Duration::from_secs(10))
+        .await?;
+
+    Ok(ParkedCaller {
+        agent_id: worker_id,
+        promise_id: promise_id_value,
+        caller: fiber,
+    })
+}
+
+/// A caller left parked inside `invoke_and_await`, and what a test needs to
+/// either answer it or take its agent away.
+struct ParkedCaller {
+    agent_id: AgentId,
+    promise_id: Value,
+    caller: JoinHandle<anyhow::Result<DataValue>>,
+}
+
+impl ParkedCaller {
+    /// Waits for the parked call to come back. The outer result says whether it
+    /// was answered at all; the inner one is what it was told.
+    async fn answer_within(
+        mut self,
+        patience: Duration,
+        gave_up: &str,
+    ) -> anyhow::Result<anyhow::Result<DataValue>> {
+        match tokio::time::timeout(patience, &mut self.caller).await {
+            Ok(joined) => Ok(joined?),
+            Err(_) => {
+                self.caller.abort();
+                Err(anyhow!("{gave_up}"))
+            }
+        }
+    }
+
+    /// Completes the promise this caller is parked on, which is what lets the
+    /// invocation it is waiting for finish.
+    async fn complete_the_promise(
+        &self,
+        executor: &TestWorkerExecutor,
+        payload: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        let oplog_idx = extract_oplog_idx_from_promise_id(&self.promise_id);
+        executor
+            .complete_promise(
+                &PromiseId {
+                    agent_id: self.agent_id.clone(),
+                    oplog_idx,
+                },
+                payload,
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Waits for the parked call and returns the value it was given, failing if
+    /// it was not answered in time or was answered with an error.
+    async fn value_within(self, patience: Duration, gave_up: &str) -> anyhow::Result<Value> {
+        self.answer_within(patience, gave_up)
+            .await??
+            .into_return_value()
+            .ok_or_else(|| anyhow!("expected return value"))
+    }
 }
 
 fn extract_oplog_idx_from_promise_id(promise_id_value: &Value) -> OplogIndex {

--- a/golem-worker-service/src/mcp/invoke/test_support.rs
+++ b/golem-worker-service/src/mcp/invoke/test_support.rs
@@ -514,7 +514,7 @@ impl WorkerClient for RecordingWorkerClient {
         _: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
         _: i32,
         _: Option<::prost_types::Timestamp>,
-        _: Option<IdempotencyKey>,
+        _: IdempotencyKey,
         _: Option<InvocationContext>,
         _: EnvironmentId,
         _: AccountId,

--- a/golem-worker-service/src/service/worker/client.rs
+++ b/golem-worker-service/src/service/worker/client.rs
@@ -228,7 +228,7 @@ pub trait WorkerClient: Send + Sync {
         method_parameters: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
         mode: i32,
         schedule_at: Option<::prost_types::Timestamp>,
-        idempotency_key: Option<IdempotencyKey>,
+        idempotency_key: IdempotencyKey,
         invocation_context: Option<InvocationContext>,
         environment_id: EnvironmentId,
         account_id: AccountId,
@@ -1294,7 +1294,7 @@ impl WorkerClient for WorkerExecutorWorkerClient {
         method_parameters: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
         mode: i32,
         schedule_at: Option<::prost_types::Timestamp>,
-        idempotency_key: Option<IdempotencyKey>,
+        idempotency_key: IdempotencyKey,
         invocation_context: Option<InvocationContext>,
         environment_id: EnvironmentId,
         account_id: AccountId,
@@ -1302,28 +1302,34 @@ impl WorkerClient for WorkerExecutorWorkerClient {
         principal: golem_api_grpc::proto::golem::component::Principal,
     ) -> WorkerResult<AgentInvocationOutput> {
         let agent_id = agent_id.clone();
-        let agent_id_clone = agent_id.clone();
+
+        // Built once here, cloned per attempt below. `call_worker_executor`
+        // retries on InvalidShardId and on transport failure, and every attempt
+        // has to be the same request as the first: `invoke_agent_internal` mints
+        // its own idempotency key for a request that arrives without one, so an
+        // attempt that differed here would have the new owner run work that had
+        // already run. Constructing this inside the retry closure is how that
+        // goes wrong, so it does not happen inside the retry closure.
+        let request = workerexecutor::v1::InvokeAgentRequest {
+            agent_id: Some(agent_id.clone().into()),
+            method_name,
+            method_parameters,
+            mode,
+            schedule_at,
+            idempotency_key: Some(idempotency_key.into()),
+            component_owner_account_id: Some(account_id.into()),
+            environment_id: Some(environment_id.into()),
+            auth_ctx: Some(auth_ctx.into()),
+            context: invocation_context,
+            principal: Some(principal),
+        };
 
         let result = self
             .call_worker_executor(
                 agent_id.clone(),
                 "invoke_agent",
                 move |worker_executor_client| {
-                    Box::pin(worker_executor_client.invoke_agent(
-                        workerexecutor::v1::InvokeAgentRequest {
-                            agent_id: Some(agent_id_clone.clone().into()),
-                            method_name: method_name.clone(),
-                            method_parameters: method_parameters.clone(),
-                            mode,
-                            schedule_at,
-                            idempotency_key: idempotency_key.clone().map(|k| k.into()),
-                            component_owner_account_id: Some(account_id.into()),
-                            environment_id: Some(environment_id.into()),
-                            auth_ctx: Some(auth_ctx.clone().into()),
-                            context: invocation_context.clone(),
-                            principal: Some(principal.clone()),
-                        },
-                    ))
+                    Box::pin(worker_executor_client.invoke_agent(request.clone()))
                 },
                 |response| match response.into_inner() {
                     workerexecutor::v1::InvokeAgentResponse {

--- a/golem-worker-service/src/service/worker/service.rs
+++ b/golem-worker-service/src/service/worker/service.rs
@@ -786,6 +786,15 @@ impl WorkerService {
             )
             .await?;
 
+        // One key for the whole logical invocation, never one per attempt.
+        // `call_worker_executor` retries on InvalidShardId and on transport
+        // failures, and `invoke_agent_internal` mints a fresh key for any
+        // request that arrives without one. So a keyless invocation that got
+        // retried used to reach its new owner looking like work nobody had
+        // started, and run a second time. The client below takes a required
+        // key so that cannot be expressed again.
+        let idempotency_key = idempotency_key.unwrap_or_else(IdempotencyKey::fresh);
+
         self.worker_client
             .invoke_agent(
                 agent_id,
@@ -1367,6 +1376,7 @@ mod tests {
     struct RecordingWorkerClient {
         created_agent_ids: Mutex<Vec<AgentId>>,
         invoked_agent_ids: Mutex<Vec<AgentId>>,
+        invoked_idempotency_keys: Mutex<Vec<IdempotencyKey>>,
         invocation_output: AgentInvocationOutput,
     }
 
@@ -1375,12 +1385,17 @@ mod tests {
             Self {
                 created_agent_ids: Mutex::new(Vec::new()),
                 invoked_agent_ids: Mutex::new(Vec::new()),
+                invoked_idempotency_keys: Mutex::new(Vec::new()),
                 invocation_output,
             }
         }
 
         fn created_agent_id(&self) -> AgentId {
             self.created_agent_ids.lock().unwrap()[0].clone()
+        }
+
+        fn invoked_idempotency_key(&self) -> IdempotencyKey {
+            self.invoked_idempotency_keys.lock().unwrap()[0].clone()
         }
 
         fn invoked_agent_id(&self) -> AgentId {
@@ -1594,7 +1609,7 @@ mod tests {
             _: Option<golem_api_grpc::proto::golem::component::UntypedDataValue>,
             _: i32,
             _: Option<::prost_types::Timestamp>,
-            _: Option<IdempotencyKey>,
+            idempotency_key: IdempotencyKey,
             _: Option<InvocationContext>,
             _: EnvironmentId,
             _: AccountId,
@@ -1605,6 +1620,10 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(agent_id.clone());
+            self.invoked_idempotency_keys
+                .lock()
+                .unwrap()
+                .push(idempotency_key);
             Ok(self.invocation_output.clone())
         }
 
@@ -1852,6 +1871,79 @@ mod tests {
         );
         assert_eq!(response.agent_id, harness.worker_client.invoked_agent_id());
         assert!(phantom_id(&response.agent_id).is_some());
+    }
+
+    /// A keyless invocation is given a key, and never a shared one.
+    ///
+    /// `call_worker_executor` retries on `InvalidShardId` and on transport
+    /// failure, re-sending the request as it stands, and `invoke_agent_internal`
+    /// mints a fresh key for any request that arrives without one. So a keyless
+    /// invocation that got retried used to look like work nobody had started and
+    /// run a second time on its new owner. `WorkerClient::invoke_agent` no longer
+    /// accepts an absent key, so the decision happens once, here, above the retry
+    /// loop.
+    ///
+    /// What this checks is that a key is always minted and that unrelated
+    /// invocations never share one. That every *attempt* of a single invocation
+    /// carries the same key is structural rather than covered here: the key is
+    /// bound before the retry closure is built and the closure only clones the
+    /// request. `RecordingWorkerClient` stands above `call_worker_executor`, so
+    /// no test at this seam can see a second attempt at all.
+    ///
+    /// Both REST invocation modes go through the same mint and both are checked,
+    /// since a mint that covered only `Await` would look correct from one call.
+    #[test]
+    async fn keyless_invocations_are_each_given_their_own_key() {
+        let harness = RestHarness::new(AgentMode::Durable);
+
+        // Twice per mode, not once each: a mint that handed every request of one
+        // mode the same constant would still look fine across two different
+        // modes, and only collides with itself.
+        for mode in [AgentInvocationMode::Await, AgentInvocationMode::Schedule] {
+            for _ in 0..2 {
+                let mut request = harness.invoke_request();
+                request.mode = mode.clone();
+                harness
+                    .worker_service
+                    .invoke_agent_rest(request, AuthCtx::system())
+                    .await
+                    .unwrap();
+            }
+        }
+
+        let keys = harness
+            .worker_client
+            .invoked_idempotency_keys
+            .lock()
+            .unwrap()
+            .clone();
+
+        assert_eq!(keys.len(), 4);
+        let distinct: BTreeSet<&str> = keys.iter().map(|key| key.value.as_str()).collect();
+        assert_eq!(
+            distinct.len(),
+            4,
+            "unrelated invocations must not be handed the same key, or one would \
+             join another instead of running: {keys:?}"
+        );
+    }
+
+    /// Minting only ever fills a gap. A key the caller chose is left alone.
+    #[test]
+    async fn a_supplied_idempotency_key_reaches_the_executor_unchanged() {
+        let harness = RestHarness::new(AgentMode::Durable);
+        let chosen = IdempotencyKey::fresh();
+
+        let mut request = harness.invoke_request();
+        request.idempotency_key = Some(chosen.clone());
+
+        harness
+            .worker_service
+            .invoke_agent_rest(request, AuthCtx::system())
+            .await
+            .unwrap();
+
+        assert_eq!(harness.worker_client.invoked_idempotency_key(), chosen);
     }
 
     #[test]


### PR DESCRIPTION
Two bugs, both surfaced by chaos scenario S11 (GOL-377) on golem-dev.

## 1. A caller is never answered once its agent moves

`Worker::wait_for_invocation_result` can end only two ways: the result turns up in this
`Worker`'s own memory, or an `Event::InvocationCompleted` arrives on *this* executor's bus.
Once the agent's shard moves, the agent is resumed by its new owner and the completion is
published over there, so neither exit can fire. There was no timeout and no ownership check,
and the caller waited for as long as it was willing to.

Run 32432046870 killed one executor pod. On the **surviving** executor, 89 callers burned the
full 120s client timeout and only got an answer by retrying, although their agents had been
resumed within ~180ms. The killed pod's own callers recovered in 12-14s, because their
transport died and #3748's reconnect path rerouted them — a healthy transport is exactly what
left the survivor with nothing to notice, so #3748 does not cover this.

**Fixed** by racing the event wait against a 5s ownership re-check. When the agent is no
longer ours the caller is handed `WorkerExecutorError::InvalidShardId`, which worker-service
already maps to invalidate-the-routing-table-and-retry. 120s becomes about 5s. Only
`InvalidShardId` ends the wait; an executor that merely has no assignment yet keeps waiting.
Before giving up, the result is re-read, so a completion that landed during the check beats a
pointless reroute.

## 2. A retried invocation with no idempotency key runs twice

Found while reviewing the fix above. `call_worker_executor` retries by re-sending the request
as it stands, and `invoke_agent_internal` mints a fresh key for any request arriving without
one — so the new owner saw work nobody had started, and ran it a second time.

Not introduced here: it fires on any transport-level failure, which is how the killed pod's
callers recovered above. Fix 1 would only have added one more trigger.

**Fixed** by deciding the key once, above the retry loop. `WorkerClient::invoke_agent` takes
`IdempotencyKey` instead of `Option<IdempotencyKey>`, and `InvokeAgentRequest` is built once
and cloned per attempt rather than rebuilt inside the retry closure.

## Tests

Six, each verified by disabling the fix and confirming that specific test goes red.

| Test | Pins |
| --- | --- |
| `…shard_is_taken_away` | the caller is answered at all; red from its own assertion, not the harness timeout |
| `…shard_comes_back` | that the pair measures a handoff, not the `InterruptKind::Restart` revoking issues |
| `a_result_that_lands_while_ownership_is_being_checked…` | a result landing mid-check beats the reroute |
| `…while_the_shard_assignment_is_missing` | a missing assignment is not a move; also bounds the re-check count, so a spin cannot hide |
| `keyless_invocations_are_each_given_their_own_key` | every invocation gets a key, and never a shared one |
| `a_supplied_idempotency_key_reaches_the_executor_unchanged` | minting only ever fills a gap |

The ownership races needed a seam that did not exist: `#[cfg(test)]` hooks are not set when
the lib is compiled for an integration-test binary. `Bootstrap` gains `create_shard_service`
and `TestExecutorOverrides` gains `wrap_shard_service`; the fake lives in
`golem-worker-executor-test-utils` beside `FailingRpc`.

## Notes for review

- Minting **inside** the retry closure is not test-covered. Both worker-service tests sit
  above `call_worker_executor`, and closing it needs a fake `WorkerExecutor` gRPC server,
  which the repo does not have. Mitigated by building the request outside the closure.
- `custom_api/call_agent/mod.rs:91` still passes `Some(IdempotencyKey::fresh())` into a
  service that now mints its own. Harmless, but a second place that decides. Say the word and
  it becomes `None`.
- The first commit is an unrelated build fix: `golem-worker-executor-test-utils` does not
  compile on rustc 1.98 without a raised `recursion_limit`.

