### PR TITLE
Update the pinned Wasmtime revision and thread MemoryKind through the limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -2080,12 +2080,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 
 [[package]]
 name = "cranelift-control"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "arbitrary",
 ]
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -2116,12 +2116,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 
 [[package]]
 name = "cranelift-native"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "cranelift-srcgen"
 version = "0.133.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 
 [[package]]
 name = "crc"
@@ -7850,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11638,7 +11638,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -11691,7 +11691,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -11721,7 +11721,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cache"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -11754,12 +11754,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 
 [[package]]
 name = "wasmtime-internal-core"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -11770,7 +11770,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -11796,7 +11796,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11810,7 +11810,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -11821,7 +11821,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cfg-if",
  "libc",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -11844,7 +11844,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11854,7 +11854,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
@@ -11866,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "async-trait",
  "bitflags 2.13.1",
@@ -11894,7 +11894,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11919,7 +11919,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11931,7 +11931,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wizer"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "log",
  "rayon",
@@ -12075,7 +12075,7 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 [[package]]
 name = "wiggle"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "bitflags 2.13.1",
  "thiserror 2.0.20",
@@ -12088,7 +12088,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "46.0.1"
-source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#9f2c0b4abe5a20e2800651d8922f861752c3e951"
+source = "git+https://github.com/golemcloud/wasmtime.git?branch=golem-wasmtime-v46.0.1-p3#252ab61f67fc16e49c83575e8477a8c4eca13d0b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/golem-common/src/wasmtime_config.rs
+++ b/golem-common/src/wasmtime_config.rs
@@ -54,8 +54,8 @@ pub fn create_wasmtime_config_without_fs_cache() -> Config {
 mod tests {
     use super::*;
     use test_r::test;
-    use wasmtime::Engine;
     use wasmtime::component::Component;
+    use wasmtime::{Engine, Module};
 
     #[test]
     fn precompiled_components_are_compatible_across_engines() -> anyhow::Result<()> {
@@ -68,5 +68,25 @@ mod tests {
         unsafe { Component::deserialize(&executor_engine, precompiled_component) }?;
 
         Ok(())
+    }
+
+    /// Golem leaves the WebAssembly GC proposal disabled, so Wasmtime never allocates a GC
+    /// heap and `MemoryKind::GcHeap` never reaches a resource limiter.
+    ///
+    /// `DurableResourceLimiter` in golem-worker-executor relies on that: it admits GC heap
+    /// growth without taking a linear-memory admission grant, because the collector's capacity
+    /// is not memory the guest declared and Golem's per-agent memory accounting is keyed to
+    /// guest linear memory. Enabling GC would make this test fail, which is the point -- that
+    /// accounting decision has to be revisited before agents can allocate GC objects.
+    #[test]
+    fn gc_proposal_is_disabled() {
+        let engine = Engine::new(&create_wasmtime_config_without_fs_cache()).unwrap();
+        // A `struct` type definition is only valid with the GC proposal enabled.
+        let error = Module::new(&engine, "(module (type (struct (field i32))))")
+            .expect_err("the GC proposal is expected to be disabled");
+        assert!(
+            format!("{error:?}").contains("gc"),
+            "expected a GC-proposal rejection, got: {error:?}"
+        );
     }
 }

--- a/golem-debugging-service/src/debug_context.rs
+++ b/golem-debugging-service/src/debug_context.rs
@@ -86,7 +86,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, RwLock, Weak};
 use uuid;
 use wasmtime::component::{Instance, Resource, ResourceAny};
-use wasmtime::{AsContextMut, ResourceLimiterAsync};
+use wasmtime::{AsContextMut, MemoryKind, ResourceLimiterAsync};
 use wasmtime_wasi::WasiView;
 
 pub struct DebugContext {
@@ -390,16 +390,22 @@ impl ResourceLimiterAsync for DebugContext {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
+        kind: MemoryKind,
     ) -> wasmtime::Result<bool> {
-        self.durable_memory_growing(current, desired, maximum).await
+        self.durable_memory_growing(current, desired, maximum, kind)
+            .await
     }
 
-    fn memory_grown(&mut self, current: usize, desired: usize) {
-        self.durable_memory_grown(current, desired);
+    fn memory_grown(&mut self, current: usize, desired: usize, kind: MemoryKind) {
+        self.durable_memory_grown(current, desired, kind);
     }
 
-    fn memory_grow_failed(&mut self, _error: wasmtime::Error) -> wasmtime::Result<()> {
-        self.durable_memory_grow_failed()
+    fn memory_grow_failed(
+        &mut self,
+        _error: wasmtime::Error,
+        kind: MemoryKind,
+    ) -> wasmtime::Result<()> {
+        self.durable_memory_grow_failed(kind)
     }
 
     async fn table_growing(

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -168,7 +168,7 @@ use tower::ServiceBuilder;
 use tracing::{Level, debug, info};
 use uuid::{Uuid, uuid};
 use wasmtime::component::{HasSelf, Instance, Linker, Resource, ResourceAny};
-use wasmtime::{AsContextMut, Engine, ResourceLimiterAsync};
+use wasmtime::{AsContextMut, Engine, MemoryKind, ResourceLimiterAsync};
 use wasmtime_wasi::WasiView;
 
 #[cfg(test)]
@@ -1845,23 +1845,30 @@ impl ResourceLimiterAsync for TestWorkerCtx {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
+        kind: MemoryKind,
     ) -> wasmtime::Result<bool> {
         debug!(
-            "Memory growing for {}: current: {}, desired: {}",
+            "Memory growing for {}: current: {}, desired: {}, kind: {:?}",
             self.agent_id(),
             current,
-            desired
+            desired,
+            kind
         );
 
-        self.durable_memory_growing(current, desired, maximum).await
+        self.durable_memory_growing(current, desired, maximum, kind)
+            .await
     }
 
-    fn memory_grown(&mut self, current: usize, desired: usize) {
-        self.durable_memory_grown(current, desired);
+    fn memory_grown(&mut self, current: usize, desired: usize, kind: MemoryKind) {
+        self.durable_memory_grown(current, desired, kind);
     }
 
-    fn memory_grow_failed(&mut self, _error: wasmtime::Error) -> wasmtime::Result<()> {
-        self.durable_memory_grow_failed()
+    fn memory_grow_failed(
+        &mut self,
+        _error: wasmtime::Error,
+        kind: MemoryKind,
+    ) -> wasmtime::Result<()> {
+        self.durable_memory_grow_failed(kind)
     }
 
     async fn table_growing(

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -174,7 +174,7 @@ use tracing::{Instrument, Level, debug, error, info, span, warn};
 use try_match::try_match;
 use uuid::Uuid;
 use wasmtime::component::{Instance, Resource, ResourceAny};
-use wasmtime::{AsContext, AsContextMut};
+use wasmtime::{AsContext, AsContextMut, MemoryKind};
 use wasmtime_wasi::p2::FsResult;
 use wasmtime_wasi::p2::bindings::filesystem::preopens::Descriptor;
 use wasmtime_wasi::{
@@ -392,6 +392,16 @@ impl PrimaryInvocationBody {
     }
 }
 
+/// Golem's memory accounting covers guest linear memory only.
+///
+/// Wasmtime also grows its internal GC heaps through the same limiter
+/// callbacks, tagged `MemoryKind::GcHeap`. That capacity belongs to the
+/// collector rather than to memory the guest declared, so it is admitted
+/// without taking a grant and correspondingly never releases one. Golem's
+/// engine config leaves the GC proposal disabled (see
+/// `golem_common::wasmtime_config`), so no store should allocate a GC heap in
+/// the first place; the arm is here so that enabling it does not silently start
+/// billing collector capacity as guest memory.
 pub trait DurableResourceLimiter<Ctx: WorkerCtx> {
     fn durable_worker_ctx(&mut self) -> &mut DurableWorkerCtx<Ctx>;
 
@@ -400,12 +410,24 @@ pub trait DurableResourceLimiter<Ctx: WorkerCtx> {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
+        kind: MemoryKind,
     ) -> impl Future<Output = wasmtime::Result<bool>> + Send {
-        self.durable_worker_ctx()
-            .admit_unshared_memory_growth(current, desired, maximum)
+        let ctx = self.durable_worker_ctx();
+        async move {
+            match kind {
+                MemoryKind::LinearMemory => {
+                    ctx.admit_unshared_memory_growth(current, desired, maximum)
+                        .await
+                }
+                MemoryKind::GcHeap => Ok(true),
+            }
+        }
     }
 
-    fn durable_memory_grown(&mut self, current: usize, desired: usize) -> bool {
+    fn durable_memory_grown(&mut self, current: usize, desired: usize, kind: MemoryKind) -> bool {
+        if kind != MemoryKind::LinearMemory {
+            return false;
+        }
         let delta = desired.saturating_sub(current) as u64;
         if delta > 0 {
             self.durable_worker_ctx().increase_memory(delta);
@@ -415,8 +437,10 @@ pub trait DurableResourceLimiter<Ctx: WorkerCtx> {
         }
     }
 
-    fn durable_memory_grow_failed(&mut self) -> wasmtime::Result<()> {
-        self.durable_worker_ctx().unshared_memory_growth_failed();
+    fn durable_memory_grow_failed(&mut self, kind: MemoryKind) -> wasmtime::Result<()> {
+        if kind == MemoryKind::LinearMemory {
+            self.durable_worker_ctx().unshared_memory_growth_failed();
+        }
         Ok(())
     }
 }

--- a/golem-worker-executor/src/workerctx/default.rs
+++ b/golem-worker-executor/src/workerctx/default.rs
@@ -89,7 +89,7 @@ use std::sync::{Arc, Weak};
 use tracing::debug;
 use uuid::Uuid;
 use wasmtime::component::{Instance, Resource, ResourceAny};
-use wasmtime::{AsContextMut, ResourceLimiterAsync};
+use wasmtime::{AsContextMut, MemoryKind, ResourceLimiterAsync};
 use wasmtime_wasi::WasiView;
 
 /// Tracks the wasmtime fuel gauge state for a single worker store.
@@ -515,26 +515,33 @@ impl ResourceLimiterAsync for Context {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
+        kind: MemoryKind,
     ) -> wasmtime::Result<bool> {
         debug!(
-            "memory_growing: current={}, desired={}, maximum={:?}, account limit={}",
+            "memory_growing: current={}, desired={}, maximum={:?}, kind={:?}, account limit={}",
             current,
             desired,
             maximum,
+            kind,
             self.get_max_memory()
         );
 
-        self.durable_memory_growing(current, desired, maximum).await
+        self.durable_memory_growing(current, desired, maximum, kind)
+            .await
     }
 
-    fn memory_grown(&mut self, current: usize, desired: usize) {
-        if self.durable_memory_grown(current, desired) {
+    fn memory_grown(&mut self, current: usize, desired: usize, kind: MemoryKind) {
+        if self.durable_memory_grown(current, desired, kind) {
             record_allocated_memory(self.durable_ctx.total_linear_memory_size() as usize);
         }
     }
 
-    fn memory_grow_failed(&mut self, _error: wasmtime::Error) -> wasmtime::Result<()> {
-        self.durable_memory_grow_failed()
+    fn memory_grow_failed(
+        &mut self,
+        _error: wasmtime::Error,
+        kind: MemoryKind,
+    ) -> wasmtime::Result<()> {
+        self.durable_memory_grow_failed(kind)
     }
 
     async fn table_growing(


### PR DESCRIPTION
Picks up [golemcloud/wasmtime#8](https://github.com/golemcloud/wasmtime/pull/8) (GOL-424, GOL-425).

`main` already sits on `9f2c0b4a`, which is one parent of #8's merge commit `252ab61f`, so the lockfile moves by exactly that merge and nothing else. Only the rev strings change in `Cargo.lock`; `cargo check --locked` passes without rewriting it.

## Limiter callbacks now carry a `MemoryKind`

`memory_growing`, `memory_grown` and `memory_grow_failed` take the kind of heap being grown. `DurableResourceLimiter` threads it through and filters in one place, so the three `ResourceLimiterAsync` impls (default, debug, test-utils) stay thin.

Golem's accounting covers guest linear memory only. `MemoryKind::GcHeap` growth is admitted without taking an admission grant and correspondingly never releases one.

This fixes a leak rather than adding information. Before #8, `memory_growing` fired for GC heap growth too, but the callback could not tell the two apart, so `admit_unshared_memory_growth` took a real grant through `try_acquire_linear_memory` and retained it. `memory_grown` then fired only for `LinearMemory`, so nothing ever resolved that grant. Every GC heap growth would have eroded host admission headroom until the store unloaded. That is GOL-425.

Counting GC heap into the same pool is not the fix. `LinearMemoryTracker` also drives the durable oplog grow hints, the per-agent memory meter, and replay reconciliation. That last one rules it out: `initially_reserved_bytes` derives from the persisted linear-memory size, and GC heap bytes have no counterpart there, so replay would under-prepay and re-acquire admission it already holds. If GC is ever enabled, the collector's heap wants its own pool.

## Golem does not enable GC

`create_wasmtime_config` starts from `Config::default()` and never calls `wasm_gc(true)`. Wasmtime's default set is `WasmFeatures::WASM2` plus a handful of extras, and GC is a wasm 3.0 feature that is not among them, so no store allocates a GC heap and `MemoryKind::GcHeap` is unreachable today.

`gc_proposal_is_disabled` in `golem-common/src/wasmtime_config.rs` pins that: it compiles a module with a `struct` type and asserts the engine rejects it. Flipping `wasm_gc(true)` fails the test, which is the point, since the accounting decision above has to be revisited first.

## Testing

- `cargo check --locked --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets` clean
- `cargo test -p golem-worker-executor --lib`: 1119 passed
- `cargo test -p golem-common --lib wasmtime_config`: 2 passed, including the new GC assertion

