### PR TITLE
Update test-r to 3.0.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ permissions:
 env:
   BUILD_TARGET: "x86_64-unknown-linux-gnu"
   WASM_RQUICKJS_VERSION: "0.4.1"
-  MOONBIT_INSTALL_VERSION: "0.10.1+a46be2066"
+  MOONBIT_INSTALL_VERSION: "0.10.2+1bb3e16cf"
   WASI_SDK_VERSION: "25"
   WASI_SDK_PATH: /opt/wasi-sdk
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7886,9 +7886,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -10084,9 +10084,9 @@ dependencies = [
 
 [[package]]
 name = "test-r"
-version = "3.0.11"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a37b0a7d3976dccffa7df6aae2dba4127093484ec6376b658d6902e2b44d9f"
+checksum = "1dfad2a3c321239151d31a82d84e9ba64ce954c1248e3e945cec27f580b54040"
 dependencies = [
  "ctor",
  "test-r-core",
@@ -10096,9 +10096,9 @@ dependencies = [
 
 [[package]]
 name = "test-r-core"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f1fc242d348bea66fb6204811b77d55a726cf043db4e256c8a6e78c6d62a7a"
+checksum = "b178477fa5ca92289c2241984b0c1f806204c0ae8513ee7530389d3e500888fb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -10113,7 +10113,7 @@ dependencies = [
  "interprocess",
  "libc",
  "parking_lot",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "rand 0.10.2",
  "serde_json",
  "tokio",
@@ -10124,9 +10124,9 @@ dependencies = [
 
 [[package]]
 name = "test-r-macro"
-version = "1.4.11"
+version = "1.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c63874a7c31d8c0dba68e6dcc8809470dfb54002407b90831ea1cf86dca167f"
+checksum = "de99e4f567d527d1f953f9e7d3c521545f65e4dd1f6db1081abf1d23b7ac7866"
 dependencies = [
  "darling 0.21.3",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ system-interface = "0.27.3"
 tap = "1.0.1"
 tempfile = "3.18.0"
 terminal_size = "0.4.2"
-test-r = { version = "3.0.11", default-features = true }
+test-r = { version = "3.0.12", default-features = true }
 testcontainers = { version = "0.27.1" }
 testcontainers-modules = { version = "0.15.0", features = ["postgres", "redis", "minio", "mysql", ] }
 textwrap = "0.16.1"

--- a/golem-test-framework/src/dsl/mod.rs
+++ b/golem-test-framework/src/dsl/mod.rs
@@ -31,6 +31,7 @@ use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::agent::AgentTypeName;
 use golem_common::model::agent::ParsedAgentId;
 use golem_common::model::application::{Application, ApplicationId};
+use golem_common::model::card::parse_polymorphic_permission;
 use golem_common::model::card::recipient::RecipientPattern;
 use golem_common::model::component::{
     AgentFilePermissions, AgentTypeInitialPermissions, AgentTypeProvisionConfigCreation,
@@ -902,13 +903,31 @@ impl<'a, Dsl: TestDsl + ?Sized> StoreComponentBuilder<'a, Dsl> {
         self
     }
 
-    /// Starts an agent type without default host permissions.
+    /// Starts an agent type without default host permissions except Golem-provided runtime
+    /// metadata.
     pub fn without_default_host_permissions(mut self, agent_type: &str) -> Self {
+        let recipient = RecipientPattern::Account {
+            account: self.dsl.account_email(),
+        }
+        .render();
+        let runtime_metadata = [
+            "GOLEM_AGENT_ID",
+            "GOLEM_AGENT_TYPE",
+            "GOLEM_WORKER_NAME",
+            "GOLEM_COMPONENT_ID",
+            "GOLEM_COMPONENT_REVISION",
+        ]
+        .into_iter()
+        .map(|name| {
+            parse_polymorphic_permission(&format!("env(?agent) @ {recipient} : read : {name}"))
+                .expect("valid Golem-provided runtime metadata permission")
+        })
+        .collect();
         self.agent_type_provision_configs.insert(
             AgentTypeName(agent_type.to_string()),
             AgentTypeProvisionConfigCreation {
                 initial_permissions: AgentTypeInitialPermissions::from_patterns(
-                    Vec::new(),
+                    runtime_metadata,
                     Vec::new(),
                     Vec::new(),
                     Vec::new(),

--- a/golem-worker-executor/src/durable_host/golem/agent.rs
+++ b/golem-worker-executor/src/durable_host/golem/agent.rs
@@ -642,18 +642,18 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             anyhow!("Expected config type for path {path_str} is not a valid schema graph: {e}")
         })?;
 
+        let is_secret_config = self.parsed_agent_id().is_some_and(|agent_id| {
+            self.owner_component_metadata()
+                .metadata
+                .find_agent_type_by_name(&agent_id.agent_type)
+                .is_some_and(|agent_type| {
+                    agent_type.config.iter().any(|entry| {
+                        entry.path == path && entry.source == AgentConfigSource::Secret
+                    })
+                })
+        });
         let is_live = self.state.is_live();
         let denied = if is_live {
-            let is_secret_config = self.parsed_agent_id().is_some_and(|agent_id| {
-                self.owner_component_metadata()
-                    .metadata
-                    .find_agent_type_by_name(&agent_id.agent_type)
-                    .is_some_and(|agent_type| {
-                        agent_type.config.iter().any(|entry| {
-                            entry.path == path && entry.source == AgentConfigSource::Secret
-                        })
-                    })
-            });
             let targets = config_segments_target(agent_owner(self), &path)
                 .map_err(|_| ())
                 .and_then(|target| {
@@ -671,124 +671,94 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             false
         };
 
-        let begun = CallHandle::<GolemAgentGetConfigValue, NotCancellable>::begin(
+        let uses_resolver = is_secret_config;
+        let handle = CallHandle::<GolemAgentGetConfigValue, NotCancellable>::start(
             self,
+            HostRequestGolemAgentGetConfigValue {
+                path: path.clone(),
+                expected_type: expected_graph.clone(),
+            },
             DurableFunctionType::ReadRemote,
         )
         .await?;
-        let request = HostRequestGolemAgentGetConfigValue {
-            path: path.clone(),
-            expected_type: expected_graph.clone(),
-        };
-        let mut handle = if begun.is_live() {
-            begun.start_live(self, request).await?
-        } else {
-            begun.start_replay(self).await?
-        };
-
-        let persisted = 'response: {
-            if !handle.is_live() {
-                match handle.replay(self).await? {
-                    CallReplayOutcome::Replayed(response) => break 'response (response, true),
-                    CallReplayOutcome::Incomplete(live) => handle = live,
+        let response = handle
+            .run(self, async move |ctx| {
+                if denied {
+                    return Ok(HostResponseGolemAgentGetConfigValue {
+                        result: Err("permission denied".to_string()),
+                    });
                 }
-            }
-            if denied {
-                break 'response (
-                    handle
-                        .complete(
-                            self,
-                            HostResponseGolemAgentGetConfigValue {
-                                result: Err("permission denied".to_string()),
-                            },
+
+                let agent_id = ctx
+                    .parsed_agent_id()
+                    .ok_or_else(|| anyhow!("only agentic workers can access agent config"))?;
+
+                let agent_type = ctx
+                    .owner_component_metadata()
+                    .metadata
+                    .find_agent_type_by_name(&agent_id.agent_type)
+                    .expect("Active agent type of agent was not declared in component metadata");
+
+                let declaration = agent_type.config.iter().find(|c| c.path == path);
+                let declaration_value_type = declaration.map(|d| d.value_type.clone());
+
+                let schema_value = match declaration {
+                    // Allow reading undeclared optional config keys so that
+                    // newer agents can run against older component schemas.
+                    None if matches!(
+                        resolve_schema_ref(&expected_graph, &expected_graph.root),
+                        SchemaType::Option { .. }
+                    ) =>
+                    {
+                        SchemaValue::Option { inner: None }
+                    }
+                    None => return Err(anyhow!("No config declared for path {path_str}")),
+                    Some(declaration) if declaration.source == AgentConfigSource::Local => ctx
+                        .resolve_local_config(
+                            &path,
+                            &path_str,
+                            &expected_graph,
+                            &expected_graph.root,
+                            &agent_type.schema,
+                            declaration_value_type
+                                .as_ref()
+                                .expect("existing config declaration must have a value type"),
+                        )?,
+                    Some(declaration) if declaration.source == AgentConfigSource::Secret => {
+                        ctx.resolve_secret_config(
+                            path,
+                            &path_str,
+                            expected_graph,
+                            &agent_type.schema,
+                            declaration_value_type
+                                .as_ref()
+                                .expect("existing config declaration must have a value type"),
                         )
-                        .await?,
-                    false,
-                );
-            }
+                        .await?
+                    }
+                    Some(declaration) => {
+                        return Err(anyhow!(
+                            "Unsupported config source {:?} for path {path_str}",
+                            declaration.source
+                        ));
+                    }
+                };
 
-            let agent_id = self
-                .parsed_agent_id()
-                .ok_or_else(|| anyhow!("only agentic workers can access agent config"))?;
+                Ok(HostResponseGolemAgentGetConfigValue {
+                    result: Ok(schema_value),
+                })
+            })
+            .await?;
 
-            let agent_type = self
-                .owner_component_metadata()
-                .metadata
-                .find_agent_type_by_name(&agent_id.agent_type)
-                .expect("Active agent type of agent was not declared in component metadata");
-
-            let declaration = agent_type.config.iter().find(|c| c.path == path);
-
-            let declaration_value_type = declaration.map(|d| d.value_type.clone());
-
-            let (schema_value, uses_resolver): (SchemaValue, bool) = match declaration {
-                // Allow reading undeclared optional config keys so that
-                // newer agents can run against older component schemas.
-                None if matches!(
-                    resolve_schema_ref(&expected_graph, &expected_graph.root),
-                    SchemaType::Option { .. }
-                ) =>
-                {
-                    (SchemaValue::Option { inner: None }, false)
-                }
-                None => return Err(anyhow!("No config declared for path {path_str}")),
-                Some(declaration) if declaration.source == AgentConfigSource::Local => (
-                    self.resolve_local_config(
-                        &path,
-                        &path_str,
-                        &expected_graph,
-                        &expected_graph.root,
-                        &agent_type.schema,
-                        declaration_value_type
-                            .as_ref()
-                            .expect("existing config declaration must have a value type"),
-                    )?,
-                    false,
-                ),
-                Some(declaration) if declaration.source == AgentConfigSource::Secret => (
-                    self.resolve_secret_config(
-                        path,
-                        &path_str,
-                        expected_graph,
-                        &agent_type.schema,
-                        declaration_value_type
-                            .as_ref()
-                            .expect("existing config declaration must have a value type"),
-                    )
-                    .await?,
-                    true,
-                ),
-                Some(declaration) => {
-                    return Err(anyhow!(
-                        "Unsupported config source {:?} for path {path_str}",
-                        declaration.source
-                    ));
-                }
-            };
-
-            // Encode the schema-native value into the wire value tree returned
-            // across the `golem:agent/host@2.0.0` boundary. Secret-backed config is
-            // the only capability-minting source here; local config still uses the
-            // pure encoder so a quota token remains a schema/config error.
-            let response = handle
-                .complete(
-                    self,
-                    HostResponseGolemAgentGetConfigValue {
-                        result: Ok(schema_value),
-                    },
-                )
-                .await?;
-            break 'response (response, uses_resolver);
-        };
-
-        let (schema_value, uses_resolver) = match persisted {
-            (HostResponseGolemAgentGetConfigValue { result: Ok(value) }, uses_resolver) => {
-                (value, uses_resolver)
-            }
-            (HostResponseGolemAgentGetConfigValue { result: Err(_) }, _) => {
+        let schema_value = match response {
+            HostResponseGolemAgentGetConfigValue { result: Ok(value) } => value,
+            HostResponseGolemAgentGetConfigValue { result: Err(_) } => {
                 return Ok(Err(ConfigValueError::PermissionDenied));
             }
         };
+
+        // Secret-backed config is the only capability-minting source here. Local config uses the
+        // pure encoder so a quota token remains a schema/config error.
         let encoded = if uses_resolver {
             encode_value_with(&schema_value, self)
         } else {

--- a/golem-worker-executor/tests/instance_layer.rs
+++ b/golem-worker-executor/tests/instance_layer.rs
@@ -1624,7 +1624,7 @@ async fn entity_filesystem_streams_share_root_and_block_executor_inspection(
                     store,
                     &parsed_agent_id,
                     principal,
-                    "stream_to_file",
+                    "write_zeroes_to_file_via_stream",
                     data_value!("/entity-stream.bin", 131_072_u64)
                         .value()
                         .clone(),
@@ -1742,7 +1742,7 @@ async fn filesystem_capable_entity_stream_reconstructs_on_clean_owner_replay(
                     store,
                     &parsed_agent_id,
                     live_principal.clone(),
-                    "stream_to_file",
+                    "write_zeroes_to_file_via_stream",
                     data_value!("/entity-replayed-stream.bin", 1024_u64)
                         .value()
                         .clone(),
@@ -1813,7 +1813,7 @@ async fn filesystem_capable_entity_stream_reconstructs_on_clean_owner_replay(
                     store,
                     &parsed_agent_id,
                     principal.clone(),
-                    "stream_to_file",
+                    "write_zeroes_to_file_via_stream",
                     data_value!("/entity-replayed-stream.bin", 1024_u64)
                         .value()
                         .clone(),

--- a/golem-worker-executor/tests/lib.rs
+++ b/golem-worker-executor/tests/lib.rs
@@ -124,6 +124,7 @@ sequential_suite!(key_value_storage);
 sequential_suite!(namespace_routed_key_value_storage);
 sequential_suite!(indexed_storage);
 sequential_suite!(oplog_blob_archive);
+sequential_suite!(resource_limits);
 
 #[derive(Debug)]
 pub struct Tracing;

--- a/golem-worker-executor/tests/scope_cards.rs
+++ b/golem-worker-executor/tests/scope_cards.rs
@@ -1707,7 +1707,7 @@ async fn filesystem_admitted_write_stream_survives_revocation_and_crash_replay(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/denied.txt", 1u64),
         )
         .await?
@@ -3320,6 +3320,7 @@ async fn remaining_host_facing_permission_classes_allow_their_backends(
         })
         .try_update_agent_provision_config("GolemHostApi", |config| {
             for grant in [
+                "agent(?agent) @ * : view : *",
                 "config(?agent) @ * : read : private",
                 "oplog(?agent) @ * : read : *",
                 "tool(?env/*/*) @ * : invoke : *",
@@ -4202,13 +4203,6 @@ async fn assert_environment_observes_revocation_at_the_next_host_boundary(
     let component = executor
         .component_dep(&context.default_environment_id, host_api_tests)
         .without_default_host_permissions("Environment")
-        .update_agent_provision_config("Environment", |config| {
-            config
-                .initial_permissions
-                .lower_bound
-                .positive
-                .push(env_permission("GOLEM_AGENT_ID"));
-        })
         .store()
         .await?;
     let agent = agent_id!(
@@ -4257,10 +4251,18 @@ async fn assert_environment_observes_revocation_at_the_next_host_boundary(
         .await?
         .into_typed::<Result<Vec<(String, String)>, String>>()?
         .map_err(anyhow::Error::msg)?;
-    assert!(
-        environment.iter().all(|(name, _)| name != "GOLEM_AGENT_ID"),
-        "revoked environment authority must disappear at the next host boundary"
-    );
+    for metadata_name in [
+        "GOLEM_AGENT_ID",
+        "GOLEM_AGENT_TYPE",
+        "GOLEM_WORKER_NAME",
+        "GOLEM_COMPONENT_ID",
+        "GOLEM_COMPONENT_REVISION",
+    ] {
+        assert!(
+            environment.iter().all(|(name, _)| name != metadata_name),
+            "revoked environment authority for {metadata_name} must disappear at the next host boundary"
+        );
+    }
     Ok(())
 }
 
@@ -4301,13 +4303,6 @@ async fn assert_environment_replay_uses_the_recorded_filtered_result(
     let component = executor
         .component_dep(&context.default_environment_id, host_api_tests)
         .without_default_host_permissions("Environment")
-        .update_agent_provision_config("Environment", |config| {
-            config
-                .initial_permissions
-                .lower_bound
-                .positive
-                .push(env_permission("GOLEM_AGENT_ID"));
-        })
         .store()
         .await?;
     let agent = agent_id!(
@@ -4356,11 +4351,23 @@ async fn assert_environment_replay_uses_the_recorded_filtered_result(
         .await?
         .into_typed::<Result<Vec<(String, String)>, String>>()?
         .map_err(anyhow::Error::msg)?;
+    for metadata_name in [
+        "GOLEM_AGENT_ID",
+        "GOLEM_AGENT_TYPE",
+        "GOLEM_WORKER_NAME",
+        "GOLEM_COMPONENT_ID",
+        "GOLEM_COMPONENT_REVISION",
+    ] {
+        assert!(
+            environment.iter().any(|(name, _)| name == metadata_name),
+            "replay must return the {metadata_name} value recorded before revocation"
+        );
+    }
     assert!(
         environment
             .iter()
             .any(|(name, value)| { name == "GOLEM_AGENT_ID" && value == &agent.to_string() }),
-        "replay must return the environment response recorded before revocation"
+        "replay must return the expected GOLEM_AGENT_ID value"
     );
     Ok(())
 }

--- a/golem-worker-executor/tests/storage_quota.rs
+++ b/golem-worker-executor/tests/storage_quota.rs
@@ -333,14 +333,14 @@ async fn agent_quota_stream_write_exceeding_limit_fails(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/stream.bin", 1024u64),
         )
         .await;
 
     assert!(
         result.is_err(),
-        "expected stream_to_file to fail when quota exceeded"
+        "expected write_zeroes_to_file_via_stream to fail when quota exceeded"
     );
     let err_str = format!("{result:?}");
     assert!(
@@ -381,7 +381,7 @@ async fn agent_quota_stream_write_within_limit_succeeds(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/stream.bin", 1024u64),
         )
         .await?;
@@ -421,11 +421,14 @@ async fn executor_pool_stream_write_failed_attempt_does_not_leak_pool_permits(
         .invoke_and_await_agent(
             &component,
             &failing_agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/big.bin", 2 * 1024 * 1024u64),
         )
         .await;
-    assert!(failed.is_err(), "expected oversized stream_to_file to fail");
+    assert!(
+        failed.is_err(),
+        "expected oversized write_zeroes_to_file_via_stream to fail"
+    );
 
     // A second worker should still be able to allocate and write if the first
     // worker's failed attempt released pool permits.
@@ -438,7 +441,7 @@ async fn executor_pool_stream_write_failed_attempt_does_not_leak_pool_permits(
         .invoke_and_await_agent(
             &component,
             &succeeding_agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/small.bin", 1024u64),
         )
         .await?;
@@ -453,8 +456,8 @@ async fn executor_pool_stream_write_failed_attempt_does_not_leak_pool_permits(
     Ok(())
 }
 
-/// Overwriting the same file with `stream_to_file` must not double-charge
-/// quota when the file does not grow.
+/// Overwriting the same file with `write_zeroes_to_file_via_stream` must not
+/// double-charge quota when the file does not grow.
 #[test]
 #[tracing::instrument]
 #[timeout("2m")]
@@ -481,7 +484,7 @@ async fn agent_quota_stream_overwrite_same_file_should_not_double_charge(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/same-stream.bin", 1024u64),
         )
         .await?;
@@ -490,7 +493,7 @@ async fn agent_quota_stream_overwrite_same_file_should_not_double_charge(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/same-stream.bin", 1024u64),
         )
         .await?;
@@ -896,8 +899,8 @@ async fn agent_quota_pwrite_overwrite_same_range_should_not_double_charge(
 }
 
 /// Storage quota is cumulative across write paths. Writing via `write_file`
-/// and then via `stream_to_file` both count against the same per-agent
-/// quota. If their combined sizes exceed the limit, the second write fails.
+/// and then via `write_zeroes_to_file_via_stream` both count against the same
+/// per-agent quota. If their combined sizes exceed the limit, the second write fails.
 #[test]
 #[tracing::instrument]
 #[timeout("2m")]
@@ -909,7 +912,8 @@ async fn agent_quota_cumulative_across_write_paths(
 ) -> anyhow::Result<()> {
     let context = TestContext::new(last_unique_id);
     // 15-byte quota. First write: 11 bytes ("hello world") via write_file.
-    // Second write: 8 bytes via stream_to_file — combined 19 bytes > 15 → fails.
+    // Second write: 8 bytes via write_zeroes_to_file_via_stream — combined
+    // 19 bytes > 15 → fails.
     let executor = start_with_agent_storage_quota(deps, &context, 15).await?;
 
     let component = executor
@@ -937,14 +941,14 @@ async fn agent_quota_cumulative_across_write_paths(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/stream.bin", 8u64),
         )
         .await;
 
     assert!(
         result.is_err(),
-        "expected stream_to_file to fail: combined writes exceed quota"
+        "expected write_zeroes_to_file_via_stream to fail: combined writes exceed quota"
     );
     let err_str = format!("{result:?}");
     assert!(

--- a/golem-worker-executor/tests/wasi.rs
+++ b/golem-worker-executor/tests/wasi.rs
@@ -3492,7 +3492,7 @@ async fn filesystem_write_via_stream_replay_restores_file_times(
         .invoke_and_await_agent(
             &component,
             &agent_id,
-            "stream_to_file",
+            "write_zeroes_to_file_via_stream",
             data_value!("/testfile.txt", 131_072_u64),
         )
         .await?;

--- a/integration-tests/tests/agent_config_live_mutation.rs
+++ b/integration-tests/tests/agent_config_live_mutation.rs
@@ -23,7 +23,7 @@ use golem_test_framework::config::{
     WorkerExecutorClusterControlStub,
 };
 use std::sync::Arc;
-use test_r::{define_matrix_dimension, matrix_suite, tag_suite, test, test_dep};
+use test_r::{define_matrix_dimension, matrix_suite, tag, tag_suite, test, test_dep};
 
 test_r::enable!();
 
@@ -31,8 +31,8 @@ tag_suite!(shared_agent_config_live_mutation, group8);
 
 // Matrix dimension for the DB backend. The `shared_agent_config_live_mutation`
 // module is runtime-multiplied via `matrix_suite!` below (zero per-test
-// annotations), while the crate-root `redis_control_round_trip` smoke test uses
-// a per-test `#[dimension(db)]` since it lives outside any named module.
+// annotations), while the crate-root smoke tests explicitly select one matching
+// dependency pair for each backend.
 define_matrix_dimension!(db: EnvBasedTestDependencies -> "postgres", "sqlite");
 
 matrix_suite!(
@@ -197,14 +197,32 @@ pub fn tracing() -> Tracing {
 // worker subprocess receives both the descriptor-reconstructed
 // `EnvBasedTestDependencies` and a `WorkerExecutorClusterControlStub` for the same
 // parent-held owner, and the two views agree about the underlying
-// parent-owned Redis instance.
+// parent-owned Redis instance. Both views are tagged explicitly so dependency
+// selection cannot pair a matrix-selected descriptor with the default owner.
 //
 // Runs in <1s and only exercises the RPC channel, so it's safe to
 // keep in this binary alongside the heavier agent-config live-mutation
 // suites.
 #[test]
-async fn redis_control_round_trip(
-    #[dimension(db)] deps: &EnvBasedTestDependencies,
+#[tag(db_postgres)]
+async fn redis_control_round_trip_postgres(
+    #[tagged_as("postgres")] deps: &EnvBasedTestDependencies,
+    #[tagged_as("postgres")] redis_control: &WorkerExecutorClusterControlStub,
+) {
+    assert_redis_control_round_trip(deps, redis_control).await;
+}
+
+#[test]
+#[tag(db_sqlite)]
+async fn redis_control_round_trip_sqlite(
+    #[tagged_as("sqlite")] deps: &EnvBasedTestDependencies,
+    #[tagged_as("sqlite")] redis_control: &WorkerExecutorClusterControlStub,
+) {
+    assert_redis_control_round_trip(deps, redis_control).await;
+}
+
+async fn assert_redis_control_round_trip(
+    deps: &EnvBasedTestDependencies,
     redis_control: &WorkerExecutorClusterControlStub,
 ) {
     // Parent-owned Redis must be reachable from a worker via the

--- a/integration-tests/tests/permissions.rs
+++ b/integration-tests/tests/permissions.rs
@@ -283,6 +283,7 @@ async fn filesystem_permissions_enforce_recipient_isolation_across_recovery(
         .name(component_name)
         .without_default_host_permissions("FileSystem")
         .try_update_agent_provision_config("FileSystem", |config| {
+            config.initial_permissions.lower_bound.positive.clear();
             for grant in [
                 format!(
                     "env(?agent) @ {} : read : GOLEM_AGENT_ID",

--- a/sdks/scala/test-agents/src/main/scala/example/integrationtests/HostApiExplorerImpl.scala
+++ b/sdks/scala/test-agents/src/main/scala/example/integrationtests/HostApiExplorerImpl.scala
@@ -164,11 +164,15 @@ final class HostApiExplorerImpl(@unused private val name: String) extends HostAp
   private def exploreRdbmsSync(): String = {
     val sb = new StringBuilder
 
-    val pgResult = golem.host.Rdbms.Postgres.open("postgresql://invalid:5432/test")
-    sb.append(s"Rdbms.Postgres.open() = ${pgResult.left.map(_.getClass.getSimpleName)}\n")
+    val pgResult = golem.host.Rdbms.Postgres
+      .open("postgresql://invalid:5432/test")
+      .flatMap(_.query("SELECT 1"))
+    sb.append(s"Rdbms.Postgres.query() = ${pgResult.left.map(_.getClass.getSimpleName)}\n")
 
-    val myResult = golem.host.Rdbms.Mysql.open("mysql://invalid:3306/test")
-    sb.append(s"Rdbms.Mysql.open() = ${myResult.left.map(_.getClass.getSimpleName)}\n")
+    val myResult = golem.host.Rdbms.Mysql
+      .open("mysql://invalid:3306/test")
+      .flatMap(_.query("SELECT 1"))
+    sb.append(s"Rdbms.Mysql.query() = ${myResult.left.map(_.getClass.getSimpleName)}\n")
 
     sb.toString()
   }

--- a/test-components/host-api-tests/src/file_system.rs
+++ b/test-components/host-api-tests/src/file_system.rs
@@ -73,7 +73,7 @@ pub trait FileSystem {
         release: PromiseId,
     ) -> Result<(), String>;
     fn hash(&self, path: String) -> Result<HashResult, String>;
-    fn stream_to_file(&self, path: String, len: u64) -> Result<(), String>;
+    fn write_zeroes_to_file_via_stream(&self, path: String, len: u64) -> Result<(), String>;
     fn stream_to_stdout(&self, len: u64) -> Result<(), String>;
     fn blocking_stream_and_flush_to_file(&self, path: String, len: u64) -> Result<(), String>;
     /// Set the size of a file using `descriptor::set_size` (the WASI pwrite-truncate path).
@@ -288,7 +288,7 @@ impl FileSystem for FileSystemImpl {
             .map_err(|e| format!("{e:?}"))
     }
 
-    fn stream_to_file(&self, path: String, len: u64) -> Result<(), String> {
+    fn write_zeroes_to_file_via_stream(&self, path: String, len: u64) -> Result<(), String> {
         let dirs = wasi::filesystem::preopens::get_directories();
         let (root, _) = dirs.into_iter().next().ok_or("no preopened directory")?;
         let rel = path.trim_start_matches('/');
@@ -301,7 +301,9 @@ impl FileSystem for FileSystemImpl {
             )
             .map_err(|e| format!("{e:?}"))?;
         let stream: OutputStream = fd.write_via_stream(0).map_err(|e| format!("{e:?}"))?;
-        stream.write_zeroes(len).map_err(|e| format!("{e:?}"))
+        stream
+            .blocking_write_zeroes_and_flush(len)
+            .map_err(|e| format!("{e:?}"))
     }
 
     fn stream_to_stdout(&self, len: u64) -> Result<(), String> {


### PR DESCRIPTION
## Summary

- update test-r from 3.0.11 to 3.0.12
- refresh test-r-core, test-r-macro, and quick-xml lockfile entries
- pick up the upstream IPC worker lifetime race fix

## Verification

- `cargo make unit-tests`
- `cargo make fix`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo make build`