### PR TITLE
Centralize worker lifecycle authority

### DIFF
--- a/golem-worker-executor/src/durable_host/golem/v1x.rs
+++ b/golem-worker-executor/src/durable_host/golem/v1x.rs
@@ -40,7 +40,7 @@ use crate::services::oplog::CommitLevel;
 use crate::services::promise::{PromiseHandle, PromiseService};
 use crate::services::worker_proxy::WorkerProxyError;
 use crate::services::{HasOplogService, HasWorker};
-use crate::worker::resolve_revert_last_invocations;
+use crate::worker::Worker;
 use crate::worker::status::calculate_last_known_status_with_checkpoint;
 use crate::workerctx::{StatusManagement, WorkerCtx};
 use anyhow::anyhow;
@@ -1223,25 +1223,19 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
                 golem_common::model::worker::RevertWorkerTarget::RevertLastInvocations(target) => {
                     let owned_agent_id =
                         OwnedAgentId::new(self.owned_agent_id.environment_id, &agent_id);
-                    let Some(agent_mode) = self
-                        .state
-                        .worker_service
-                        .get_agent_mode(&owned_agent_id)
-                        .await
-                    else {
-                        return Ok(Err(agent_operation_error(format!(
-                            "agent {owned_agent_id} does not exist"
-                        ))));
-                    };
-                    match resolve_revert_last_invocations(
-                        self.state.oplog_service().as_ref(),
+                    match Worker::<Ctx>::resolve_revert_last_invocations(
+                        &self.state,
                         &owned_agent_id,
-                        agent_mode,
                         target.number_of_invocations,
                     )
                     .await
                     {
                         Ok(resolved) => Some(resolved),
+                        Err(WorkerExecutorError::AgentNotFound { .. }) => {
+                            return Ok(Err(agent_operation_error(format!(
+                                "agent {owned_agent_id} does not exist"
+                            ))));
+                        }
                         Err(error) => return Ok(Err(agent_operation_error(error.to_string()))),
                     }
                 }

--- a/golem-worker-executor/src/grpc/mod.rs
+++ b/golem-worker-executor/src/grpc/mod.rs
@@ -35,7 +35,7 @@ use crate::services::{
 pub use crate::worker::{
     PERMISSION_CARD_INSTALL_RECIPIENT_MISMATCH, PERMISSION_CARD_TRANSFER_PAYLOAD_CONFLICT,
 };
-use crate::worker::{Worker, resolve_revert_last_invocations};
+use crate::worker::{Worker, WorkerUpdateMode};
 use crate::workerctx::WorkerCtx;
 use chrono::{DateTime, Utc};
 use futures::Stream;
@@ -67,8 +67,8 @@ use golem_common::model::card::{CardId, ScopeCard, StoredCard, card_matches_agen
 use golem_common::model::component::{CanonicalFilePath, ComponentId, PluginPriority};
 use golem_common::model::environment::EnvironmentId;
 use golem_common::model::invocation_context::InvocationContextStack;
+use golem_common::model::oplog::OplogIndex;
 use golem_common::model::oplog::types::AgentMetadataForGuests;
-use golem_common::model::oplog::{OplogIndex, UpdateDescription};
 use golem_common::model::protobuf::to_protobuf_resource_description;
 use golem_common::model::worker::{
     AgentConfigEntryDto, AgentMetadataDto, ResolvedRevert, TypedAgentConfigEntry,
@@ -76,7 +76,7 @@ use golem_common::model::worker::{
 use golem_common::model::{
     AgentEvent, AgentFilter, AgentFingerprint, AgentId, AgentInvocation, AgentInvocationOutput,
     AgentInvocationResult, AgentMetadata, AgentStatus, IdempotencyKey, InvocationStatus,
-    OwnedAgentId, PendingUpdateKind, ScanCursor, ScheduledAction, ShardId, Timestamp,
+    OwnedAgentId, ScanCursor, ScheduledAction, ShardId, Timestamp,
 };
 use golem_common::schema::SchemaValue;
 use golem_common::{model as common_model, recorded_grpc_api_request};
@@ -97,7 +97,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tonic::{Request, Response, Status};
 use tracing::info_span;
-use tracing::{Instrument, debug, info, warn};
+use tracing::{Instrument, info};
 use wasmtime::Error;
 
 /// This is the implementation of the Worker Executor gRPC API
@@ -465,38 +465,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
 
         let principal = extract_principal(&request.principal);
 
-        Worker::<Ctx>::get_latest_metadata(&self.services, &owned_agent_id)
-            .await
-            .ok_or(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            ))?;
-
-        let worker = Worker::get_or_create_suspended(
-            self,
-            &owned_agent_id,
-            None,
-            Vec::new(),
-            None,
-            None,
-            &InvocationContextStack::fresh(),
-            principal,
-        )
-        .await?;
-
-        info!("Interrupting worker before deletion");
-        worker
-            .set_interrupting(InterruptKind::Interrupt(Timestamp::now_utc()))
-            .await;
-        info!("Marking worker for deletion");
-        worker.start_deleting().await?;
-
-        self.worker_service().remove(&owned_agent_id).await;
-        self.active_agents().remove(&owned_agent_id).await;
-
-        // ensure we are holding the worker while we are doing cleanup.
-        drop(worker);
-
-        Ok(())
+        Worker::<Ctx>::delete(self, &owned_agent_id, principal).await
     }
 
     async fn fork_worker_internal(
@@ -591,28 +560,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
             .try_into()
             .map_err(WorkerExecutorError::invalid_request)?;
 
-        let metadata = self.worker_service().get(&owned_agent_id).await;
-
-        match metadata {
-            Some(_) => {
-                let worker = Worker::get_or_create_suspended(
-                    self,
-                    &owned_agent_id,
-                    None,
-                    Vec::new(),
-                    None,
-                    None,
-                    &InvocationContextStack::fresh(),
-                    principal,
-                )
-                .await?;
-                worker.revert(target, resolved_revert).await?;
-                Ok(())
-            }
-            None => Err(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            )),
-        }
+        Worker::<Ctx>::revert(self, &owned_agent_id, target, resolved_revert, principal).await
     }
 
     async fn resolve_revert_last_invocations_internal(
@@ -625,16 +573,9 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
         self.ensure_worker_belongs_to_this_executor(&owned_agent_id)?;
         Self::validate_auth_ctx(&request.auth_ctx)?;
 
-        let agent_mode = self
-            .worker_service()
-            .get_agent_mode(&owned_agent_id)
-            .await
-            .ok_or_else(|| WorkerExecutorError::worker_not_found(owned_agent_id.agent_id()))?;
-
-        resolve_revert_last_invocations(
-            self.oplog_service().as_ref(),
+        Worker::<Ctx>::resolve_revert_last_invocations(
+            self,
             &owned_agent_id,
-            agent_mode,
             request.number_of_invocations,
         )
         .await
@@ -707,95 +648,13 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
 
         let principal = extract_principal(&request.principal);
 
-        let metadata = Worker::<Ctx>::get_latest_metadata(&self.services, &owned_agent_id).await;
-
-        if let Some(metadata) = metadata {
-            match &metadata.last_known_status.status {
-                AgentStatus::Exited => {
-                    warn!("Attempted interrupting worker which already exited")
-                }
-                AgentStatus::Idle => {
-                    warn!("Attempted interrupting worker which is idle")
-                }
-                AgentStatus::Failed => {
-                    warn!("Attempted interrupting worker which is failed")
-                }
-                AgentStatus::Interrupted => {
-                    warn!("Attempted interrupting worker which is already interrupted")
-                }
-                AgentStatus::Suspended => {
-                    debug!("Marking suspended worker as interrupted");
-                    let worker = Worker::get_or_create_suspended(
-                        self,
-                        &owned_agent_id,
-                        None,
-                        Vec::new(),
-                        None,
-                        None,
-                        &InvocationContextStack::fresh(),
-                        principal.clone(),
-                    )
-                    .await?;
-                    if let Some(mut await_interruption) = worker
-                        .set_interrupting(InterruptKind::Interrupt(Timestamp::now_utc()))
-                        .await
-                    {
-                        await_interruption.recv().await.unwrap();
-                    };
-                    // Explicitly drop from the active worker cache - this will drop websocket connections etc.
-                    self.active_agents().remove(&owned_agent_id).await;
-                }
-                AgentStatus::Retrying => {
-                    debug!("Marking worker scheduled to be retried as interrupted");
-                    let worker = Worker::get_or_create_suspended(
-                        self,
-                        &owned_agent_id,
-                        None,
-                        Vec::new(),
-                        None,
-                        None,
-                        &InvocationContextStack::fresh(),
-                        principal.clone(),
-                    )
-                    .await?;
-                    if let Some(mut await_interruption) = worker
-                        .set_interrupting(InterruptKind::Interrupt(Timestamp::now_utc()))
-                        .await
-                    {
-                        await_interruption.recv().await.unwrap();
-                    };
-                    // Explicitly drop from the active worker cache - this will drop websocket connections etc.
-                    self.active_agents().remove(&owned_agent_id).await;
-                }
-                AgentStatus::Running => {
-                    let worker = Worker::get_or_create_suspended(
-                        self,
-                        &owned_agent_id,
-                        None,
-                        Vec::new(),
-                        None,
-                        None,
-                        &InvocationContextStack::fresh(),
-                        principal,
-                    )
-                    .await?;
-                    if let Some(mut await_interruption) = worker
-                        .set_interrupting(if request.recover_immediately {
-                            InterruptKind::Restart
-                        } else {
-                            InterruptKind::Interrupt(Timestamp::now_utc())
-                        })
-                        .await
-                    {
-                        await_interruption.recv().await.unwrap();
-                    };
-
-                    // Explicitly drop from the active worker cache - this will drop websocket connections etc.
-                    self.active_agents().remove(&owned_agent_id).await;
-                }
-            }
-        }
-        Ok(())
+        Worker::<Ctx>::interrupt(
+            self,
+            &owned_agent_id,
+            request.recover_immediately,
+            principal,
+        )
+        .await
     }
 
     async fn resume_worker_internal(
@@ -812,57 +671,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
 
         let force_resume = request.force.unwrap_or(false);
 
-        let metadata = Worker::<Ctx>::get_latest_metadata(&self.services, &owned_agent_id)
-            .await
-            .ok_or(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            ))?;
-
-        self.ensure_not_failed(&owned_agent_id, metadata.agent_mode, &metadata)
-            .await?;
-
-        match &metadata.last_known_status.status {
-            AgentStatus::Suspended | AgentStatus::Interrupted | AgentStatus::Idle => {
-                info!(
-                    "Activating {:?} worker {owned_agent_id} due to explicit resume request",
-                    metadata.last_known_status.status
-                );
-                let _ = Worker::get_or_create_running(
-                    &self.services,
-                    &owned_agent_id,
-                    None,
-                    Vec::new(),
-                    None,
-                    None,
-                    &InvocationContextStack::fresh(),
-                    principal.clone(),
-                )
-                .await?;
-                Ok(())
-            }
-            _ if force_resume => {
-                info!(
-                    "Force activating {:?} worker {owned_agent_id} due to explicit resume request",
-                    metadata.last_known_status.status
-                );
-                let _ = Worker::get_or_create_running(
-                    &self.services,
-                    &owned_agent_id,
-                    None,
-                    Vec::new(),
-                    None,
-                    None,
-                    &InvocationContextStack::fresh(),
-                    principal,
-                )
-                .await?;
-                Ok(())
-            }
-            _ => Err(WorkerExecutorError::invalid_request(format!(
-                "Worker {agent_id} is not suspended, interrupted or idle",
-                agent_id = owned_agent_id.agent_id
-            ))),
-        }
+        Worker::<Ctx>::resume(self, &owned_agent_id, force_resume, principal).await
     }
 
     async fn get_or_create<Req: CanStartWorker>(
@@ -1186,196 +995,20 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
         self.ensure_worker_belongs_to_this_executor(&owned_agent_id)?;
         Self::validate_auth_ctx(&request.auth_ctx)?;
 
-        let metadata = Worker::<Ctx>::get_latest_metadata(self, &owned_agent_id)
-            .await
-            .ok_or(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            ))?;
+        let mode = match request.mode() {
+            UpdateMode::Automatic => WorkerUpdateMode::Automatic,
+            UpdateMode::Manual => WorkerUpdateMode::Manual,
+        };
 
-        if metadata.last_known_status.component_revision == target_revision {
-            return Err(WorkerExecutorError::invalid_request(
-                "Worker is already at the target version",
-            ));
-        }
-
-        let component_metadata = self
-            .component_service()
-            .get_metadata(
-                owned_agent_id.agent_id.component_id,
-                Some(metadata.last_known_status.component_revision),
-            )
-            .await?;
-
-        if let Ok(agent_id) = ParsedAgentId::parse(
-            &owned_agent_id.agent_id.agent_id,
-            &component_metadata.metadata,
-        ) && let Some(agent_type) = component_metadata
-            .metadata
-            .find_agent_type_by_name_ref(&agent_id.agent_type)
-            && agent_type.mode == AgentMode::Ephemeral
-        {
-            return Err(WorkerExecutorError::invalid_request(
-                "Ephemeral workers cannot be updated",
-            ));
-        }
-
-        // Reject mode-changing updates: the target component revision must keep the worker's
-        // agent type at the same `agent_mode` that the worker was created with. Changing the
-        // mode would route subsequent oplog reads/writes to a different namespace and silently
-        // lose the worker's history.
-        //
-        // If the target revision cannot be resolved (e.g. it does not exist yet), we skip the
-        // check and let the update be queued; the worker's update loop is the canonical place
-        // that records a FailedUpdate for unknown revisions, and we must not bypass that path
-        // by failing synchronously here.
-        if let Ok(target_component_metadata) = self
-            .component_service()
-            .get_metadata(owned_agent_id.agent_id.component_id, Some(target_revision))
-            .await
-            && let Ok(agent_id) = ParsedAgentId::parse(
-                &owned_agent_id.agent_id.agent_id,
-                &target_component_metadata.metadata,
-            )
-            && let Some(target_agent_type) = target_component_metadata
-                .metadata
-                .find_agent_type_by_name_ref(&agent_id.agent_type)
-        {
-            let persisted_mode = metadata.agent_mode;
-            if target_agent_type.mode != persisted_mode {
-                return Err(WorkerExecutorError::invalid_request(format!(
-                    "Cannot update worker {} from {:?} to component revision {}: the agent type \
-                     '{}' has mode {:?} in the target revision but the worker was created with \
-                     mode {:?}. Changing an agent type's mode across revisions is not supported.",
-                    owned_agent_id,
-                    persisted_mode,
-                    target_revision,
-                    agent_id.agent_type,
-                    target_agent_type.mode,
-                    persisted_mode,
-                )));
-            }
-        }
-
-        let disable_wakeup = request.disable_wakeup;
-
-        match request.mode() {
-            UpdateMode::Automatic => {
-                let update_description = UpdateDescription::Automatic { target_revision };
-
-                if metadata
-                    .last_known_status
-                    .pending_updates
-                    .iter()
-                    .any(|update| {
-                        update.kind == PendingUpdateKind::Automatic
-                            && update.target_revision == target_revision
-                    })
-                {
-                    return Err(WorkerExecutorError::invalid_request(
-                        "The same update is already in progress",
-                    ));
-                }
-
-                match &metadata.last_known_status.status {
-                    AgentStatus::Exited => {
-                        warn!("Attempted updating worker which already exited")
-                    }
-                    AgentStatus::Interrupted
-                    | AgentStatus::Suspended
-                    | AgentStatus::Retrying
-                    | AgentStatus::Failed => {
-                        // The worker is not active.
-
-                        debug!("Activating worker for update",);
-                        let worker = Worker::get_or_create_suspended(
-                            self,
-                            &owned_agent_id,
-                            None,
-                            Vec::new(),
-                            Some(metadata.last_known_status.component_revision),
-                            None,
-                            &InvocationContextStack::fresh(),
-                            principal.clone(),
-                        )
-                        .await?;
-
-                        debug!("Enqueuing update");
-                        worker.enqueue_update(update_description.clone()).await;
-
-                        if disable_wakeup {
-                            debug!("Skipping worker activation due to disable_wakeup flag");
-                        } else {
-                            debug!("Resuming initialization to perform the update",);
-                            Worker::start_if_needed(worker.clone()).await?;
-                        }
-                    }
-                    AgentStatus::Running | AgentStatus::Idle => {
-                        // If the worker is already running we need to write to its oplog the
-                        // update attempt, and then interrupt it and have it immediately restarting
-                        // to begin the update.
-                        let worker = Worker::get_or_create_suspended(
-                            self,
-                            &owned_agent_id,
-                            None,
-                            Vec::new(),
-                            None,
-                            None,
-                            &InvocationContextStack::fresh(),
-                            principal.clone(),
-                        )
-                        .await?;
-
-                        worker.enqueue_update(update_description.clone()).await;
-
-                        debug!("Enqueued update for running worker");
-
-                        worker.set_interrupting(InterruptKind::Restart).await;
-
-                        debug!("Interrupted running worker for update");
-                    }
-                }
-            }
-
-            UpdateMode::Manual => {
-                if metadata
-                    .last_known_status
-                    .pending_invocations
-                    .iter()
-                    .any(|invocation| {
-                        invocation.manual_update_target_revision == Some(target_revision)
-                    })
-                {
-                    return Err(WorkerExecutorError::invalid_request(
-                        "The same update is already in progress",
-                    ));
-                }
-
-                // For manual update we need to invoke the worker to save the custom snapshot.
-                // This is in a race condition with other worker invocations, so the whole update
-                // process need to be initiated through the worker's invocation queue.
-
-                let worker = Worker::get_or_create_suspended(
-                    self,
-                    &owned_agent_id,
-                    None,
-                    Vec::new(),
-                    None,
-                    None,
-                    &InvocationContextStack::fresh(),
-                    principal,
-                )
-                .await?;
-                worker.enqueue_manual_update(target_revision).await?;
-
-                if disable_wakeup {
-                    debug!("Skipping worker activation due to disable_wakeup flag");
-                } else {
-                    Worker::start_if_needed(worker.clone()).await?;
-                }
-            }
-        }
-
-        Ok(())
+        Worker::<Ctx>::update(
+            self,
+            &owned_agent_id,
+            mode,
+            target_revision,
+            request.disable_wakeup,
+            principal,
+        )
+        .await
     }
 
     async fn connect_worker_internal(
@@ -1805,61 +1438,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
 
         let plugin_priority: PluginPriority = PluginPriority(request.plugin_priority);
 
-        let metadata = Worker::get_latest_metadata(&self.services, &owned_agent_id).await;
-
-        match metadata {
-            Some(metadata) => {
-                let component_metadata = self
-                    .component_service()
-                    .get_metadata(
-                        owned_agent_id.agent_id.component_id,
-                        Some(metadata.last_known_status.component_revision),
-                    )
-                    .await?;
-
-                let agent_type =
-                    ParsedAgentId::parse_agent_type_name(&owned_agent_id.agent_id.agent_id).ok();
-
-                let installation = agent_type
-                    .as_ref()
-                    .and_then(|t| component_metadata.metadata.agent_type_plugins(t))
-                    .and_then(|plugins| plugins.iter().find(|p| p.priority == plugin_priority));
-
-                match installation {
-                    Some(installation) => {
-                        let grant_id = installation.environment_plugin_grant_id;
-                        if metadata
-                            .last_known_status
-                            .active_plugins
-                            .contains(&grant_id)
-                        {
-                            warn!("Plugin is already activated");
-                            Ok(())
-                        } else {
-                            let worker = Worker::get_or_create_suspended(
-                                self,
-                                &owned_agent_id,
-                                None,
-                                Vec::new(),
-                                None,
-                                None,
-                                &InvocationContextStack::fresh(),
-                                principal,
-                            )
-                            .await?;
-                            worker.activate_plugin(grant_id).await?;
-                            Ok(())
-                        }
-                    }
-                    None => Err(WorkerExecutorError::invalid_request(
-                        "Plugin installation does not belong to this worker's component",
-                    )),
-                }
-            }
-            None => Err(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            )),
-        }
+        Worker::<Ctx>::activate_plugin(self, &owned_agent_id, plugin_priority, principal).await
     }
 
     async fn deactivate_plugin_internal(
@@ -1875,58 +1454,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
 
         let plugin_priority = PluginPriority(request.plugin_priority);
 
-        let metadata = Worker::<Ctx>::get_latest_metadata(&self.services, &owned_agent_id)
-            .await
-            .ok_or(WorkerExecutorError::worker_not_found(
-                owned_agent_id.agent_id(),
-            ))?;
-
-        let component_metadata = self
-            .component_service()
-            .get_metadata(
-                owned_agent_id.agent_id.component_id,
-                Some(metadata.last_known_status.component_revision),
-            )
-            .await?;
-
-        let agent_type =
-            ParsedAgentId::parse_agent_type_name(&owned_agent_id.agent_id.agent_id).ok();
-        let installation = agent_type
-            .as_ref()
-            .and_then(|t| component_metadata.metadata.agent_type_plugins(t))
-            .and_then(|plugins| plugins.iter().find(|p| p.priority == plugin_priority))
-            .cloned();
-
-        match installation {
-            Some(installation) => {
-                let grant_id = installation.environment_plugin_grant_id;
-                if !metadata
-                    .last_known_status
-                    .active_plugins
-                    .contains(&grant_id)
-                {
-                    warn!("Plugin is already deactivated");
-                    Ok(())
-                } else {
-                    let worker = Worker::get_or_create_suspended(
-                        self,
-                        &owned_agent_id,
-                        None,
-                        Vec::new(),
-                        None,
-                        None,
-                        &InvocationContextStack::fresh(),
-                        principal,
-                    )
-                    .await?;
-                    worker.deactivate_plugin(grant_id).await?;
-                    Ok(())
-                }
-            }
-            None => Err(WorkerExecutorError::invalid_request(
-                "Plugin installation does not belong to this worker's component",
-            )),
-        }
+        Worker::<Ctx>::deactivate_plugin(self, &owned_agent_id, plugin_priority, principal).await
     }
 
     async fn invoke_agent_internal(

--- a/golem-worker-executor/src/worker/lifecycle.rs
+++ b/golem-worker-executor/src/worker/lifecycle.rs
@@ -1,0 +1,703 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Worker;
+use crate::services::{HasAll, HasOplogService, HasWorkerService};
+use crate::workerctx::WorkerCtx;
+use golem_common::model::agent::{AgentMode, ParsedAgentId, Principal};
+use golem_common::model::component::{ComponentRevision, PluginPriority};
+use golem_common::model::invocation_context::InvocationContextStack;
+use golem_common::model::oplog::{OplogEntry, OplogIndex, UpdateDescription};
+use golem_common::model::worker::{ResolvedRevert, RevertWorkerTarget};
+use golem_common::model::{AgentMetadata, AgentStatus, OwnedAgentId, PendingUpdateKind, Timestamp};
+use golem_service_base::error::worker_executor::{InterruptKind, WorkerExecutorError};
+use tracing::{debug, info, warn};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpdateMode {
+    Automatic,
+    Manual,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InterruptDecision {
+    Ignore,
+    Interrupt,
+    Restart,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResumeDecision {
+    Start,
+    ForceStart,
+    Reject,
+    PreviousFailed,
+    PreviousExited,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UpdateDecision {
+    Ignore,
+    Queue,
+    QueueAndStart,
+    QueueAndRestart,
+}
+
+fn interrupt_decision(status: &AgentStatus, recover_immediately: bool) -> InterruptDecision {
+    match status {
+        AgentStatus::Exited
+        | AgentStatus::Idle
+        | AgentStatus::Failed
+        | AgentStatus::Interrupted => InterruptDecision::Ignore,
+        AgentStatus::Suspended | AgentStatus::Retrying => InterruptDecision::Interrupt,
+        AgentStatus::Running if recover_immediately => InterruptDecision::Restart,
+        AgentStatus::Running => InterruptDecision::Interrupt,
+    }
+}
+
+fn resume_decision(status: &AgentStatus, force: bool) -> ResumeDecision {
+    match status {
+        AgentStatus::Failed => ResumeDecision::PreviousFailed,
+        AgentStatus::Exited => ResumeDecision::PreviousExited,
+        AgentStatus::Suspended | AgentStatus::Interrupted | AgentStatus::Idle => {
+            ResumeDecision::Start
+        }
+        _ if force => ResumeDecision::ForceStart,
+        _ => ResumeDecision::Reject,
+    }
+}
+
+fn update_decision(status: &AgentStatus, mode: UpdateMode, disable_wakeup: bool) -> UpdateDecision {
+    match mode {
+        UpdateMode::Automatic => match status {
+            AgentStatus::Exited => UpdateDecision::Ignore,
+            AgentStatus::Interrupted
+            | AgentStatus::Suspended
+            | AgentStatus::Retrying
+            | AgentStatus::Failed => {
+                if disable_wakeup {
+                    UpdateDecision::Queue
+                } else {
+                    UpdateDecision::QueueAndStart
+                }
+            }
+            AgentStatus::Running | AgentStatus::Idle => UpdateDecision::QueueAndRestart,
+        },
+        UpdateMode::Manual => {
+            if disable_wakeup {
+                UpdateDecision::Queue
+            } else {
+                UpdateDecision::QueueAndStart
+            }
+        }
+    }
+}
+
+impl<Ctx: WorkerCtx> Worker<Ctx> {
+    async fn existing_metadata<T: HasAll<Ctx>>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+    ) -> Result<AgentMetadata, WorkerExecutorError> {
+        Self::get_latest_metadata(deps, owned_agent_id)
+            .await
+            .ok_or_else(|| WorkerExecutorError::worker_not_found(owned_agent_id.agent_id()))
+    }
+
+    async fn get_existing_suspended<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        component_revision: Option<ComponentRevision>,
+        principal: Principal,
+    ) -> Result<std::sync::Arc<Self>, WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        Self::get_or_create_suspended(
+            deps,
+            owned_agent_id,
+            None,
+            Vec::new(),
+            component_revision,
+            None,
+            &InvocationContextStack::fresh(),
+            principal,
+        )
+        .await
+    }
+
+    pub async fn delete<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        Self::existing_metadata(deps, owned_agent_id).await?;
+        let worker = Self::get_existing_suspended(deps, owned_agent_id, None, principal).await?;
+
+        info!("Interrupting worker before deletion");
+        worker
+            .set_interrupting(InterruptKind::Interrupt(Timestamp::now_utc()))
+            .await;
+        info!("Marking worker for deletion");
+        worker.start_deleting_internal().await?;
+
+        worker.worker_service().remove(owned_agent_id).await;
+        worker.remove_from_active_agents().await;
+
+        // Keep the worker alive until durable metadata and cache cleanup has completed.
+        drop(worker);
+        Ok(())
+    }
+
+    pub async fn interrupt<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        recover_immediately: bool,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        let Some(metadata) = Self::get_latest_metadata(deps, owned_agent_id).await else {
+            return Ok(());
+        };
+
+        let decision = interrupt_decision(&metadata.last_known_status.status, recover_immediately);
+        if decision == InterruptDecision::Ignore {
+            match metadata.last_known_status.status {
+                AgentStatus::Exited => warn!("Attempted interrupting worker which already exited"),
+                AgentStatus::Idle => warn!("Attempted interrupting worker which is idle"),
+                AgentStatus::Failed => warn!("Attempted interrupting worker which is failed"),
+                AgentStatus::Interrupted => {
+                    warn!("Attempted interrupting worker which is already interrupted")
+                }
+                _ => unreachable!(),
+            }
+            return Ok(());
+        }
+
+        match metadata.last_known_status.status {
+            AgentStatus::Suspended => debug!("Marking suspended worker as interrupted"),
+            AgentStatus::Retrying => {
+                debug!("Marking worker scheduled to be retried as interrupted")
+            }
+            _ => {}
+        }
+
+        let worker = Self::get_existing_suspended(deps, owned_agent_id, None, principal).await?;
+        let interrupt_kind = match decision {
+            InterruptDecision::Interrupt => InterruptKind::Interrupt(Timestamp::now_utc()),
+            InterruptDecision::Restart => InterruptKind::Restart,
+            InterruptDecision::Ignore => unreachable!(),
+        };
+        if let Some(mut await_interruption) = worker.set_interrupting(interrupt_kind).await {
+            await_interruption.recv().await.unwrap();
+        }
+
+        // Dropping the resident worker also closes live connections associated with it.
+        worker.remove_from_active_agents().await;
+        Ok(())
+    }
+
+    pub async fn resume<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        force: bool,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        let metadata = Self::existing_metadata(deps, owned_agent_id).await?;
+
+        match resume_decision(&metadata.last_known_status.status, force) {
+            ResumeDecision::PreviousFailed => {
+                let error_and_retry_count = Ctx::get_last_error_and_retry_count(
+                    deps,
+                    owned_agent_id,
+                    metadata.agent_mode,
+                    &metadata.last_known_status,
+                )
+                .await;
+                if let Some(last_error) = error_and_retry_count {
+                    return Err(WorkerExecutorError::PreviousInvocationFailed {
+                        error: last_error.error,
+                        stderr: last_error.stderr,
+                    });
+                }
+                Err(WorkerExecutorError::runtime(
+                    "Previous invocation failed, but failed to get error details",
+                ))
+            }
+            ResumeDecision::PreviousExited => Err(WorkerExecutorError::PreviousInvocationExited),
+            decision @ (ResumeDecision::Start | ResumeDecision::ForceStart) => {
+                match decision {
+                    ResumeDecision::Start => info!(
+                        "Activating {:?} worker {owned_agent_id} due to explicit resume request",
+                        metadata.last_known_status.status
+                    ),
+                    ResumeDecision::ForceStart => info!(
+                        "Force activating {:?} worker {owned_agent_id} due to explicit resume request",
+                        metadata.last_known_status.status
+                    ),
+                    _ => unreachable!(),
+                }
+                Self::get_or_create_running(
+                    deps,
+                    owned_agent_id,
+                    None,
+                    Vec::new(),
+                    None,
+                    None,
+                    &InvocationContextStack::fresh(),
+                    principal,
+                )
+                .await?;
+                Ok(())
+            }
+            ResumeDecision::Reject => Err(WorkerExecutorError::invalid_request(format!(
+                "Worker {agent_id} is not suspended, interrupted or idle",
+                agent_id = owned_agent_id.agent_id
+            ))),
+        }
+    }
+
+    pub async fn update<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        mode: UpdateMode,
+        target_revision: ComponentRevision,
+        disable_wakeup: bool,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        let metadata = Self::existing_metadata(deps, owned_agent_id).await?;
+
+        if metadata.last_known_status.component_revision == target_revision {
+            return Err(WorkerExecutorError::invalid_request(
+                "Worker is already at the target version",
+            ));
+        }
+
+        let component_metadata = deps
+            .component_service()
+            .get_metadata(
+                owned_agent_id.agent_id.component_id,
+                Some(metadata.last_known_status.component_revision),
+            )
+            .await?;
+
+        if let Ok(agent_id) = ParsedAgentId::parse(
+            &owned_agent_id.agent_id.agent_id,
+            &component_metadata.metadata,
+        ) && let Some(agent_type) = component_metadata
+            .metadata
+            .find_agent_type_by_name_ref(&agent_id.agent_type)
+            && agent_type.mode == AgentMode::Ephemeral
+        {
+            return Err(WorkerExecutorError::invalid_request(
+                "Ephemeral workers cannot be updated",
+            ));
+        }
+
+        // A worker's durable agent mode selects its oplog namespace and cannot change across
+        // component revisions. Unknown revisions are still queued so the update loop records the
+        // canonical FailedUpdate entry.
+        if let Ok(target_component_metadata) = deps
+            .component_service()
+            .get_metadata(owned_agent_id.agent_id.component_id, Some(target_revision))
+            .await
+            && let Ok(agent_id) = ParsedAgentId::parse(
+                &owned_agent_id.agent_id.agent_id,
+                &target_component_metadata.metadata,
+            )
+            && let Some(target_agent_type) = target_component_metadata
+                .metadata
+                .find_agent_type_by_name_ref(&agent_id.agent_type)
+        {
+            let persisted_mode = metadata.agent_mode;
+            if target_agent_type.mode != persisted_mode {
+                return Err(WorkerExecutorError::invalid_request(format!(
+                    "Cannot update worker {} from {:?} to component revision {}: the agent type \
+                     '{}' has mode {:?} in the target revision but the worker was created with \
+                     mode {:?}. Changing an agent type's mode across revisions is not supported.",
+                    owned_agent_id,
+                    persisted_mode,
+                    target_revision,
+                    agent_id.agent_type,
+                    target_agent_type.mode,
+                    persisted_mode,
+                )));
+            }
+        }
+
+        match mode {
+            UpdateMode::Automatic => {
+                if metadata
+                    .last_known_status
+                    .pending_updates
+                    .iter()
+                    .any(|update| {
+                        update.kind == PendingUpdateKind::Automatic
+                            && update.target_revision == target_revision
+                    })
+                {
+                    return Err(WorkerExecutorError::invalid_request(
+                        "The same update is already in progress",
+                    ));
+                }
+            }
+            UpdateMode::Manual => {
+                if metadata
+                    .last_known_status
+                    .pending_invocations
+                    .iter()
+                    .any(|invocation| {
+                        invocation.manual_update_target_revision == Some(target_revision)
+                    })
+                {
+                    return Err(WorkerExecutorError::invalid_request(
+                        "The same update is already in progress",
+                    ));
+                }
+            }
+        }
+
+        let decision = update_decision(&metadata.last_known_status.status, mode, disable_wakeup);
+        match (mode, decision) {
+            (UpdateMode::Automatic, UpdateDecision::Ignore) => {
+                warn!("Attempted updating worker which already exited");
+            }
+            (UpdateMode::Automatic, decision) => {
+                let current_revision = metadata.last_known_status.component_revision;
+                let component_revision = match decision {
+                    UpdateDecision::Queue | UpdateDecision::QueueAndStart => Some(current_revision),
+                    UpdateDecision::QueueAndRestart => None,
+                    UpdateDecision::Ignore => unreachable!(),
+                };
+                let worker = Self::get_existing_suspended(
+                    deps,
+                    owned_agent_id,
+                    component_revision,
+                    principal,
+                )
+                .await?;
+
+                debug!("Enqueuing update");
+                worker
+                    .enqueue_update(UpdateDescription::Automatic { target_revision })
+                    .await;
+
+                match decision {
+                    UpdateDecision::Queue => {
+                        debug!("Skipping worker activation due to disable_wakeup flag")
+                    }
+                    UpdateDecision::QueueAndStart => {
+                        debug!("Resuming initialization to perform the update");
+                        Self::start_if_needed(worker).await?;
+                    }
+                    UpdateDecision::QueueAndRestart => {
+                        debug!("Enqueued update for running worker");
+                        worker.set_interrupting(InterruptKind::Restart).await;
+                        debug!("Interrupted running worker for update");
+                    }
+                    UpdateDecision::Ignore => unreachable!(),
+                }
+            }
+            (UpdateMode::Manual, decision) => {
+                let worker =
+                    Self::get_existing_suspended(deps, owned_agent_id, None, principal).await?;
+                worker.enqueue_manual_update(target_revision).await?;
+
+                match decision {
+                    UpdateDecision::Queue => {
+                        debug!("Skipping worker activation due to disable_wakeup flag")
+                    }
+                    UpdateDecision::QueueAndStart => {
+                        Self::start_if_needed(worker).await?;
+                    }
+                    UpdateDecision::Ignore | UpdateDecision::QueueAndRestart => unreachable!(),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn revert<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        target: RevertWorkerTarget,
+        resolved_revert: Option<ResolvedRevert>,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        Self::existing_metadata(deps, owned_agent_id).await?;
+        let worker = Self::get_existing_suspended(deps, owned_agent_id, None, principal).await?;
+        worker.revert_internal(target, resolved_revert).await
+    }
+
+    pub async fn resolve_revert_last_invocations<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        number_of_invocations: u64,
+    ) -> Result<ResolvedRevert, WorkerExecutorError>
+    where
+        T: HasWorkerService + HasOplogService,
+    {
+        let agent_mode = deps
+            .worker_service()
+            .get_agent_mode(owned_agent_id)
+            .await
+            .ok_or_else(|| WorkerExecutorError::worker_not_found(owned_agent_id.agent_id()))?;
+
+        let oplog_service = deps.oplog_service();
+        let observed_oplog_index = oplog_service
+            .get_last_index(owned_agent_id, agent_mode)
+            .await;
+        let mut current = observed_oplog_index;
+        let mut found = 0;
+
+        loop {
+            let entries = oplog_service
+                .read(owned_agent_id, agent_mode, current, 1)
+                .await;
+            let entry = entries.get(&current).ok_or_else(|| {
+                WorkerExecutorError::invalid_request(format!(
+                    "Could not read oplog entry {current} while resolving revert"
+                ))
+            })?;
+
+            if matches!(entry, OplogEntry::AgentInvocationStarted { .. }) {
+                found += 1;
+                if found == number_of_invocations {
+                    return Ok(ResolvedRevert {
+                        last_oplog_index: current.previous(),
+                        observed_oplog_index,
+                    });
+                }
+            }
+
+            if current == OplogIndex::INITIAL {
+                return Err(WorkerExecutorError::invalid_request(format!(
+                    "Could not find {number_of_invocations} invocations to revert"
+                )));
+            }
+            current = current.previous();
+        }
+    }
+
+    pub async fn activate_plugin<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        plugin_priority: PluginPriority,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        Self::set_plugin_activation(deps, owned_agent_id, plugin_priority, principal, true).await
+    }
+
+    pub async fn deactivate_plugin<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        plugin_priority: PluginPriority,
+        principal: Principal,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        Self::set_plugin_activation(deps, owned_agent_id, plugin_priority, principal, false).await
+    }
+
+    async fn set_plugin_activation<T>(
+        deps: &T,
+        owned_agent_id: &OwnedAgentId,
+        plugin_priority: PluginPriority,
+        principal: Principal,
+        activate: bool,
+    ) -> Result<(), WorkerExecutorError>
+    where
+        T: HasAll<Ctx> + Send + Sync + Clone + 'static,
+    {
+        let metadata = Self::existing_metadata(deps, owned_agent_id).await?;
+        let component_metadata = deps
+            .component_service()
+            .get_metadata(
+                owned_agent_id.agent_id.component_id,
+                Some(metadata.last_known_status.component_revision),
+            )
+            .await?;
+        let agent_type =
+            ParsedAgentId::parse_agent_type_name(&owned_agent_id.agent_id.agent_id).ok();
+        let grant_id = agent_type
+            .as_ref()
+            .and_then(|agent_type| component_metadata.metadata.agent_type_plugins(agent_type))
+            .and_then(|plugins| {
+                plugins
+                    .iter()
+                    .find(|installation| installation.priority == plugin_priority)
+            })
+            .map(|installation| installation.environment_plugin_grant_id)
+            .ok_or_else(|| {
+                WorkerExecutorError::invalid_request(
+                    "Plugin installation does not belong to this worker's component",
+                )
+            })?;
+
+        let is_active = metadata
+            .last_known_status
+            .active_plugins
+            .contains(&grant_id);
+        if activate == is_active {
+            if activate {
+                warn!("Plugin is already activated");
+            } else {
+                warn!("Plugin is already deactivated");
+            }
+            return Ok(());
+        }
+
+        let worker = Self::get_existing_suspended(deps, owned_agent_id, None, principal).await?;
+        if activate {
+            worker.activate_plugin_internal(grant_id).await
+        } else {
+            worker.deactivate_plugin_internal(grant_id).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_r::test;
+
+    const STATUSES: [AgentStatus; 7] = [
+        AgentStatus::Running,
+        AgentStatus::Idle,
+        AgentStatus::Suspended,
+        AgentStatus::Interrupted,
+        AgentStatus::Retrying,
+        AgentStatus::Failed,
+        AgentStatus::Exited,
+    ];
+
+    #[test]
+    fn interrupt_policy_covers_every_status() {
+        let expected = [
+            InterruptDecision::Interrupt,
+            InterruptDecision::Ignore,
+            InterruptDecision::Interrupt,
+            InterruptDecision::Ignore,
+            InterruptDecision::Interrupt,
+            InterruptDecision::Ignore,
+            InterruptDecision::Ignore,
+        ];
+        let expected_recovering = [
+            InterruptDecision::Restart,
+            InterruptDecision::Ignore,
+            InterruptDecision::Interrupt,
+            InterruptDecision::Ignore,
+            InterruptDecision::Interrupt,
+            InterruptDecision::Ignore,
+            InterruptDecision::Ignore,
+        ];
+
+        for ((status, expected), expected_recovering) in
+            STATUSES.iter().zip(expected).zip(expected_recovering)
+        {
+            assert_eq!(interrupt_decision(status, false), expected);
+            assert_eq!(interrupt_decision(status, true), expected_recovering);
+        }
+    }
+
+    #[test]
+    fn resume_policy_covers_every_status() {
+        let expected = [
+            ResumeDecision::Reject,
+            ResumeDecision::Start,
+            ResumeDecision::Start,
+            ResumeDecision::Start,
+            ResumeDecision::Reject,
+            ResumeDecision::PreviousFailed,
+            ResumeDecision::PreviousExited,
+        ];
+        let expected_forced = [
+            ResumeDecision::ForceStart,
+            ResumeDecision::Start,
+            ResumeDecision::Start,
+            ResumeDecision::Start,
+            ResumeDecision::ForceStart,
+            ResumeDecision::PreviousFailed,
+            ResumeDecision::PreviousExited,
+        ];
+
+        for ((status, expected), expected_forced) in
+            STATUSES.iter().zip(expected).zip(expected_forced)
+        {
+            assert_eq!(resume_decision(status, false), expected);
+            assert_eq!(resume_decision(status, true), expected_forced);
+        }
+    }
+
+    #[test]
+    fn update_policy_covers_every_status_and_wakeup_mode() {
+        let automatic = [
+            UpdateDecision::QueueAndRestart,
+            UpdateDecision::QueueAndRestart,
+            UpdateDecision::QueueAndStart,
+            UpdateDecision::QueueAndStart,
+            UpdateDecision::QueueAndStart,
+            UpdateDecision::QueueAndStart,
+            UpdateDecision::Ignore,
+        ];
+        let automatic_without_wakeup = [
+            UpdateDecision::QueueAndRestart,
+            UpdateDecision::QueueAndRestart,
+            UpdateDecision::Queue,
+            UpdateDecision::Queue,
+            UpdateDecision::Queue,
+            UpdateDecision::Queue,
+            UpdateDecision::Ignore,
+        ];
+
+        for ((status, expected), expected_without_wakeup) in
+            STATUSES.iter().zip(automatic).zip(automatic_without_wakeup)
+        {
+            assert_eq!(
+                update_decision(status, UpdateMode::Automatic, false),
+                expected
+            );
+            assert_eq!(
+                update_decision(status, UpdateMode::Automatic, true),
+                expected_without_wakeup
+            );
+            assert_eq!(
+                update_decision(status, UpdateMode::Manual, false),
+                UpdateDecision::QueueAndStart
+            );
+            assert_eq!(
+                update_decision(status, UpdateMode::Manual, true),
+                UpdateDecision::Queue
+            );
+        }
+    }
+}

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -19,12 +19,15 @@ pub mod entity_slot;
 pub mod instance;
 pub mod invocation;
 mod invocation_loop;
+mod lifecycle;
 pub mod owner_lane;
 pub mod read_only_cache;
 mod state_actor;
 pub mod status;
 pub mod status_checkpointer;
 pub mod status_flusher;
+
+pub use lifecycle::UpdateMode as WorkerUpdateMode;
 
 use self::agent_config::{
     effective_agent_config, ensure_required_agent_secrets_are_configured,
@@ -45,7 +48,7 @@ use crate::services::events::{Event, EventsSubscription};
 use crate::services::golem_config::SnapshotPolicy;
 use crate::services::linear_memory::{LinearMemoryTracker, SHARED_LINEAR_MEMORY_ERROR};
 use crate::services::oplog::plugin::ForwardingOplog;
-use crate::services::oplog::{CommitLevel, Oplog, OplogOps, OplogService, downcast_oplog};
+use crate::services::oplog::{CommitLevel, Oplog, OplogOps, downcast_oplog};
 use crate::services::worker::GetWorkerMetadataResult;
 use crate::services::worker_event::{WorkerEventService, WorkerEventServiceDefault};
 use crate::services::{
@@ -116,47 +119,6 @@ use wasmtime::component::Instance;
 pub const PERMISSION_CARD_TRANSFER_PAYLOAD_CONFLICT: &str =
     "permission card transfer payload conflict";
 pub const PERMISSION_CARD_INSTALL_RECIPIENT_MISMATCH: &str = "install-recipient-mismatch";
-
-pub async fn resolve_revert_last_invocations(
-    oplog_service: &dyn OplogService,
-    owned_agent_id: &OwnedAgentId,
-    agent_mode: AgentMode,
-    number_of_invocations: u64,
-) -> Result<ResolvedRevert, WorkerExecutorError> {
-    let observed_oplog_index = oplog_service
-        .get_last_index(owned_agent_id, agent_mode)
-        .await;
-    let mut current = observed_oplog_index;
-    let mut found = 0;
-
-    loop {
-        let entries = oplog_service
-            .read(owned_agent_id, agent_mode, current, 1)
-            .await;
-        let entry = entries.get(&current).ok_or_else(|| {
-            WorkerExecutorError::invalid_request(format!(
-                "Could not read oplog entry {current} while resolving revert"
-            ))
-        })?;
-
-        if matches!(entry, OplogEntry::AgentInvocationStarted { .. }) {
-            found += 1;
-            if found == number_of_invocations {
-                return Ok(ResolvedRevert {
-                    last_oplog_index: current.previous(),
-                    observed_oplog_index,
-                });
-            }
-        }
-
-        if current == OplogIndex::INITIAL {
-            return Err(WorkerExecutorError::invalid_request(format!(
-                "Could not find {number_of_invocations} invocations to revert"
-            )));
-        }
-        current = current.previous();
-    }
-}
 
 /// Resolved read-only `AgentMethod` invocation data needed to build the
 /// cache key and entry.
@@ -1132,7 +1094,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     /// Transition the worker into a deleting state.
     /// Rejects all new invocations and stops any running execution.
-    pub async fn start_deleting(&self) -> Result<(), WorkerExecutorError> {
+    async fn start_deleting_internal(&self) -> Result<(), WorkerExecutorError> {
         self.queue_interrupt(InterruptKind::Interrupt(Timestamp::now_utc()), false)
             .await;
         if let Some(active_agent) = self
@@ -3064,7 +3026,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         result
     }
 
-    pub async fn activate_plugin(
+    async fn activate_plugin_internal(
         &self,
         plugin_grant_id: EnvironmentPluginGrantId,
     ) -> Result<(), WorkerExecutorError> {
@@ -3089,7 +3051,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         Ok(())
     }
 
-    pub async fn deactivate_plugin(
+    async fn deactivate_plugin_internal(
         &self,
         plugin_grant_id: EnvironmentPluginGrantId,
     ) -> Result<(), WorkerExecutorError> {
@@ -3119,7 +3081,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     ///
     /// The revert operations is implemented by inserting a special oplog entry that
     /// extends the worker's deleted oplog regions, skipping entries from the end of the oplog.
-    pub async fn revert(
+    async fn revert_internal(
         &self,
         target: RevertWorkerTarget,
         resolved_revert: Option<ResolvedRevert>,


### PR DESCRIPTION
## Summary

- move worker lifecycle orchestration for delete, interrupt, resume, update, revert, and plugin activation into `Worker`
- keep gRPC lifecycle handlers focused on request validation, routing, authorization, and response conversion
- route count-based revert resolution from both gRPC and the durable host through the `Worker` authority
- add exhaustive policy tests for every worker status, update mode, force-resume behavior, and `disable_wakeup`

## Testing

- `cargo make fix`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo make build`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p golem-worker-executor --lib -- lifecycle::tests --report-time` (3 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The full worker-executor integration suite was attempted after building its required WASM fixtures. A bounded-concurrency run reached 559/825 tests; lifecycle-related API and revert coverage passed, but four read-only-cache tests timed out (`t7_ttl_expires_cache_entry`, `t8_no_cache_runs_every_time`, `r3_rpc_parallel_reads_coalesce`, and `t11_concurrent_misses_coalesce`) and the run was stopped after subsequent tests stalled in the same fixture area.
