### PR TITLE
Report a delete whose reply was lost as having succeeded

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ permissions:
 
 env:
   BUILD_TARGET: "x86_64-unknown-linux-gnu"
-  MOONBIT_INSTALL_VERSION: "0.10.1+a46be2066"
+  MOONBIT_INSTALL_VERSION: "0.10.2+1bb3e16cf"
   WASM_RQUICKJS_VERSION: "0.3.4"
   WASI_SDK_VERSION: "25"
   WASI_SDK_PATH: /opt/wasi-sdk

--- a/golem-worker-service/src/service/worker/client.rs
+++ b/golem-worker-service/src/service/worker/client.rs
@@ -1524,10 +1524,16 @@ impl DeleteReply {
 /// which for an ordinary rebalance over an agent that never existed needs no
 /// crash at all to happen.
 ///
-/// The one case that does round the other way is a delete of an agent that never
-/// existed whose earlier dispatch failed at the *transport*: that caller sees
-/// success instead of not-found. Nothing can distinguish it from the lost-reply
-/// case, and success is the ordinary reading of deleting something already gone.
+/// What stops this from swallowing the answer #3133 deliberately introduced is
+/// that `WorkerService::delete` settles existence with a *read* before any
+/// delete goes out. An agent that was never there is refused up there, and never
+/// reaches this. So by the time a not-found arrives here, the agent did exist
+/// when the caller asked, and something removed it since.
+///
+/// Which leaves one case rounding the other way: the agent existed at that read
+/// and a *third party* deleted it before an earlier dispatch of ours landed. The
+/// caller sees success for a delete somebody else performed. It is narrow, it
+/// needs a concurrent deleter, and the agent is gone either way.
 ///
 /// Every other failure is passed through unchanged at any dispatch count.
 fn map_delete_worker_response(

--- a/golem-worker-service/src/service/worker/client.rs
+++ b/golem-worker-service/src/service/worker/client.rs
@@ -532,12 +532,19 @@ impl WorkerClient for WorkerExecutorWorkerClient {
             principal: None,
         };
 
-        // How many times the request has actually gone out. Both retry layers
-        // bump this: `call_worker_executor` reroutes to a new owner when an
-        // attempt fails at the transport, and the gRPC client beneath it
-        // reconnects and re-sends on a broken connection. Counting the
-        // dispatches rather than the routing attempts is deliberate, because
-        // only the lower layer knows about the second kind.
+        // How many times the request has been handed to a connection. Both
+        // retry layers bump this: `call_worker_executor` reroutes to a new
+        // owner when an attempt fails at the transport, and the gRPC client
+        // beneath it reconnects and re-sends on a broken connection. Counting
+        // dispatches rather than routing attempts is deliberate, because only
+        // the lower layer knows about the second kind.
+        //
+        // A dispatch that was handed to a connection may or may not have
+        // reached the executor: `attempt` races the call against the connection
+        // being retired, and a lost reply looks the same as a request that
+        // never left. That ambiguity is what is being counted — it is the
+        // reason the count exists, not an imprecision in it. Dispatches the
+        // executor provably turned away are taken back out again below.
         let dispatches = Arc::new(AtomicU64::new(0));
 
         self.call_worker_executor(
@@ -552,12 +559,7 @@ impl WorkerClient for WorkerExecutorWorkerClient {
             },
             {
                 let dispatches = dispatches.clone();
-                move |response| {
-                    map_delete_worker_response(
-                        response.into_inner(),
-                        dispatches.load(Ordering::SeqCst),
-                    )
-                }
+                move |response| handle_delete_reply(response.into_inner(), &dispatches)
             },
             WorkerServiceError::InternalCallError,
         )
@@ -1453,7 +1455,53 @@ impl WorkerClient for WorkerExecutorWorkerClient {
     }
 }
 
-/// Reads a `delete_worker` reply, given how many times the request has gone out.
+/// One attempt's worth of `delete_worker` reply handling.
+///
+/// Reads the reply against the dispatch count, and takes the dispatch back out
+/// of the count when the executor proved it touched nothing. Shared with the
+/// retry closure in [`WorkerExecutorWorkerClient::delete`] so that a test can
+/// drive a real sequence of attempts through the same arithmetic.
+fn handle_delete_reply(
+    response: workerexecutor::v1::DeleteWorkerResponse,
+    dispatches: &AtomicU64,
+) -> Result<(), ResponseMapResult> {
+    let reply = map_delete_worker_response(response, dispatches.load(Ordering::SeqCst));
+    if reply.touched_nothing {
+        dispatches.fetch_sub(1, Ordering::SeqCst);
+    }
+    reply.result
+}
+
+/// What a `delete_worker` reply means for the caller, and what it proves about
+/// the dispatch that produced it.
+struct DeleteReply {
+    result: Result<(), ResponseMapResult>,
+    /// Set when the executor turned the dispatch away before touching the
+    /// agent, so it must not be counted among the dispatches that might have
+    /// deleted it.
+    touched_nothing: bool,
+}
+
+impl DeleteReply {
+    /// The executor answered for this agent.
+    fn answered(result: Result<(), ResponseMapResult>) -> Self {
+        Self {
+            result,
+            touched_nothing: false,
+        }
+    }
+
+    /// The executor refused the dispatch before looking the agent up.
+    fn turned_away(error: ResponseMapResult) -> Self {
+        Self {
+            result: Err(error),
+            touched_nothing: true,
+        }
+    }
+}
+
+/// Reads a `delete_worker` reply, given how many dispatches of the request
+/// might have reached the executor.
 ///
 /// Deleting is not idempotent in its *response*. `delete_worker_internal` opens
 /// with a metadata lookup and reports the agent missing when there is nothing
@@ -1462,36 +1510,50 @@ impl WorkerClient for WorkerExecutorWorkerClient {
 /// executor dying between doing the work and answering produces: the agent is
 /// really gone, and the caller is told it was never there.
 ///
-/// So a not-found answer is only trustworthy on the first dispatch. After that,
-/// the agent being absent is equally well explained by an earlier dispatch of
-/// this very delete having done it, and the delete is reported as having
-/// succeeded. The one case that rounds the other way is a delete of an agent
-/// that never existed whose first dispatch failed at the transport: that caller
-/// now sees success instead of not-found, which is the ordinary reading of
-/// deleting something already gone.
+/// So a not-found answer is only trustworthy while this is the only dispatch
+/// that could have done anything. Past that, the agent being absent is equally
+/// well explained by an earlier dispatch of this very delete having done it, and
+/// the delete is reported as having succeeded.
 ///
-/// Every other failure is passed through untouched at any dispatch count,
-/// `InvalidShardId` included — that one is what drives the reroute.
+/// Which is why the routing refusals are singled out rather than just passed
+/// through. `delete_worker_internal` checks it owns the agent *before* it looks
+/// up metadata and before it touches anything, so a dispatch answered with
+/// `InvalidShardId` or `ShardingNotReady` is one that provably deleted nothing.
+/// It is retried, and if it still counted, the honest not-found that came back
+/// from the real owner would be reported to the caller as a successful delete —
+/// which for an ordinary rebalance over an agent that never existed needs no
+/// crash at all to happen.
+///
+/// The one case that does round the other way is a delete of an agent that never
+/// existed whose earlier dispatch failed at the *transport*: that caller sees
+/// success instead of not-found. Nothing can distinguish it from the lost-reply
+/// case, and success is the ordinary reading of deleting something already gone.
+///
+/// Every other failure is passed through unchanged at any dispatch count.
 fn map_delete_worker_response(
     response: workerexecutor::v1::DeleteWorkerResponse,
     dispatches: u64,
-) -> Result<(), ResponseMapResult> {
+) -> DeleteReply {
     match response {
         workerexecutor::v1::DeleteWorkerResponse {
             result: Some(workerexecutor::v1::delete_worker_response::Result::Success(_)),
-        } => Ok(()),
+        } => DeleteReply::answered(Ok(())),
         workerexecutor::v1::DeleteWorkerResponse {
             result: Some(workerexecutor::v1::delete_worker_response::Result::Failure(err)),
         } => {
             let mapped: ResponseMapResult = err.into();
             match mapped {
+                error @ (ResponseMapResult::InvalidShardId { .. }
+                | ResponseMapResult::ShardingNotReady) => DeleteReply::turned_away(error),
                 ResponseMapResult::Expected(WorkerServiceError::GolemError(
                     WorkerExecutorError::AgentNotFound { .. },
-                )) if dispatches > 1 => Ok(()),
-                other => Err(other),
+                )) if dispatches > 1 => DeleteReply::answered(Ok(())),
+                other => DeleteReply::answered(Err(other)),
             }
         }
-        workerexecutor::v1::DeleteWorkerResponse { .. } => Err("Empty response".into()),
+        workerexecutor::v1::DeleteWorkerResponse { .. } => {
+            DeleteReply::answered(Err("Empty response".into()))
+        }
     }
 }
 
@@ -1538,6 +1600,23 @@ mod tests {
         }
     }
 
+    fn not_found() -> workerexecutor::v1::DeleteWorkerResponse {
+        failure(WorkerExecutorError::worker_not_found(agent_id()))
+    }
+
+    fn wrong_shard() -> workerexecutor::v1::DeleteWorkerResponse {
+        failure(WorkerExecutorError::InvalidShardId {
+            shard_id: ShardId::new(1),
+            shard_ids: vec![ShardId::new(2)],
+        })
+    }
+
+    /// Mirrors the one line in the retry closure that records a dispatch, so a
+    /// sequence test drives the same arithmetic the production path does.
+    fn dispatched(dispatches: &AtomicU64) {
+        dispatches.fetch_add(1, Ordering::SeqCst);
+    }
+
     /// The one dispatch that can honestly say the agent was never there.
     ///
     /// Nothing else has touched the agent on this code path, so the executor's
@@ -1546,13 +1625,11 @@ mod tests {
     /// `AGENT_NOT_FOUND`.
     #[test]
     fn the_only_dispatch_of_a_delete_still_reports_a_missing_agent() {
-        let result = map_delete_worker_response(
-            failure(WorkerExecutorError::worker_not_found(agent_id())),
-            1,
-        );
+        let reply = map_delete_worker_response(not_found(), 1);
 
+        assert!(!reply.touched_nothing);
         assert!(matches!(
-            result,
+            reply.result,
             Err(ResponseMapResult::Expected(WorkerServiceError::GolemError(
                 WorkerExecutorError::AgentNotFound { .. }
             )))
@@ -1572,55 +1649,99 @@ mod tests {
     #[test]
     fn a_delete_whose_reply_was_lost_is_not_reported_as_a_missing_agent() {
         for dispatches in [2, 3, 7] {
-            let result = map_delete_worker_response(
-                failure(WorkerExecutorError::worker_not_found(agent_id())),
-                dispatches,
-            );
+            let reply = map_delete_worker_response(not_found(), dispatches);
 
             assert!(
-                result.is_ok(),
+                reply.result.is_ok(),
                 "dispatch {dispatches} must read a missing agent as its own delete having \
-                 landed, got {result:?}"
+                 landed, got {:?}",
+                reply.result
             );
         }
     }
 
-    /// Only not-found is reinterpreted, and only ever into success.
+    /// A dispatch the executor refused deleted nothing, and must not make the
+    /// next answer ambiguous.
     ///
-    /// `InvalidShardId` is the load-bearing one: it is what makes
-    /// `call_worker_executor` invalidate its routing table and try the new
-    /// owner, so swallowing it on a later dispatch would strand the delete on
-    /// an executor that does not own the agent.
+    /// `delete_worker_internal` checks ownership before it looks the agent up,
+    /// so `InvalidShardId` and `ShardingNotReady` both prove the dispatch was
+    /// turned away untouched. Both are retried. Without taking them back out of
+    /// the count, deleting an agent that never existed during an ordinary
+    /// rebalance would report success — no crash, no lost reply, just a stale
+    /// routing table.
+    ///
+    /// Driven through `handle_delete_reply` rather than asserted on the flag
+    /// alone, so the count really does come back down.
+    #[test]
+    fn a_dispatch_the_executor_turned_away_is_taken_back_out_of_the_count() {
+        for refusal in [wrong_shard, || {
+            failure(WorkerExecutorError::ShardingNotReady)
+        }] {
+            let dispatches = AtomicU64::new(0);
+
+            dispatched(&dispatches);
+            let refused = handle_delete_reply(refusal(), &dispatches);
+            assert!(refused.is_err(), "the refusal itself must still reroute");
+            assert_eq!(
+                dispatches.load(Ordering::SeqCst),
+                0,
+                "a refused dispatch must not stay in the count"
+            );
+
+            dispatched(&dispatches);
+            let answer = handle_delete_reply(not_found(), &dispatches);
+            assert!(
+                matches!(
+                    answer,
+                    Err(ResponseMapResult::Expected(WorkerServiceError::GolemError(
+                        WorkerExecutorError::AgentNotFound { .. }
+                    )))
+                ),
+                "only the reroute preceded this, so the agent really was never \
+                 there: {answer:?}"
+            );
+        }
+    }
+
+    /// The positive control for the test above: an earlier dispatch that got no
+    /// reply at all is the ambiguous one, and still converts.
+    ///
+    /// A transport failure never reaches `handle_delete_reply`, so the count
+    /// keeps it — which is the whole point of counting dispatches rather than
+    /// replies.
+    #[test]
+    fn a_dispatch_that_was_never_answered_still_makes_the_next_answer_ambiguous() {
+        let dispatches = AtomicU64::new(0);
+
+        dispatched(&dispatches); // lost at the transport: no reply to handle
+        dispatched(&dispatches);
+
+        assert!(handle_delete_reply(not_found(), &dispatches).is_ok());
+    }
+
+    /// Only not-found is reinterpreted, and only ever into success.
     #[test]
     fn a_re_sent_delete_still_surfaces_every_other_failure() {
-        let invalid_shard = map_delete_worker_response(
-            failure(WorkerExecutorError::InvalidShardId {
-                shard_id: ShardId::new(1),
-                shard_ids: vec![ShardId::new(2)],
-            }),
-            2,
-        );
-        assert!(matches!(
-            invalid_shard,
-            Err(ResponseMapResult::InvalidShardId { .. })
-        ));
-
         let unrelated =
             map_delete_worker_response(failure(WorkerExecutorError::unknown("boom")), 2);
-        assert!(matches!(unrelated, Err(ResponseMapResult::Other(_))));
+        assert!(!unrelated.touched_nothing);
+        assert!(matches!(unrelated.result, Err(ResponseMapResult::Other(_))));
 
         let empty = map_delete_worker_response(
             workerexecutor::v1::DeleteWorkerResponse { result: None },
             2,
         );
-        assert!(matches!(empty, Err(ResponseMapResult::Other(_))));
+        assert!(!empty.touched_nothing);
+        assert!(matches!(empty.result, Err(ResponseMapResult::Other(_))));
     }
 
     /// A delete that is answered is a delete that succeeded, on any dispatch.
     #[test]
     fn a_confirmed_delete_reads_the_same_on_every_dispatch() {
         for dispatches in [1, 2] {
-            assert!(map_delete_worker_response(success(), dispatches).is_ok());
+            let reply = map_delete_worker_response(success(), dispatches);
+            assert!(!reply.touched_nothing);
+            assert!(reply.result.is_ok());
         }
     }
 }

--- a/golem-worker-service/src/service/worker/client.rs
+++ b/golem-worker-service/src/service/worker/client.rs
@@ -53,6 +53,7 @@ use golem_service_base::model::auth::AuthCtx;
 use golem_service_base::model::{ComponentFileSystemNode, GetOplogResponse};
 use golem_service_base::service::routing_table::{HasRoutingTableService, RoutingTableService};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{collections::HashMap, sync::Arc};
 use tonic::Code;
 use tonic::transport::Channel;
@@ -519,30 +520,44 @@ impl WorkerClient for WorkerExecutorWorkerClient {
         environment_id: EnvironmentId,
         auth_ctx: AuthCtx,
     ) -> WorkerResult<()> {
-        let agent_id_clone = agent_id.clone();
+        // Built once here, cloned per attempt below, the same way
+        // `invoke_agent` builds its request: every attempt has to be the same
+        // request as the first.
+        let request = workerexecutor::v1::DeleteWorkerRequest {
+            agent_id: Some(golem_api_grpc::proto::golem::worker::AgentId::from(
+                agent_id.clone(),
+            )),
+            environment_id: Some(environment_id.into()),
+            auth_ctx: Some(auth_ctx.into()),
+            principal: None,
+        };
+
+        // How many times the request has actually gone out. Both retry layers
+        // bump this: `call_worker_executor` reroutes to a new owner when an
+        // attempt fails at the transport, and the gRPC client beneath it
+        // reconnects and re-sends on a broken connection. Counting the
+        // dispatches rather than the routing attempts is deliberate, because
+        // only the lower layer knows about the second kind.
+        let dispatches = Arc::new(AtomicU64::new(0));
+
         self.call_worker_executor(
             agent_id.clone(),
             "delete_worker",
-            move |worker_executor_client| {
-                Box::pin(worker_executor_client.delete_worker(
-                    workerexecutor::v1::DeleteWorkerRequest {
-                        agent_id: Some(golem_api_grpc::proto::golem::worker::AgentId::from(
-                            agent_id_clone.clone(),
-                        )),
-                        environment_id: Some(environment_id.into()),
-                        auth_ctx: Some(auth_ctx.clone().into()),
-                        principal: None,
-                    },
-                ))
+            {
+                let dispatches = dispatches.clone();
+                move |worker_executor_client| {
+                    dispatches.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(worker_executor_client.delete_worker(request.clone()))
+                }
             },
-            |response| match response.into_inner() {
-                workerexecutor::v1::DeleteWorkerResponse {
-                    result: Some(workerexecutor::v1::delete_worker_response::Result::Success(_)),
-                } => Ok(()),
-                workerexecutor::v1::DeleteWorkerResponse {
-                    result: Some(workerexecutor::v1::delete_worker_response::Result::Failure(err)),
-                } => Err(err.into()),
-                workerexecutor::v1::DeleteWorkerResponse { .. } => Err("Empty response".into()),
+            {
+                let dispatches = dispatches.clone();
+                move |response| {
+                    map_delete_worker_response(
+                        response.into_inner(),
+                        dispatches.load(Ordering::SeqCst),
+                    )
+                }
             },
             WorkerServiceError::InternalCallError,
         )
@@ -1438,6 +1453,48 @@ impl WorkerClient for WorkerExecutorWorkerClient {
     }
 }
 
+/// Reads a `delete_worker` reply, given how many times the request has gone out.
+///
+/// Deleting is not idempotent in its *response*. `delete_worker_internal` opens
+/// with a metadata lookup and reports the agent missing when there is nothing
+/// left to delete, so a delete that landed and then lost its reply comes back on
+/// the next dispatch as though the agent had never existed. That is what an
+/// executor dying between doing the work and answering produces: the agent is
+/// really gone, and the caller is told it was never there.
+///
+/// So a not-found answer is only trustworthy on the first dispatch. After that,
+/// the agent being absent is equally well explained by an earlier dispatch of
+/// this very delete having done it, and the delete is reported as having
+/// succeeded. The one case that rounds the other way is a delete of an agent
+/// that never existed whose first dispatch failed at the transport: that caller
+/// now sees success instead of not-found, which is the ordinary reading of
+/// deleting something already gone.
+///
+/// Every other failure is passed through untouched at any dispatch count,
+/// `InvalidShardId` included — that one is what drives the reroute.
+fn map_delete_worker_response(
+    response: workerexecutor::v1::DeleteWorkerResponse,
+    dispatches: u64,
+) -> Result<(), ResponseMapResult> {
+    match response {
+        workerexecutor::v1::DeleteWorkerResponse {
+            result: Some(workerexecutor::v1::delete_worker_response::Result::Success(_)),
+        } => Ok(()),
+        workerexecutor::v1::DeleteWorkerResponse {
+            result: Some(workerexecutor::v1::delete_worker_response::Result::Failure(err)),
+        } => {
+            let mapped: ResponseMapResult = err.into();
+            match mapped {
+                ResponseMapResult::Expected(WorkerServiceError::GolemError(
+                    WorkerExecutorError::AgentNotFound { .. },
+                )) if dispatches > 1 => Ok(()),
+                other => Err(other),
+            }
+        }
+        workerexecutor::v1::DeleteWorkerResponse { .. } => Err("Empty response".into()),
+    }
+}
+
 fn is_filter_with_running_status(filter: &AgentFilter) -> bool {
     match filter {
         AgentFilter::Status(f)
@@ -1447,5 +1504,123 @@ fn is_filter_with_running_status(filter: &AgentFilter) -> bool {
         }
         AgentFilter::And(f) => f.filters.iter().any(is_filter_with_running_status),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_common::model::ShardId;
+    use golem_common::model::component::ComponentId;
+    use test_r::test;
+    use uuid::Uuid;
+
+    fn agent_id() -> AgentId {
+        AgentId {
+            component_id: ComponentId(Uuid::new_v4()),
+            agent_id: "counter-1".to_string(),
+        }
+    }
+
+    fn success() -> workerexecutor::v1::DeleteWorkerResponse {
+        workerexecutor::v1::DeleteWorkerResponse {
+            result: Some(workerexecutor::v1::delete_worker_response::Result::Success(
+                golem_api_grpc::proto::golem::common::Empty {},
+            )),
+        }
+    }
+
+    fn failure(error: WorkerExecutorError) -> workerexecutor::v1::DeleteWorkerResponse {
+        workerexecutor::v1::DeleteWorkerResponse {
+            result: Some(workerexecutor::v1::delete_worker_response::Result::Failure(
+                error.into(),
+            )),
+        }
+    }
+
+    /// The one dispatch that can honestly say the agent was never there.
+    ///
+    /// Nothing else has touched the agent on this code path, so the executor's
+    /// answer is the whole story and the caller gets the not-found it asked
+    /// about. Deleting an agent that does not exist keeps returning
+    /// `AGENT_NOT_FOUND`.
+    #[test]
+    fn the_only_dispatch_of_a_delete_still_reports_a_missing_agent() {
+        let result = map_delete_worker_response(
+            failure(WorkerExecutorError::worker_not_found(agent_id())),
+            1,
+        );
+
+        assert!(matches!(
+            result,
+            Err(ResponseMapResult::Expected(WorkerServiceError::GolemError(
+                WorkerExecutorError::AgentNotFound { .. }
+            )))
+        ));
+    }
+
+    /// The bug this exists for: a delete that worked, reported as if it had not.
+    ///
+    /// `delete_worker_internal` opens with a metadata lookup, so an executor
+    /// that deleted the agent and died before replying leaves the next dispatch
+    /// nothing to find. Chaos scenario S6 saw 7 of 10 in-flight deletes come
+    /// back as `AGENT_NOT_FOUND` this way, every one of them against an agent
+    /// that really was gone.
+    ///
+    /// Checked past the second dispatch as well, because the reroute is not
+    /// bounded at one: the answer must not flip back on the third.
+    #[test]
+    fn a_delete_whose_reply_was_lost_is_not_reported_as_a_missing_agent() {
+        for dispatches in [2, 3, 7] {
+            let result = map_delete_worker_response(
+                failure(WorkerExecutorError::worker_not_found(agent_id())),
+                dispatches,
+            );
+
+            assert!(
+                result.is_ok(),
+                "dispatch {dispatches} must read a missing agent as its own delete having \
+                 landed, got {result:?}"
+            );
+        }
+    }
+
+    /// Only not-found is reinterpreted, and only ever into success.
+    ///
+    /// `InvalidShardId` is the load-bearing one: it is what makes
+    /// `call_worker_executor` invalidate its routing table and try the new
+    /// owner, so swallowing it on a later dispatch would strand the delete on
+    /// an executor that does not own the agent.
+    #[test]
+    fn a_re_sent_delete_still_surfaces_every_other_failure() {
+        let invalid_shard = map_delete_worker_response(
+            failure(WorkerExecutorError::InvalidShardId {
+                shard_id: ShardId::new(1),
+                shard_ids: vec![ShardId::new(2)],
+            }),
+            2,
+        );
+        assert!(matches!(
+            invalid_shard,
+            Err(ResponseMapResult::InvalidShardId { .. })
+        ));
+
+        let unrelated =
+            map_delete_worker_response(failure(WorkerExecutorError::unknown("boom")), 2);
+        assert!(matches!(unrelated, Err(ResponseMapResult::Other(_))));
+
+        let empty = map_delete_worker_response(
+            workerexecutor::v1::DeleteWorkerResponse { result: None },
+            2,
+        );
+        assert!(matches!(empty, Err(ResponseMapResult::Other(_))));
+    }
+
+    /// A delete that is answered is a delete that succeeded, on any dispatch.
+    #[test]
+    fn a_confirmed_delete_reads_the_same_on_every_dispatch() {
+        for dispatches in [1, 2] {
+            assert!(map_delete_worker_response(success(), dispatches).is_ok());
+        }
     }
 }

--- a/golem-worker-service/src/service/worker/service.rs
+++ b/golem-worker-service/src/service/worker/service.rs
@@ -1414,10 +1414,6 @@ mod tests {
             *self.agent_exists.lock().unwrap() = true;
         }
 
-        fn deleted_agent_ids(&self) -> Vec<AgentId> {
-            self.deleted_agent_ids.lock().unwrap().clone()
-        }
-
         fn created_agent_id(&self) -> AgentId {
             self.created_agent_ids.lock().unwrap()[0].clone()
         }
@@ -2082,7 +2078,12 @@ mod tests {
             "expected AgentNotFound, got {err:?}"
         );
         assert!(
-            harness.worker_client.deleted_agent_ids().is_empty(),
+            harness
+                .worker_client
+                .deleted_agent_ids
+                .lock()
+                .unwrap()
+                .is_empty(),
             "the read already answered, so no delete may be dispatched to be retried"
         );
     }
@@ -2101,6 +2102,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(harness.worker_client.deleted_agent_ids(), vec![agent_id]);
+        assert_eq!(
+            *harness.worker_client.deleted_agent_ids.lock().unwrap(),
+            vec![agent_id]
+        );
     }
 }

--- a/golem-worker-service/src/service/worker/service.rs
+++ b/golem-worker-service/src/service/worker/service.rs
@@ -230,6 +230,18 @@ impl WorkerService {
             )
             .await?;
 
+        // #3133 made deleting an agent that does not exist an error, and that
+        // answer has to survive the routing layer's retries. A retried *delete*
+        // cannot tell "I already deleted it" from "it was never here":
+        // `delete_worker_internal` opens with a metadata lookup and reports the
+        // agent missing either way. A read can. Reads do not change their answer
+        // by being repeated, so asking once here settles whether the agent was
+        // there when the caller asked, before any delete goes out and before any
+        // retry can muddy it.
+        self.worker_client
+            .get_metadata(agent_id, component.environment_id, auth_ctx.clone())
+            .await?;
+
         self.worker_client
             .delete(agent_id, component.environment_id, auth_ctx)
             .await?;
@@ -1066,7 +1078,7 @@ mod tests {
     use crate::service::auth::{AuthService, AuthServiceError};
     use crate::service::component::{ComponentService, ComponentServiceError};
     use crate::service::limit::{LimitService, LimitServiceError};
-    use crate::service::worker::{WorkerClient, WorkerResult, WorkerStream};
+    use crate::service::worker::{WorkerClient, WorkerResult, WorkerServiceError, WorkerStream};
     use async_trait::async_trait;
     use bytes::Bytes;
     use chrono::Utc;
@@ -1093,11 +1105,13 @@ mod tests {
     use golem_common::model::oplog::{OplogCursor, OplogIndex};
     use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto, RevertWorkerTarget};
     use golem_common::model::{AgentFilter, AgentFingerprint, AgentId, IdempotencyKey, ScanCursor};
+    use golem_common::model::{AgentStatus, Timestamp};
     use golem_service_base::clients::registry::{RegistryService, RegistryServiceError};
+    use golem_service_base::error::worker_executor::WorkerExecutorError;
     use golem_service_base::model::auth::{AuthCtx, AuthDetailsForEnvironment, EnvironmentAction};
     use golem_service_base::model::component::Component;
     use golem_service_base::model::{ComponentFileSystemNode, GetOplogResponse};
-    use std::collections::{BTreeMap, BTreeSet, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -1378,6 +1392,10 @@ mod tests {
         invoked_agent_ids: Mutex<Vec<AgentId>>,
         invoked_idempotency_keys: Mutex<Vec<IdempotencyKey>>,
         invocation_output: AgentInvocationOutput,
+        /// Whether `get_metadata` finds anything. Agents do not exist by
+        /// default, so a test that means to delete one has to say so.
+        agent_exists: Mutex<bool>,
+        deleted_agent_ids: Mutex<Vec<AgentId>>,
     }
 
     impl RecordingWorkerClient {
@@ -1387,7 +1405,17 @@ mod tests {
                 invoked_agent_ids: Mutex::new(Vec::new()),
                 invoked_idempotency_keys: Mutex::new(Vec::new()),
                 invocation_output,
+                agent_exists: Mutex::new(false),
+                deleted_agent_ids: Mutex::new(Vec::new()),
             }
+        }
+
+        fn agent_exists(&self) {
+            *self.agent_exists.lock().unwrap() = true;
+        }
+
+        fn deleted_agent_ids(&self) -> Vec<AgentId> {
+            self.deleted_agent_ids.lock().unwrap().clone()
         }
 
         fn created_agent_id(&self) -> AgentId {
@@ -1434,8 +1462,17 @@ mod tests {
             unimplemented!()
         }
 
-        async fn delete(&self, _: &AgentId, _: EnvironmentId, _: AuthCtx) -> WorkerResult<()> {
-            unimplemented!()
+        async fn delete(
+            &self,
+            agent_id: &AgentId,
+            _: EnvironmentId,
+            _: AuthCtx,
+        ) -> WorkerResult<()> {
+            self.deleted_agent_ids
+                .lock()
+                .unwrap()
+                .push(agent_id.clone());
+            Ok(())
         }
 
         async fn complete_promise(
@@ -1461,11 +1498,17 @@ mod tests {
 
         async fn get_metadata(
             &self,
-            _: &AgentId,
-            _: EnvironmentId,
+            agent_id: &AgentId,
+            environment_id: EnvironmentId,
             _: AuthCtx,
         ) -> WorkerResult<AgentMetadataDto> {
-            unimplemented!()
+            if *self.agent_exists.lock().unwrap() {
+                Ok(test_agent_metadata(agent_id.clone(), environment_id))
+            } else {
+                Err(WorkerServiceError::GolemError(
+                    WorkerExecutorError::worker_not_found(agent_id.clone()),
+                ))
+            }
         }
 
         async fn find_metadata(
@@ -1709,6 +1752,15 @@ mod tests {
             }
         }
 
+        /// Any well-formed id in this harness's component. The delete path never
+        /// resolves it against the registry, so the name is arbitrary.
+        fn some_agent_id(&self) -> AgentId {
+            AgentId {
+                component_id: self.component_id,
+                agent_id: "weather-agent(\"oslo\")".to_string(),
+            }
+        }
+
         fn create_request(&self) -> CreateAgentRequest {
             CreateAgentRequest {
                 app_name: ApplicationName::try_from("weather-app".to_string()).unwrap(),
@@ -1735,6 +1787,31 @@ mod tests {
                 deployment_revision: None,
                 owner_account_email: None,
             }
+        }
+    }
+
+    /// Nothing on the delete path reads these fields; it only needs the lookup
+    /// to succeed or fail, so everything past identity is filler.
+    fn test_agent_metadata(agent_id: AgentId, environment_id: EnvironmentId) -> AgentMetadataDto {
+        AgentMetadataDto {
+            agent_id,
+            environment_id,
+            created_by: AccountId(Uuid::new_v4()),
+            env: HashMap::new(),
+            config: vec![],
+            status: AgentStatus::Idle,
+            component_revision: ComponentRevision::INITIAL,
+            retry_count: 0,
+            pending_invocation_count: 0,
+            updates: vec![],
+            created_at: Timestamp::now_utc(),
+            last_error: None,
+            component_size: 0,
+            total_linear_memory_size: 0,
+            exported_resource_instances: vec![],
+            active_plugins: HashSet::new(),
+            skipped_regions: vec![],
+            deleted_regions: vec![],
         }
     }
 
@@ -1971,5 +2048,59 @@ mod tests {
         );
         assert!(phantom_id(&create_response.agent_id).is_none());
         assert!(phantom_id(&invoke_response.agent_id).is_none());
+    }
+
+    /// #3133's answer survives the routing layer, which is the whole point of
+    /// settling existence with a read.
+    ///
+    /// Issue #2404 was a user deleting an agent that did not exist and being
+    /// told it worked. #3133 made that an error. A retried *delete* cannot keep
+    /// that promise — `delete_worker_internal` opens with a metadata lookup, so
+    /// "I already deleted it" and "it was never here" arrive identically — so
+    /// `delete` asks first, with a read, and refuses before dispatching
+    /// anything.
+    ///
+    /// The second assertion is the load-bearing one: it is not enough to return
+    /// the right error, nothing may go out at all. A dispatched delete is a
+    /// delete that can be retried, and a retry is what turns this answer into a
+    /// success.
+    #[test]
+    async fn deleting_an_agent_that_never_existed_still_reports_it_missing() {
+        let harness = RestHarness::new(AgentMode::Durable);
+
+        let err = harness
+            .worker_service
+            .delete(&harness.some_agent_id(), AuthCtx::system())
+            .await
+            .expect_err("deleting an agent that is not there must fail");
+
+        assert!(
+            matches!(
+                err,
+                WorkerServiceError::GolemError(WorkerExecutorError::AgentNotFound { .. })
+            ),
+            "expected AgentNotFound, got {err:?}"
+        );
+        assert!(
+            harness.worker_client.deleted_agent_ids().is_empty(),
+            "the read already answered, so no delete may be dispatched to be retried"
+        );
+    }
+
+    /// The other half: an agent that is there is still deleted, and the delete
+    /// really does reach the client rather than being swallowed by the check.
+    #[test]
+    async fn deleting_an_existing_agent_dispatches_the_delete() {
+        let harness = RestHarness::new(AgentMode::Durable);
+        harness.worker_client.agent_exists();
+        let agent_id = harness.some_agent_id();
+
+        harness
+            .worker_service
+            .delete(&agent_id, AuthCtx::system())
+            .await
+            .unwrap();
+
+        assert_eq!(harness.worker_client.deleted_agent_ids(), vec![agent_id]);
     }
 }


### PR DESCRIPTION
Chaos scenario S6 (GOL-372) killed an executor mid-deletion on golem-dev, twice, against v1.5.10. Both runs reported deletes that had in fact succeeded as `AGENT_NOT_FOUND`.

| Run | Deletes in flight at the kill | Reported `AGENT_NOT_FOUND` despite succeeding |
| -- | --: | --: |
| [32795611004](https://github.com/golemcloud/golem-cloud/actions/runs/32795611004) | 8 | 4 |
| [32798585154](https://github.com/golemcloud/golem-cloud/actions/runs/32798585154) | 10 | 7 |

`delete_worker_internal` opens with `get_latest_metadata(...).ok_or(worker_not_found)`, so deleting is not idempotent in its *response*. The first attempt lands, its executor dies before replying, worker-service invalidates its routing table and retries, and the new owner correctly reports nothing there. All seven took 11s, matching the executor client's ~10s connect timeout before the retry; a healthy delete p50s at 42ms.

The effect was always correct — the resurrection oracle was clean across 138,900 rounds. Only the answer was wrong. Same family as #3752: the routing layer re-sends a request whose meaning depends on work the first attempt already did.

## The fix

**Settle existence with a read.** A retried *delete* cannot tell "I already deleted it" from "it was never here". A read can, because repeating it does not change the answer. `WorkerService::delete` now does one `get_metadata` before anything is dispatched. Absent → `AGENT_NOT_FOUND`, nothing dispatched, nothing to retry. This is what keeps #3133's answer (which resolved #2404, a user told a delete worked when no agent existed) intact rather than trading one wrong answer for another.

**Count dispatches, not routing attempts.** Given the agent existed, a not-found from a *retried* dispatch means our own delete landed, so it is reported as success. The counter lives in the remote-call closure rather than reading `call_worker_executor`'s attempt number, because there are two retry layers: `MultiTargetGrpcClient::call` has its own `retries_on_unavailable` loop that reconnects and re-sends, and the routing layer never sees those. A counted dispatch is one handed to a connection, not one known to have arrived — `attempt` races the call against connection retirement, so a request that never left looks identical to a reply that was lost. That ambiguity is the thing being counted.

**Discount dispatches the executor turned away.** `delete_worker_internal` calls `ensure_worker_belongs_to_this_executor` *before* the metadata lookup, so an `InvalidShardId` or `ShardingNotReady` reply proves that dispatch deleted nothing. It still gets retried. Counting it would mean an ordinary rebalance reported success for a delete that never happened — no crash required.

The request is also built once above the retry closure and cloned per attempt, as #3752 left `invoke_agent`.

What remains rounding the other way is narrow: the agent existed at the read and a **third party** deleted it before one of our dispatches landed. That needs a concurrent deleter on the same id, and the agent is gone either way.

## Tests

Eight. `handle_delete_reply` is shared between the retry closure and the tests, so the sequence tests drive the real arithmetic rather than a copy of it. Every guard was verified by disabling it:

| Disabled | Fails |
| --- | --- |
| pre-delete read | `deleting_an_agent_that_never_existed_still_reports_it_missing` |
| not-found guard | `a_delete_whose_reply_was_lost_is_not_reported_as_a_missing_agent` |
| not-found guard widened to `> 0` | `the_only_dispatch_of_a_delete_still_reports_a_missing_agent` |
| turned-away discount | `a_dispatch_the_executor_turned_away_is_taken_back_out_of_the_count` |

The pre-check test asserts that **nothing was dispatched**, not merely that the right error came back — a dispatched delete is one that can be retried, and the retry is what would turn the answer into a success. `a_dispatch_that_was_never_answered_still_makes_the_next_answer_ambiguous` is the positive control: a transport failure never reaches `handle_delete_reply`, which is why dispatches are counted rather than replies. The turned-away test covers `ShardingNotReady` as well as `InvalidShardId`, exercising the proto round-trip both take.

## Notes for review

- **That every attempt shares one counter is structural, not covered.** `RecordingWorkerClient` sits above `call_worker_executor`, so no test at that seam sees a second attempt — the same gap #3752 documented. Closing it needs a fake `WorkerExecutor` gRPC server, which the repo does not have.
- **The recreate case is untouched.** Delete carries no identity tying an attempt to an *incarnation* of an agent id, so a retry can still delete a newly recreated X. That is the real exactly-once violation; this PR fixes the cosmetic one. S6 cannot produce it — each slot's emitter is sequential and never recreates an id with a delete outstanding. Reasoned from the code, not observed.
- **The S6 driver's `max_retries: 0` on delete stays necessary.** A driver-level retry is a fresh request with its own dispatch count.
- **Revert is the remaining operation in this family.** S7 (GOL-373) shows it has the same property with a worse consequence: retrying "the last two invocations" takes back four.
- **One commit is an unrelated CI fix.** `build-golem-moonbit` and `it-cli` are both red on `1.5.x` because the pinned `0.10.1+a46be2066` toolchain 404s out of the CDN. #3760 fixed this on `main` as part of a `test-r` update; this is the one line of it that matters, applied by hand. Both jobs now pass. `main` also dropped `moon install` from these jobs — deliberately not backported, since it does not fix this and came with a MoonBit workspace restructure `1.5.x` does not have.
