### PR TITLE
feat(ts-sdk): add route() helper for building endpoint URLs

### DIFF
--- a/docs/src/content/next/invoke/making-custom-apis.mdx
+++ b/docs/src/content/next/invoke/making-custom-apis.mdx
@@ -232,6 +232,28 @@ pub fn MyAgent::serve_file(self : Self, path : String) -> FileData {
 </Tabs.Tab>
 </Tabs>
 
+### Generating URLs for endpoints
+
+In the TypeScript SDK, the `route` helper renders a URL for an endpoint path template, substituting named arguments into its path and query placeholders. This is useful when an agent needs to hand out links to its own endpoints — for example in emails or rendered pages:
+
+```typescript
+import { route } from '@golemcloud/golem-ts-sdk';
+
+// Fully qualified URL, including the deployment host:
+route('/assets/{assetName}', { assetName: 'logo.png' }, { baseUrl: 'mygolemhost.com' })
+// → 'https://mygolemhost.com/assets/logo.png'
+
+// Absolute path only (when no base URL is given):
+route('/assets/{assetName}', { assetName: 'logo.png' })
+// → '/assets/logo.png'
+
+// Inline query parameters are substituted and percent-encoded:
+route('/search?q={term}&page={page}', { term: 'hello world', page: 2 })
+// → '/search?q=hello%20world&page=2'
+```
+
+Every `{var}` placeholder in the template must have a corresponding entry in the arguments record, and unknown entries are rejected. Use the `scheme` option (`'http' | 'https'`, default `'https'`) to control the scheme used when `baseUrl` does not already include one.
+
 ### Response Conventions
 
 Return types control the HTTP response:

--- a/sdks/ts/packages/golem-ts-sdk/src/index.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/index.ts
@@ -54,6 +54,8 @@ export { AgentClassName } from './agentClassName';
 export { CancellationToken } from 'golem:agent/host@2.0.0';
 export { AgentTypeRegistry } from './internal/registry/agentTypeRegistry';
 export * from './webhook';
+export { route } from './route';
+export type { RouteArgs, RouteOptions } from './route';
 export * from './host/hostapi';
 export * as oplog from './host/oplog';
 export * from './host/guard';

--- a/sdks/ts/packages/golem-ts-sdk/src/route.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/route.ts
@@ -1,0 +1,172 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PathSegment } from 'golem:agent/common@2.0.0';
+import { parsePath } from './internal/http/path';
+import { parseQuery } from './internal/http/query';
+
+/**
+ * Options controlling how a routed URL is rendered.
+ */
+export interface RouteOptions {
+  /**
+   * Base URL of the Golem deployment, e.g. `"mygolemhost.com"`.
+   * May include a scheme (`https://mygolemhost.com`), in which case {@link scheme}
+   * is ignored. When omitted, the returned URL is an absolute path
+   * (e.g. `/assets/myasset`).
+   */
+  baseUrl?: string;
+  /**
+   * Scheme used when {@link baseUrl} does not already include one.
+   * Defaults to `'https'`.
+   */
+  scheme?: 'http' | 'https';
+}
+
+/**
+ * Values substituted into an endpoint path template's `{var}` placeholders,
+ * for both path segments and inline query parameters.
+ */
+export type RouteArgs = Record<string, string | number | boolean>;
+
+function splitTemplate(template: string): { pathPart: string; queryPart: string } {
+  const qIdx = template.indexOf('?');
+  return {
+    pathPart: qIdx < 0 ? template : template.slice(0, qIdx),
+    queryPart: qIdx < 0 ? '' : template.slice(qIdx + 1),
+  };
+}
+
+function encodePathValue(value: string, allowSlashes: boolean): string {
+  const encoded = encodeURIComponent(value);
+  // A `{*rest}` catch-all segment legitimately spans multiple path segments,
+  // so its separators must survive encoding.
+  return allowSlashes ? encoded.replace(/%2F/gi, '/') : encoded;
+}
+
+/**
+ * Builds a URL for an HTTP endpoint declared via `method({ http: ... })`,
+ * substituting named arguments into the endpoint's `{var}` path segments and
+ * inline query parameters.
+ *
+ * Mirrors the template syntax accepted by the HTTP routing surface:
+ *
+ * ```ts
+ * import { route } from '@golemcloud/golem-ts-sdk';
+ *
+ * // Fully qualified URL against a deployment host:
+ * route('/assets/{assetName}', { assetName: 'logo.png' }, { baseUrl: 'mygolemhost.com' })
+ * // → 'https://mygolemhost.com/assets/logo.png'
+ *
+ * // Absolute path only:
+ * route('/assets/{assetName}', { assetName: 'logo.png' })
+ * // → '/assets/logo.png'
+ *
+ * // Inline query parameters:
+ * route('/search?q={term}&page={page}', { term: 'hello world', page: 2 })
+ * // → '/search?q=hello%20world&page=2'
+ * ```
+ *
+ * Every `{var}` placeholder in the template (path or query) must have a
+ * corresponding entry in `args`; conversely, unknown entries are rejected.
+ * Values are percent-encoded; a `{*rest}` catch-all variable preserves `/`
+ * separators so multi-segment paths remain valid.
+ *
+ * Note that the template is an endpoint path relative to the agent's HTTP
+ * mount. If the mount prefix contains variables (including the system
+ * variables `{agent-type}` / `{agent-version}`), pass their values as regular
+ * entries in `args` and include the prefix in the template.
+ *
+ * @param template - Endpoint path template, e.g. `/assets/{assetName}` or
+ *   `/add?by={by}`.
+ * @param args - Named values for every variable referenced by the template.
+ * @param options - Optional base URL / scheme controls.
+ * @returns The rendered URL string.
+ * @throws If the template is malformed or the arguments do not match it.
+ */
+export function route(template: string, args: RouteArgs = {}, options: RouteOptions = {}): string {
+  const { pathPart, queryPart } = splitTemplate(template);
+
+  const segments: PathSegment[] = parsePath(pathPart);
+  const queryVars = queryPart ? parseQuery(queryPart) : [];
+
+  const missing: string[] = [];
+  const consume = (variableName: string): string => {
+    const value = args[variableName];
+    if (value === undefined) {
+      missing.push(variableName);
+      return '';
+    }
+    return String(value);
+  };
+
+  let path = '';
+  for (const segment of segments) {
+    switch (segment.tag) {
+      case 'literal':
+        path += `/${segment.val}`;
+        break;
+      case 'path-variable':
+        path += `/${encodePathValue(consume(segment.val.variableName), false)}`;
+        break;
+      case 'remaining-path-variable':
+        path += `/${encodePathValue(consume(segment.val.variableName), true)}`;
+        break;
+      case 'system-variable':
+        path += `/${encodePathValue(consume(segment.val), false)}`;
+        break;
+    }
+  }
+
+  let query = '';
+  for (const [index, { queryParamName, variableName }] of queryVars.entries()) {
+    const separator = index === 0 ? '?' : '&';
+    query += `${separator}${encodeURIComponent(queryParamName)}=${encodeURIComponent(consume(variableName))}`;
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing value(s) for route variable(s): ${missing.map((n) => `"${n}"`).join(', ')}`,
+    );
+  }
+
+  const known = new Set<string>();
+  for (const segment of segments) {
+    if (segment.tag === 'path-variable' || segment.tag === 'remaining-path-variable') {
+      known.add(segment.val.variableName);
+    } else if (segment.tag === 'system-variable') {
+      known.add(segment.val);
+    }
+  }
+  for (const { variableName } of queryVars) {
+    known.add(variableName);
+  }
+  for (const name of Object.keys(args)) {
+    if (!known.has(name)) {
+      throw new Error(`Unknown route argument "${name}"`);
+    }
+  }
+
+  const baseUrl = options.baseUrl?.trim();
+  if (!baseUrl) {
+    return path + query;
+  }
+
+  const stripped = baseUrl.replace(/\/+$/, '');
+  const prefixed = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(stripped)
+    ? stripped
+    : `${options.scheme ?? 'https'}://${stripped}`;
+
+  return `${prefixed}${path}${query}`;
+}

--- a/sdks/ts/packages/golem-ts-sdk/tests/route.test.ts
+++ b/sdks/ts/packages/golem-ts-sdk/tests/route.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { route } from '../src/route';
+
+describe('route()', () => {
+  describe('absolute paths (no baseUrl)', () => {
+    it('substitutes a single path variable', () => {
+      expect(route('/assets/{assetName}', { assetName: 'logo.png' })).toBe('/assets/logo.png');
+    });
+
+    it('renders literal-only templates unchanged', () => {
+      expect(route('/health', {})).toBe('/health');
+    });
+
+    it('substitutes multiple path variables', () => {
+      expect(route('/a/{x}/b/{y}', { x: '1', y: '2' })).toBe('/a/1/b/2');
+    });
+
+    it('percent-encodes substituted values', () => {
+      expect(route('/files/{name}', { name: 'a b/c?d' })).toBe('/files/a%20b%2Fc%3Fd');
+    });
+
+    it('coerces numeric and boolean args', () => {
+      expect(route('/items/{id}/flag/{on}', { id: 42, on: true })).toBe('/items/42/flag/true');
+    });
+
+    it('keeps slashes for a remaining-path variable', () => {
+      expect(route('/static/{*rest}', { rest: 'img/icons/logo.svg' })).toBe(
+        '/static/img/icons/logo.svg',
+      );
+    });
+
+    it('appends inline query parameters', () => {
+      expect(route('/search?q={term}&page={page}', { term: 'hello world', page: 2 })).toBe(
+        '/search?q=hello%20world&page=2',
+      );
+    });
+
+    it('reuses one arg when a variable appears in both path and query', () => {
+      expect(route('/users/{name}?u={name}', { name: 'amy' })).toBe('/users/amy?u=amy');
+    });
+
+    it('encodes query parameter names and values', () => {
+      expect(route('/lookup?a b={v}', { v: 'x&y' })).toBe('/lookup?a%20b=x%26y');
+    });
+  });
+
+  describe('fully qualified URLs (baseUrl)', () => {
+    it('prefixes a bare host with https by default', () => {
+      expect(
+        route('/assets/{assetName}', { assetName: 'logo.png' }, { baseUrl: 'mygolemhost.com' }),
+      ).toBe('https://mygolemhost.com/assets/logo.png');
+    });
+
+    it('honours the http scheme flag', () => {
+      expect(
+        route(
+          '/assets/{assetName}',
+          { assetName: 'logo.png' },
+          { baseUrl: 'mygolemhost.com', scheme: 'http' },
+        ),
+      ).toBe('http://mygolemhost.com/assets/logo.png');
+    });
+
+    it('keeps the scheme embedded in baseUrl', () => {
+      expect(route('/x', {}, { baseUrl: 'http://example.com', scheme: 'https' })).toBe(
+        'http://example.com/x',
+      );
+    });
+
+    it('strips trailing slashes from baseUrl', () => {
+      expect(route('/x', {}, { baseUrl: 'example.com///' })).toBe('https://example.com/x');
+    });
+
+    it('includes the query string in qualified URLs', () => {
+      expect(route('/add?by={by}', { by: 5 }, { baseUrl: 'example.com' })).toBe(
+        'https://example.com/add?by=5',
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('throws listing missing path variables', () => {
+      expect(() => route('/a/{x}/b/{y}', { x: '1' })).toThrow(
+        'Missing value(s) for route variable(s): "y"',
+      );
+    });
+
+    it('throws listing missing query variables', () => {
+      expect(() => route('/search?q={term}', {})).toThrow('"term"');
+    });
+
+    it('throws on unknown arguments', () => {
+      expect(() => route('/a/{x}', { x: '1', extra: 'nope' })).toThrow(
+        'Unknown route argument "extra"',
+      );
+    });
+
+    it('rejects templates that do not start with "/"', () => {
+      expect(() => route('assets/{name}', { name: 'x' })).toThrow();
+    });
+
+    it('rejects invalid query segments', () => {
+      expect(() => route('/search?q={term}&oops', { term: 'x' })).toThrow();
+    });
+
+    it('rejects empty string templates', () => {
+      expect(() => route('', {})).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `route()` helper to the TypeScript SDK that renders URLs for HTTP endpoint path templates, substituting named arguments into `{var}` path segments and inline query parameters.

Closes #3694

## Behavior

- **Fully qualified URLs** via optional `baseUrl` / `scheme` (`'http' | 'https'`, default `https`); returns an **absolute path** when no base URL is given
- **Validation**: every template variable (path or query) must have a provided argument; unknown arguments are rejected with a clear error listing the offending name(s)
- **Encoding**: values are percent-encoded; a `{*rest}` catch-all preserves `/` separators so multi-segment paths stay valid
- Reuses the existing `parsePath`/`parseQuery` parsers from `src/internal/http`, so template validation errors match the rest of the HTTP surface
- One argument can feed a variable used in both path and query positions

```ts
import { route } from '@golemcloud/golem-ts-sdk';

route('/assets/{assetName}', { assetName: 'logo.png' }, { baseUrl: 'mygolemhost.com' })
// → 'https://mygolemhost.com/assets/logo.png'

route('/assets/{assetName}', { assetName: 'logo.png' })
// → '/assets/logo.png'

route('/search?q={term}&page={page}', { term: 'hello world', page: 2 })
// → '/search?q=hello%20world&page=2'
```

Note on the hostname requirement from #3694: the host API currently exposes no way for a guest to discover its deployment's public base URL, so fully qualified output requires an explicit `baseUrl`. If a host-side base-URL getter is added later, `route()` can default to it without an API change.

## Testing

- 20 new unit tests in `tests/route.test.ts` covering substitution, encoding, catch-all segments, query params, scheme/baseUrl handling, and all validation errors — all passing
- `pnpm run lint` and `pnpm run format:check` clean for the touched files
- Docs: added a "Generating URLs for endpoints" section to `making-custom-apis.mdx`