### PR TITLE
Install Rust quality components in Amp orbs

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -35,6 +35,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 
 rustup update stable --no-self-update
 rustup default stable
+rustup component add clippy rustfmt
 rustup target add wasm32-wasip1 wasm32-wasip2
 
 if ! command -v cargo-binstall >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- install Clippy and rustfmt after updating the orb's latest stable Rust toolchain
- keep `cargo make fix` available when rustup was installed with the minimal profile

## Verification

- `cargo make fix` (Rust 1.98.0)
- `bash -n .agents/setup`
- `.agents/setup` run twice successfully (warm run: 1.7s)

## Build note

`cargo make build` was attempted twice. The full `--workspace --all-targets` build exhausted the 64 GB orb disk during linking (`target/` reached 53 GB), including after `cargo clean`; no source compilation error was reported before disk pressure caused linker failures.
