### PR TITLE
Extract durable call session coordination

### DIFF
--- a/golem-worker-executor/src/durable_host/blobstore/container.rs
+++ b/golem-worker-executor/src/durable_host/blobstore/container.rs
@@ -34,7 +34,8 @@ use crate::durable_host::blobstore::{
     authorize_targets, classify_blob_store_error, container_target, object_target,
 };
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, NotCancellable, authorize_live_permissions_at_serialized_access,
+    CallReplayOutcome, DurableCallSession, NotCancellable,
+    authorize_live_permissions_at_serialized_access,
 };
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx, InternalRetryResult};
 use crate::metrics::storage::{
@@ -85,15 +86,16 @@ async fn list_objects_durable_access<Ctx: WorkerCtx, T: 'static>(
         None => None,
     };
 
-    let mut handle = CallHandle::<BlobstoreContainerListObject, NotCancellable>::start_access(
-        accessor,
-        accessor.getter(),
-        HostRequestBlobStoreContainer {
-            container: container_name.clone(),
-        },
-        DurableFunctionType::ReadRemote,
-    )
-    .await?;
+    let mut handle =
+        DurableCallSession::<BlobstoreContainerListObject, NotCancellable>::start_access(
+            accessor,
+            accessor.getter(),
+            HostRequestBlobStoreContainer {
+                container: container_name.clone(),
+            },
+            DurableFunctionType::ReadRemote,
+        )
+        .await?;
 
     let result = 'resp: {
         if !handle.is_live() {
@@ -183,7 +185,7 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
             None
         };
 
-        let mut handle = CallHandle::<BlobstoreContainerGetData, NotCancellable>::start(
+        let mut handle = DurableCallSession::<BlobstoreContainerGetData, NotCancellable>::start(
             self,
             HostRequestBlobStoreGetData {
                 container: container_name.clone(),
@@ -261,7 +263,7 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         name: ObjectName,
         data: Resource<OutgoingValue>,
     ) -> anyhow::Result<Result<(), Error>> {
-        let begun = CallHandle::<BlobstoreContainerWriteData, NotCancellable>::begin(
+        let begun = DurableCallSession::<BlobstoreContainerWriteData, NotCancellable>::begin(
             self,
             DurableFunctionType::WriteRemote,
         )
@@ -407,15 +409,16 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
             None
         };
 
-        let mut handle = CallHandle::<BlobstoreContainerDeleteObject, NotCancellable>::start(
-            self,
-            HostRequestBlobStoreContainerAndObject {
-                container: container_name.clone(),
-                object: name.clone(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut handle =
+            DurableCallSession::<BlobstoreContainerDeleteObject, NotCancellable>::start(
+                self,
+                HostRequestBlobStoreContainerAndObject {
+                    container: container_name.clone(),
+                    object: name.clone(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         // Unlike the other sites a durability error here is softened into a guest-visible `Error`
         // rather than propagated, so `complete`/`replay` are matched instead of `?`-ed.
@@ -503,15 +506,16 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
         };
         let count = names.len() as u64;
 
-        let mut handle = CallHandle::<BlobstoreContainerDeleteObjects, NotCancellable>::start(
-            self,
-            HostRequestBlobStoreContainerAndObjects {
-                container: container_name.clone(),
-                objects: names.clone(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut handle =
+            DurableCallSession::<BlobstoreContainerDeleteObjects, NotCancellable>::start(
+                self,
+                HostRequestBlobStoreContainerAndObjects {
+                    container: container_name.clone(),
+                    objects: names.clone(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         let result = 'resp: {
             if !handle.is_live() {
@@ -585,7 +589,7 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
             None
         };
 
-        let mut handle = CallHandle::<BlobstoreContainerHasObject, NotCancellable>::start(
+        let mut handle = DurableCallSession::<BlobstoreContainerHasObject, NotCancellable>::start(
             self,
             HostRequestBlobStoreContainerAndObject {
                 container: container_name.clone(),
@@ -657,7 +661,7 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
             None
         };
 
-        let mut handle = CallHandle::<BlobstoreContainerObjectInfo, NotCancellable>::start(
+        let mut handle = DurableCallSession::<BlobstoreContainerObjectInfo, NotCancellable>::start(
             self,
             HostRequestBlobStoreContainerAndObject {
                 container: container_name.clone(),
@@ -739,7 +743,7 @@ impl<Ctx: WorkerCtx> HostContainer for DurableWorkerCtx<Ctx> {
             None
         };
 
-        let mut handle = CallHandle::<BlobstoreContainerClear, NotCancellable>::start(
+        let mut handle = DurableCallSession::<BlobstoreContainerClear, NotCancellable>::start(
             self,
             HostRequestBlobStoreContainer {
                 container: container_name.clone(),

--- a/golem-worker-executor/src/durable_host/blobstore/mod.rs
+++ b/golem-worker-executor/src/durable_host/blobstore/mod.rs
@@ -26,7 +26,7 @@ use wasmtime_wasi::IoView;
 use crate::durable_host::LiveAuthorizationPermit;
 use crate::durable_host::authorization::targets::{blob_container_target, blob_target};
 use crate::durable_host::blobstore::types::ContainerEntry;
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::HostFailureKind;
 use crate::durable_host::{DurableWorkerCtx, InternalRetryResult};
 use crate::metrics::storage::{STORAGE_TYPE_BLOB_STORE, record_storage_objects_deleted};
@@ -103,15 +103,17 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreCreateContainer, NotCancellable>::start(
-                self,
-                HostRequestBlobStoreContainer {
-                    container: name.clone(),
-                },
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreCreateContainer,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestBlobStoreContainer {
+                container: name.clone(),
+            },
+            DurableFunctionType::WriteRemote,
+        )
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {
@@ -183,15 +185,17 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreGetContainer, NotCancellable>::start(
-                self,
-                HostRequestBlobStoreContainer {
-                    container: name.clone(),
-                },
-                DurableFunctionType::ReadRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreGetContainer,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestBlobStoreContainer {
+                container: name.clone(),
+            },
+            DurableFunctionType::ReadRemote,
+        )
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {
@@ -257,15 +261,17 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreDeleteContainer, NotCancellable>::start(
-                self,
-                HostRequestBlobStoreContainer {
-                    container: name.clone(),
-                },
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreDeleteContainer,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestBlobStoreContainer {
+                container: name.clone(),
+            },
+            DurableFunctionType::WriteRemote,
+        )
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {
@@ -331,15 +337,17 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreContainerExists, NotCancellable>::start(
-                self,
-                HostRequestBlobStoreContainer {
-                    container: name.clone(),
-                },
-                DurableFunctionType::ReadRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreContainerExists,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestBlobStoreContainer {
+                container: name.clone(),
+            },
+            DurableFunctionType::ReadRemote,
+        )
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {
@@ -405,13 +413,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             target_container: dest.container,
             target_object: dest.object,
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreCopyObject, NotCancellable>::start(
-                self,
-                input.clone(),
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreCopyObject,
+            NotCancellable,
+        >::start(self, input.clone(), DurableFunctionType::WriteRemote)
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {
@@ -484,13 +490,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             target_container: dest.container,
             target_object: dest.object,
         };
-        let mut handle =
-            CallHandle::<host_functions::BlobstoreBlobstoreMoveObject, NotCancellable>::start(
-                self,
-                input.clone(),
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::BlobstoreBlobstoreMoveObject,
+            NotCancellable,
+        >::start(self, input.clone(), DurableFunctionType::WriteRemote)
+        .await?;
         let result = 'resp: {
             if !handle.is_live() {
                 match handle.replay(self).await? {

--- a/golem-worker-executor/src/durable_host/blobstore/types.rs
+++ b/golem-worker-executor/src/durable_host/blobstore/types.rs
@@ -33,7 +33,7 @@ use wasmtime_wasi::IoView;
 
 use crate::durable_host::LiveAuthorizationPermit;
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, CallReplayOutcome, Cancellable,
+    AccessClaimOptions, CallReplayOutcome, Cancellable, DurableCallSession,
     resolve_current_observational_owner,
 };
 use crate::durable_host::durability::CustomInvocationContext;
@@ -165,21 +165,21 @@ where
         accessor: &Accessor<T, HasSelf<DurableWorkerCtx<Ctx>>>,
     ) -> wasmtime::Result<()> {
         let result = async {
-            let mut handle = CallHandle::<
+            let mut handle = DurableCallSession::<
                 P3BlobstoreTypesIncomingValueConsumeAsync,
                 Cancellable,
             >::start_access_with_options(
-                    accessor,
-                    accessor.getter(),
-                    DurableFunctionType::ReadRemote,
-                    AccessClaimOptions {
-                        observational_owner: self.observational_owner,
-                        ..Default::default()
-                    },
-                    async |_| Ok(HostRequestNoInput {}),
-                )
-                .await
-                .map_err(wasmtime::Error::from)?;
+                accessor,
+                accessor.getter(),
+                DurableFunctionType::ReadRemote,
+                AccessClaimOptions {
+                    observational_owner: self.observational_owner,
+                    ..Default::default()
+                },
+                async |_| Ok(HostRequestNoInput {}),
+            )
+            .await
+            .map_err(wasmtime::Error::from)?;
 
             if !handle.is_live() {
                 match handle

--- a/golem-worker-executor/src/durable_host/call_coordinator.rs
+++ b/golem-worker-executor/src/durable_host/call_coordinator.rs
@@ -1,0 +1,1581 @@
+// Copyright 2024-2026 Golem Cloud
+//
+// Licensed under the Golem Source License v1.1 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://license.golem.cloud/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::durable_host::{
+    LiveAuthorizationPermit, authority_snapshot_is_current_at, authorize_effective_surface,
+    record_permission_decisions,
+};
+use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
+use std::sync::atomic::Ordering;
+use wasmtime::component::{Accessor, HasData};
+
+/// Inputs checked before a durable host call may write or claim its `Start` record.
+///
+/// The function type selects read-only and durable-scope behavior, while the fully qualified host
+/// function name identifies any read-only violation.
+#[derive(Clone, Copy)]
+pub(crate) struct DurableCallAdmission<'a> {
+    function_type: &'a DurableFunctionType,
+    host_function: &'a str,
+}
+
+impl<'a> DurableCallAdmission<'a> {
+    pub(crate) fn new(function_type: &'a DurableFunctionType, host_function: &'a str) -> Self {
+        Self {
+            function_type,
+            host_function,
+        }
+    }
+}
+
+/// The result of successful admission and durable-scope recovery for a host call.
+///
+/// This carries the exact begin index that must later finish the same durable function. For a
+/// scoped function it is the scope's `Start` index; for an unscoped function it is the oplog index
+/// immediately before the call.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DurableCallBoundary {
+    begin_index: OplogIndex,
+}
+
+impl DurableCallBoundary {
+    pub(crate) fn from_begin_index(begin_index: OplogIndex) -> Self {
+        Self { begin_index }
+    }
+
+    pub(crate) fn begin_index(self) -> OplogIndex {
+        self.begin_index
+    }
+}
+
+/// Owns the ordering around a durable host call on [`DurableWorkerCtx`].
+///
+/// Before writing or claiming `Start`, it checks read-only access, stabilizes wallet and authority
+/// state, and then opens or recovers the durable scope. After a terminal record, it closes the
+/// scope, commits durability, and only then permits a safe checkpoint. This ordering must not move
+/// relative to the host call's `Start` and terminal records.
+pub(crate) struct DurableCallCoordinator<'a, Ctx: WorkerCtx> {
+    ctx: &'a mut DurableWorkerCtx<Ctx>,
+}
+
+impl<'a, Ctx: WorkerCtx> DurableCallCoordinator<'a, Ctx> {
+    pub(crate) fn new(ctx: &'a mut DurableWorkerCtx<Ctx>) -> Self {
+        Self { ctx }
+    }
+
+    pub(crate) async fn admit(
+        self,
+        admission: DurableCallAdmission<'_>,
+    ) -> Result<DurableCallBoundary, WorkerExecutorError> {
+        self.check_allowed(admission)?;
+        self.ctx.synchronize_agent_wallet_at_boundary().await?;
+        let begin_index = self.ctx.begin_function(admission.function_type).await?;
+        Ok(DurableCallBoundary::from_begin_index(begin_index))
+    }
+
+    pub(crate) async fn admit_with_agent_authority(
+        self,
+        admission: DurableCallAdmission<'_>,
+    ) -> Result<(DurableCallBoundary, Option<AuthCtx>), WorkerExecutorError> {
+        self.admit_with_agent_authority_capture(admission, |ctx| ctx.agent_auth_ctx())
+            .await
+    }
+
+    pub(crate) async fn admit_with_agent_authority_capture<T>(
+        self,
+        admission: DurableCallAdmission<'_>,
+        mut capture: impl FnMut(&mut DurableWorkerCtx<Ctx>) -> T,
+    ) -> Result<(DurableCallBoundary, Option<T>), WorkerExecutorError> {
+        self.check_allowed(admission)?;
+        let mut captured = self
+            .ctx
+            .capture_live_agent_authority_at_boundary(&mut capture)
+            .await?;
+        let begin_index = self.ctx.begin_function(admission.function_type).await?;
+        if captured.is_none() {
+            if self.ctx.state.snapshotting_mode && self.ctx.state.is_replay() {
+                // Snapshot loading executes guest code without durable host-call records while
+                // replay is positioned at the snapshot. Use the authority reconstructed from the
+                // persisted snapshot rather than consulting current card state.
+                captured = Some(capture(self.ctx));
+            } else if self.ctx.state.is_live() {
+                captured = self
+                    .ctx
+                    .capture_live_agent_authority_at_boundary(&mut capture)
+                    .await?;
+            }
+        }
+        Ok((DurableCallBoundary::from_begin_index(begin_index), captured))
+    }
+
+    pub(crate) async fn finish(
+        self,
+        function_type: &DurableFunctionType,
+        boundary: DurableCallBoundary,
+        forced_commit: bool,
+    ) -> Result<(), WorkerExecutorError> {
+        self.ctx
+            .end_function(function_type, boundary.begin_index())
+            .await?;
+        if !self.ctx.state.snapshotting_mode
+            && (function_type == &DurableFunctionType::WriteRemote
+                || matches!(function_type, DurableFunctionType::WriteRemoteBatched(_))
+                || matches!(
+                    function_type,
+                    DurableFunctionType::WriteRemoteTransaction(_)
+                )
+                || forced_commit)
+        {
+            self.ctx
+                .public_state
+                .worker()
+                .commit_oplog_and_update_state(CommitLevel::DurableOnly)
+                .await;
+            // The status checkpoint is only safe after the durable boundary has committed.
+            self.ctx.maybe_mid_invocation_checkpoint().await;
+        }
+        Ok(())
+    }
+
+    fn check_allowed(
+        &self,
+        admission: DurableCallAdmission<'_>,
+    ) -> Result<(), WorkerExecutorError> {
+        if durability::is_write_side_effect(admission.function_type)
+            && let Err(GolemSpecificWasmTrap::WorkerReadOnlyViolation {
+                method,
+                host_function,
+            }) = DurableWorkerCtx::check_read_only_allows(self.ctx, admission.host_function)
+        {
+            return Err(WorkerExecutorError::ReadOnlyViolation {
+                method,
+                host_function,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) async fn authorize_live_permissions_at_serialized_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    targets: &[golem_common::model::card::PermissionTarget],
+) -> Result<Result<LiveAuthorizationPermit, AuthorizationError>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    enum FastResult {
+        OperatorAuthorized,
+        Stable(Result<(), AuthorizationError>),
+        Slow,
+    }
+
+    let fast_result = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        assert!(
+            ctx.state.is_live(),
+            "live permission authorization must not run during replay"
+        );
+        if ctx.operator_authorizes_current_invocation() {
+            return FastResult::OperatorAuthorized;
+        }
+        let published_generation = ctx
+            .state
+            .published_authority_generation
+            .load(Ordering::Acquire);
+        let now = chrono::Utc::now();
+        if authority_snapshot_is_current_at(
+            ctx.state.authority_initialized,
+            ctx.state.card_interest_index.authority_is_open(),
+            ctx.state.processed_authority_generation,
+            published_generation,
+            ctx.state.next_authority_expiration,
+            now,
+        ) {
+            let result = authorize_effective_surface(&ctx.state.agent_effective_surface, targets);
+            if ctx.authority_snapshot_is_stable(published_generation) {
+                FastResult::Stable(result)
+            } else {
+                FastResult::Slow
+            }
+        } else {
+            FastResult::Slow
+        }
+    });
+    match fast_result {
+        FastResult::OperatorAuthorized => {
+            record_permission_decisions(targets, true);
+            return Ok(Ok(LiveAuthorizationPermit { _private: () }));
+        }
+        FastResult::Stable(result) => {
+            crate::metrics::wasm::record_agent_permission_authority_fast_path();
+            record_permission_decisions(targets, result.is_ok());
+            return Ok(result.map(|()| LiveAuthorizationPermit { _private: () }));
+        }
+        FastResult::Slow => {}
+    }
+
+    let started = std::time::Instant::now();
+    loop {
+        let boundary_guard =
+            lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, true)
+                .await?
+                .expect("waiting authority boundary always returns a guard");
+        let result = store.with(|mut access| {
+            let ctx = get_ctx(access.data_mut());
+            if ctx.operator_authorizes_current_invocation() {
+                return Some(Ok(()));
+            }
+            let generation = ctx
+                .state
+                .published_authority_generation
+                .load(Ordering::Acquire);
+            let result = authorize_effective_surface(&ctx.state.agent_effective_surface, targets);
+            // A due cached deadline sent us through synchronization. Recompute it from the
+            // synchronized wallet before deciding whether the snapshot is stable.
+            ctx.refresh_authority_expiration_deadline();
+            if ctx.authority_snapshot_is_stable(generation) {
+                ctx.adopt_authority_generation(generation);
+                Some(result)
+            } else {
+                None
+            }
+        });
+        if let Some(result) = result {
+            crate::metrics::wasm::record_agent_permission_authority_slow_path(started.elapsed());
+            record_permission_decisions(targets, result.is_ok());
+            return Ok(result.map(|()| LiveAuthorizationPermit { _private: () }));
+        }
+        drop(boundary_guard);
+    }
+}
+
+pub(crate) async fn try_agent_auth_ctx_at_serialized_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<Option<AuthCtx>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let Some(_boundary_guard) =
+        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, false).await?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(store.with(|mut access| {
+        get_ctx(access.data_mut()).agent_auth_ctx()
+    })))
+}
+
+pub(crate) async fn agent_auth_ctx_at_serialized_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<AuthCtx, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let _boundary_guard =
+        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, true)
+            .await?
+            .expect("waiting authority boundary always returns a guard");
+    Ok(store.with(|mut access| get_ctx(access.data_mut()).agent_auth_ctx()))
+}
+
+pub(super) async fn lock_synchronized_card_event_boundary_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<tokio::sync::OwnedMutexGuard<()>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    Ok(
+        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, false, true)
+            .await?
+            .expect("unrestricted card boundary always returns a guard"),
+    )
+}
+
+async fn lock_synchronized_card_event_boundary_access_inner<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    requires_agent_authority: bool,
+    wait_for_authority: bool,
+) -> Result<Option<tokio::sync::OwnedMutexGuard<()>>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let boundary_lock = store.with(|mut access| {
+        get_ctx(access.data_mut())
+            .state
+            .card_event_boundary_lock
+            .clone()
+    });
+    loop {
+        let boundary_guard = boundary_lock.clone().lock_owned().await;
+        let (authority_checked, authority_open, card_interest_index) = store.with(|mut access| {
+            let ctx = get_ctx(access.data_mut());
+            (
+                requires_agent_authority && ctx.state.is_live(),
+                ctx.state.card_interest_index.authority_is_open(),
+                ctx.state.card_interest_index.clone(),
+            )
+        });
+        if authority_checked && !authority_open {
+            drop(boundary_guard);
+            if !wait_for_authority {
+                return Ok(None);
+            }
+            card_interest_index.wait_until_authority_open().await;
+            continue;
+        }
+        synchronize_agent_wallet_at_boundary_access(store, get_ctx).await?;
+        if requires_agent_authority && !authority_checked {
+            let authority_open_after_replay = store.with(|mut access| {
+                let ctx = get_ctx(access.data_mut());
+                !ctx.state.is_live() || ctx.state.card_interest_index.authority_is_open()
+            });
+            if !authority_open_after_replay {
+                drop(boundary_guard);
+                if !wait_for_authority {
+                    return Ok(None);
+                }
+                card_interest_index.wait_until_authority_open().await;
+                continue;
+            }
+        }
+        let has_pending_source_transfer = store.with(|mut access| {
+            get_ctx(access.data_mut())
+                .state
+                .card_event_boundary_scan
+                .as_ref()
+                .is_some_and(|scan| {
+                    scan.pending.iter().any(|pending| {
+                        matches!(&pending.event, QueuedCardEvent::TransferStarted(_))
+                    })
+                })
+        });
+        let retries = if has_pending_source_transfer {
+            prepare_pending_source_card_transfers_access(store, get_ctx).await?
+        } else {
+            Vec::new()
+        };
+        if retries.is_empty() {
+            return Ok(Some(boundary_guard));
+        }
+        // Target delivery takes the target worker's boundary lock. Release the source lock while
+        // delivering, then reconcile again before returning the guard that protects live Start.
+        drop(boundary_guard);
+        complete_pending_source_card_transfers_access(store, get_ctx, retries).await?;
+    }
+}
+
+async fn synchronize_agent_wallet_at_boundary_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    process_pending_replay_events_access(store, get_ctx).await?;
+    drain_card_revocations_and_expiry_access(store, get_ctx).await
+}
+
+async fn drain_card_revocations_and_expiry_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let is_live = store.with(|mut access| get_ctx(access.data_mut()).state.is_live());
+    if !is_live {
+        return Ok(());
+    }
+
+    loop {
+        let pending_events = crate::durable_host::next_drainable_card_events(
+            pending_card_events_at_boundary_access(store, get_ctx).await?,
+        );
+        let Some(pending_event) = pending_events.first() else {
+            break;
+        };
+        match &pending_event.event {
+            QueuedCardEvent::Revoke(_) => {
+                let card_ids = pending_events
+                    .into_iter()
+                    .filter_map(|pending_event| match pending_event.event {
+                        QueuedCardEvent::Revoke(event) => Some(event.card_id),
+                        QueuedCardEvent::Install(_)
+                        | QueuedCardEvent::TransferStarted(_)
+                        | QueuedCardEvent::TransferReceived(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                apply_card_revocations_access(store, get_ctx, card_ids).await?;
+            }
+            QueuedCardEvent::Install(event) => {
+                let Some(card) = event.card.clone() else {
+                    return Err(WorkerExecutorError::runtime(
+                        "queued card install is missing card payload",
+                    ));
+                };
+                apply_card_install_access(store, get_ctx, pending_event.oplog_index, card).await?;
+            }
+            QueuedCardEvent::TransferReceived(event) => {
+                let Some(card) = event.card.clone() else {
+                    return Err(WorkerExecutorError::runtime(
+                        "received card transfer is missing card payload",
+                    ));
+                };
+                apply_received_card_transfer_access(
+                    store,
+                    get_ctx,
+                    pending_event.oplog_index,
+                    event.transfer_id,
+                    event.source_card_id,
+                    card,
+                )
+                .await?;
+            }
+            QueuedCardEvent::TransferStarted(_) => {
+                unreachable!("filtered above")
+            }
+        }
+    }
+    remove_expired_wallet_cards_access(store, get_ctx).await?;
+
+    let expired_scope_root_ids = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        crate::durable_host::expired_wallet_card_ids_at(
+            &ctx.state.invocation_scope_root_cards,
+            chrono::Utc::now(),
+        )
+    });
+    apply_card_revocations_access(store, get_ctx, expired_scope_root_ids).await
+}
+
+async fn pending_card_events_at_boundary_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<Vec<golem_common::model::PendingCardEventRef>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let (worker, oplog) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (ctx.public_state.worker().clone(), ctx.state.oplog.clone())
+    });
+    let status = worker.get_non_detached_last_known_status().await;
+    let current_idx = oplog.current_oplog_index().await;
+    let unread_range = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        match &mut ctx.state.card_event_boundary_scan {
+            Some(scan) => {
+                scan.synchronize(status.oplog_idx, &status.pending_card_events, current_idx)
+            }
+            None => {
+                ctx.state.card_event_boundary_scan =
+                    Some(crate::durable_host::CardEventBoundaryScan::new(
+                        status.oplog_idx,
+                        status.pending_card_events,
+                    ));
+            }
+        }
+        ctx.state
+            .card_event_boundary_scan
+            .as_ref()
+            .expect("card event boundary scan must be initialized")
+            .unread_range(current_idx)
+    });
+
+    if let Some((start, count)) = unread_range {
+        let entries = oplog.read_many(start, count).await;
+        store.with(|mut access| {
+            get_ctx(access.data_mut())
+                .state
+                .card_event_boundary_scan
+                .as_mut()
+                .expect("card event boundary scan must be initialized")
+                .fold_through(current_idx, &entries);
+        });
+    }
+
+    Ok(store.with(|mut access| {
+        get_ctx(access.data_mut())
+            .state
+            .card_event_boundary_scan
+            .as_ref()
+            .expect("card event boundary scan must be initialized")
+            .pending
+            .clone()
+    }))
+}
+
+async fn admit_card_to_wallet_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    card: &golem_common::model::card::StoredCard,
+) -> Result<Result<u64, CardInstallFailure>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let card_id = card.card_id();
+    let (owned_agent_id, mut candidate_card_ids, interest_index, card_service) =
+        store.with(|mut access| {
+            let ctx = get_ctx(access.data_mut());
+            (
+                ctx.owned_agent_id.clone(),
+                ctx.interested_card_ids(),
+                ctx.state.card_interest_index.clone(),
+                ctx.state.card_service.clone(),
+            )
+        });
+    if !candidate_card_ids.contains(&card_id) {
+        candidate_card_ids.push(card_id);
+    }
+    interest_index
+        .set_card_interest(owned_agent_id, &candidate_card_ids)
+        .await;
+
+    let card_state = card_service
+        .check_cards(vec![card_id])
+        .await?
+        .remove(&card_id);
+    let failure = match card_state {
+        Some(CardState::Live(registered_card)) if registered_card.as_ref() == card => None,
+        Some(CardState::Live(_)) => Some(CardInstallFailure::NotPermitted),
+        Some(CardState::Revoked) => Some(CardInstallFailure::CardRevoked),
+        Some(CardState::Unknown) | None => Some(CardInstallFailure::NotFound),
+    };
+
+    let (result, owned_agent_id, interested_card_ids, interest_index) =
+        store.with(|mut access| -> Result<_, WorkerExecutorError> {
+            let ctx = get_ctx(access.data_mut());
+            let result = if let Some(failure) = failure {
+                Err(failure)
+            } else {
+                if crate::durable_host::add_wallet_card(
+                    &mut ctx.state.agent_wallet_cards,
+                    &mut ctx.state.wallet_generation,
+                    card.clone(),
+                )? {
+                    ctx.rederive_agent_effective_surface_from_wallet();
+                }
+                Ok(ctx.state.wallet_generation)
+            };
+            Ok((
+                result,
+                ctx.owned_agent_id.clone(),
+                ctx.interested_card_ids(),
+                ctx.state.card_interest_index.clone(),
+            ))
+        })?;
+    interest_index
+        .set_card_interest(owned_agent_id, &interested_card_ids)
+        .await;
+    Ok(result)
+}
+
+async fn apply_card_install_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    queued_event_index: OplogIndex,
+    card: golem_common::model::card::StoredCard,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let card_id = card.card_id();
+    let result = admit_card_to_wallet_access(store, get_ctx, &card).await?;
+    let worker = store.with(|mut access| get_ctx(access.data_mut()).public_state.worker().clone());
+    let entry = match result {
+        Ok(wallet_generation) => {
+            OplogEntry::card_installed(Some(queued_event_index), card, Some(wallet_generation))
+        }
+        Err(reason) => OplogEntry::card_install_failed(queued_event_index, card_id, reason),
+    };
+    worker.add_and_commit_oplog(entry).await;
+    Ok(())
+}
+
+async fn apply_received_card_transfer_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    queued_event_index: OplogIndex,
+    transfer_id: uuid::Uuid,
+    source_card_id: Option<golem_common::model::card::CardId>,
+    card: golem_common::model::card::StoredCard,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let card_id = card.card_id();
+    let result = admit_card_to_wallet_access(store, get_ctx, &card).await?;
+    let (agent_id, worker) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (
+            ctx.owned_agent_id.agent_id.clone(),
+            ctx.public_state.worker().clone(),
+        )
+    });
+    let entry = match result {
+        Ok(wallet_generation) => OplogEntry::card_transferred(
+            transfer_id,
+            source_card_id,
+            card_id,
+            golem_common::model::card::CardHolder::Agent(
+                golem_common::model::card::AgentCardHolder { agent_id },
+            ),
+            card,
+            Some(wallet_generation),
+        ),
+        Err(reason) => OplogEntry::card_install_failed(queued_event_index, card_id, reason),
+    };
+    worker.add_and_commit_oplog(entry).await;
+    Ok(())
+}
+
+async fn remove_expired_wallet_cards_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let (expired_card_generations, owned_agent_id, interested_card_ids, interest_index, worker) =
+        store.with(|mut access| -> Result<_, WorkerExecutorError> {
+            let ctx = get_ctx(access.data_mut());
+            let expired_card_ids = crate::durable_host::expired_wallet_card_ids_at(
+                &ctx.state.agent_wallet_cards,
+                chrono::Utc::now(),
+            );
+            let mut expired_card_generations = Vec::with_capacity(expired_card_ids.len());
+            for card_id in expired_card_ids {
+                if crate::durable_host::remove_wallet_card(
+                    &mut ctx.state.agent_wallet_cards,
+                    &mut ctx.state.wallet_generation,
+                    card_id,
+                )? {
+                    expired_card_generations.push((card_id, ctx.state.wallet_generation));
+                }
+            }
+            if !expired_card_generations.is_empty() {
+                ctx.rederive_agent_effective_surface_from_wallet();
+            }
+            Ok((
+                expired_card_generations,
+                ctx.owned_agent_id.clone(),
+                ctx.interested_card_ids(),
+                ctx.state.card_interest_index.clone(),
+                ctx.public_state.worker().clone(),
+            ))
+        })?;
+
+    if expired_card_generations.is_empty() {
+        return Ok(());
+    }
+    interest_index
+        .set_card_interest(owned_agent_id, &interested_card_ids)
+        .await;
+    for (card_id, wallet_generation) in expired_card_generations {
+        worker
+            .add_and_commit_oplog(OplogEntry::card_expired(card_id, Some(wallet_generation)))
+            .await;
+    }
+    Ok(())
+}
+
+pub(super) async fn process_pending_replay_events_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let replay_state =
+        store.with(|mut access| get_ctx(access.data_mut()).state.replay_state.clone());
+    let replay_events = replay_state.take_new_replay_events();
+    for event in replay_events {
+        match event {
+            crate::durable_host::replay_state::ReplayEvent::ForkReplayed { new_phantom_id } => {
+                store.with(|mut access| {
+                    let ctx = get_ctx(access.data_mut());
+                    ctx.state.current_phantom_id = Some(new_phantom_id);
+                });
+            }
+            crate::durable_host::replay_state::ReplayEvent::UpdateReplayed { new_revision } => {
+                tracing::debug!(
+                    "Updating worker state to component metadata revision {new_revision}"
+                );
+                update_state_to_new_component_revision_access(store, get_ctx, new_revision).await?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::InvocationWalletPinned {
+                wallet_pin,
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    if crate::durable_host::apply_invocation_wallet_pin(
+                        &mut ctx.state.agent_wallet_cards,
+                        ctx.state.wallet_id_hash,
+                        &mut ctx.state.wallet_generation,
+                        wallet_pin,
+                    )? {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    Ok(())
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardInstalled {
+                card,
+                wallet_generation,
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    let card_id = card.card_id();
+                    tracing::debug!(card_id = %card_id, "Applying replayed card installation");
+                    if crate::durable_host::add_wallet_card(
+                        &mut ctx.state.agent_wallet_cards,
+                        &mut ctx.state.wallet_generation,
+                        card,
+                    )? {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardDerived {
+                wallet_generation,
+                ..
+            } => {
+                store.with(|mut access| {
+                    let ctx = get_ctx(access.data_mut());
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardTransferStarted {
+                card_id,
+                source_holder,
+                source_wallet_generation,
+                ..
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    if source_holder.as_ref().is_none_or(|source_holder| {
+                        crate::durable_host::card_holder_is_agent(
+                            source_holder,
+                            &ctx.owned_agent_id.agent_id,
+                        )
+                    }) && crate::durable_host::transfer_started_removes_source_membership(
+                        ctx.state.agent_wallet_cards.get(&card_id),
+                        &source_holder,
+                        &ctx.owned_agent_id.agent_id,
+                    ) && crate::durable_host::remove_wallet_card(
+                        &mut ctx.state.agent_wallet_cards,
+                        &mut ctx.state.wallet_generation,
+                        card_id,
+                    )? {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        source_wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardTransferred {
+                target_holder,
+                card,
+                target_wallet_generation,
+                ..
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    if crate::durable_host::card_holder_is_agent(
+                        &target_holder,
+                        &ctx.owned_agent_id.agent_id,
+                    ) && crate::durable_host::add_wallet_card(
+                        &mut ctx.state.agent_wallet_cards,
+                        &mut ctx.state.wallet_generation,
+                        card,
+                    )? {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        target_wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardTransferConfirmed { .. } => {}
+            crate::durable_host::replay_state::ReplayEvent::CardRevokedCascade {
+                card_ids,
+                local_wallet_generation,
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    let wallet_changed = crate::durable_host::remove_wallet_cards(
+                        &mut ctx.state.agent_wallet_cards,
+                        &mut ctx.state.wallet_generation,
+                        &card_ids,
+                    )?;
+                    let scope_changed = ctx.clear_invocation_scope_if_roots_include(&card_ids);
+                    if wallet_changed || scope_changed {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        local_wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::CardRevoked {
+                card_id,
+                wallet_generation,
+            }
+            | crate::durable_host::replay_state::ReplayEvent::CardExpired {
+                card_id,
+                wallet_generation,
+            } => {
+                store.with(|mut access| -> Result<(), WorkerExecutorError> {
+                    let ctx = get_ctx(access.data_mut());
+                    let wallet_changed = crate::durable_host::remove_wallet_card(
+                        &mut ctx.state.agent_wallet_cards,
+                        &mut ctx.state.wallet_generation,
+                        card_id,
+                    )?;
+                    let scope_changed = ctx.clear_invocation_scope_if_roots_include(&[card_id]);
+                    if wallet_changed || scope_changed {
+                        ctx.rederive_agent_effective_surface_from_wallet();
+                    }
+                    crate::durable_host::adopt_recorded_wallet_generation(
+                        &mut ctx.state.wallet_generation,
+                        wallet_generation,
+                    )
+                })?;
+            }
+            crate::durable_host::replay_state::ReplayEvent::ReplayFinished => {
+                tracing::debug!("Replaying oplog finished");
+                finalize_pending_automatic_update_access(store, get_ctx).await?;
+                check_post_replay_wallet_liveness_access(store, get_ctx).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn check_post_replay_wallet_liveness_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let (
+        owned_agent_id,
+        interested_card_ids,
+        invocation_scope_card,
+        interest_index,
+        card_service,
+        worker,
+    ) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (
+            ctx.owned_agent_id.clone(),
+            ctx.interested_card_ids(),
+            ctx.state.invocation_scope_card.clone(),
+            ctx.state.card_interest_index.clone(),
+            ctx.state.card_service.clone(),
+            ctx.public_state.worker().clone(),
+        )
+    });
+
+    interest_index
+        .set_card_interest(owned_agent_id, &interested_card_ids)
+        .await;
+    if interested_card_ids.is_empty() {
+        return Ok(());
+    }
+
+    let card_states = card_service.check_cards(interested_card_ids).await?;
+    let live_scope_root_cards = crate::durable_host::live_scope_root_cards_from_states(
+        invocation_scope_card.as_ref(),
+        &card_states,
+    )?;
+    store.with(|mut access| {
+        get_ctx(access.data_mut()).state.invocation_scope_root_cards = live_scope_root_cards;
+    });
+    let revoked_card_ids = card_states
+        .into_iter()
+        .filter_map(|(card_id, state)| (state == CardState::Revoked).then_some(card_id))
+        .collect::<Vec<_>>();
+    worker
+        .queue_card_revocations_locked(&revoked_card_ids)
+        .await;
+    Ok(())
+}
+
+async fn prepare_pending_source_card_transfers_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<
+    Vec<crate::durable_host::permissions::PendingSourceCardTransferRetry>,
+    WorkerExecutorError,
+>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let (is_live, oplog, source_agent_id) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (
+            ctx.state.is_live(),
+            ctx.state.oplog.clone(),
+            ctx.owned_agent_id.agent_id.clone(),
+        )
+    });
+    if !is_live {
+        return Ok(Vec::new());
+    }
+
+    let pending_events = pending_card_events_at_boundary_access(store, get_ctx).await?;
+    let mut retries = Vec::new();
+    let mut first_error = None;
+    for pending in pending_events {
+        if let QueuedCardEvent::TransferStarted(transfer) = &pending.event {
+            let retry =
+                crate::durable_host::permissions::prepare_pending_source_card_transfer_retry(
+                    oplog.as_ref(),
+                    &source_agent_id,
+                    &pending,
+                    transfer,
+                )
+                .await;
+            match retry {
+                Ok(Some(mut retry)) => {
+                    match ensure_pending_source_card_transfer_started_access(store, get_ctx, &retry)
+                        .await
+                    {
+                        Ok(()) => {
+                            retry.started = true;
+                            retries.push(retry);
+                        }
+                        Err(error) if first_error.is_none() => first_error = Some(error),
+                        Err(_) => {}
+                    }
+                }
+                Ok(None) => {}
+                Err(error) if first_error.is_none() => first_error = Some(error),
+                Err(_) => {}
+            }
+        }
+    }
+
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(retries),
+    }
+}
+
+async fn ensure_pending_source_card_transfer_started_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    retry: &crate::durable_host::permissions::PendingSourceCardTransferRetry,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    if retry.started {
+        return Ok(());
+    }
+
+    let (worker, source_agent_id) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (
+            ctx.public_state.worker().clone(),
+            ctx.owned_agent_id.agent_id.clone(),
+        )
+    });
+    let target_holder =
+        golem_common::model::card::CardHolder::Agent(golem_common::model::card::AgentCardHolder {
+            agent_id: retry.target_agent_id.clone(),
+        });
+
+    let refresh_interest = store.with(|mut access| -> Result<Option<_>, WorkerExecutorError> {
+        let ctx = get_ctx(access.data_mut());
+        let changed = retry.remove_source_membership
+            && crate::durable_host::remove_wallet_card(
+                &mut ctx.state.agent_wallet_cards,
+                &mut ctx.state.wallet_generation,
+                retry.source_card_id,
+            )?;
+        if changed {
+            ctx.rederive_agent_effective_surface_from_wallet();
+            Ok(Some((
+                ctx.owned_agent_id.clone(),
+                ctx.interested_card_ids(),
+                ctx.state.card_interest_index.clone(),
+            )))
+        } else {
+            Ok(None)
+        }
+    })?;
+    if let Some((owned_agent_id, interested_card_ids, interest_index)) = refresh_interest {
+        interest_index
+            .set_card_interest(owned_agent_id, &interested_card_ids)
+            .await;
+    }
+
+    worker
+        .add_and_commit_oplog(OplogEntry::card_transfer_started(
+            retry.transfer_id,
+            retry.source_card_id,
+            Some(golem_common::model::card::CardHolder::Agent(
+                golem_common::model::card::AgentCardHolder {
+                    agent_id: source_agent_id,
+                },
+            )),
+            target_holder,
+            store.with(|mut access| Some(get_ctx(access.data_mut()).state.wallet_generation)),
+        ))
+        .await;
+
+    Ok(())
+}
+
+async fn complete_pending_source_card_transfers_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    retries: Vec<crate::durable_host::permissions::PendingSourceCardTransferRetry>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    for retry in retries {
+        complete_pending_source_card_transfer_access(store, get_ctx, retry).await?;
+    }
+
+    Ok(())
+}
+
+async fn complete_pending_source_card_transfer_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    retry: crate::durable_host::permissions::PendingSourceCardTransferRetry,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let (worker, worker_proxy, environment_id) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (
+            ctx.public_state.worker().clone(),
+            ctx.worker_proxy().clone(),
+            ctx.owned_agent_id.environment_id,
+        )
+    });
+    let target_holder =
+        golem_common::model::card::CardHolder::Agent(golem_common::model::card::AgentCardHolder {
+            agent_id: retry.target_agent_id.clone(),
+        });
+
+    worker_proxy
+        .deliver_card_transfer(
+            &retry.target_agent_id,
+            environment_id,
+            retry.transfer_id,
+            retry.source_card_id,
+            &retry.installed_card,
+        )
+        .await
+        .map_err(|error| {
+            WorkerExecutorError::runtime(format!(
+                "permission-card transfer delivery failed: {error}"
+            ))
+        })?;
+
+    let boundary_lock = store.with(|mut access| {
+        get_ctx(access.data_mut())
+            .state
+            .card_event_boundary_lock
+            .clone()
+    });
+    let _boundary_guard = boundary_lock.lock().await;
+    let (oplog, source_agent_id) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (ctx.state.oplog.clone(), ctx.owned_agent_id.agent_id.clone())
+    });
+    if retry.is_confirmed(oplog.as_ref(), &source_agent_id).await? {
+        return Ok(());
+    }
+    worker
+        .add_and_commit_oplog(OplogEntry::card_transfer_confirmed(
+            retry.transfer_id,
+            retry.source_card_id,
+            retry.installed_card.card_id(),
+            target_holder,
+        ))
+        .await;
+    Ok(())
+}
+
+async fn apply_card_revocations_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    mut card_ids: Vec<golem_common::model::card::CardId>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    card_ids.sort_unstable();
+    card_ids.dedup();
+    if card_ids.is_empty() {
+        return Ok(());
+    }
+
+    let (
+        owned_agent_id,
+        interested_card_ids,
+        interest_index,
+        worker,
+        affected_wallets,
+        wallet_generation,
+    ) = store.with(|mut access| -> Result<_, WorkerExecutorError> {
+        let ctx = get_ctx(access.data_mut());
+        let wallet_changed = crate::durable_host::remove_wallet_cards(
+            &mut ctx.state.agent_wallet_cards,
+            &mut ctx.state.wallet_generation,
+            &card_ids,
+        )?;
+        let scope_changed = ctx.clear_invocation_scope_if_roots_include(&card_ids);
+        if wallet_changed || scope_changed {
+            ctx.rederive_agent_effective_surface_from_wallet();
+        }
+        let affected_wallets = if wallet_changed {
+            vec![golem_common::model::card::CardHolder::Agent(
+                golem_common::model::card::AgentCardHolder {
+                    agent_id: ctx.owned_agent_id.agent_id.clone(),
+                },
+            )]
+        } else {
+            Vec::new()
+        };
+        Ok((
+            ctx.owned_agent_id.clone(),
+            ctx.interested_card_ids(),
+            ctx.state.card_interest_index.clone(),
+            ctx.public_state.worker().clone(),
+            affected_wallets,
+            ctx.state.wallet_generation,
+        ))
+    })?;
+
+    interest_index
+        .set_card_interest(owned_agent_id, &interested_card_ids)
+        .await;
+    worker
+        .add_and_commit_oplog(OplogEntry::CardRevokedCascade {
+            timestamp: Timestamp::now_utc(),
+            revoked_card_ids: card_ids,
+            affected_wallets,
+            local_wallet_generation: Some(wallet_generation),
+        })
+        .await;
+    Ok(())
+}
+
+struct AccessRevisionUpdateInputs {
+    component_service: Arc<dyn ComponentService>,
+    file_loader: Arc<FileLoader>,
+    owned_agent_id: golem_common::model::OwnedAgentId,
+    agent_id: Option<ParsedAgentId>,
+    initial_agent_config: Vec<golem_common::model::worker::TypedAgentConfigEntry>,
+    worker_dir: PathBuf,
+    current_revision: ComponentRevision,
+}
+
+type AccessRevisionUpdateAgentState = (
+    HashMap<Vec<String>, golem_common::schema::TypedSchemaValue>,
+    BTreeMap<golem_common::model::card::CardId, golem_common::model::card::StoredCard>,
+);
+
+struct AccessRevisionUpdate {
+    metadata: Component,
+    agent_state: Option<AccessRevisionUpdateAgentState>,
+    files: HashMap<PathBuf, IFSWorkerFile>,
+}
+
+async fn finalize_pending_automatic_update_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let pending_update = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        let pending_update = ctx
+            .state
+            .pending_update
+            .try_lock()
+            .map_err(|_| {
+                WorkerExecutorError::runtime(
+                    "p3 accessor durable call path cannot inspect pending component update state",
+                )
+            })?
+            .take();
+        Ok::<_, WorkerExecutorError>(pending_update)
+    });
+
+    let pending_update = if let Some(pending_update) = pending_update? {
+        pending_update
+    } else {
+        return Ok(());
+    };
+
+    match pending_update.description {
+        UpdateDescription::Automatic { target_revision } => {
+            tracing::debug!("Finalizing pending automatic update");
+            if let Err(error) =
+                update_state_to_new_component_revision_access(store, get_ctx, target_revision).await
+            {
+                let stringified_error = format!("Applying worker update failed: {error}");
+                record_worker_update_failed_access(
+                    store,
+                    get_ctx,
+                    target_revision,
+                    stringified_error,
+                )
+                .await?;
+                return Err(error);
+            }
+
+            let (component_size, active_plugins) = store.with(|mut access| {
+                let ctx = get_ctx(access.data_mut());
+                (
+                    ctx.state.component_metadata.component_size,
+                    HashSet::from_iter({
+                        ctx.agent_type_provision_config()
+                            .map(|c| c.plugins.as_slice())
+                            .unwrap_or_default()
+                            .iter()
+                            .map(|installation| installation.environment_plugin_grant_id)
+                    }),
+                )
+            });
+            record_worker_update_succeeded_access(
+                store,
+                get_ctx,
+                target_revision,
+                component_size,
+                active_plugins,
+            )
+            .await?;
+            tracing::debug!("Finalizing automatic update to revision {target_revision}");
+            Ok(())
+        }
+        _ => Err(WorkerExecutorError::runtime(
+            "pending replay event finalization expected an automatic update description",
+        )),
+    }
+}
+
+async fn update_state_to_new_component_revision_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    new_revision: ComponentRevision,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let inputs = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        AccessRevisionUpdateInputs {
+            component_service: ctx.state.component_service.clone(),
+            file_loader: ctx.state.file_loader.clone(),
+            owned_agent_id: ctx.owned_agent_id.clone(),
+            agent_id: ctx.state.agent_id.clone(),
+            initial_agent_config: ctx.state.initial_agent_config.clone(),
+            worker_dir: ctx.owner_filesystem.path().to_path_buf(),
+            current_revision: ctx.state.component_metadata.revision,
+        }
+    });
+
+    if new_revision <= inputs.current_revision {
+        tracing::debug!("Update {new_revision} was already applied, skipping");
+        return Ok(());
+    }
+
+    let update = prepare_revision_update_access(store, get_ctx, &inputs, new_revision).await?;
+    store.with(|mut access| -> Result<(), WorkerExecutorError> {
+        let ctx = get_ctx(access.data_mut());
+        apply_revision_update_access(ctx, update)
+    })
+}
+
+async fn prepare_revision_update_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    inputs: &AccessRevisionUpdateInputs,
+    new_revision: ComponentRevision,
+) -> Result<AccessRevisionUpdate, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let metadata = inputs
+        .component_service
+        .get_metadata(inputs.owned_agent_id.component_id(), Some(new_revision))
+        .await?;
+
+    let provision_config = inputs.agent_id.as_ref().and_then(|agent_id| {
+        metadata
+            .metadata
+            .agent_type_provision_configs()
+            .get(&agent_id.agent_type)
+            .cloned()
+    });
+
+    let agent_state = if let Some(agent_id) = &inputs.agent_id {
+        let agent_type = metadata
+            .metadata
+            .find_agent_type_by_name_ref(&agent_id.agent_type)
+            .ok_or_else(|| {
+                WorkerExecutorError::invalid_request(format!(
+                    "Agent type {} not found in updated agent metadata",
+                    agent_id.agent_type
+                ))
+            })?;
+
+        let updated_agent_config = effective_agent_config(
+            inputs.initial_agent_config.clone(),
+            provision_config
+                .as_ref()
+                .map(|c| c.config.clone())
+                .unwrap_or_default(),
+        )?;
+        validate_agent_config(&updated_agent_config, agent_type)?;
+
+        let initial_card = super::agent_initial_card_from_component_metadata(&metadata, agent_id)?;
+        let initial_wallet_cards = BTreeMap::from([(initial_card.card_id(), initial_card)]);
+        Some((updated_agent_config, initial_wallet_cards))
+    } else {
+        None
+    };
+
+    let mut files = take_initial_files_access(store, get_ctx)?;
+    let update_result = super::update_filesystem(
+        &mut files,
+        &inputs.file_loader,
+        inputs.owned_agent_id.environment_id,
+        &inputs.worker_dir,
+        provision_config
+            .as_ref()
+            .map(|c| c.files.as_slice())
+            .unwrap_or_default(),
+    )
+    .await;
+
+    if let Err(error) = update_result {
+        restore_initial_files_access(store, get_ctx, files)?;
+        return Err(error);
+    }
+
+    Ok(AccessRevisionUpdate {
+        metadata,
+        agent_state,
+        files,
+    })
+}
+
+fn take_initial_files_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+) -> Result<HashMap<PathBuf, IFSWorkerFile>, WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        let mut files = ctx.state.files.try_write().map_err(|_| {
+            WorkerExecutorError::runtime(
+                "p3 accessor durable call path cannot acquire initial-files lock",
+            )
+        })?;
+        Ok(std::mem::take(&mut *files))
+    })
+}
+
+fn restore_initial_files_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    restored: HashMap<PathBuf, IFSWorkerFile>,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        let mut files = ctx.state.files.try_write().map_err(|_| {
+            WorkerExecutorError::runtime(
+                "p3 accessor durable call path cannot restore initial-files state",
+            )
+        })?;
+        *files = restored;
+        Ok(())
+    })
+}
+
+fn apply_revision_update_access<Ctx: WorkerCtx>(
+    ctx: &mut DurableWorkerCtx<Ctx>,
+    update: AccessRevisionUpdate,
+) -> Result<(), WorkerExecutorError> {
+    let read_only_paths = super::compute_read_only_paths(&update.files);
+    {
+        let mut files = ctx
+            .state
+            .files
+            .try_write()
+            .expect("initial-files state was taken by this update path");
+        *files = update.files;
+    }
+    {
+        let mut read_only = ctx.state.read_only_paths.write().unwrap();
+        *read_only = read_only_paths;
+    }
+
+    ctx.state.component_metadata = update.metadata;
+
+    if let Some((agent_config, initial_wallet_cards)) = update.agent_state {
+        ctx.state.agent_config = agent_config;
+        ctx.state.cached_agent_config_retry_policies = None;
+        crate::durable_host::replace_wallet_cards(
+            &mut ctx.state.agent_wallet_cards,
+            &mut ctx.state.wallet_generation,
+            initial_wallet_cards,
+        )?;
+        ctx.rederive_agent_effective_surface_from_wallet();
+    }
+    Ok(())
+}
+
+async fn record_worker_update_failed_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    target_revision: ComponentRevision,
+    details: String,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    let public_state = store.with(|mut access| get_ctx(access.data_mut()).public_state.clone());
+    public_state
+        .worker()
+        .add_and_commit_oplog(OplogEntry::failed_update(
+            target_revision,
+            Some(details.clone()),
+        ))
+        .await;
+    tracing::warn!(
+        "Worker failed to update to {}: {}, update attempt aborted",
+        target_revision,
+        details
+    );
+    Ok(())
+}
+
+async fn record_worker_update_succeeded_access<T, D, Ctx>(
+    store: &Accessor<T, D>,
+    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
+    target_revision: ComponentRevision,
+    component_size: u64,
+    active_plugins: HashSet<
+        golem_common::base_model::environment_plugin_grant::EnvironmentPluginGrantId,
+    >,
+) -> Result<(), WorkerExecutorError>
+where
+    T: 'static,
+    D: HasData + ?Sized,
+    Ctx: WorkerCtx,
+{
+    tracing::info!("Worker update to {} finished successfully", target_revision);
+    let (public_state, linear_memory) = store.with(|mut access| {
+        let ctx = get_ctx(access.data_mut());
+        (ctx.public_state.clone(), ctx.linear_memory_tracker())
+    });
+    let worker = public_state.worker();
+    worker
+        .persist_successful_update(
+            &linear_memory,
+            target_revision,
+            component_size,
+            active_plugins,
+        )
+        .await;
+    Ok(())
+}

--- a/golem-worker-executor/src/durable_host/cli/environment.rs
+++ b/golem-worker-executor/src/durable_host/cli/environment.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::authorization::targets::{agent_owner, env_target};
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::model::AgentConfig;
 use crate::services::HasWorker;
@@ -140,7 +140,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
     pub(crate) async fn get_durable_environment(
         &mut self,
     ) -> wasmtime::Result<Vec<(String, String)>> {
-        let (begun, captured) = CallHandle::<
+        let (begun, captured) = DurableCallSession::<
             WasiCliEnvironmentGetEnvironment,
             NotCancellable,
         >::begin_with_agent_authority_capture(

--- a/golem-worker-executor/src/durable_host/clocks/monotonic_clock.rs
+++ b/golem-worker-executor/src/durable_host/clocks/monotonic_clock.rs
@@ -14,7 +14,7 @@
 
 use wasmtime::component::Resource;
 
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::services::HasWorker;
 use crate::services::oplog::CommitLevel;
@@ -28,15 +28,16 @@ use wasmtime_wasi::p2::bindings::clocks::monotonic_clock::{Duration, Host, Insta
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn now(&mut self) -> wasmtime::Result<Instant> {
-        // `now()` is a re-executable `ReadLocal`, so it uses the `CallHandle::run` combinator: the
+        // `now()` is a re-executable `ReadLocal`, so it uses the `DurableCallSession::run` combinator: the
         // live clock read is supplied as the action and is run on the live path or re-run if replay
         // finds the `Start` without its `End`; a committed `End` replays without touching the clock.
-        let handle = CallHandle::<host_functions::MonotonicClockNow, NotCancellable>::start(
-            self,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<host_functions::MonotonicClockNow, NotCancellable>::start(
+                self,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {
@@ -50,12 +51,13 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn resolution(&mut self) -> wasmtime::Result<Instant> {
-        let handle = CallHandle::<host_functions::MonotonicClockResolution, NotCancellable>::start(
-            self,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<host_functions::MonotonicClockResolution, NotCancellable>::start(
+                self,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {
@@ -80,13 +82,15 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         &mut self,
         duration_in_nanos: Duration,
     ) -> wasmtime::Result<Resource<Pollable>> {
-        let handle =
-            CallHandle::<host_functions::MonotonicClockSubscribeDuration, NotCancellable>::start(
-                self,
-                HostRequestMonotonicClockDuration { duration_in_nanos },
-                DurableFunctionType::ReadLocal,
-            )
-            .await?;
+        let handle = DurableCallSession::<
+            host_functions::MonotonicClockSubscribeDuration,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestMonotonicClockDuration { duration_in_nanos },
+            DurableFunctionType::ReadLocal,
+        )
+        .await?;
 
         let now = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {

--- a/golem-worker-executor/src/durable_host/clocks/wall_clock.rs
+++ b/golem-worker-executor/src/durable_host/clocks/wall_clock.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::DurableWorkerCtx;
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::workerctx::WorkerCtx;
 use golem_common::model::oplog::{
     DurableFunctionType, HostRequestNoInput, HostResponseWallClock, host_functions,
@@ -23,9 +23,9 @@ use wasmtime_wasi::p2::bindings::clocks::wall_clock::{Datetime, Host};
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn now(&mut self) -> wasmtime::Result<Datetime> {
-        // Re-executable `ReadLocal`: the `CallHandle::run` combinator reads the clock on the live /
+        // Re-executable `ReadLocal`: the `DurableCallSession::run` combinator reads the clock on the live /
         // incomplete-replay paths and replays a recorded value otherwise.
-        let handle = CallHandle::<host_functions::WallClockNow, NotCancellable>::start(
+        let handle = DurableCallSession::<host_functions::WallClockNow, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -48,12 +48,13 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn resolution(&mut self) -> wasmtime::Result<Datetime> {
-        let handle = CallHandle::<host_functions::WallClockResolution, NotCancellable>::start(
-            self,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<host_functions::WallClockResolution, NotCancellable>::start(
+                self,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {

--- a/golem-worker-executor/src/durable_host/concurrent/call.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/call.rs
@@ -13,13 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::durable_host::{
-    LiveAuthorizationPermit, authority_snapshot_is_current_at, authorize_effective_surface,
-    record_permission_decisions,
-};
-use crate::services::card::CardState;
-use golem_common::base_model::oplog::{CardInstallFailure, QueuedCardEvent};
-use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
+use golem_service_base::model::auth::AuthCtx;
 
 pub(super) fn ambient_trap_context<Ctx: WorkerCtx>(
     ctx: &DurableWorkerCtx<Ctx>,
@@ -30,7 +24,7 @@ pub(super) fn ambient_trap_context<Ctx: WorkerCtx>(
     }
 }
 
-/// Compile-time policy describing what happens when a [`CallHandle`] is dropped without being
+/// Compile-time policy describing what happens when a [`DurableCallSession`] is dropped without being
 /// explicitly finished or cancelled.
 pub trait DropPolicy {
     fn unfinished_drop(call: DroppedCall, sink: Option<&UnboundedSender<DropEvent>>);
@@ -110,20 +104,18 @@ impl DropPolicy for NotCancellable {
     }
 }
 
-/// A handle to one durable host call.
+/// The state machine for one durable host call.
 ///
-/// Created by [`CallHandle::start`], which eagerly appends the call's `Start` (live) or claims it
-/// from the oplog (replay). The call is finished with [`CallHandle::complete`] (live) /
-/// [`CallHandle::replay`] (replay), or cancelled with [`CallHandle::cancel`]. All terminal methods
-/// consume the handle so a call cannot be finished twice; an unfinished drop runs the `P` drop
-/// policy.
-pub struct CallHandle<Pair: HostPayloadPair, P: DropPolicy> {
+/// Created by [`DurableCallSession::start`], which eagerly appends the call's `Start` (live) or
+/// claims it from the oplog (replay). The call is finished with [`DurableCallSession::complete`]
+/// (live) / [`DurableCallSession::replay`] (replay), or cancelled with
+/// [`DurableCallSession::cancel`]. All terminal methods consume the session so a call cannot be
+/// finished twice; an unfinished drop runs the `P` drop policy.
+pub struct DurableCallSession<Pair: HostPayloadPair, P: DropPolicy> {
     pub(super) start_idx: OplogIndex,
-    /// The index returned by `begin_durable_function` / `begin_function`. For a non-idempotent
-    /// `WriteRemote` (or a `WriteRemoteBatched(None)`) this is the **durable scope** `Start` that
-    /// must be closed via `end_durable_function`; for every other function type it is just the
-    /// pre-call index and `end_durable_function` only uses it to commit at the right boundary.
-    pub(super) begin_index: OplogIndex,
+    /// Carries the [`DurableCallBoundary`] admitted for this session. Its begin index is the
+    /// durable-scope `Start` for a non-idempotent remote write and the pre-call index otherwise.
+    pub(super) boundary: DurableCallBoundary,
     pub(super) is_live: bool,
     /// `true` when a `Start` entry was actually appended. It is `false` while snapshotting (where
     /// nothing is persisted) and for replay handles.
@@ -368,7 +360,7 @@ struct ExecutedAccessStart<Pair: HostPayloadPair, P: DropPolicy> {
     drop_sink: Option<UnboundedSender<DropEvent>>,
     cleanup_sink: Option<UnboundedSender<DropEvent>>,
     /// The in-flight permit taken at prepare time (or when a replayed scope switched to live),
-    /// handed on to the [`CallHandle`] so the call stays counted continuously from before its
+    /// handed on to the [`DurableCallSession`] so the call stays counted continuously from before its
     /// first oplog append until its terminal is recorded.
     live_call_permit: Option<LiveCallPermit>,
     _phantom: PhantomData<(Pair, P)>,
@@ -386,13 +378,13 @@ struct AccessStartCleanup {
     atomic_lease: Option<Arc<AtomicRegionLease>>,
 }
 
-/// Context handed to the request builder of [`CallHandle::start_access_with`], available after the
+/// Context handed to the request builder of [`DurableCallSession::start_access_with`], available after the
 /// durable scope (if any) has been opened but before the host-call `Start` is written or claimed.
 pub struct AccessStartContext {
     /// The begin index of the call, mirroring `begin_durable_function`: the durable-scope `Start`
     /// index when the call opens a scope, otherwise the pre-call oplog index. Stable across
     /// live/replay for scope-opening calls; approximately stable otherwise (see
-    /// [`CallHandle::start_access_with`]).
+    /// [`DurableCallSession::start_access_with`]).
     pub begin_index: OplogIndex,
     /// Whether the call executes live (the built request will be persisted) or replays (the built
     /// request is discarded; the builder still runs for its positional replay side effects).
@@ -621,7 +613,7 @@ impl<H: DurabilityHost + Send + Sync> DurabilityHost for ScopedRetryHost<'_, H> 
     }
 }
 
-impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
+impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
     /// Begins a durable call.
     ///
     /// Observes the function call, then runs `begin_durable_function` — which applies the read-only
@@ -1412,9 +1404,9 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             ctx.state.current_retry_point = scope.begin_index;
         }
         let is_live = executed.replay.is_none();
-        Ok(CallHandle {
+        Ok(DurableCallSession {
             start_idx: executed.start_idx,
-            begin_index: executed.begin_index,
+            boundary: DurableCallBoundary::from_begin_index(executed.begin_index),
             is_live,
             persisted: executed.persisted,
             request_upload: executed.request_upload,
@@ -1481,10 +1473,9 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             .await
             .map_err(|err| err.source)?;
         DurabilityHost::observe_function_call(ctx, Pair::INTERFACE, Pair::FUNCTION);
-        let (begin_index, captured) = ctx
-            .begin_durable_function_with_agent_authority_capture(
-                &function_type,
-                Pair::FQFN,
+        let (boundary, captured) = DurableCallCoordinator::new(ctx)
+            .admit_with_agent_authority_capture(
+                DurableCallAdmission::new(&function_type, Pair::FQFN),
                 capture,
             )
             .await?;
@@ -1492,7 +1483,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             Self::finish_begin(
                 ctx,
                 function_type,
-                begin_index,
+                boundary,
                 false,
                 None,
                 observational_owner,
@@ -1519,16 +1510,17 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             .map_err(|err| err.source)?;
         DurabilityHost::observe_function_call(ctx, Pair::INTERFACE, Pair::FUNCTION);
 
-        // Read-only guard, pending replay events and durable-scope open all happen inside
-        // `begin_durable_function`.
-        let (begin_index, agent_auth_ctx) = if requires_agent_authority {
-            let (begin_index, auth_ctx) = ctx
-                .begin_durable_function_with_agent_authority(&function_type, Pair::FQFN)
+        // Read-only guard, pending replay events and durable-scope recovery all happen inside the
+        // durable-call coordinator.
+        let (boundary, agent_auth_ctx) = if requires_agent_authority {
+            let (boundary, auth_ctx) = DurableCallCoordinator::new(ctx)
+                .admit_with_agent_authority(DurableCallAdmission::new(&function_type, Pair::FQFN))
                 .await?;
-            (begin_index, auth_ctx)
+            (boundary, auth_ctx)
         } else {
             (
-                ctx.begin_durable_function(&function_type, Pair::FQFN)
+                DurableCallCoordinator::new(ctx)
+                    .admit(DurableCallAdmission::new(&function_type, Pair::FQFN))
                     .await?,
                 None,
             )
@@ -1536,7 +1528,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
         Ok(Self::finish_begin(
             ctx,
             function_type,
-            begin_index,
+            boundary,
             requires_agent_authority,
             agent_auth_ctx,
             observational_owner,
@@ -1546,11 +1538,12 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     fn finish_begin<Ctx: WorkerCtx>(
         ctx: &DurableWorkerCtx<Ctx>,
         function_type: DurableFunctionType,
-        begin_index: OplogIndex,
+        boundary: DurableCallBoundary,
         requires_agent_authority: bool,
         agent_auth_ctx: Option<AuthCtx>,
         observational_owner: Option<OplogIndex>,
     ) -> BegunCall<Pair, P> {
+        let begin_index = boundary.begin_index();
         let durable_execution_state = InFunctionRetryHost::durable_execution_state(ctx);
         let execution_scope = BegunCallExecutionScope {
             parent_start_index: ctx.child_parent_start_index(&function_type, begin_index),
@@ -1565,7 +1558,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             InFunctionRetryController::new(function_type, durable_execution_state, Pair::FQFN);
 
         BegunCall {
-            begin_index,
+            boundary,
             execution_scope,
             retry,
             requires_agent_authority,
@@ -1627,7 +1620,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     /// Used by call sites that derive a stable identifier from that index (e.g. the idempotency-key
     /// derivation).
     pub fn begin_index(&self) -> OplogIndex {
-        self.begin_index
+        self.boundary.begin_index()
     }
 
     pub fn agent_auth_ctx(&self) -> &AuthCtx {
@@ -1688,7 +1681,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     fn dropped_call_snapshot(&self, live_call_permit: Option<LiveCallPermit>) -> DroppedCall {
         DroppedCall {
             start_idx: self.start_idx,
-            begin_index: self.begin_index,
+            begin_index: self.begin_index(),
             function_type: self.retry.function_type().clone(),
             request_upload: self.request_upload.clone(),
             atomic_lease: self.execution_scope.atomic_lease.clone(),
@@ -1707,10 +1700,10 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
         // marker carries no call-owned atomic-region side-effect bit (`TrapType::from_error` sources
         // that from ambient state), which is only sound because the side-effect bit is consulted
         // solely for `AgentError::DeterministicTrap` and a host error is never one. Guest wasm traps
-        // are classified on the invocation path without a `CallHandle`, so they never reach here.
+        // are classified on the invocation path without a `DurableCallSession`, so they never reach here.
         debug_assert!(
             err.root_cause().downcast_ref::<wasmtime::Trap>().is_none(),
-            "CallHandle::trap must not wrap a deterministic wasm trap (root cause was a wasmtime::Trap)"
+            "DurableCallSession::trap must not wrap a deterministic wasm trap (root cause was a wasmtime::Trap)"
         );
         let context = self.trap_context();
         self.abandon_for_trap();
@@ -1914,7 +1907,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     {
         debug_assert!(
             self.retry.can_reexecute_on_incomplete_replay(),
-            "CallHandle::run is only valid for re-executable calls (reads / idempotent writes); \
+            "DurableCallSession::run is only valid for re-executable calls (reads / idempotent writes); \
              use start/complete/replay explicitly for non-idempotent / batched / transaction writes"
         );
         if self.is_live() {
@@ -2013,9 +2006,8 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             }
             oplog.add(end).await;
             self.execution_scope.release_atomic_lease();
-            // Close the durable scope (if one was opened), commit at the right boundary, and run the
-            // mid-invocation checkpoint, all via `end_durable_function`.
-            ctx.end_durable_function(self.retry.function_type(), self.begin_index, false)
+            DurableCallCoordinator::new(ctx)
+                .finish(self.retry.function_type(), self.boundary, false)
                 .await?;
         }
         Ok(response)
@@ -2109,7 +2101,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
             ));
         }
         let function_type = self.retry.function_type().clone();
-        let begin_index = self.begin_index;
+        let begin_index = self.begin_index();
         {
             let (oplog, completion_marker_recorder) = store.with(|mut access| {
                 let ctx = get_ctx(access.data_mut());
@@ -2283,7 +2275,8 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
                 self.finished = true;
                 let oplog = ctx.state.oplog.clone();
                 let response = decode_replayed_payload::<Pair>(&oplog, payload).await?;
-                ctx.end_durable_function(self.retry.function_type(), self.begin_index, false)
+                DurableCallCoordinator::new(ctx)
+                    .finish(self.retry.function_type(), self.boundary, false)
                     .await?;
                 Ok(CallReplayOutcome::Replayed(response))
             }
@@ -2331,7 +2324,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     {
         self.ensure_accessor_terminal_supported("replay_access")?;
         let function_type = self.retry.function_type().clone();
-        let begin_index = self.begin_index;
+        let begin_index = self.begin_index();
         let (replay_state, oplog, completion_marker_recorder) = store.with(|mut access| {
             let ctx = get_ctx(access.data_mut());
             (
@@ -2432,7 +2425,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     {
         self.ensure_accessor_terminal_supported("replay_reconstruction_access")?;
         let function_type = self.retry.function_type().clone();
-        let begin_index = self.begin_index;
+        let begin_index = self.begin_index();
         let (replay_state, oplog, completion_marker_recorder) = store.with(|mut access| {
             let ctx = get_ctx(access.data_mut());
             (
@@ -2508,7 +2501,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
     {
         self.ensure_accessor_terminal_supported("replay_access_deferred")?;
         let function_type = self.retry.function_type().clone();
-        let begin_index = self.begin_index;
+        let begin_index = self.begin_index();
         let (replay_state, oplog, completion_marker_recorder) = store.with(|mut access| {
             let ctx = get_ctx(access.data_mut());
             (
@@ -2687,7 +2680,8 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
                     .append_cancelled_with_oplog(oplog, partial_payload)
                     .await?;
                 dropped_call.release_atomic_lease();
-                ctx.end_durable_function(self.retry.function_type(), self.begin_index, false)
+                DurableCallCoordinator::new(ctx)
+                    .finish(self.retry.function_type(), self.boundary, false)
                     .await?;
             }
         } else {
@@ -2697,7 +2691,8 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
                 .expect("cancel() in replay called on a live handle");
             let resolution = ctx.state.replay_state.await_resolution(replay).await?;
             expect_cancelled_resolution(&resolution)?;
-            ctx.end_durable_function(self.retry.function_type(), self.begin_index, false)
+            DurableCallCoordinator::new(ctx)
+                .finish(self.retry.function_type(), self.boundary, false)
                 .await?;
         }
         Ok(())
@@ -2739,7 +2734,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> CallHandle<Pair, P> {
         self.ensure_accessor_terminal_supported("cancel_access")?;
         self.finished = true;
         let function_type = self.retry.function_type().clone();
-        let begin_index = self.begin_index;
+        let begin_index = self.begin_index();
         if self.is_live {
             if self.persisted {
                 let oplog = store.with(|mut access| get_ctx(access.data_mut()).state.oplog.clone());
@@ -3086,8 +3081,8 @@ fn expect_cancelled_resolution(resolution: &Resolution) -> Result<(), WorkerExec
     }
 }
 
-/// Store-free persistence preparation shared by the direct ([`CallHandle::complete`]) and
-/// accessor ([`CallHandle::persist_access_terminal`]) completion paths: waits for the (possibly
+/// Store-free persistence preparation shared by the direct ([`DurableCallSession::complete`]) and
+/// accessor ([`DurableCallSession::persist_access_terminal`]) completion paths: waits for the (possibly
 /// deferred) request upload, uploads the response payload, and constructs the terminal `End`
 /// entry — without appending it, touching atomic-region state, or closing scopes, which the two
 /// paths deliberately order differently (direct appends inline; accessor hands the append to an
@@ -3358,1424 +3353,12 @@ fn is_accessor_terminal_supported_function_type(function_type: &DurableFunctionT
         || matches!(function_type, DurableFunctionType::WriteRemote)
 }
 
-pub(crate) async fn authorize_live_permissions_at_serialized_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    targets: &[golem_common::model::card::PermissionTarget],
-) -> Result<Result<LiveAuthorizationPermit, AuthorizationError>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    enum FastResult {
-        OperatorAuthorized,
-        Stable(Result<(), AuthorizationError>),
-        Slow,
-    }
-
-    let fast_result = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        assert!(
-            ctx.state.is_live(),
-            "live permission authorization must not run during replay"
-        );
-        if ctx.operator_authorizes_current_invocation() {
-            return FastResult::OperatorAuthorized;
-        }
-        let published_generation = ctx
-            .state
-            .published_authority_generation
-            .load(Ordering::Acquire);
-        let now = chrono::Utc::now();
-        if authority_snapshot_is_current_at(
-            ctx.state.authority_initialized,
-            ctx.state.card_interest_index.authority_is_open(),
-            ctx.state.processed_authority_generation,
-            published_generation,
-            ctx.state.next_authority_expiration,
-            now,
-        ) {
-            let result = authorize_effective_surface(&ctx.state.agent_effective_surface, targets);
-            if ctx.authority_snapshot_is_stable(published_generation) {
-                FastResult::Stable(result)
-            } else {
-                FastResult::Slow
-            }
-        } else {
-            FastResult::Slow
-        }
-    });
-    match fast_result {
-        FastResult::OperatorAuthorized => {
-            record_permission_decisions(targets, true);
-            return Ok(Ok(LiveAuthorizationPermit { _private: () }));
-        }
-        FastResult::Stable(result) => {
-            crate::metrics::wasm::record_agent_permission_authority_fast_path();
-            record_permission_decisions(targets, result.is_ok());
-            return Ok(result.map(|()| LiveAuthorizationPermit { _private: () }));
-        }
-        FastResult::Slow => {}
-    }
-
-    let started = std::time::Instant::now();
-    loop {
-        let boundary_guard =
-            lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, true)
-                .await?
-                .expect("waiting authority boundary always returns a guard");
-        let result = store.with(|mut access| {
-            let ctx = get_ctx(access.data_mut());
-            if ctx.operator_authorizes_current_invocation() {
-                return Some(Ok(()));
-            }
-            let generation = ctx
-                .state
-                .published_authority_generation
-                .load(Ordering::Acquire);
-            let result = authorize_effective_surface(&ctx.state.agent_effective_surface, targets);
-            // A due cached deadline sent us through synchronization. Recompute it from the
-            // synchronized wallet before deciding whether the snapshot is stable.
-            ctx.refresh_authority_expiration_deadline();
-            if ctx.authority_snapshot_is_stable(generation) {
-                ctx.adopt_authority_generation(generation);
-                Some(result)
-            } else {
-                None
-            }
-        });
-        if let Some(result) = result {
-            crate::metrics::wasm::record_agent_permission_authority_slow_path(started.elapsed());
-            record_permission_decisions(targets, result.is_ok());
-            return Ok(result.map(|()| LiveAuthorizationPermit { _private: () }));
-        }
-        drop(boundary_guard);
-    }
-}
-
-pub(crate) async fn try_agent_auth_ctx_at_serialized_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<Option<AuthCtx>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let Some(_boundary_guard) =
-        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, false).await?
-    else {
-        return Ok(None);
-    };
-    Ok(Some(store.with(|mut access| {
-        get_ctx(access.data_mut()).agent_auth_ctx()
-    })))
-}
-
-pub(crate) async fn agent_auth_ctx_at_serialized_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<AuthCtx, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let _boundary_guard =
-        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, true, true)
-            .await?
-            .expect("waiting authority boundary always returns a guard");
-    Ok(store.with(|mut access| get_ctx(access.data_mut()).agent_auth_ctx()))
-}
-
-async fn lock_synchronized_card_event_boundary_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<tokio::sync::OwnedMutexGuard<()>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    Ok(
-        lock_synchronized_card_event_boundary_access_inner(store, get_ctx, false, true)
-            .await?
-            .expect("unrestricted card boundary always returns a guard"),
-    )
-}
-
-async fn lock_synchronized_card_event_boundary_access_inner<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    requires_agent_authority: bool,
-    wait_for_authority: bool,
-) -> Result<Option<tokio::sync::OwnedMutexGuard<()>>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let boundary_lock = store.with(|mut access| {
-        get_ctx(access.data_mut())
-            .state
-            .card_event_boundary_lock
-            .clone()
-    });
-    loop {
-        let boundary_guard = boundary_lock.clone().lock_owned().await;
-        let (authority_checked, authority_open, card_interest_index) = store.with(|mut access| {
-            let ctx = get_ctx(access.data_mut());
-            (
-                requires_agent_authority && ctx.state.is_live(),
-                ctx.state.card_interest_index.authority_is_open(),
-                ctx.state.card_interest_index.clone(),
-            )
-        });
-        if authority_checked && !authority_open {
-            drop(boundary_guard);
-            if !wait_for_authority {
-                return Ok(None);
-            }
-            card_interest_index.wait_until_authority_open().await;
-            continue;
-        }
-        synchronize_agent_wallet_at_boundary_access(store, get_ctx).await?;
-        if requires_agent_authority && !authority_checked {
-            let authority_open_after_replay = store.with(|mut access| {
-                let ctx = get_ctx(access.data_mut());
-                !ctx.state.is_live() || ctx.state.card_interest_index.authority_is_open()
-            });
-            if !authority_open_after_replay {
-                drop(boundary_guard);
-                if !wait_for_authority {
-                    return Ok(None);
-                }
-                card_interest_index.wait_until_authority_open().await;
-                continue;
-            }
-        }
-        let has_pending_source_transfer = store.with(|mut access| {
-            get_ctx(access.data_mut())
-                .state
-                .card_event_boundary_scan
-                .as_ref()
-                .is_some_and(|scan| {
-                    scan.pending.iter().any(|pending| {
-                        matches!(&pending.event, QueuedCardEvent::TransferStarted(_))
-                    })
-                })
-        });
-        let retries = if has_pending_source_transfer {
-            prepare_pending_source_card_transfers_access(store, get_ctx).await?
-        } else {
-            Vec::new()
-        };
-        if retries.is_empty() {
-            return Ok(Some(boundary_guard));
-        }
-        // Target delivery takes the target worker's boundary lock. Release the source lock while
-        // delivering, then reconcile again before returning the guard that protects live Start.
-        drop(boundary_guard);
-        complete_pending_source_card_transfers_access(store, get_ctx, retries).await?;
-    }
-}
-
-async fn synchronize_agent_wallet_at_boundary_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    process_pending_replay_events_access(store, get_ctx).await?;
-    drain_card_revocations_and_expiry_access(store, get_ctx).await
-}
-
-async fn drain_card_revocations_and_expiry_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let is_live = store.with(|mut access| get_ctx(access.data_mut()).state.is_live());
-    if !is_live {
-        return Ok(());
-    }
-
-    loop {
-        let pending_events = crate::durable_host::next_drainable_card_events(
-            pending_card_events_at_boundary_access(store, get_ctx).await?,
-        );
-        let Some(pending_event) = pending_events.first() else {
-            break;
-        };
-        match &pending_event.event {
-            QueuedCardEvent::Revoke(_) => {
-                let card_ids = pending_events
-                    .into_iter()
-                    .filter_map(|pending_event| match pending_event.event {
-                        QueuedCardEvent::Revoke(event) => Some(event.card_id),
-                        QueuedCardEvent::Install(_)
-                        | QueuedCardEvent::TransferStarted(_)
-                        | QueuedCardEvent::TransferReceived(_) => None,
-                    })
-                    .collect::<Vec<_>>();
-                apply_card_revocations_access(store, get_ctx, card_ids).await?;
-            }
-            QueuedCardEvent::Install(event) => {
-                let Some(card) = event.card.clone() else {
-                    return Err(WorkerExecutorError::runtime(
-                        "queued card install is missing card payload",
-                    ));
-                };
-                apply_card_install_access(store, get_ctx, pending_event.oplog_index, card).await?;
-            }
-            QueuedCardEvent::TransferReceived(event) => {
-                let Some(card) = event.card.clone() else {
-                    return Err(WorkerExecutorError::runtime(
-                        "received card transfer is missing card payload",
-                    ));
-                };
-                apply_received_card_transfer_access(
-                    store,
-                    get_ctx,
-                    pending_event.oplog_index,
-                    event.transfer_id,
-                    event.source_card_id,
-                    card,
-                )
-                .await?;
-            }
-            QueuedCardEvent::TransferStarted(_) => {
-                unreachable!("filtered above")
-            }
-        }
-    }
-    remove_expired_wallet_cards_access(store, get_ctx).await?;
-
-    let expired_scope_root_ids = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        crate::durable_host::expired_wallet_card_ids_at(
-            &ctx.state.invocation_scope_root_cards,
-            chrono::Utc::now(),
-        )
-    });
-    apply_card_revocations_access(store, get_ctx, expired_scope_root_ids).await
-}
-
-async fn pending_card_events_at_boundary_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<Vec<golem_common::model::PendingCardEventRef>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let (worker, oplog) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (ctx.public_state.worker().clone(), ctx.state.oplog.clone())
-    });
-    let status = worker.get_non_detached_last_known_status().await;
-    let current_idx = oplog.current_oplog_index().await;
-    let unread_range = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        match &mut ctx.state.card_event_boundary_scan {
-            Some(scan) => {
-                scan.synchronize(status.oplog_idx, &status.pending_card_events, current_idx)
-            }
-            None => {
-                ctx.state.card_event_boundary_scan =
-                    Some(crate::durable_host::CardEventBoundaryScan::new(
-                        status.oplog_idx,
-                        status.pending_card_events,
-                    ));
-            }
-        }
-        ctx.state
-            .card_event_boundary_scan
-            .as_ref()
-            .expect("card event boundary scan must be initialized")
-            .unread_range(current_idx)
-    });
-
-    if let Some((start, count)) = unread_range {
-        let entries = oplog.read_many(start, count).await;
-        store.with(|mut access| {
-            get_ctx(access.data_mut())
-                .state
-                .card_event_boundary_scan
-                .as_mut()
-                .expect("card event boundary scan must be initialized")
-                .fold_through(current_idx, &entries);
-        });
-    }
-
-    Ok(store.with(|mut access| {
-        get_ctx(access.data_mut())
-            .state
-            .card_event_boundary_scan
-            .as_ref()
-            .expect("card event boundary scan must be initialized")
-            .pending
-            .clone()
-    }))
-}
-
-async fn admit_card_to_wallet_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    card: &golem_common::model::card::StoredCard,
-) -> Result<Result<u64, CardInstallFailure>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let card_id = card.card_id();
-    let (owned_agent_id, mut candidate_card_ids, interest_index, card_service) =
-        store.with(|mut access| {
-            let ctx = get_ctx(access.data_mut());
-            (
-                ctx.owned_agent_id.clone(),
-                ctx.interested_card_ids(),
-                ctx.state.card_interest_index.clone(),
-                ctx.state.card_service.clone(),
-            )
-        });
-    if !candidate_card_ids.contains(&card_id) {
-        candidate_card_ids.push(card_id);
-    }
-    interest_index
-        .set_card_interest(owned_agent_id, &candidate_card_ids)
-        .await;
-
-    let card_state = card_service
-        .check_cards(vec![card_id])
-        .await?
-        .remove(&card_id);
-    let failure = match card_state {
-        Some(CardState::Live(registered_card)) if registered_card.as_ref() == card => None,
-        Some(CardState::Live(_)) => Some(CardInstallFailure::NotPermitted),
-        Some(CardState::Revoked) => Some(CardInstallFailure::CardRevoked),
-        Some(CardState::Unknown) | None => Some(CardInstallFailure::NotFound),
-    };
-
-    let (result, owned_agent_id, interested_card_ids, interest_index) =
-        store.with(|mut access| -> Result<_, WorkerExecutorError> {
-            let ctx = get_ctx(access.data_mut());
-            let result = if let Some(failure) = failure {
-                Err(failure)
-            } else {
-                if crate::durable_host::add_wallet_card(
-                    &mut ctx.state.agent_wallet_cards,
-                    &mut ctx.state.wallet_generation,
-                    card.clone(),
-                )? {
-                    ctx.rederive_agent_effective_surface_from_wallet();
-                }
-                Ok(ctx.state.wallet_generation)
-            };
-            Ok((
-                result,
-                ctx.owned_agent_id.clone(),
-                ctx.interested_card_ids(),
-                ctx.state.card_interest_index.clone(),
-            ))
-        })?;
-    interest_index
-        .set_card_interest(owned_agent_id, &interested_card_ids)
-        .await;
-    Ok(result)
-}
-
-async fn apply_card_install_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    queued_event_index: OplogIndex,
-    card: golem_common::model::card::StoredCard,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let card_id = card.card_id();
-    let result = admit_card_to_wallet_access(store, get_ctx, &card).await?;
-    let worker = store.with(|mut access| get_ctx(access.data_mut()).public_state.worker().clone());
-    let entry = match result {
-        Ok(wallet_generation) => {
-            OplogEntry::card_installed(Some(queued_event_index), card, Some(wallet_generation))
-        }
-        Err(reason) => OplogEntry::card_install_failed(queued_event_index, card_id, reason),
-    };
-    worker.add_and_commit_oplog(entry).await;
-    Ok(())
-}
-
-async fn apply_received_card_transfer_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    queued_event_index: OplogIndex,
-    transfer_id: uuid::Uuid,
-    source_card_id: Option<golem_common::model::card::CardId>,
-    card: golem_common::model::card::StoredCard,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let card_id = card.card_id();
-    let result = admit_card_to_wallet_access(store, get_ctx, &card).await?;
-    let (agent_id, worker) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (
-            ctx.owned_agent_id.agent_id.clone(),
-            ctx.public_state.worker().clone(),
-        )
-    });
-    let entry = match result {
-        Ok(wallet_generation) => OplogEntry::card_transferred(
-            transfer_id,
-            source_card_id,
-            card_id,
-            golem_common::model::card::CardHolder::Agent(
-                golem_common::model::card::AgentCardHolder { agent_id },
-            ),
-            card,
-            Some(wallet_generation),
-        ),
-        Err(reason) => OplogEntry::card_install_failed(queued_event_index, card_id, reason),
-    };
-    worker.add_and_commit_oplog(entry).await;
-    Ok(())
-}
-
-async fn remove_expired_wallet_cards_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let (expired_card_generations, owned_agent_id, interested_card_ids, interest_index, worker) =
-        store.with(|mut access| -> Result<_, WorkerExecutorError> {
-            let ctx = get_ctx(access.data_mut());
-            let expired_card_ids = crate::durable_host::expired_wallet_card_ids_at(
-                &ctx.state.agent_wallet_cards,
-                chrono::Utc::now(),
-            );
-            let mut expired_card_generations = Vec::with_capacity(expired_card_ids.len());
-            for card_id in expired_card_ids {
-                if crate::durable_host::remove_wallet_card(
-                    &mut ctx.state.agent_wallet_cards,
-                    &mut ctx.state.wallet_generation,
-                    card_id,
-                )? {
-                    expired_card_generations.push((card_id, ctx.state.wallet_generation));
-                }
-            }
-            if !expired_card_generations.is_empty() {
-                ctx.rederive_agent_effective_surface_from_wallet();
-            }
-            Ok((
-                expired_card_generations,
-                ctx.owned_agent_id.clone(),
-                ctx.interested_card_ids(),
-                ctx.state.card_interest_index.clone(),
-                ctx.public_state.worker().clone(),
-            ))
-        })?;
-
-    if expired_card_generations.is_empty() {
-        return Ok(());
-    }
-    interest_index
-        .set_card_interest(owned_agent_id, &interested_card_ids)
-        .await;
-    for (card_id, wallet_generation) in expired_card_generations {
-        worker
-            .add_and_commit_oplog(OplogEntry::card_expired(card_id, Some(wallet_generation)))
-            .await;
-    }
-    Ok(())
-}
-
-async fn process_pending_replay_events_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let replay_state =
-        store.with(|mut access| get_ctx(access.data_mut()).state.replay_state.clone());
-    let replay_events = replay_state.take_new_replay_events();
-    for event in replay_events {
-        match event {
-            crate::durable_host::replay_state::ReplayEvent::ForkReplayed { new_phantom_id } => {
-                store.with(|mut access| {
-                    let ctx = get_ctx(access.data_mut());
-                    ctx.state.current_phantom_id = Some(new_phantom_id);
-                });
-            }
-            crate::durable_host::replay_state::ReplayEvent::UpdateReplayed { new_revision } => {
-                tracing::debug!(
-                    "Updating worker state to component metadata revision {new_revision}"
-                );
-                update_state_to_new_component_revision_access(store, get_ctx, new_revision).await?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::InvocationWalletPinned {
-                wallet_pin,
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    if crate::durable_host::apply_invocation_wallet_pin(
-                        &mut ctx.state.agent_wallet_cards,
-                        ctx.state.wallet_id_hash,
-                        &mut ctx.state.wallet_generation,
-                        wallet_pin,
-                    )? {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    Ok(())
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardInstalled {
-                card,
-                wallet_generation,
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    let card_id = card.card_id();
-                    tracing::debug!(card_id = %card_id, "Applying replayed card installation");
-                    if crate::durable_host::add_wallet_card(
-                        &mut ctx.state.agent_wallet_cards,
-                        &mut ctx.state.wallet_generation,
-                        card,
-                    )? {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardDerived {
-                wallet_generation,
-                ..
-            } => {
-                store.with(|mut access| {
-                    let ctx = get_ctx(access.data_mut());
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardTransferStarted {
-                card_id,
-                source_holder,
-                source_wallet_generation,
-                ..
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    if source_holder.as_ref().is_none_or(|source_holder| {
-                        crate::durable_host::card_holder_is_agent(
-                            source_holder,
-                            &ctx.owned_agent_id.agent_id,
-                        )
-                    }) && crate::durable_host::transfer_started_removes_source_membership(
-                        ctx.state.agent_wallet_cards.get(&card_id),
-                        &source_holder,
-                        &ctx.owned_agent_id.agent_id,
-                    ) && crate::durable_host::remove_wallet_card(
-                        &mut ctx.state.agent_wallet_cards,
-                        &mut ctx.state.wallet_generation,
-                        card_id,
-                    )? {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        source_wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardTransferred {
-                target_holder,
-                card,
-                target_wallet_generation,
-                ..
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    if crate::durable_host::card_holder_is_agent(
-                        &target_holder,
-                        &ctx.owned_agent_id.agent_id,
-                    ) && crate::durable_host::add_wallet_card(
-                        &mut ctx.state.agent_wallet_cards,
-                        &mut ctx.state.wallet_generation,
-                        card,
-                    )? {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        target_wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardTransferConfirmed { .. } => {}
-            crate::durable_host::replay_state::ReplayEvent::CardRevokedCascade {
-                card_ids,
-                local_wallet_generation,
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    let wallet_changed = crate::durable_host::remove_wallet_cards(
-                        &mut ctx.state.agent_wallet_cards,
-                        &mut ctx.state.wallet_generation,
-                        &card_ids,
-                    )?;
-                    let scope_changed = ctx.clear_invocation_scope_if_roots_include(&card_ids);
-                    if wallet_changed || scope_changed {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        local_wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::CardRevoked {
-                card_id,
-                wallet_generation,
-            }
-            | crate::durable_host::replay_state::ReplayEvent::CardExpired {
-                card_id,
-                wallet_generation,
-            } => {
-                store.with(|mut access| -> Result<(), WorkerExecutorError> {
-                    let ctx = get_ctx(access.data_mut());
-                    let wallet_changed = crate::durable_host::remove_wallet_card(
-                        &mut ctx.state.agent_wallet_cards,
-                        &mut ctx.state.wallet_generation,
-                        card_id,
-                    )?;
-                    let scope_changed = ctx.clear_invocation_scope_if_roots_include(&[card_id]);
-                    if wallet_changed || scope_changed {
-                        ctx.rederive_agent_effective_surface_from_wallet();
-                    }
-                    crate::durable_host::adopt_recorded_wallet_generation(
-                        &mut ctx.state.wallet_generation,
-                        wallet_generation,
-                    )
-                })?;
-            }
-            crate::durable_host::replay_state::ReplayEvent::ReplayFinished => {
-                tracing::debug!("Replaying oplog finished");
-                finalize_pending_automatic_update_access(store, get_ctx).await?;
-                check_post_replay_wallet_liveness_access(store, get_ctx).await?;
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn check_post_replay_wallet_liveness_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let (
-        owned_agent_id,
-        interested_card_ids,
-        invocation_scope_card,
-        interest_index,
-        card_service,
-        worker,
-    ) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (
-            ctx.owned_agent_id.clone(),
-            ctx.interested_card_ids(),
-            ctx.state.invocation_scope_card.clone(),
-            ctx.state.card_interest_index.clone(),
-            ctx.state.card_service.clone(),
-            ctx.public_state.worker().clone(),
-        )
-    });
-
-    interest_index
-        .set_card_interest(owned_agent_id, &interested_card_ids)
-        .await;
-    if interested_card_ids.is_empty() {
-        return Ok(());
-    }
-
-    let card_states = card_service.check_cards(interested_card_ids).await?;
-    let live_scope_root_cards = crate::durable_host::live_scope_root_cards_from_states(
-        invocation_scope_card.as_ref(),
-        &card_states,
-    )?;
-    store.with(|mut access| {
-        get_ctx(access.data_mut()).state.invocation_scope_root_cards = live_scope_root_cards;
-    });
-    let revoked_card_ids = card_states
-        .into_iter()
-        .filter_map(|(card_id, state)| (state == CardState::Revoked).then_some(card_id))
-        .collect::<Vec<_>>();
-    worker
-        .queue_card_revocations_locked(&revoked_card_ids)
-        .await;
-    Ok(())
-}
-
-async fn prepare_pending_source_card_transfers_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<
-    Vec<crate::durable_host::permissions::PendingSourceCardTransferRetry>,
-    WorkerExecutorError,
->
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let (is_live, oplog, source_agent_id) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (
-            ctx.state.is_live(),
-            ctx.state.oplog.clone(),
-            ctx.owned_agent_id.agent_id.clone(),
-        )
-    });
-    if !is_live {
-        return Ok(Vec::new());
-    }
-
-    let pending_events = pending_card_events_at_boundary_access(store, get_ctx).await?;
-    let mut retries = Vec::new();
-    let mut first_error = None;
-    for pending in pending_events {
-        if let QueuedCardEvent::TransferStarted(transfer) = &pending.event {
-            let retry =
-                crate::durable_host::permissions::prepare_pending_source_card_transfer_retry(
-                    oplog.as_ref(),
-                    &source_agent_id,
-                    &pending,
-                    transfer,
-                )
-                .await;
-            match retry {
-                Ok(Some(mut retry)) => {
-                    match ensure_pending_source_card_transfer_started_access(store, get_ctx, &retry)
-                        .await
-                    {
-                        Ok(()) => {
-                            retry.started = true;
-                            retries.push(retry);
-                        }
-                        Err(error) if first_error.is_none() => first_error = Some(error),
-                        Err(_) => {}
-                    }
-                }
-                Ok(None) => {}
-                Err(error) if first_error.is_none() => first_error = Some(error),
-                Err(_) => {}
-            }
-        }
-    }
-
-    match first_error {
-        Some(error) => Err(error),
-        None => Ok(retries),
-    }
-}
-
-async fn ensure_pending_source_card_transfer_started_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    retry: &crate::durable_host::permissions::PendingSourceCardTransferRetry,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    if retry.started {
-        return Ok(());
-    }
-
-    let (worker, source_agent_id) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (
-            ctx.public_state.worker().clone(),
-            ctx.owned_agent_id.agent_id.clone(),
-        )
-    });
-    let target_holder =
-        golem_common::model::card::CardHolder::Agent(golem_common::model::card::AgentCardHolder {
-            agent_id: retry.target_agent_id.clone(),
-        });
-
-    let refresh_interest = store.with(|mut access| -> Result<Option<_>, WorkerExecutorError> {
-        let ctx = get_ctx(access.data_mut());
-        let changed = retry.remove_source_membership
-            && crate::durable_host::remove_wallet_card(
-                &mut ctx.state.agent_wallet_cards,
-                &mut ctx.state.wallet_generation,
-                retry.source_card_id,
-            )?;
-        if changed {
-            ctx.rederive_agent_effective_surface_from_wallet();
-            Ok(Some((
-                ctx.owned_agent_id.clone(),
-                ctx.interested_card_ids(),
-                ctx.state.card_interest_index.clone(),
-            )))
-        } else {
-            Ok(None)
-        }
-    })?;
-    if let Some((owned_agent_id, interested_card_ids, interest_index)) = refresh_interest {
-        interest_index
-            .set_card_interest(owned_agent_id, &interested_card_ids)
-            .await;
-    }
-
-    worker
-        .add_and_commit_oplog(OplogEntry::card_transfer_started(
-            retry.transfer_id,
-            retry.source_card_id,
-            Some(golem_common::model::card::CardHolder::Agent(
-                golem_common::model::card::AgentCardHolder {
-                    agent_id: source_agent_id,
-                },
-            )),
-            target_holder,
-            store.with(|mut access| Some(get_ctx(access.data_mut()).state.wallet_generation)),
-        ))
-        .await;
-
-    Ok(())
-}
-
-async fn complete_pending_source_card_transfers_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    retries: Vec<crate::durable_host::permissions::PendingSourceCardTransferRetry>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    for retry in retries {
-        complete_pending_source_card_transfer_access(store, get_ctx, retry).await?;
-    }
-
-    Ok(())
-}
-
-async fn complete_pending_source_card_transfer_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    retry: crate::durable_host::permissions::PendingSourceCardTransferRetry,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let (worker, worker_proxy, environment_id) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (
-            ctx.public_state.worker().clone(),
-            ctx.worker_proxy().clone(),
-            ctx.owned_agent_id.environment_id,
-        )
-    });
-    let target_holder =
-        golem_common::model::card::CardHolder::Agent(golem_common::model::card::AgentCardHolder {
-            agent_id: retry.target_agent_id.clone(),
-        });
-
-    worker_proxy
-        .deliver_card_transfer(
-            &retry.target_agent_id,
-            environment_id,
-            retry.transfer_id,
-            retry.source_card_id,
-            &retry.installed_card,
-        )
-        .await
-        .map_err(|error| {
-            WorkerExecutorError::runtime(format!(
-                "permission-card transfer delivery failed: {error}"
-            ))
-        })?;
-
-    let boundary_lock = store.with(|mut access| {
-        get_ctx(access.data_mut())
-            .state
-            .card_event_boundary_lock
-            .clone()
-    });
-    let _boundary_guard = boundary_lock.lock().await;
-    let (oplog, source_agent_id) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (ctx.state.oplog.clone(), ctx.owned_agent_id.agent_id.clone())
-    });
-    if retry.is_confirmed(oplog.as_ref(), &source_agent_id).await? {
-        return Ok(());
-    }
-    worker
-        .add_and_commit_oplog(OplogEntry::card_transfer_confirmed(
-            retry.transfer_id,
-            retry.source_card_id,
-            retry.installed_card.card_id(),
-            target_holder,
-        ))
-        .await;
-    Ok(())
-}
-
-async fn apply_card_revocations_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    mut card_ids: Vec<golem_common::model::card::CardId>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    card_ids.sort_unstable();
-    card_ids.dedup();
-    if card_ids.is_empty() {
-        return Ok(());
-    }
-
-    let (
-        owned_agent_id,
-        interested_card_ids,
-        interest_index,
-        worker,
-        affected_wallets,
-        wallet_generation,
-    ) = store.with(|mut access| -> Result<_, WorkerExecutorError> {
-        let ctx = get_ctx(access.data_mut());
-        let wallet_changed = crate::durable_host::remove_wallet_cards(
-            &mut ctx.state.agent_wallet_cards,
-            &mut ctx.state.wallet_generation,
-            &card_ids,
-        )?;
-        let scope_changed = ctx.clear_invocation_scope_if_roots_include(&card_ids);
-        if wallet_changed || scope_changed {
-            ctx.rederive_agent_effective_surface_from_wallet();
-        }
-        let affected_wallets = if wallet_changed {
-            vec![golem_common::model::card::CardHolder::Agent(
-                golem_common::model::card::AgentCardHolder {
-                    agent_id: ctx.owned_agent_id.agent_id.clone(),
-                },
-            )]
-        } else {
-            Vec::new()
-        };
-        Ok((
-            ctx.owned_agent_id.clone(),
-            ctx.interested_card_ids(),
-            ctx.state.card_interest_index.clone(),
-            ctx.public_state.worker().clone(),
-            affected_wallets,
-            ctx.state.wallet_generation,
-        ))
-    })?;
-
-    interest_index
-        .set_card_interest(owned_agent_id, &interested_card_ids)
-        .await;
-    worker
-        .add_and_commit_oplog(OplogEntry::CardRevokedCascade {
-            timestamp: Timestamp::now_utc(),
-            revoked_card_ids: card_ids,
-            affected_wallets,
-            local_wallet_generation: Some(wallet_generation),
-        })
-        .await;
-    Ok(())
-}
-
-struct AccessRevisionUpdateInputs {
-    component_service: Arc<dyn ComponentService>,
-    file_loader: Arc<FileLoader>,
-    owned_agent_id: golem_common::model::OwnedAgentId,
-    agent_id: Option<ParsedAgentId>,
-    initial_agent_config: Vec<golem_common::model::worker::TypedAgentConfigEntry>,
-    worker_dir: PathBuf,
-    current_revision: ComponentRevision,
-}
-
-type AccessRevisionUpdateAgentState = (
-    HashMap<Vec<String>, golem_common::schema::TypedSchemaValue>,
-    BTreeMap<golem_common::model::card::CardId, golem_common::model::card::StoredCard>,
-);
-
-struct AccessRevisionUpdate {
-    metadata: Component,
-    agent_state: Option<AccessRevisionUpdateAgentState>,
-    files: HashMap<PathBuf, IFSWorkerFile>,
-}
-
-async fn finalize_pending_automatic_update_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let pending_update = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        let pending_update = ctx
-            .state
-            .pending_update
-            .try_lock()
-            .map_err(|_| {
-                WorkerExecutorError::runtime(
-                    "p3 accessor durable call path cannot inspect pending component update state",
-                )
-            })?
-            .take();
-        Ok::<_, WorkerExecutorError>(pending_update)
-    });
-
-    let pending_update = if let Some(pending_update) = pending_update? {
-        pending_update
-    } else {
-        return Ok(());
-    };
-
-    match pending_update.description {
-        UpdateDescription::Automatic { target_revision } => {
-            tracing::debug!("Finalizing pending automatic update");
-            if let Err(error) =
-                update_state_to_new_component_revision_access(store, get_ctx, target_revision).await
-            {
-                let stringified_error = format!("Applying worker update failed: {error}");
-                record_worker_update_failed_access(
-                    store,
-                    get_ctx,
-                    target_revision,
-                    stringified_error,
-                )
-                .await?;
-                return Err(error);
-            }
-
-            let (component_size, active_plugins) = store.with(|mut access| {
-                let ctx = get_ctx(access.data_mut());
-                (
-                    ctx.state.component_metadata.component_size,
-                    HashSet::from_iter({
-                        ctx.agent_type_provision_config()
-                            .map(|c| c.plugins.as_slice())
-                            .unwrap_or_default()
-                            .iter()
-                            .map(|installation| installation.environment_plugin_grant_id)
-                    }),
-                )
-            });
-            record_worker_update_succeeded_access(
-                store,
-                get_ctx,
-                target_revision,
-                component_size,
-                active_plugins,
-            )
-            .await?;
-            tracing::debug!("Finalizing automatic update to revision {target_revision}");
-            Ok(())
-        }
-        _ => Err(WorkerExecutorError::runtime(
-            "pending replay event finalization expected an automatic update description",
-        )),
-    }
-}
-
-async fn update_state_to_new_component_revision_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    new_revision: ComponentRevision,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let inputs = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        AccessRevisionUpdateInputs {
-            component_service: ctx.state.component_service.clone(),
-            file_loader: ctx.state.file_loader.clone(),
-            owned_agent_id: ctx.owned_agent_id.clone(),
-            agent_id: ctx.state.agent_id.clone(),
-            initial_agent_config: ctx.state.initial_agent_config.clone(),
-            worker_dir: ctx.owner_filesystem.path().to_path_buf(),
-            current_revision: ctx.state.component_metadata.revision,
-        }
-    });
-
-    if new_revision <= inputs.current_revision {
-        tracing::debug!("Update {new_revision} was already applied, skipping");
-        return Ok(());
-    }
-
-    let update = prepare_revision_update_access(store, get_ctx, &inputs, new_revision).await?;
-    store.with(|mut access| -> Result<(), WorkerExecutorError> {
-        let ctx = get_ctx(access.data_mut());
-        apply_revision_update_access(ctx, update)
-    })
-}
-
-async fn prepare_revision_update_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    inputs: &AccessRevisionUpdateInputs,
-    new_revision: ComponentRevision,
-) -> Result<AccessRevisionUpdate, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let metadata = inputs
-        .component_service
-        .get_metadata(inputs.owned_agent_id.component_id(), Some(new_revision))
-        .await?;
-
-    let provision_config = inputs.agent_id.as_ref().and_then(|agent_id| {
-        metadata
-            .metadata
-            .agent_type_provision_configs()
-            .get(&agent_id.agent_type)
-            .cloned()
-    });
-
-    let agent_state = if let Some(agent_id) = &inputs.agent_id {
-        let agent_type = metadata
-            .metadata
-            .find_agent_type_by_name_ref(&agent_id.agent_type)
-            .ok_or_else(|| {
-                WorkerExecutorError::invalid_request(format!(
-                    "Agent type {} not found in updated agent metadata",
-                    agent_id.agent_type
-                ))
-            })?;
-
-        let updated_agent_config = effective_agent_config(
-            inputs.initial_agent_config.clone(),
-            provision_config
-                .as_ref()
-                .map(|c| c.config.clone())
-                .unwrap_or_default(),
-        )?;
-        validate_agent_config(&updated_agent_config, agent_type)?;
-
-        let initial_card =
-            super::super::agent_initial_card_from_component_metadata(&metadata, agent_id)?;
-        let initial_wallet_cards = BTreeMap::from([(initial_card.card_id(), initial_card)]);
-        Some((updated_agent_config, initial_wallet_cards))
-    } else {
-        None
-    };
-
-    let mut files = take_initial_files_access(store, get_ctx)?;
-    let update_result = super::super::update_filesystem(
-        &mut files,
-        &inputs.file_loader,
-        inputs.owned_agent_id.environment_id,
-        &inputs.worker_dir,
-        provision_config
-            .as_ref()
-            .map(|c| c.files.as_slice())
-            .unwrap_or_default(),
-    )
-    .await;
-
-    if let Err(error) = update_result {
-        restore_initial_files_access(store, get_ctx, files)?;
-        return Err(error);
-    }
-
-    Ok(AccessRevisionUpdate {
-        metadata,
-        agent_state,
-        files,
-    })
-}
-
-fn take_initial_files_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-) -> Result<HashMap<PathBuf, IFSWorkerFile>, WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        let mut files = ctx.state.files.try_write().map_err(|_| {
-            WorkerExecutorError::runtime(
-                "p3 accessor durable call path cannot acquire initial-files lock",
-            )
-        })?;
-        Ok(std::mem::take(&mut *files))
-    })
-}
-
-fn restore_initial_files_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    restored: HashMap<PathBuf, IFSWorkerFile>,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        let mut files = ctx.state.files.try_write().map_err(|_| {
-            WorkerExecutorError::runtime(
-                "p3 accessor durable call path cannot restore initial-files state",
-            )
-        })?;
-        *files = restored;
-        Ok(())
-    })
-}
-
-fn apply_revision_update_access<Ctx: WorkerCtx>(
-    ctx: &mut DurableWorkerCtx<Ctx>,
-    update: AccessRevisionUpdate,
-) -> Result<(), WorkerExecutorError> {
-    let read_only_paths = super::super::compute_read_only_paths(&update.files);
-    {
-        let mut files = ctx
-            .state
-            .files
-            .try_write()
-            .expect("initial-files state was taken by this update path");
-        *files = update.files;
-    }
-    {
-        let mut read_only = ctx.state.read_only_paths.write().unwrap();
-        *read_only = read_only_paths;
-    }
-
-    ctx.state.component_metadata = update.metadata;
-
-    if let Some((agent_config, initial_wallet_cards)) = update.agent_state {
-        ctx.state.agent_config = agent_config;
-        ctx.state.cached_agent_config_retry_policies = None;
-        crate::durable_host::replace_wallet_cards(
-            &mut ctx.state.agent_wallet_cards,
-            &mut ctx.state.wallet_generation,
-            initial_wallet_cards,
-        )?;
-        ctx.rederive_agent_effective_surface_from_wallet();
-    }
-    Ok(())
-}
-
-async fn record_worker_update_failed_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    target_revision: ComponentRevision,
-    details: String,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    let public_state = store.with(|mut access| get_ctx(access.data_mut()).public_state.clone());
-    public_state
-        .worker()
-        .add_and_commit_oplog(OplogEntry::failed_update(
-            target_revision,
-            Some(details.clone()),
-        ))
-        .await;
-    tracing::warn!(
-        "Worker failed to update to {}: {}, update attempt aborted",
-        target_revision,
-        details
-    );
-    Ok(())
-}
-
-async fn record_worker_update_succeeded_access<T, D, Ctx>(
-    store: &Accessor<T, D>,
-    get_ctx: fn(&mut T) -> &mut DurableWorkerCtx<Ctx>,
-    target_revision: ComponentRevision,
-    component_size: u64,
-    active_plugins: HashSet<
-        golem_common::base_model::environment_plugin_grant::EnvironmentPluginGrantId,
-    >,
-) -> Result<(), WorkerExecutorError>
-where
-    T: 'static,
-    D: HasData + ?Sized,
-    Ctx: WorkerCtx,
-{
-    tracing::info!("Worker update to {} finished successfully", target_revision);
-    let (public_state, linear_memory) = store.with(|mut access| {
-        let ctx = get_ctx(access.data_mut());
-        (ctx.public_state.clone(), ctx.linear_memory_tracker())
-    });
-    let worker = public_state.worker();
-    worker
-        .persist_successful_update(
-            &linear_memory,
-            target_revision,
-            component_size,
-            active_plugins,
-        )
-        .await;
-    Ok(())
-}
-
-/// The first phase of a two-phase durable call, produced by [`CallHandle::begin`]. The durable
+/// The first phase of a two-phase durable call, produced by [`DurableCallSession::begin`]. The durable
 /// scope is already open and the begin index is known; the host-call `Start` has not yet been
-/// written (live) nor claimed (replay). Finalised into a [`CallHandle`] with [`Self::start_live`]
+/// written (live) nor claimed (replay). Finalised into a [`DurableCallSession`] with [`Self::start_live`]
 /// (after the request has been built) or [`Self::start_replay`].
 pub struct BegunCall<Pair: HostPayloadPair, P: DropPolicy> {
-    begin_index: OplogIndex,
+    boundary: DurableCallBoundary,
     execution_scope: BegunCallExecutionScope,
     retry: InFunctionRetryController,
     requires_agent_authority: bool,
@@ -4796,10 +3379,10 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
             .expect("agent authority context requested from a call without live agent authority")
     }
 
-    /// The index returned by `begin_durable_function` — see [`CallHandle::begin_index`]. Available
+    /// The index returned by `begin_durable_function` — see [`DurableCallSession::begin_index`]. Available
     /// before the request is finalised, so a two-step call can derive its request payload from it.
     pub fn begin_index(&self) -> OplogIndex {
-        self.begin_index
+        self.boundary.begin_index()
     }
 
     /// Second phase on the live path: upload the request and append the eager host-call `Start`
@@ -4808,7 +3391,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
         self,
         ctx: &mut DurableWorkerCtx<Ctx>,
         request: Pair::Req,
-    ) -> Result<CallHandle<Pair, P>, WorkerExecutorError> {
+    ) -> Result<DurableCallSession<Pair, P>, WorkerExecutorError> {
         debug_assert!(self.is_live(), "start_live() called on a replay handle");
         let snapshotting = self.retry.durable_execution_state().snapshotting_mode;
         // The host-call `Start` nests inside the enclosing durable scope captured at initiation
@@ -4878,9 +3461,9 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
             )
         };
         let execution_scope = self.execution_scope.finish(start_idx, atomic_lease);
-        Ok(CallHandle {
+        Ok(DurableCallSession {
             start_idx,
-            begin_index: self.begin_index,
+            boundary: self.boundary,
             is_live: true,
             persisted,
             request_upload,
@@ -4903,7 +3486,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
     pub async fn start_replay<Ctx: WorkerCtx>(
         self,
         ctx: &mut DurableWorkerCtx<Ctx>,
-    ) -> Result<CallHandle<Pair, P>, WorkerExecutorError> {
+    ) -> Result<DurableCallSession<Pair, P>, WorkerExecutorError> {
         debug_assert!(!self.is_live(), "start_replay() called on a live handle");
         let replay = match self.execution_scope.parent_start_index {
             Some(parent_start_index) => {
@@ -4931,9 +3514,9 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
             self.retry.can_reexecute_on_incomplete_replay(),
         );
         let execution_scope = self.execution_scope.finish(start_idx, atomic_lease);
-        Ok(CallHandle {
+        Ok(DurableCallSession {
             start_idx,
-            begin_index: self.begin_index,
+            boundary: self.boundary,
             is_live: false,
             persisted: false,
             request_upload: PendingUpload::already_durable(),
@@ -4952,7 +3535,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> BegunCall<Pair, P> {
     }
 }
 
-impl<Pair: HostPayloadPair, P: DropPolicy> Drop for CallHandle<Pair, P> {
+impl<Pair: HostPayloadPair, P: DropPolicy> Drop for DurableCallSession<Pair, P> {
     fn drop(&mut self) {
         if self.finished {
             return;
@@ -4975,7 +3558,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> Drop for CallHandle<Pair, P> {
             {
                 let _ = sink.send(DropEvent::CloseDurableScope {
                     function_type: self.retry.function_type().clone(),
-                    begin_index: self.begin_index,
+                    begin_index: self.begin_index(),
                     span_id: None,
                 });
             }

--- a/golem-worker-executor/src/durable_host/concurrent/delivery.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/delivery.rs
@@ -141,8 +141,8 @@ pub(super) fn task_for_marker_receipt(
     tokio::spawn(async move { await_marker_receipt(&mut receipt).await })
 }
 
-/// A deferred guest-delivery token returned by [`CallHandle::complete_access_deferred`] /
-/// [`CallHandle::replay_access_deferred`] for call sites whose result crosses one more fallible
+/// A deferred guest-delivery token returned by [`DurableCallSession::complete_access_deferred`] /
+/// [`DurableCallSession::replay_access_deferred`] for call sites whose result crosses one more fallible
 /// boundary *after* the durable terminal is recorded — a second-stage channel send to the guest
 /// task, a span finish plus resource-state transition before the host method returns, or a wire
 /// conversion. The plain `complete_access` boundary (the accessor terminal itself) is too early
@@ -463,7 +463,7 @@ impl CompletionDelivery {
     ///
     /// Starting a later durable call on the same host subtask while this observer is still armed
     /// is a forbidden host-function pattern (see
-    /// [`CallHandle::supersede_prior_completion_delivery`], which hard-errors): host code must
+    /// [`DurableCallSession::supersede_prior_completion_delivery`], which hard-errors): host code must
     /// arm the observer only as the tail operation of its host function. That invariant is what
     /// lets a markerless `End` be tail-gated on replay — a completion consumed host-internally
     /// would legitimize durable tail entries that depend on an unmarked delivery.
@@ -602,7 +602,7 @@ impl CompletionDelivery {
 impl CompletionDelivery {
     /// A live-armed token over `oplog` whose torn/failed delivery appends a
     /// `CompletionDiscarded` marker for `start_idx`, exactly as
-    /// [`CallHandle::complete_access_deferred`] arms one for a persisted live call whose `End`
+    /// [`DurableCallSession::complete_access_deferred`] arms one for a persisted live call whose `End`
     /// is already durable. `oplog` must already contain the call's `Start`/`End` entries (the
     /// token's replay state is built over its current contents).
     pub(crate) async fn test_live_armed(
@@ -641,7 +641,7 @@ impl CompletionDelivery {
     }
 
     /// A replay token for a recorded discarded completion, as
-    /// [`CallHandle::replay_access_deferred`] returns when the recorded run persisted the `End`
+    /// [`DurableCallSession::replay_access_deferred`] returns when the recorded run persisted the `End`
     /// but never delivered it.
     pub(crate) fn test_replay_discarded() -> Self {
         Self::replay_discarded()
@@ -657,7 +657,7 @@ impl CompletionDelivery {
 
     /// A tail-gated replay token for a markerless completed `End` (the recorded run crashed
     /// after the `End` became durable but before the completion crossed to the guest), exactly
-    /// as [`CallHandle::replay_access_deferred`] builds one. `replay_state` must be the state
+    /// as [`DurableCallSession::replay_access_deferred`] builds one. `replay_state` must be the state
     /// replaying `oplog`, with the call's `Start` already claimed and resolved — as the real
     /// replay path guarantees before it constructs the token.
     pub(crate) fn test_replay_at_tail(

--- a/golem-worker-executor/src/durable_host/concurrent/drop_events.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/drop_events.rs
@@ -116,7 +116,7 @@ impl DroppedCall {
 /// Deferred work emitted from `Drop` impls that cannot touch the worker store themselves.
 ///
 /// Each worker owns a `dropped_call_events` channel (see `PrivateDurableWorkerState`); `Drop`
-/// impls ([`CallHandle`], [`AccessTerminalGuard`], resource wrappers) enqueue these events, and
+/// impls ([`DurableCallSession`], [`AccessTerminalGuard`], resource wrappers) enqueue these events, and
 /// they are drained from the next safe worker-access window: [`drain_queued_dropped_call_events`]
 /// at the start of every `&mut ctx` durable call and [`drain_dropped_call_events_access`] on the
 /// accessor path (call start and terminals). The drain records durable effects (`Cancelled`
@@ -239,7 +239,7 @@ impl Drop for AccessDropEventDrainGuard {
 /// (cancellable drops as `Cancelled`, deferred terminal joins, scope closes, span finishes).
 ///
 /// Called from the next safe worker-access window after the events were enqueued — the start of
-/// every `&mut ctx` durable call ([`CallHandle::begin`]). The helper deliberately drains only
+/// every `&mut ctx` durable call ([`DurableCallSession::begin`]). The helper deliberately drains only
 /// currently available events; callers decide where to wait for more work.
 pub async fn drain_queued_dropped_call_events<Ctx: WorkerCtx>(
     ctx: &mut DurableWorkerCtx<Ctx>,

--- a/golem-worker-executor/src/durable_host/concurrent/mod.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/mod.rs
@@ -17,28 +17,24 @@
 //! A durable host call is identified by the [`OplogIndex`] of its `Start` entry. While live,
 //! the call eagerly appends a `Start` (capturing its request) and later an `End` (its response)
 //! or a `Cancelled`. During replay the [`ConcurrentReplayResolver`] matches each completed
-//! `End`/`Cancelled` back to the awaiting [`CallHandle`] via a [`ReplayableOneshot`], so the two
+//! `End`/`Cancelled` back to the awaiting [`DurableCallSession`] via a [`ReplayableOneshot`], so the two
 //! halves of a call no longer have to be adjacent in the oplog — which is what lets us track
 //! async, parallel host functions.
 //!
-//! Every durable host call runs through this path via [`CallHandle`]. Calls made through the
-//! p3 `Accessor` entry points ([`CallHandle::start_access_with`] and friends) run concurrently;
+//! Every durable host call runs through this path via [`DurableCallSession`]. Calls made through the
+//! p3 `Accessor` entry points ([`DurableCallSession::start_access_with`] and friends) run concurrently;
 //! host methods still taking `&mut self` remain serialized by the store borrow.
 
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::marker::PhantomData;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Error;
 use async_trait::async_trait;
-use golem_common::model::agent::ParsedAgentId;
-use golem_common::model::component::ComponentRevision;
 use golem_common::model::invocation_context::SpanId;
-use golem_common::model::oplog::UpdateDescription;
 use golem_common::model::oplog::{
     DurableFunctionType, HostPayloadPair, HostRequest, HostResponse, OplogEntry, OplogIndex,
     OplogPayload, ScopeScanState, host_functions::HostFunctionName,
@@ -48,7 +44,6 @@ use golem_common::model::{RetryProperties, Timestamp};
 use golem_service_base::error::worker_executor::{
     GolemSpecificWasmTrap, InterruptKind, WorkerExecutorError,
 };
-use golem_service_base::model::component::Component;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use wasmtime::component::{Accessor, HasData, TerminalConsumption};
@@ -62,13 +57,10 @@ use crate::durable_host::durability::{
 };
 use crate::durable_host::replay_state::{OplogEntryLookupResult, ReplayState};
 use crate::durable_host::{
-    AtomicRegionLease, DurableScopeKind, DurableWorkerCtx, IFSWorkerFile, PublicDurableWorkerState,
+    AtomicRegionLease, DurableScopeKind, DurableWorkerCtx, PublicDurableWorkerState,
 };
 use crate::services::HasWorker;
-use crate::services::component::ComponentService;
-use crate::services::file_loader::FileLoader;
 use crate::services::oplog::{CommitLevel, Oplog, OplogOps, PendingUpload};
-use crate::worker::agent_config::{effective_agent_config, validate_agent_config};
 use crate::workerctx::{InvocationContextManagement, WorkerCtx};
 use std::fmt::Display;
 
@@ -78,6 +70,14 @@ mod delivery;
 mod drop_events;
 mod replay;
 
+pub(super) use super::call_coordinator::{
+    DurableCallAdmission, DurableCallBoundary, DurableCallCoordinator,
+    lock_synchronized_card_event_boundary_access, process_pending_replay_events_access,
+};
+pub(crate) use super::call_coordinator::{
+    agent_auth_ctx_at_serialized_access, authorize_live_permissions_at_serialized_access,
+    try_agent_auth_ctx_at_serialized_access,
+};
 use access::*;
 pub use call::*;
 #[cfg(test)]

--- a/golem-worker-executor/src/durable_host/concurrent/replay.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/replay.rs
@@ -15,7 +15,7 @@
 use super::*;
 
 /// Replayable single-shot channel used to deliver a call's [`Resolution`] from the replay cursor
-/// to the awaiting [`CallHandle`].
+/// to the awaiting [`DurableCallSession`].
 ///
 /// `tokio::sync::oneshot` already supports send-before-await, which is all this currently needs.
 /// The only "resolve happened before the awaiter registered" case is handled by the resolver's
@@ -54,7 +54,7 @@ pub enum Resolution {
     /// Replay must not deliver the response to the *guest* either — the replaying guest parks
     /// (at the recorded delivery boundary) until it drops the future at the same point it did
     /// live. The recorded response payload is still carried: deferred-delivery replay sites
-    /// ([`CallHandle::replay_access_deferred`]) must decode it to reconstruct deterministic
+    /// ([`DurableCallSession::replay_access_deferred`]) must decode it to reconstruct deterministic
     /// host-side state (span finishes, terminal-child bookkeeping) executed between the `End`
     /// and the point where delivery would have happened.
     CompletedButDiscarded {
@@ -79,7 +79,7 @@ pub enum ResolutionOutcome {
     Incomplete,
 }
 
-/// The result of [`CallHandle::replay`].
+/// The result of [`DurableCallSession::replay`].
 ///
 /// Transient: callers destructure it immediately, so the size difference between the variants
 /// never lives beyond the replay call itself.
@@ -89,9 +89,9 @@ pub enum CallReplayOutcome<Pair: HostPayloadPair, P: DropPolicy> {
     Replayed(Pair::Resp),
     /// The call's `Start` was committed but its `End` never was. The returned handle has been
     /// switched to live completion of that existing `Start`: the caller must re-run the side effect
-    /// and call [`CallHandle::complete`] (which appends the missing `End`). Only produced for
+    /// and call [`DurableCallSession::complete`] (which appends the missing `End`). Only produced for
     /// function types that are safe to re-execute.
-    Incomplete(CallHandle<Pair, P>),
+    Incomplete(DurableCallSession<Pair, P>),
 }
 
 /// Replay outcome used by executor-owned entity reconstruction tasks. Cancellation is observable
@@ -101,10 +101,10 @@ pub enum CallReplayOutcome<Pair: HostPayloadPair, P: DropPolicy> {
 pub enum ReconstructionReplayOutcome<Pair: HostPayloadPair, P: DropPolicy> {
     Replayed(Pair::Resp),
     Cancelled,
-    Incomplete(CallHandle<Pair, P>),
+    Incomplete(DurableCallSession<Pair, P>),
 }
 
-/// The result of [`CallHandle::replay_access_deferred`]: like [`CallReplayOutcome`], but each
+/// The result of [`DurableCallSession::replay_access_deferred`]: like [`CallReplayOutcome`], but each
 /// replayed response carries the [`CompletionDelivery`] token describing the recorded delivery
 /// status the caller must mirror.
 #[allow(clippy::large_enum_variant)]
@@ -115,11 +115,11 @@ pub enum DeferredCallReplayOutcome<Pair: HostPayloadPair, P: DropPolicy> {
     /// its deterministic post-`End` continuation.
     Replayed(Pair::Resp, CompletionDelivery),
     /// See [`CallReplayOutcome::Incomplete`]; the caller re-runs the side effect and completes
-    /// via [`CallHandle::complete_access_deferred`].
-    Incomplete(CallHandle<Pair, P>),
+    /// via [`DurableCallSession::complete_access_deferred`].
+    Incomplete(DurableCallSession<Pair, P>),
 }
 
-/// Matches replayed `End`/`Cancelled` entries back to the [`CallHandle`]s awaiting them, keyed by
+/// Matches replayed `End`/`Cancelled` entries back to the [`DurableCallSession`]s awaiting them, keyed by
 /// the `OplogIndex` of the call's `Start`.
 ///
 /// Lives inside the replay state behind its lock. It is fed **only** from the committed-consume

--- a/golem-worker-executor/src/durable_host/concurrent/tests.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/tests.rs
@@ -158,12 +158,12 @@ fn resolver_duplicate_resolution_is_ignored() {
     }
 }
 
-// ---- CallHandle drop policy ----
+// ---- DurableCallSession drop policy ----
 
 fn live_unfinished_handle<P: DropPolicy>(
     start_idx: OplogIndex,
     sink: mpsc::UnboundedSender<DropEvent>,
-) -> CallHandle<host_functions::MonotonicClockNow, P> {
+) -> DurableCallSession<host_functions::MonotonicClockNow, P> {
     live_unfinished_handle_with_atomic_region(start_idx, None, sink)
 }
 
@@ -171,7 +171,7 @@ fn live_unfinished_handle_with_atomic_region<P: DropPolicy>(
     start_idx: OplogIndex,
     atomic_region: Option<OplogIndex>,
     sink: mpsc::UnboundedSender<DropEvent>,
-) -> CallHandle<host_functions::MonotonicClockNow, P> {
+) -> DurableCallSession<host_functions::MonotonicClockNow, P> {
     use crate::durable_host::durability::DurableExecutionState;
     use std::time::Duration;
     let durable_execution_state = DurableExecutionState {
@@ -180,9 +180,9 @@ fn live_unfinished_handle_with_atomic_region<P: DropPolicy>(
         assume_idempotence: false,
         max_in_function_retry_delay: Duration::ZERO,
     };
-    CallHandle {
+    DurableCallSession {
         start_idx,
-        begin_index: start_idx,
+        boundary: DurableCallBoundary::from_begin_index(start_idx),
         is_live: true,
         persisted: true,
         request_upload: PendingUpload::already_durable(),
@@ -213,11 +213,11 @@ fn live_unfinished_handle_with_atomic_region<P: DropPolicy>(
 /// Terminal-failure tests use this to drive `trap_context()` (the call-owned classification a
 /// terminal-step failure attaches) for a call initiated in a specific scope, without standing up
 /// a full `DurableWorkerCtx`. `finished` is set so dropping the handle is a no-op (no drop
-/// event), and no `drop_sink` is attached. `start_idx`/`begin_index` are set from
+/// event), and no `drop_sink` is attached. `start_idx` and the boundary lease are set from
 /// `scope.retry_from` only so the struct is well-formed; the tests read nothing but the scope.
 fn synthetic_finished_handle_with_scope<P: DropPolicy>(
     scope: CallExecutionScope,
-) -> CallHandle<host_functions::MonotonicClockNow, P> {
+) -> DurableCallSession<host_functions::MonotonicClockNow, P> {
     use crate::durable_host::durability::DurableExecutionState;
     use std::time::Duration;
     let durable_execution_state = DurableExecutionState {
@@ -227,9 +227,9 @@ fn synthetic_finished_handle_with_scope<P: DropPolicy>(
         max_in_function_retry_delay: Duration::ZERO,
     };
     let start_idx = scope.retry_from;
-    CallHandle {
+    DurableCallSession {
         start_idx,
-        begin_index: start_idx,
+        boundary: DurableCallBoundary::from_begin_index(start_idx),
         is_live: true,
         persisted: true,
         request_upload: PendingUpload::already_durable(),
@@ -1117,7 +1117,7 @@ async fn dropped_cancellable_call_records_cancelled_at_next_drain_point() {
 #[test]
 async fn access_terminal_end_is_appended_before_cleanup_and_permit_release() {
     // Ordering is proven against the production persistence stage itself
-    // (`CallHandle::persist_access_terminal`, the exact code `complete_access_impl` runs for a
+    // (`DurableCallSession::persist_access_terminal`, the exact code `complete_access_impl` runs for a
     // persisted live call): while the terminal `End` append is still in flight, the live-call
     // permit must stay held and no cleanup event may become visible; both are released only
     // after the append completes (production releases them via `disarm()` after
@@ -1180,7 +1180,7 @@ async fn access_terminal_end_is_appended_before_cleanup_and_permit_release() {
         CompletionMarkerRecorder::new(persist_oplog.clone(), persist_replay_state);
     let persist = tokio::spawn(async move {
         let response = HostResponseMonotonicClockTimestamp { nanos: 42 };
-        let result = CallHandle::<host_functions::MonotonicClockNow, NotCancellable>::
+        let result = DurableCallSession::<host_functions::MonotonicClockNow, NotCancellable>::
                 persist_access_terminal(persist_oplog, completion_marker_recorder, &mut guard, start_idx, &response, None)
             .await;
         (result, guard)
@@ -1861,7 +1861,7 @@ fn can_reexecute_matches_internal_retry_eligibility() {
     // nor the `Some(begin_index)` (in-scope host call) variants. The `Some(..)` variants are the
     // ones a migrated batched/transaction host call carries, so a lone committed host-call
     // `Start` for them must hard-error on incomplete replay rather than re-execute and risk
-    // duplicating an external write (`CallHandle::replay` Incomplete arm).
+    // duplicating an external write (`DurableCallSession::replay` Incomplete arm).
     assert!(
         !controller(DurableFunctionType::WriteRemote, false).can_reexecute_on_incomplete_replay()
     );

--- a/golem-worker-executor/src/durable_host/config/mod.rs
+++ b/golem-worker-executor/src/durable_host/config/mod.rs
@@ -14,7 +14,7 @@
 
 use super::DurableWorkerCtx;
 use crate::durable_host::authorization::targets::{agent_owner, config_segments_target};
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::preview2::wasi::config::store::{Error, Host};
 use crate::workerctx::WorkerCtx;
 use golem_common::base_model::render_config_path;
@@ -57,7 +57,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             false
         };
-        let begun = CallHandle::<WasiConfigGet, NotCancellable>::begin(
+        let begun = DurableCallSession::<WasiConfigGet, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadLocal,
         )
@@ -120,7 +120,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let begun = CallHandle::<WasiConfigGetAll, NotCancellable>::begin(
+        let begun = DurableCallSession::<WasiConfigGetAll, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadLocal,
         )

--- a/golem-worker-executor/src/durable_host/durability.rs
+++ b/golem-worker-executor/src/durable_host/durability.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use crate::durable_host::DurableWorkerCtx;
+use crate::durable_host::call_coordinator::{
+    DurableCallAdmission, DurableCallBoundary, DurableCallCoordinator,
+};
 use crate::durable_host::concurrent::{self, DropEvent, Resolution, ResolutionOutcome};
 use crate::metrics::wasm::{
     record_custom_invocation_scope_open, record_host_function_call, record_in_function_retry,
@@ -20,7 +23,7 @@ use crate::metrics::wasm::{
 use crate::model::ExecutionStatus;
 use crate::preview2::golem::durability::durability;
 use crate::services::environment_state::EnvironmentStateService;
-use crate::services::oplog::{CommitLevel, OplogOps};
+use crate::services::oplog::OplogOps;
 use crate::services::{HasOplog, HasWorker};
 use crate::workerctx::WorkerCtx;
 use anyhow::Error;
@@ -37,7 +40,6 @@ use golem_common::model::{
 use golem_service_base::error::worker_executor::{
     GolemSpecificWasmTrap, InterruptKind, WorkerExecutorError,
 };
-use golem_service_base::model::auth::AuthCtx;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::future::Future;
@@ -493,7 +495,7 @@ pub fn find_durable_call_trap_context(error: &anyhow::Error) -> Option<DurableCa
 }
 
 /// An error type that can carry a [`DurableCallTrapContextMarker`] in its chain, used as the error
-/// bound of the Shape-A `CallHandle::run` combinator.
+/// bound of the Shape-A `DurableCallSession::run` combinator.
 ///
 /// Implemented only for `anyhow::Error` / `wasmtime::Error` (which preserve the marker chain). It is
 /// deliberately **not** implemented for typed errors such as `WorkerExecutorError`: converting a
@@ -501,7 +503,7 @@ pub fn find_durable_call_trap_context(error: &anyhow::Error) -> Option<DurableCa
 /// ambient-fallback misclassification under overlap. So a `run` call site that wants a typed error
 /// must instead return `wasmtime::Result`/`anyhow::Result` and map the error at the boundary.
 pub trait DurableCallTrapError: From<WorkerExecutorError> + Into<anyhow::Error> {
-    /// Re-wraps a marked `anyhow::Error` (produced by [`CallHandle::trap`]) back into this error
+    /// Re-wraps a marked `anyhow::Error` (produced by [`DurableCallSession::trap`]) back into this error
     /// type, preserving the marker chain.
     fn from_durable_call_trap(error: anyhow::Error) -> Self;
 }
@@ -518,7 +520,7 @@ impl DurableCallTrapError for wasmtime::Error {
     }
 }
 
-/// A failure escaping a live *terminal* durable-call step — `CallHandle::complete` /
+/// A failure escaping a live *terminal* durable-call step — `DurableCallSession::complete` /
 /// `complete_access` / `cancel` / `cancel_access` and the dropped-call cancellation drain — paired
 /// with that call's own [`DurableCallTrapContext`].
 ///
@@ -1001,7 +1003,7 @@ pub trait DurabilityHost: InFunctionRetryHost {
     /// when the worker is executing a read-only agent method. This is the single, central
     /// place where that guard lives: every host call that wants to perform a write side
     /// effect funnels through `begin_durable_function` (either directly or via the concurrent
-    /// durability `CallHandle`), so the read-only trap is uniformly enforced here without any
+    /// durability `DurableCallSession`), so the read-only trap is uniformly enforced here without any
     /// per-callsite checks.
     async fn begin_durable_function(
         &mut self,
@@ -1848,77 +1850,6 @@ impl<Ctx: WorkerCtx> InFunctionRetryHost for DurableWorkerCtx<Ctx> {
     }
 }
 
-impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
-    pub(crate) async fn begin_durable_function_with_agent_authority(
-        &mut self,
-        function_type: &DurableFunctionType,
-        host_function: &str,
-    ) -> Result<(OplogIndex, Option<AuthCtx>), WorkerExecutorError> {
-        self.begin_durable_function_with_agent_authority_capture(
-            function_type,
-            host_function,
-            |ctx| ctx.agent_auth_ctx(),
-        )
-        .await
-    }
-
-    pub(crate) async fn begin_durable_function_with_agent_authority_capture<T>(
-        &mut self,
-        function_type: &DurableFunctionType,
-        host_function: &str,
-        mut capture: impl FnMut(&mut Self) -> T,
-    ) -> Result<(OplogIndex, Option<T>), WorkerExecutorError> {
-        self.check_durable_function_allowed(function_type, host_function)?;
-        let mut captured = self
-            .capture_live_agent_authority_at_boundary(&mut capture)
-            .await?;
-        let begin_index = self.begin_function(function_type).await?;
-        if captured.is_none() {
-            if self.state.snapshotting_mode && self.state.is_replay() {
-                // Snapshot loading executes guest code without durable host-call records while
-                // replay is positioned at the snapshot. Use the authority reconstructed from the
-                // persisted snapshot rather than consulting current card state.
-                captured = Some(capture(self));
-            } else if self.state.is_live() {
-                captured = self
-                    .capture_live_agent_authority_at_boundary(&mut capture)
-                    .await?;
-            }
-        }
-        Ok((begin_index, captured))
-    }
-
-    fn check_durable_function_allowed(
-        &self,
-        function_type: &DurableFunctionType,
-        host_function: &str,
-    ) -> Result<(), WorkerExecutorError> {
-        // Generic read-only side-effect trap. For any `Write*` durable function type, refuse
-        // the call up front when the worker is executing a read-only agent method. This is the
-        // single, central place that enforces the read-only contract — outgoing HTTP, RPC,
-        // KV/blobstore writes, RDBMS queries/transactions, worker-management calls, websocket
-        // writes, etc. all funnel through `begin_durable_function` (directly or via the
-        // concurrent durability `CallHandle`) and are uniformly rejected here before any oplog
-        // entry is appended. The `GolemSpecificWasmTrap` is folded into
-        // `WorkerExecutorError::ReadOnlyViolation` so the trap survives the conversion chain
-        // (anyhow → wasmtime::Error → StreamError / SocketError) and can later be recognised
-        // by `TrapType::from_error` as `AgentError::ReadOnlyViolation`.
-        if is_write_side_effect(function_type)
-            && let Err(GolemSpecificWasmTrap::WorkerReadOnlyViolation {
-                method,
-                host_function,
-            }) = DurableWorkerCtx::check_read_only_allows(self, host_function)
-        {
-            return Err(WorkerExecutorError::ReadOnlyViolation {
-                method,
-                host_function,
-            });
-        }
-
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl<Ctx: WorkerCtx> DurabilityHost for DurableWorkerCtx<Ctx> {
     fn observe_function_call(&self, interface: &str, function: &str) {
@@ -1930,9 +1861,10 @@ impl<Ctx: WorkerCtx> DurabilityHost for DurableWorkerCtx<Ctx> {
         function_type: &DurableFunctionType,
         host_function: &str,
     ) -> Result<OplogIndex, WorkerExecutorError> {
-        self.check_durable_function_allowed(function_type, host_function)?;
-        self.synchronize_agent_wallet_at_boundary().await?;
-        self.begin_function(function_type).await
+        DurableCallCoordinator::new(self)
+            .admit(DurableCallAdmission::new(function_type, host_function))
+            .await
+            .map(DurableCallBoundary::begin_index)
     }
 
     async fn end_durable_function(
@@ -1941,25 +1873,13 @@ impl<Ctx: WorkerCtx> DurabilityHost for DurableWorkerCtx<Ctx> {
         begin_index: OplogIndex,
         forced_commit: bool,
     ) -> Result<(), WorkerExecutorError> {
-        self.end_function(function_type, begin_index).await?;
-        if !self.state.snapshotting_mode
-            && (function_type == &DurableFunctionType::WriteRemote
-                || matches!(function_type, DurableFunctionType::WriteRemoteBatched(_))
-                || matches!(
-                    function_type,
-                    DurableFunctionType::WriteRemoteTransaction(_)
-                )
-                || forced_commit)
-        {
-            self.public_state
-                .worker()
-                .commit_oplog_and_update_state(CommitLevel::DurableOnly)
-                .await;
-            // Just committed at a durable-op boundary: this is the single safe place to advance the
-            // mid-invocation clean status checkpoint (status now reflects the committed tip).
-            self.maybe_mid_invocation_checkpoint().await;
-        }
-        Ok(())
+        DurableCallCoordinator::new(self)
+            .finish(
+                function_type,
+                DurableCallBoundary::from_begin_index(begin_index),
+                forced_commit,
+            )
+            .await
     }
 
     async fn persist_durable_function_invocation(
@@ -2119,7 +2039,7 @@ pub enum OplogEntryVersion {
 
 /// Holds the in-function retry decision logic for a single durable host call, decoupled from how
 /// the call's request/response is persisted or replayed. Both the sequential [`Durability`] and the
-/// concurrent [`crate::durable_host::concurrent::CallHandle`] own one and route their
+/// concurrent [`crate::durable_host::concurrent::DurableCallSession`] own one and route their
 /// `try_trigger_retry*` methods through it, so the retry logic has a single home.
 ///
 /// Every method takes `&mut impl DurabilityHost`, so the controller stays unit-testable against

--- a/golem-worker-executor/src/durable_host/entity.rs
+++ b/golem-worker-executor/src/durable_host/entity.rs
@@ -20,7 +20,7 @@
 
 use crate::durable_host::DurableWorkerCtx;
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, Cancellable, ReconstructionReplayOutcome,
+    AccessClaimOptions, Cancellable, DurableCallSession, ReconstructionReplayOutcome,
 };
 use crate::worker::entity_invocation::EntityInvocationHandle;
 use crate::worker::instance::HistoricalReconstruction;
@@ -63,7 +63,7 @@ enum EntityReconstructionOutcome<R, H> {
 /// Task-owned durable state for one entity body. Its `Start` index is the entity invocation ID;
 /// dropping it before a terminal records cancellation through the generic concurrent-call path.
 pub struct EntityInvocationDurability {
-    handle: CallHandle<GolemEntityInvoke, Cancellable>,
+    handle: DurableCallSession<GolemEntityInvoke, Cancellable>,
     scope: EntityInvocationScope,
     parent: OwnerInvocationId,
     call_mode: EntityCallMode,
@@ -100,18 +100,19 @@ impl EntityInvocationDurability {
         })?;
         let request = HostRequestEntityInvocation { metadata, input };
         let request_identity: HostRequest = request.clone().into();
-        let handle = CallHandle::<GolemEntityInvoke, Cancellable>::start_access_with_options(
-            store,
-            get_ctx,
-            DurableFunctionType::WriteLocal,
-            AccessClaimOptions {
-                request_identity: Some(request_identity),
-                parent_start_index: Some(parent_start_index),
-                ..AccessClaimOptions::default()
-            },
-            async move |_| Ok(request),
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<GolemEntityInvoke, Cancellable>::start_access_with_options(
+                store,
+                get_ctx,
+                DurableFunctionType::WriteLocal,
+                AccessClaimOptions {
+                    request_identity: Some(request_identity),
+                    parent_start_index: Some(parent_start_index),
+                    ..AccessClaimOptions::default()
+                },
+                async move |_| Ok(request),
+            )
+            .await?;
         let owner =
             store.with(|mut access| get_ctx(access.data_mut()).state.owned_agent_id.clone());
         let invocation_id =

--- a/golem-worker-executor/src/durable_host/filesystem/types.rs
+++ b/golem-worker-executor/src/durable_host/filesystem/types.rs
@@ -29,7 +29,7 @@ use wasmtime_wasi::p2::bindings::filesystem::types::{
 };
 use wasmtime_wasi::runtime::spawn_blocking;
 
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::durable_host::filesystem::{
     authorize_paths, descriptor_path, forget_path, remember_path,
 };
@@ -337,8 +337,8 @@ impl<Ctx: WorkerCtx> HostDescriptor for DurableWorkerCtx<Ctx> {
         };
 
         // `ReadLocal`: the local stat always runs (its timestamps are then overridden by the durable
-        // value), so only the file-times are made durable via `CallHandle::run`.
-        let handle = CallHandle::<FilesystemTypesDescriptorStat, NotCancellable>::start(
+        // value), so only the file-times are made durable via `DurableCallSession::run`.
+        let handle = DurableCallSession::<FilesystemTypesDescriptorStat, NotCancellable>::start(
             self,
             HostRequestFileSystemPath {
                 path: path.to_string_lossy().to_string(),
@@ -420,8 +420,8 @@ impl<Ctx: WorkerCtx> HostDescriptor for DurableWorkerCtx<Ctx> {
         };
 
         // `ReadLocal`: the local stat always runs (its timestamps are then overridden by the durable
-        // value), so only the file-times are made durable via `CallHandle::run`.
-        let handle = CallHandle::<FilesystemTypesDescriptorStatAt, NotCancellable>::start(
+        // value), so only the file-times are made durable via `DurableCallSession::run`.
+        let handle = DurableCallSession::<FilesystemTypesDescriptorStatAt, NotCancellable>::start(
             self,
             HostRequestFileSystemPath {
                 path: full_path.to_string_lossy().to_string(),

--- a/golem-worker-executor/src/durable_host/golem/agent.rs
+++ b/golem-worker-executor/src/durable_host/golem/agent.rs
@@ -15,7 +15,7 @@
 use crate::durable_host::authorization::targets::{
     agent_method_target, agent_owner, config_segments_target,
 };
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::HostFailureKind;
 use crate::durable_host::secrets::secret_hold_target_for_path;
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx, InternalRetryResult};
@@ -303,7 +303,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
     pub(crate) async fn get_all_agent_types_model(
         &mut self,
     ) -> anyhow::Result<Vec<RegisteredAgentTypeSchema>> {
-        let mut handle = CallHandle::<GolemAgentGetAllAgentTypes, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemAgentGetAllAgentTypes, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadRemote,
@@ -353,7 +353,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         &mut self,
         agent_type_name: AgentTypeName,
     ) -> anyhow::Result<Option<RegisteredAgentTypeSchema>> {
-        let mut handle = CallHandle::<GolemAgentGetAgentType, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemAgentGetAgentType, NotCancellable>::start(
             self,
             HostRequestGolemAgentGetAgentType {
                 agent_type_name: agent_type_name.clone(),
@@ -545,7 +545,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             false
         };
-        let mut handle = CallHandle::<GolemAgentCreateWebhook, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemAgentCreateWebhook, NotCancellable>::start(
             self,
             HostRequestGolemApiPromiseId {
                 promise_id: promise_id.clone(),
@@ -671,7 +671,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             false
         };
 
-        let begun = CallHandle::<GolemAgentGetConfigValue, NotCancellable>::begin(
+        let begun = DurableCallSession::<GolemAgentGetConfigValue, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )

--- a/golem-worker-executor/src/durable_host/golem/retry_api.rs
+++ b/golem-worker-executor/src/durable_host/golem/retry_api.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::get_oplog_entry;
 use crate::preview2::golem_api_1_x::retry::{
@@ -36,7 +36,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_retry_policies(&mut self) -> anyhow::Result<Vec<WitNamedRetryPolicy>> {
         self.observe_function_call("golem::api::retry", "get_retry_policies");
 
-        let handle = CallHandle::<GolemApiRetryGetRetryPolicies, NotCancellable>::start(
+        let handle = DurableCallSession::<GolemApiRetryGetRetryPolicies, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadRemote,
@@ -59,12 +59,13 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     ) -> anyhow::Result<Option<WitNamedRetryPolicy>> {
         self.observe_function_call("golem::api::retry", "get_retry_policy_by_name");
 
-        let handle = CallHandle::<GolemApiRetryGetRetryPolicyByName, NotCancellable>::start(
-            self,
-            HostRequestGolemRetryPolicyByName { name: name.clone() },
-            DurableFunctionType::ReadRemote,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<GolemApiRetryGetRetryPolicyByName, NotCancellable>::start(
+                self,
+                HostRequestGolemRetryPolicyByName { name: name.clone() },
+                DurableFunctionType::ReadRemote,
+            )
+            .await?;
 
         let persisted = handle
             .run(self, async |ctx| -> anyhow::Result<_> {
@@ -95,7 +96,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             })
             .collect();
 
-        let handle = CallHandle::<GolemApiRetryResolveRetryPolicy, NotCancellable>::start(
+        let handle = DurableCallSession::<GolemApiRetryResolveRetryPolicy, NotCancellable>::start(
             self,
             HostRequestGolemRetryResolvePolicy {
                 verb,

--- a/golem-worker-executor/src/durable_host/golem/v1x.rs
+++ b/golem-worker-executor/src/durable_host/golem/v1x.rs
@@ -14,8 +14,8 @@
 
 use crate::durable_host::authorization::targets::{agent_worker_target, oplog_target};
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, Cancellable, NotCancellable, drain_dropped_call_events_access,
-    drain_queued_dropped_call_events,
+    CallReplayOutcome, Cancellable, DurableCallSession, NotCancellable,
+    drain_dropped_call_events_access, drain_queued_dropped_call_events,
 };
 use crate::durable_host::durability::HostFailureKind;
 use crate::durable_host::suspendable_wait::{
@@ -391,7 +391,7 @@ impl<Ctx: WorkerCtx> HostGetAgents for DurableWorkerCtx<Ctx> {
         if let Some(cursor) = cursor {
             let denied =
                 self.state.is_live() && component_agents_view_denied(self, &component_id).await?;
-            let handle = CallHandle::<GolemApiGetAgents, NotCancellable>::start(
+            let handle = DurableCallSession::<GolemApiGetAgents, NotCancellable>::start(
                 self,
                 HostRequestGolemApiGetAgents { component_id },
                 DurableFunctionType::ReadRemote,
@@ -452,7 +452,7 @@ impl<Ctx: WorkerCtx> HostGetAgents for DurableWorkerCtx<Ctx> {
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn create_promise(&mut self) -> anyhow::Result<golem_api_1_x::host::PromiseId> {
-        let mut handle = CallHandle::<GolemApiCreatePromise, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemApiCreatePromise, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::WriteLocal,
@@ -515,14 +515,14 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             promise_id: promise_id.clone(),
         };
         let mut handle = if initial_is_local_worker == Some(false) {
-            CallHandle::<GolemApiCompletePromise, NotCancellable>::start_with_agent_authority(
+            DurableCallSession::<GolemApiCompletePromise, NotCancellable>::start_with_agent_authority(
                 self,
                 request,
                 DurableFunctionType::WriteLocal,
             )
             .await?
         } else {
-            CallHandle::<GolemApiCompletePromise, NotCancellable>::start(
+            DurableCallSession::<GolemApiCompletePromise, NotCancellable>::start(
                 self,
                 request,
                 DurableFunctionType::WriteLocal,
@@ -892,7 +892,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn generate_idempotency_key(&mut self) -> anyhow::Result<golem_api_1_x::host::Uuid> {
-        let handle = CallHandle::<GolemApiGenerateIdempotencyKey, NotCancellable>::start(
+        let handle = DurableCallSession::<GolemApiGenerateIdempotencyKey, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::WriteRemote,
@@ -950,7 +950,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .await?;
 
         let mut handle =
-            CallHandle::<GolemApiUpdateWorker, NotCancellable>::start_with_agent_authority(
+            DurableCallSession::<GolemApiUpdateWorker, NotCancellable>::start_with_agent_authority(
                 self,
                 HostRequestGolemApiUpdateAgent {
                     agent_id,
@@ -1029,7 +1029,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
                 AgentResourcePattern::Empty,
             )
             .await?;
-        let handle = CallHandle::<GolemApiGetSelfMetadata, NotCancellable>::start(
+        let handle = DurableCallSession::<GolemApiGetSelfMetadata, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -1073,7 +1073,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             )
             .await?;
 
-        let handle = CallHandle::<GolemApiGetAgentMetadata, NotCancellable>::start(
+        let handle = DurableCallSession::<GolemApiGetAgentMetadata, NotCancellable>::start(
             self,
             HostRequestGolemApiAgentId {
                 agent_id: agent_id.clone(),
@@ -1145,7 +1145,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             .await?;
 
         let mut handle =
-            CallHandle::<GolemApiForkWorker, NotCancellable>::start_with_agent_authority(
+            DurableCallSession::<GolemApiForkWorker, NotCancellable>::start_with_agent_authority(
                 self,
                 HostRequestGolemApiForkAgent {
                     source_agent_id: source_agent_id.clone(),
@@ -1265,7 +1265,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
             && agent_operation_denied(self, &agent_id, AgentVerb::Revert, resource).await?;
 
         let mut handle =
-            CallHandle::<GolemApiRevertWorker, NotCancellable>::start_with_agent_authority(
+            DurableCallSession::<GolemApiRevertWorker, NotCancellable>::start_with_agent_authority(
                 self,
                 HostRequestGolemApiRevertAgent {
                     agent_id: agent_id.clone(),
@@ -1336,7 +1336,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         &mut self,
         component_slug: String,
     ) -> anyhow::Result<Option<golem_api_1_x::host::ComponentId>> {
-        let mut handle = CallHandle::<GolemApiResolveComponentId, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemApiResolveComponentId, NotCancellable>::start(
             self,
             HostRequestGolemApiComponentSlug {
                 component_slug: component_slug.clone(),
@@ -1424,7 +1424,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
                 AgentResourcePattern::Empty,
             )
             .await?;
-        let mut handle = CallHandle::<GolemApiResolveAgentIdStrict, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemApiResolveAgentIdStrict, NotCancellable>::start(
             self,
             HostRequestGolemApiComponentSlugAndAgentName {
                 component_slug,
@@ -1496,12 +1496,13 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
                 AgentResourcePattern::Empty,
             )
             .await?;
-        let mut handle = CallHandle::<GolemApiFork, NotCancellable>::start_with_agent_authority(
-            self,
-            HostRequestNoInput {},
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut handle =
+            DurableCallSession::<GolemApiFork, NotCancellable>::start_with_agent_authority(
+                self,
+                HostRequestNoInput {},
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         let result = 'result: {
             if !handle.is_live() {
@@ -1648,7 +1649,7 @@ impl<Ctx: WorkerCtx> HostGetOplog for DurableWorkerCtx<Ctx> {
     {
         self.observe_function_call("golem::api::get-oplog", "get-next");
 
-        let begun = CallHandle::<GolemApiGetOplogNext, NotCancellable>::begin(
+        let begun = DurableCallSession::<GolemApiGetOplogNext, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )
@@ -1807,7 +1808,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostGetPromiseResultWithStore<U>
             .await
             .map_err(anyhow::Error::from)?;
 
-        let mut handle = CallHandle::<GolemApiGetPromiseResult, Cancellable>::start_access(
+        let mut handle = DurableCallSession::<GolemApiGetPromiseResult, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestNoInput {},
@@ -2003,7 +2004,7 @@ impl<Ctx: WorkerCtx> HostSearchOplog for DurableWorkerCtx<Ctx> {
     > {
         self.observe_function_call("golem::api::search-oplog", "get-next");
 
-        let begun = CallHandle::<GolemApiSearchOplogNext, NotCancellable>::begin(
+        let begun = DurableCallSession::<GolemApiSearchOplogNext, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )
@@ -2165,7 +2166,7 @@ impl<Ctx: WorkerCtx> OplogHost for DurableWorkerCtx<Ctx> {
     ) -> anyhow::Result<Result<Vec<golem_api_1_x::oplog::PublicOplogEntry>, String>> {
         self.observe_function_call("golem::api::oplog", "enrich-oplog-entries");
 
-        let begun = CallHandle::<GolemApiEnrichOplogEntries, NotCancellable>::begin(
+        let begun = DurableCallSession::<GolemApiEnrichOplogEntries, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )

--- a/golem-worker-executor/src/durable_host/http/types.rs
+++ b/golem-worker-executor/src/durable_host/http/types.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::HttpOutgoingBodyState;
-use crate::durable_host::concurrent::{CallHandle, NotCancellable, Resolution};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable, Resolution};
 use crate::durable_host::durability::{ClassifiedHostError, HostFailureKind, InFunctionRetryHost};
 use crate::durable_host::http::inline_retry::{
     StatusRetryOutcome, take_http_background_retry_fallback, try_status_code_retry,
@@ -505,7 +505,7 @@ impl<Ctx: WorkerCtx> HostFutureTrailers for DurableWorkerCtx<Ctx> {
             // `WriteRemoteBatched`: not re-executable on an incomplete `Start`, so replay never
             // yields `Incomplete` (it hard-errors instead) and the lone batched `Start` is recovered
             // by the surrounding durable scope.
-            let mut call = CallHandle::<HttpTypesFutureTrailersGet, NotCancellable>::start(
+            let mut call = DurableCallSession::<HttpTypesFutureTrailersGet, NotCancellable>::start(
                 self,
                 request,
                 DurableFunctionType::WriteRemoteBatched(Some(request_state.begin_index)),

--- a/golem-worker-executor/src/durable_host/io/poll.rs
+++ b/golem-worker-executor/src/durable_host/io/poll.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::InFunctionRetryHost;
 use crate::durable_host::suspendable_wait::{
     ParkOutcome, PromiseWaiting, SuspendableWaitContext, chrono_duration_to_nanos,
@@ -39,7 +39,7 @@ impl<Ctx: WorkerCtx> HostPollable for DurableWorkerCtx<Ctx> {
     async fn ready(&mut self, self_: Resource<Pollable>) -> wasmtime::Result<bool> {
         self.observe_function_call("io::poll:pollable", "ready");
         let rep = self_.rep();
-        let handle = CallHandle::<IoPollReady, NotCancellable>::start(
+        let handle = DurableCallSession::<IoPollReady, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -181,7 +181,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         };
 
         let count = in_.len();
-        let mut handle = CallHandle::<IoPollPoll, NotCancellable>::start(
+        let mut handle = DurableCallSession::<IoPollPoll, NotCancellable>::start(
             self,
             HostRequestPollCount { count },
             DurableFunctionType::ReadLocal,

--- a/golem-worker-executor/src/durable_host/io/streams.rs
+++ b/golem-worker-executor/src/durable_host/io/streams.rs
@@ -15,7 +15,7 @@
 use wasmtime::component::Resource;
 use wasmtime_wasi::StreamError;
 
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::HostFailureKind;
 use crate::durable_host::http::{continue_http_request, end_http_request};
 use crate::durable_host::io::{ManagedStdErr, ManagedStdOut};
@@ -61,12 +61,13 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
             let request = get_http_stream_request(self, handle)?;
-            let mut call = CallHandle::<HttpTypesIncomingBodyStreamRead, NotCancellable>::start(
-                self,
-                request,
-                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
-            )
-            .await?;
+            let mut call =
+                DurableCallSession::<HttpTypesIncomingBodyStreamRead, NotCancellable>::start(
+                    self,
+                    request,
+                    DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                )
+                .await?;
 
             let result = if call.is_live() {
                 let first_try = HostInputStream::read(self.table(), self_, len).await;
@@ -128,7 +129,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             // chunk is recorded (the bytes themselves are not needed, as the
             // initial file system is restored to the same contents for replay),
             // and replay re-reads exactly that many bytes from the file.
-            let call = CallHandle::<FilesystemInputStreamRead, NotCancellable>::start(
+            let call = DurableCallSession::<FilesystemInputStreamRead, NotCancellable>::start(
                 self,
                 HostRequestNoInput {},
                 DurableFunctionType::ReadLocal,
@@ -188,13 +189,15 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
             let request = get_http_stream_request(self, handle)?;
-            let mut call =
-                CallHandle::<HttpTypesIncomingBodyStreamBlockingRead, NotCancellable>::start(
-                    self,
-                    request,
-                    DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
-                )
-                .await?;
+            let mut call = DurableCallSession::<
+                HttpTypesIncomingBodyStreamBlockingRead,
+                NotCancellable,
+            >::start(
+                self,
+                request,
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
+            )
+            .await?;
             let result = if call.is_live() {
                 let first_try = HostInputStream::blocking_read(self.table(), self_, len).await;
 
@@ -262,12 +265,13 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
             let request = get_http_stream_request(self, handle)?;
-            let mut call = CallHandle::<HttpTypesIncomingBodyStreamSkip, NotCancellable>::start(
-                self,
-                request,
-                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
-            )
-            .await?;
+            let mut call =
+                DurableCallSession::<HttpTypesIncomingBodyStreamSkip, NotCancellable>::start(
+                    self,
+                    request,
+                    DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
+                )
+                .await?;
             let result = if call.is_live() {
                 let result = HostInputStream::skip(self.table(), self_, len).await;
                 call.try_trigger_retry(self, &ignore_closed_error(&result), |_| {
@@ -301,7 +305,7 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             // on host scheduling, so the skipped length is recorded and replay
             // skips exactly that many bytes from the restored file.
             let handle = self_.rep();
-            let call = CallHandle::<FilesystemInputStreamSkip, NotCancellable>::start(
+            let call = DurableCallSession::<FilesystemInputStreamSkip, NotCancellable>::start(
                 self,
                 HostRequestNoInput {},
                 DurableFunctionType::ReadLocal,
@@ -366,13 +370,15 @@ impl<Ctx: WorkerCtx> HostInputStream for DurableWorkerCtx<Ctx> {
             let begin_idx = get_http_request_begin_idx(self, handle)?;
 
             let request = get_http_stream_request(self, handle)?;
-            let mut call =
-                CallHandle::<HttpTypesIncomingBodyStreamBlockingSkip, NotCancellable>::start(
-                    self,
-                    request,
-                    DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
-                )
-                .await?;
+            let mut call = DurableCallSession::<
+                HttpTypesIncomingBodyStreamBlockingSkip,
+                NotCancellable,
+            >::start(
+                self,
+                request,
+                DurableFunctionType::WriteRemoteBatched(Some(begin_idx)),
+            )
+            .await?;
 
             let result = if call.is_live() {
                 let result = HostInputStream::blocking_skip(self.table(), self_, len).await;
@@ -445,13 +451,14 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         let rep = self_.rep();
         if is_outgoing_http_body_stream(self, rep) {
             let state = get_http_output_stream_state(self, rep)?;
-            let call = CallHandle::<HttpTypesOutgoingBodyStreamCheckWrite, NotCancellable>::start(
-                self,
-                state.request,
-                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-            )
-            .await
-            .map_err(StreamError::from)?;
+            let call =
+                DurableCallSession::<HttpTypesOutgoingBodyStreamCheckWrite, NotCancellable>::start(
+                    self,
+                    state.request,
+                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+                )
+                .await
+                .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // If the peer already closed the request body stream after an
@@ -501,12 +508,13 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
                 // recorded non-zero budget is replayed, the real stream is first
                 // driven to readiness so that subsequent re-executed writes are
                 // permitted by its state machine.
-                let call = CallHandle::<FilesystemOutputStreamCheckWrite, NotCancellable>::start(
-                    self,
-                    HostRequestNoInput {},
-                    DurableFunctionType::ReadLocal,
-                )
-                .await?;
+                let call =
+                    DurableCallSession::<FilesystemOutputStreamCheckWrite, NotCancellable>::start(
+                        self,
+                        HostRequestNoInput {},
+                        DurableFunctionType::ReadLocal,
+                    )
+                    .await?;
 
                 if call.is_live() {
                     let result = HostOutputStream::check_write(self.table(), self_).await;
@@ -570,13 +578,14 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
 
         if is_outgoing_http_body_stream(self, rep) {
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call = CallHandle::<HttpTypesOutgoingBodyStreamWrite, NotCancellable>::start(
-                self,
-                state.request,
-                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-            )
-            .await
-            .map_err(StreamError::from)?;
+            let mut call =
+                DurableCallSession::<HttpTypesOutgoingBodyStreamWrite, NotCancellable>::start(
+                    self,
+                    state.request,
+                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+                )
+                .await
+                .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // Attempt inline retry BEFORE persisting so the retried result is what gets recorded
@@ -668,13 +677,14 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
             // handles backpressure via write_ready() loops, and persist a single
             // combined oplog entry.
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call = CallHandle::<HttpTypesOutgoingBodyStreamWrite, NotCancellable>::start(
-                self,
-                state.request,
-                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-            )
-            .await
-            .map_err(StreamError::from)?;
+            let mut call =
+                DurableCallSession::<HttpTypesOutgoingBodyStreamWrite, NotCancellable>::start(
+                    self,
+                    state.request,
+                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+                )
+                .await
+                .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 let first_try =
@@ -754,13 +764,14 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         let rep = self_.rep();
         if is_outgoing_http_body_stream(self, rep) {
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call = CallHandle::<HttpTypesOutgoingBodyStreamFlush, NotCancellable>::start(
-                self,
-                state.request,
-                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-            )
-            .await
-            .map_err(StreamError::from)?;
+            let mut call =
+                DurableCallSession::<HttpTypesOutgoingBodyStreamFlush, NotCancellable>::start(
+                    self,
+                    state.request,
+                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+                )
+                .await
+                .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // Attempt inline retry BEFORE persisting so the retried result is what gets recorded
@@ -807,14 +818,16 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         let rep = self_.rep();
         if is_outgoing_http_body_stream(self, rep) {
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call =
-                CallHandle::<HttpTypesOutgoingBodyStreamBlockingFlush, NotCancellable>::start(
-                    self,
-                    state.request,
-                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-                )
-                .await
-                .map_err(StreamError::from)?;
+            let mut call = DurableCallSession::<
+                HttpTypesOutgoingBodyStreamBlockingFlush,
+                NotCancellable,
+            >::start(
+                self,
+                state.request,
+                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+            )
+            .await
+            .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // Attempt inline retry BEFORE persisting so the retried result is what gets recorded
@@ -890,14 +903,16 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
         let rep = self_.rep();
         if is_outgoing_http_body_stream(self, rep) {
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call =
-                CallHandle::<HttpTypesOutgoingBodyStreamWriteZeroes, NotCancellable>::start(
-                    self,
-                    state.request,
-                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-                )
-                .await
-                .map_err(StreamError::from)?;
+            let mut call = DurableCallSession::<
+                HttpTypesOutgoingBodyStreamWriteZeroes,
+                NotCancellable,
+            >::start(
+                self,
+                state.request,
+                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+            )
+            .await
+            .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // Attempt inline retry BEFORE persisting so the retried result is what gets recorded
@@ -979,14 +994,16 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
             // Instead, call the underlying blocking_write_zeroes_and_flush which properly
             // handles backpressure, and persist a single combined oplog entry.
             let state = get_http_output_stream_state(self, rep)?;
-            let mut call =
-                CallHandle::<HttpTypesOutgoingBodyStreamWriteZeroes, NotCancellable>::start(
-                    self,
-                    state.request,
-                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-                )
-                .await
-                .map_err(StreamError::from)?;
+            let mut call = DurableCallSession::<
+                HttpTypesOutgoingBodyStreamWriteZeroes,
+                NotCancellable,
+            >::start(
+                self,
+                state.request,
+                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+            )
+            .await
+            .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 // For HTTP body streams, Closed is also retryable (hyper consumer
@@ -1059,13 +1076,14 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
                     .has_unreconstructable_body = true;
             }
             let state = get_http_output_stream_state(self, rep)?;
-            let call = CallHandle::<HttpTypesOutgoingBodyStreamSplice, NotCancellable>::start(
-                self,
-                state.request,
-                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-            )
-            .await
-            .map_err(StreamError::from)?;
+            let call =
+                DurableCallSession::<HttpTypesOutgoingBodyStreamSplice, NotCancellable>::start(
+                    self,
+                    state.request,
+                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+                )
+                .await
+                .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 let result = HostOutputStream::splice(self.table(), self_, src, len).await;
@@ -1127,14 +1145,16 @@ impl<Ctx: WorkerCtx> HostOutputStream for DurableWorkerCtx<Ctx> {
                     .has_unreconstructable_body = true;
             }
             let state = get_http_output_stream_state(self, rep)?;
-            let call =
-                CallHandle::<HttpTypesOutgoingBodyStreamBlockingSplice, NotCancellable>::start(
-                    self,
-                    state.request,
-                    DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
-                )
-                .await
-                .map_err(StreamError::from)?;
+            let call = DurableCallSession::<
+                HttpTypesOutgoingBodyStreamBlockingSplice,
+                NotCancellable,
+            >::start(
+                self,
+                state.request,
+                DurableFunctionType::WriteRemoteBatched(Some(state.begin_index)),
+            )
+            .await
+            .map_err(StreamError::from)?;
 
             let result = if call.is_live() {
                 let result = HostOutputStream::blocking_splice(self.table(), self_, src, len).await;

--- a/golem-worker-executor/src/durable_host/keyvalue/caching.rs
+++ b/golem-worker-executor/src/durable_host/keyvalue/caching.rs
@@ -27,7 +27,8 @@ use wasmtime::component::{Accessor, HasSelf, Resource};
 
 use crate::durable_host::authorization::targets::kv_target;
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, Cancellable, authorize_live_permissions_at_serialized_access,
+    CallReplayOutcome, Cancellable, DurableCallSession,
+    authorize_live_permissions_at_serialized_access,
 };
 use crate::durable_host::keyvalue::error::ErrorEntry;
 use crate::durable_host::keyvalue::types::{
@@ -45,14 +46,14 @@ use crate::preview2::wasi::keyvalue::cache::{
 use crate::workerctx::WorkerCtx;
 
 pub struct CacheFutureGetResultEntry {
-    handle: Option<CallHandle<P3KeyvalueCacheGet, Cancellable>>,
+    handle: Option<DurableCallSession<P3KeyvalueCacheGet, Cancellable>>,
     environment_id: EnvironmentId,
     key: Key,
     denial: Option<String>,
 }
 
 pub struct CacheFutureExistsResultEntry {
-    handle: Option<CallHandle<P3KeyvalueCacheExists, Cancellable>>,
+    handle: Option<DurableCallSession<P3KeyvalueCacheExists, Cancellable>>,
     environment_id: EnvironmentId,
     key: Key,
     denial: Option<String>,
@@ -63,7 +64,7 @@ pub struct CacheFutureResultEntry {
 }
 
 pub struct CacheFutureGetOrSetResultEntry {
-    handle: Option<CallHandle<P3KeyvalueCacheGetOrSet, Cancellable>>,
+    handle: Option<DurableCallSession<P3KeyvalueCacheGetOrSet, Cancellable>>,
     environment_id: EnvironmentId,
     key: Key,
     permit: Option<LiveAuthorizationPermit>,
@@ -79,14 +80,14 @@ pub struct CacheVacancyEntry {
 
 enum CacheFutureResultOperation {
     Set {
-        handle: Option<CallHandle<P3KeyvalueCacheSet, Cancellable>>,
+        handle: Option<DurableCallSession<P3KeyvalueCacheSet, Cancellable>>,
         environment_id: EnvironmentId,
         key: Key,
         value: Vec<u8>,
         denial: Option<String>,
     },
     Delete {
-        handle: Option<CallHandle<P3KeyvalueCacheDelete, Cancellable>>,
+        handle: Option<DurableCallSession<P3KeyvalueCacheDelete, Cancellable>>,
         environment_id: EnvironmentId,
         key: Key,
         denial: Option<String>,
@@ -286,8 +287,8 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostFutureResultWithStore<U>
 {
     async fn drop(accessor: &Accessor<U, Self>, rep: Resource<FutureResult>) -> anyhow::Result<()> {
         enum Handle {
-            Set(CallHandle<P3KeyvalueCacheSet, Cancellable>),
-            Delete(CallHandle<P3KeyvalueCacheDelete, Cancellable>),
+            Set(DurableCallSession<P3KeyvalueCacheSet, Cancellable>),
+            Delete(DurableCallSession<P3KeyvalueCacheDelete, Cancellable>),
         }
 
         let handle = accessor.with(|mut access| {
@@ -322,14 +323,14 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostFutureResultWithStore<U>
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
         enum Action {
             Set {
-                handle: CallHandle<P3KeyvalueCacheSet, Cancellable>,
+                handle: DurableCallSession<P3KeyvalueCacheSet, Cancellable>,
                 environment_id: EnvironmentId,
                 key: Key,
                 value: Vec<u8>,
                 denial: Option<String>,
             },
             Delete {
-                handle: CallHandle<P3KeyvalueCacheDelete, Cancellable>,
+                handle: DurableCallSession<P3KeyvalueCacheDelete, Cancellable>,
                 environment_id: EnvironmentId,
                 key: Key,
                 denial: Option<String>,
@@ -558,7 +559,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostVacancyWithStore<U> for HasSelf<Dura
                 Ok::<_, anyhow::Error>(())
             })?;
         }
-        let handle = CallHandle::<P3KeyvalueCacheVacancyFill, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheVacancyFill, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKeyAndTtl {
@@ -596,13 +597,14 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostVacancyWithStore<U> for HasSelf<Dura
             Ok::<_, anyhow::Error>((entry.filled, entry.key.clone()))
         })?;
         if !filled {
-            let mut handle = CallHandle::<P3KeyvalueCacheVacancyDrop, Cancellable>::start_access(
-                accessor,
-                accessor.getter(),
-                HostRequestKVCacheKey { key },
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+            let mut handle =
+                DurableCallSession::<P3KeyvalueCacheVacancyDrop, Cancellable>::start_access(
+                    accessor,
+                    accessor.getter(),
+                    HostRequestKVCacheKey { key },
+                    DurableFunctionType::WriteRemote,
+                )
+                .await?;
 
             accessor.with(|mut access| {
                 access.get().table().delete(rep)?;
@@ -650,7 +652,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWithStore<U> for HasSelf<DurableWork
         } else {
             None
         };
-        let handle = CallHandle::<P3KeyvalueCacheGet, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheGet, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKey { key: k.clone() },
@@ -681,7 +683,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWithStore<U> for HasSelf<DurableWork
         } else {
             None
         };
-        let handle = CallHandle::<P3KeyvalueCacheExists, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheExists, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKey { key: k.clone() },
@@ -721,7 +723,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWithStore<U> for HasSelf<DurableWork
         } else {
             Vec::new()
         };
-        let handle = CallHandle::<P3KeyvalueCacheSet, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheSet, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKeyValueAndTtl {
@@ -778,7 +780,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWithStore<U> for HasSelf<DurableWork
         } else {
             (None, None)
         };
-        let handle = CallHandle::<P3KeyvalueCacheGetOrSet, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheGetOrSet, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKey { key: k.clone() },
@@ -810,7 +812,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWithStore<U> for HasSelf<DurableWork
         } else {
             None
         };
-        let handle = CallHandle::<P3KeyvalueCacheDelete, Cancellable>::start_access(
+        let handle = DurableCallSession::<P3KeyvalueCacheDelete, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             HostRequestKVCacheKey { key: k.clone() },

--- a/golem-worker-executor/src/durable_host/keyvalue/eventual.rs
+++ b/golem-worker-executor/src/durable_host/keyvalue/eventual.rs
@@ -24,7 +24,7 @@ use wasmtime::component::Resource;
 use wasmtime_wasi::IoView;
 
 use crate::durable_host::authorization::targets::kv_target;
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::keyvalue::error::ErrorEntry;
 use crate::durable_host::keyvalue::types::{BucketEntry, IncomingValueEntry, OutgoingValueEntry};
 use crate::durable_host::keyvalue::{denial, environment_owner};
@@ -44,7 +44,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         bucket: Resource<Bucket>,
         key: Key,
     ) -> anyhow::Result<Result<Option<Resource<IncomingValue>>, Resource<Error>>> {
-        let begun = CallHandle::<KeyvalueEventualGet, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualGet, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )
@@ -140,7 +140,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         key: Key,
         outgoing_value: Resource<OutgoingValue>,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
-        let begun = CallHandle::<KeyvalueEventualSet, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualSet, NotCancellable>::begin(
             self,
             DurableFunctionType::WriteRemote,
         )
@@ -282,7 +282,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         bucket: Resource<Bucket>,
         key: Key,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
-        let begun = CallHandle::<KeyvalueEventualDelete, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualDelete, NotCancellable>::begin(
             self,
             DurableFunctionType::WriteRemote,
         )
@@ -380,7 +380,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         bucket: Resource<Bucket>,
         key: Key,
     ) -> anyhow::Result<Result<bool, Resource<Error>>> {
-        let begun = CallHandle::<KeyvalueEventualExists, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualExists, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )

--- a/golem-worker-executor/src/durable_host/keyvalue/eventual_batch.rs
+++ b/golem-worker-executor/src/durable_host/keyvalue/eventual_batch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::authorization::targets::{kv_bucket_target, kv_target};
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::keyvalue::error::ErrorEntry;
 use crate::durable_host::keyvalue::types::{BucketEntry, IncomingValueEntry, OutgoingValueEntry};
 use crate::durable_host::keyvalue::{denial, environment_owner};
@@ -70,7 +70,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let begun = CallHandle::<KeyvalueEventualBatchGetMany, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualBatchGetMany, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )
@@ -174,7 +174,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let begun = CallHandle::<KeyvalueEventualBatchGetKeys, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualBatchGetKeys, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )
@@ -237,7 +237,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         bucket: Resource<Bucket>,
         key_values: Vec<(Key, Resource<OutgoingValue>)>,
     ) -> anyhow::Result<Result<(), Resource<Error>>> {
-        let begun = CallHandle::<KeyvalueEventualBatchSetMany, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualBatchSetMany, NotCancellable>::begin(
             self,
             DurableFunctionType::WriteRemote,
         )
@@ -427,7 +427,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         } else {
             None
         };
-        let begun = CallHandle::<KeyvalueEventualBatchDeleteMany, NotCancellable>::begin(
+        let begun = DurableCallSession::<KeyvalueEventualBatchDeleteMany, NotCancellable>::begin(
             self,
             DurableFunctionType::WriteRemote,
         )

--- a/golem-worker-executor/src/durable_host/keyvalue/types.rs
+++ b/golem-worker-executor/src/durable_host/keyvalue/types.rs
@@ -29,7 +29,7 @@ use golem_common::model::oplog::{
 };
 
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, CallReplayOutcome, Cancellable,
+    AccessClaimOptions, CallReplayOutcome, Cancellable, DurableCallSession,
     resolve_current_observational_owner,
 };
 use crate::durable_host::durability::CustomInvocationContext;
@@ -164,21 +164,21 @@ where
         accessor: &Accessor<T, HasSelf<DurableWorkerCtx<Ctx>>>,
     ) -> wasmtime::Result<()> {
         let result = async {
-            let mut handle = CallHandle::<
+            let mut handle = DurableCallSession::<
                 P3KeyvalueTypesIncomingValueConsumeAsync,
                 Cancellable,
             >::start_access_with_options(
-                    accessor,
-                    accessor.getter(),
-                    DurableFunctionType::ReadRemote,
-                    AccessClaimOptions {
-                        observational_owner: self.observational_owner,
-                        ..Default::default()
-                    },
-                    async |_| Ok(HostRequestNoInput {}),
-                )
-                .await
-                .map_err(wasmtime::Error::from)?;
+                accessor,
+                accessor.getter(),
+                DurableFunctionType::ReadRemote,
+                AccessClaimOptions {
+                    observational_owner: self.observational_owner,
+                    ..Default::default()
+                },
+                async |_| Ok(HostRequestNoInput {}),
+            )
+            .await
+            .map_err(wasmtime::Error::from)?;
 
             if !handle.is_live() {
                 match handle
@@ -484,7 +484,7 @@ impl OutgoingValueEntry {
 }
 
 pub(crate) struct CacheFillState {
-    pub handle: Option<CallHandle<P3KeyvalueCacheVacancyFill, Cancellable>>,
+    pub handle: Option<DurableCallSession<P3KeyvalueCacheVacancyFill, Cancellable>>,
     pub environment_id: EnvironmentId,
     pub key: String,
     pub _permit: Option<LiveAuthorizationPermit>,

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -17,6 +17,7 @@
 
 pub(crate) mod authorization;
 pub mod blobstore;
+mod call_coordinator;
 mod cli;
 mod clocks;
 mod concurrent;
@@ -3139,7 +3140,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
     }
 
     /// Appends a completed child host call inside a durable scope, as an eager `Start` immediately
-    /// followed by its matching `End`. Unlike [`crate::durable_host::concurrent::CallHandle::start`]
+    /// followed by its matching `End`. Unlike [`crate::durable_host::concurrent::DurableCallSession::start`]
     /// this never opens a new durable scope — it records the result of a poll on an async future
     /// (HTTP / RPC) within a request/invoke scope that the caller opens and closes itself.
     ///

--- a/golem-worker-executor/src/durable_host/p3/clocks.rs
+++ b/golem-worker-executor/src/durable_host/p3/clocks.rs
@@ -14,7 +14,7 @@
 
 use crate::durable_host::DurabilityHost;
 use crate::durable_host::concurrent::{
-    CallHandle, Cancellable, DeferredCallReplayOutcome, NotCancellable,
+    Cancellable, DeferredCallReplayOutcome, DurableCallSession, NotCancellable,
     drain_queued_dropped_call_events,
 };
 use crate::durable_host::p3::{DurableP3, DurableP3View, run_read_access};
@@ -49,7 +49,7 @@ impl<Ctx: WorkerCtx> system_clock::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3SystemClockNow, NotCancellable>::start(
+        let handle = DurableCallSession::<P3SystemClockNow, NotCancellable>::start(
             ctx,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -76,7 +76,7 @@ impl<Ctx: WorkerCtx> system_clock::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3SystemClockGetResolution, NotCancellable>::start(
+        let handle = DurableCallSession::<P3SystemClockGetResolution, NotCancellable>::start(
             ctx,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -103,7 +103,7 @@ impl<Ctx: WorkerCtx> monotonic_clock::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3MonotonicClockNow, NotCancellable>::start(
+        let handle = DurableCallSession::<P3MonotonicClockNow, NotCancellable>::start(
             ctx,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -128,7 +128,7 @@ impl<Ctx: WorkerCtx> monotonic_clock::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3MonotonicClockGetResolution, NotCancellable>::start(
+        let handle = DurableCallSession::<P3MonotonicClockGetResolution, NotCancellable>::start(
             ctx,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -171,7 +171,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> monotonic_clock::HostWithStore<U> for Du
         store: &Accessor<U, Self>,
         how_long: types::Duration,
     ) -> wasmtime::Result<()> {
-        let mut handle = CallHandle::<P3MonotonicClockNow, Cancellable>::start_access(
+        let mut handle = DurableCallSession::<P3MonotonicClockNow, Cancellable>::start_access(
             store,
             super::durable_worker_ctx::<Ctx, U>,
             HostRequestNoInput {},

--- a/golem-worker-executor/src/durable_host/p3/filesystem.rs
+++ b/golem-worker-executor/src/durable_host/p3/filesystem.rs
@@ -25,7 +25,8 @@ use std::task::{Context, Poll};
 use crate::durable_host::LiveAuthorizationPermit;
 use crate::durable_host::authorization::targets::{CanonicalGuestPath, filesystem_target};
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, NotCancellable, authorize_live_permissions_at_serialized_access,
+    CallReplayOutcome, DurableCallSession, NotCancellable,
+    authorize_live_permissions_at_serialized_access,
 };
 use crate::durable_host::filesystem::types::calculate_metadata_hash_parts;
 use crate::durable_host::p3::{
@@ -968,7 +969,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostDescriptorWithStore<U> for Du
         let authorization_result = Arc::new(Mutex::new(None));
         let authorization_for_start = Arc::clone(&authorization_result);
         let fd_rep = fd.rep();
-        let mut handle = CallHandle::<
+        let mut handle = DurableCallSession::<
             P3FilesystemTypesDescriptorWriteViaStream,
             NotCancellable,
         >::start_access_with(
@@ -983,12 +984,9 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostDescriptorWithStore<U> for Du
                         "",
                     );
                     let result = match path {
-                        Ok(path) => authorize_paths(
-                            accessor,
-                            &[(FilesystemVerb::Write, path)],
-                        )
-                        .await
-                        .map_err(|_| ()),
+                        Ok(path) => authorize_paths(accessor, &[(FilesystemVerb::Write, path)])
+                            .await
+                            .map_err(|_| ()),
                         Err(_) => Err(()),
                     };
                     *authorization_for_start.lock().unwrap() = Some(result);
@@ -1099,7 +1097,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostDescriptorWithStore<U> for Du
         let authorization_result = Arc::new(Mutex::new(None));
         let authorization_for_start = Arc::clone(&authorization_result);
         let fd_rep = fd.rep();
-        let mut handle = CallHandle::<
+        let mut handle = DurableCallSession::<
             P3FilesystemTypesDescriptorAppendViaStream,
             NotCancellable,
         >::start_access_with(
@@ -1114,12 +1112,9 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostDescriptorWithStore<U> for Du
                         "",
                     );
                     let result = match path {
-                        Ok(path) => authorize_paths(
-                            accessor,
-                            &[(FilesystemVerb::Write, path)],
-                        )
-                        .await
-                        .map_err(|_| ()),
+                        Ok(path) => authorize_paths(accessor, &[(FilesystemVerb::Write, path)])
+                            .await
+                            .map_err(|_| ()),
                         Err(_) => Err(()),
                     };
                     *authorization_for_start.lock().unwrap() = Some(result);

--- a/golem-worker-executor/src/durable_host/p3/http/request_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/request_body.rs
@@ -16,7 +16,7 @@ use super::serialization::{
     deserialize_error_code, deserialize_headers, serialize_error_code, serialize_headers,
 };
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, CallReplayOutcome, LeaveIncompleteOnDrop,
+    AccessClaimOptions, CallReplayOutcome, DurableCallSession, LeaveIncompleteOnDrop,
 };
 use crate::durable_host::durability::{DurableCallTrapContext, mark_durable_call_trap_context};
 use crate::durable_host::p3::{
@@ -1169,7 +1169,7 @@ where
         // upload outcome (the send itself is the write), so an incomplete
         // `Start` (crash before the upload result was recorded) safely
         // re-executes on replay instead of failing the worker.
-        let mut handle = match CallHandle::<
+        let mut handle = match DurableCallSession::<
             P3HttpClientRequestBodyTransmission,
             LeaveIncompleteOnDrop,
         >::start_access_with_options(

--- a/golem-worker-executor/src/durable_host/p3/http/response_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/response_body.rs
@@ -19,8 +19,8 @@ use super::serialization::{deserialize_error_code, serialize_error_code};
 use super::serialization::{deserialize_headers, serialize_headers};
 use super::*;
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, Cancellable, CompletionDelivery, DeferredCallReplayOutcome,
-    DropEvent, NotCancellable,
+    AccessClaimOptions, Cancellable, CompletionDelivery, DeferredCallReplayOutcome, DropEvent,
+    DurableCallSession, NotCancellable,
 };
 use crate::durable_host::durability::{
     AsyncRetryDecision, DurabilityHost, DurableCallTrapContext, HostFailureKind,
@@ -649,7 +649,7 @@ pub(super) fn deserialize_consume_body_result(
 /// `Start` rather than observing committed-but-corrupt durable state.
 ///
 /// The `error` must already carry the failing call's [`DurableCallTrapContext`]
-/// (via `CallHandle::trap`, a `TerminalCallError`, or `mark_durable_call_trap_context`)
+/// (via `DurableCallSession::trap`, a `TerminalCallError`, or `mark_durable_call_trap_context`)
 /// so post-trap retry grouping stays owned by that call's scope; this helper does
 /// not stringify it for the returned trap.
 ///
@@ -953,7 +953,7 @@ where
         // agent. Responses that did not come from `client::send` have no span and keep the plain
         // scope name.
         let mut parent =
-            match CallHandle::<P3HttpClientConsumeBody, Cancellable>::start_access_with_options(
+            match DurableCallSession::<P3HttpClientConsumeBody, Cancellable>::start_access_with_options(
                 accessor,
                 durable_worker_ctx::<Ctx, U>,
                 DurableFunctionType::WriteRemoteBatched(None),
@@ -1004,7 +1004,7 @@ where
                 None => break,
             };
 
-            let mut child = match CallHandle::<
+            let mut child = match DurableCallSession::<
                 P3HttpClientConsumeBodyChunk,
                 NotCancellable,
             >::start_access_with_options(

--- a/golem-worker-executor/src/durable_host/p3/http/send.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/send.rs
@@ -20,7 +20,7 @@ use super::serialization::{
 use super::*;
 use crate::durable_host::authorization::targets::http_target;
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, Cancellable, DeferredCallReplayOutcome, DropPolicy,
+    AccessClaimOptions, Cancellable, DeferredCallReplayOutcome, DropPolicy, DurableCallSession,
     LeaveIncompleteOnDrop, authorize_live_permissions_at_serialized_access, finish_span_in_memory,
 };
 use crate::durable_host::durability::{
@@ -221,7 +221,7 @@ where
         parent_start_index: None,
         observational_owner: None,
     };
-    let mut handle = CallHandle::<P3HttpClientSend, P>::start_access_with_options(
+    let mut handle = DurableCallSession::<P3HttpClientSend, P>::start_access_with_options(
         store,
         durable_worker_ctx::<Ctx, U>,
         function_type.clone(),

--- a/golem-worker-executor/src/durable_host/p3/mod.rs
+++ b/golem-worker-executor/src/durable_host/p3/mod.rs
@@ -36,7 +36,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 
 use crate::durable_host::DurableWorkerCtx;
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, Cancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, Cancellable, DurableCallSession};
 use crate::durable_host::durability::{ClassifiedHostError, DurabilityHost};
 use crate::workerctx::WorkerCtx;
 use golem_common::model::RetryProperties;
@@ -96,7 +96,7 @@ fn durable_worker_ctx<Ctx: WorkerCtx, U: 'static>(u: &mut U) -> &mut DurableWork
 }
 
 /// Records a pass-through (non-durable) p3 host function call for metrics and debug tracing.
-/// Durable calls are observed by `CallHandle::start_access` / `prepare_access_start` with their
+/// Durable calls are observed by `DurableCallSession::start_access` / `prepare_access_start` with their
 /// host-function pair's interface/function names; every other host method observes explicitly
 /// through this helper, mirroring the P2 wrappers.
 fn observe_function_call<Ctx: WorkerCtx>(ctx: &Ctx, interface: &str, function: &str) {
@@ -118,7 +118,7 @@ fn observe_function_call_store<Ctx: WorkerCtx, U: 'static>(
 /// retried by the host).
 ///
 /// Durable p3 host wrappers surface failures in two ways: traps, which escape via
-/// [`CallHandle::trap`] and are classified by the trap-recovery machinery; and error *values*
+/// [`DurableCallSession::trap`] and are classified by the trap-recovery machinery; and error *values*
 /// recorded in the response payload and returned to the guest (`wasi:sockets` error codes,
 /// `wasi:http` error codes, ...). Error values bypass trap classification entirely — the guest
 /// unwraps them and the worker fails deterministically — so any wrapper whose response payload
@@ -151,7 +151,7 @@ where
 
 /// Like [`run_read_access`], but classifies a guest-visible error *value* carried in the live
 /// response payload before it is persisted, routing transient failures through the worker-level
-/// retry machinery ([`CallHandle::try_trigger_retry_access`]) instead of returning them to the
+/// retry machinery ([`DurableCallSession::try_trigger_retry_access`]) instead of returning them to the
 /// guest.
 ///
 /// `classify` inspects the response about to be persisted: it returns `None` for a success and
@@ -178,7 +178,7 @@ where
     F: FnOnce() -> Fut,
     Fut: Future<Output = wasmtime::Result<Pair::Resp>>,
 {
-    let mut handle = CallHandle::<Pair, Cancellable>::start_access(
+    let mut handle = DurableCallSession::<Pair, Cancellable>::start_access(
         store,
         durable_worker_ctx::<Ctx, T>,
         request,

--- a/golem-worker-executor/src/durable_host/p3/random.rs
+++ b/golem-worker-executor/src/durable_host/p3/random.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::concurrent::{
-    CallHandle, NotCancellable, drain_queued_dropped_call_events,
+    DurableCallSession, NotCancellable, drain_queued_dropped_call_events,
 };
 use crate::durable_host::p3::DurableP3View;
 use crate::workerctx::WorkerCtx;
@@ -34,7 +34,7 @@ impl<Ctx: WorkerCtx> random::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3RandomRandomGetRandomBytes, NotCancellable>::start(
+        let handle = DurableCallSession::<P3RandomRandomGetRandomBytes, NotCancellable>::start(
             ctx,
             HostRequestRandomBytes { length: len },
             DurableFunctionType::ReadLocal,
@@ -59,7 +59,7 @@ impl<Ctx: WorkerCtx> random::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3RandomRandomGetRandomU64, NotCancellable>::start(
+        let handle = DurableCallSession::<P3RandomRandomGetRandomU64, NotCancellable>::start(
             ctx,
             HostRequestNoInput {},
             DurableFunctionType::ReadLocal,
@@ -86,12 +86,13 @@ impl<Ctx: WorkerCtx> insecure::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3RandomInsecureGetInsecureRandomBytes, NotCancellable>::start(
-            ctx,
-            HostRequestRandomBytes { length: len },
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<P3RandomInsecureGetInsecureRandomBytes, NotCancellable>::start(
+                ctx,
+                HostRequestRandomBytes { length: len },
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(ctx, async |ctx| -> wasmtime::Result<_> {
@@ -111,12 +112,13 @@ impl<Ctx: WorkerCtx> insecure::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3RandomInsecureGetInsecureRandomU64, NotCancellable>::start(
-            ctx,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<P3RandomInsecureGetInsecureRandomU64, NotCancellable>::start(
+                ctx,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(ctx, async |ctx| -> wasmtime::Result<_> {
@@ -138,12 +140,13 @@ impl<Ctx: WorkerCtx> insecure_seed::Host for DurableP3View<'_, Ctx> {
         drain_queued_dropped_call_events(ctx)
             .await
             .map_err(wasmtime::Error::from)?;
-        let handle = CallHandle::<P3RandomInsecureSeedGetInsecureSeed, NotCancellable>::start(
-            ctx,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<P3RandomInsecureSeedGetInsecureSeed, NotCancellable>::start(
+                ctx,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
 
         let result = handle
             .run(ctx, async |ctx| -> wasmtime::Result<_> {

--- a/golem-worker-executor/src/durable_host/p3/sockets/tcp.rs
+++ b/golem-worker-executor/src/durable_host/p3/sockets/tcp.rs
@@ -19,7 +19,7 @@ use std::task::{Context, Poll};
 use crate::durable_host::TcpSocketStreamDirection;
 use crate::durable_host::authorization::targets::tcp_target;
 use crate::durable_host::concurrent::{
-    AccessClaimOptions, CallHandle, CallReplayOutcome, Cancellable, NotCancellable,
+    AccessClaimOptions, CallReplayOutcome, Cancellable, DurableCallSession, NotCancellable,
     authorize_live_permissions_at_serialized_access, resolve_current_observational_owner,
 };
 use crate::durable_host::durability::{
@@ -742,7 +742,7 @@ enum TcpSendMode {
 }
 
 struct TcpSocketSendTask<Ctx> {
-    call: CallHandle<P3SocketsTypesTcpSocketSend, Cancellable>,
+    call: DurableCallSession<P3SocketsTypesTcpSocketSend, Cancellable>,
     mode: TcpSendMode,
     result_tx: oneshot::Sender<wasmtime::Result<Result<(), types::ErrorCode>>>,
     activity: TailActivity,
@@ -751,7 +751,7 @@ struct TcpSocketSendTask<Ctx> {
 
 impl<Ctx> TcpSocketSendTask<Ctx> {
     fn live(
-        call: CallHandle<P3SocketsTypesTcpSocketSend, Cancellable>,
+        call: DurableCallSession<P3SocketsTypesTcpSocketSend, Cancellable>,
         socket_result_rx: oneshot::Receiver<Result<(), types::ErrorCode>>,
         result_tx: oneshot::Sender<wasmtime::Result<Result<(), types::ErrorCode>>>,
         activity: TailActivity,
@@ -766,7 +766,7 @@ impl<Ctx> TcpSocketSendTask<Ctx> {
     }
 
     fn replay(
-        call: CallHandle<P3SocketsTypesTcpSocketSend, Cancellable>,
+        call: DurableCallSession<P3SocketsTypesTcpSocketSend, Cancellable>,
         input_rx: oneshot::Receiver<Vec<u8>>,
         socket: Resource<TcpSocket>,
         result_tx: oneshot::Sender<wasmtime::Result<Result<(), types::ErrorCode>>>,
@@ -818,7 +818,7 @@ where
 /// in the oplog).
 async fn complete_tcp_socket_send<Ctx, U>(
     accessor: &Accessor<U, DurableP3<Ctx>>,
-    call: CallHandle<P3SocketsTypesTcpSocketSend, Cancellable>,
+    call: DurableCallSession<P3SocketsTypesTcpSocketSend, Cancellable>,
     socket_result_rx: oneshot::Receiver<Result<(), types::ErrorCode>>,
 ) -> wasmtime::Result<Result<(), types::ErrorCode>>
 where
@@ -847,7 +847,7 @@ where
 /// result.
 async fn replay_tcp_socket_send<Ctx, U>(
     accessor: &Accessor<U, DurableP3<Ctx>>,
-    call: CallHandle<P3SocketsTypesTcpSocketSend, Cancellable>,
+    call: DurableCallSession<P3SocketsTypesTcpSocketSend, Cancellable>,
     input_rx: oneshot::Receiver<Vec<u8>>,
     socket: Resource<TcpSocket>,
     activity: &TailActivity,
@@ -1005,7 +1005,7 @@ where
 {
     // Open the parent batched scope. Children nest under its begin index.
     let mut parent =
-        match CallHandle::<P3SocketsTypesTcpSocketReceive, Cancellable>::start_access_with_options(
+        match DurableCallSession::<P3SocketsTypesTcpSocketReceive, Cancellable>::start_access_with_options(
             accessor,
             durable_worker_ctx::<Ctx, U>,
             DurableFunctionType::WriteRemoteBatched(None),
@@ -1077,37 +1077,37 @@ where
         // Safe park: waiting for the guest to demand the next chunk.
         let demand = activity.park(demand_rx.recv()).await;
 
-        let mut child = match CallHandle::<
+        let mut child = match DurableCallSession::<
             P3SocketsTypesTcpSocketReceiveChunk,
             NotCancellable,
         >::start_access_with_options(
-                accessor,
-                durable_worker_ctx::<Ctx, U>,
-                DurableFunctionType::WriteRemoteBatched(Some(parent_begin)),
-                AccessClaimOptions {
-                    observational_owner,
-                    ..Default::default()
-                },
-                async |_| Ok(HostRequestNoInput {}),
-            )
-            .await
-            {
-                Ok(child) => child,
-                Err(error) => {
-                    let trap_context = parent.trap_context();
-                    if let Some(reply_tx) = demand {
-                        let _ = reply_tx.send(TcpReceiveReply::Failed {
-                            message: error.to_string(),
-                            trap_context,
-                        });
-                    }
-                    return fail_tcp_receive_task(
-                        result_tx,
-                        wasmtime::Error::from_anyhow(parent.trap(error)),
-                        Some(trap_context),
-                    );
+            accessor,
+            durable_worker_ctx::<Ctx, U>,
+            DurableFunctionType::WriteRemoteBatched(Some(parent_begin)),
+            AccessClaimOptions {
+                observational_owner,
+                ..Default::default()
+            },
+            async |_| Ok(HostRequestNoInput {}),
+        )
+        .await
+        {
+            Ok(child) => child,
+            Err(error) => {
+                let trap_context = parent.trap_context();
+                if let Some(reply_tx) = demand {
+                    let _ = reply_tx.send(TcpReceiveReply::Failed {
+                        message: error.to_string(),
+                        trap_context,
+                    });
                 }
-            };
+                return fail_tcp_receive_task(
+                    result_tx,
+                    wasmtime::Error::from_anyhow(parent.trap(error)),
+                    Some(trap_context),
+                );
+            }
+        };
 
         // Produce the next item: replay the recorded child (replay) or read the
         // upstream socket and persist it (live).
@@ -1621,7 +1621,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostTcpSocketWithStore<U> for Dur
             });
         }
 
-        let call = CallHandle::<P3SocketsTypesTcpSocketSend, Cancellable>::start_access(
+        let call = DurableCallSession::<P3SocketsTypesTcpSocketSend, Cancellable>::start_access(
             accessor,
             durable_worker_ctx::<Ctx, U>,
             HostRequestNoInput {},

--- a/golem-worker-executor/src/durable_host/p3/sockets/udp.rs
+++ b/golem-worker-executor/src/durable_host/p3/sockets/udp.rs
@@ -14,7 +14,8 @@
 
 use crate::durable_host::authorization::targets::udp_target;
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, NotCancellable, authorize_live_permissions_at_serialized_access,
+    CallReplayOutcome, DurableCallSession, NotCancellable,
+    authorize_live_permissions_at_serialized_access,
 };
 use crate::durable_host::p3::{
     DurableP3, DurableP3View, durable_worker_ctx, observe_function_call, run_read_access,
@@ -81,15 +82,16 @@ impl<Ctx: WorkerCtx> types::HostUdpSocket for DurableP3View<'_, Ctx> {
         } else {
             false
         };
-        let mut handle = CallHandle::<P3SocketsTypesUdpSocketConnect, NotCancellable>::start(
-            self.0.durable_ctx_mut(),
-            HostRequestP3SocketsConnect {
-                remote_address: remote_address.into(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await
-        .map_err(SocketError::trap)?;
+        let mut handle =
+            DurableCallSession::<P3SocketsTypesUdpSocketConnect, NotCancellable>::start(
+                self.0.durable_ctx_mut(),
+                HostRequestP3SocketsConnect {
+                    remote_address: remote_address.into(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await
+            .map_err(SocketError::trap)?;
         if !handle.is_live() {
             match handle
                 .replay(self.0.durable_ctx_mut())

--- a/golem-worker-executor/src/durable_host/permissions/mod.rs
+++ b/golem-worker-executor/src/durable_host/permissions/mod.rs
@@ -29,7 +29,7 @@
 //! durable/cross-executor representation is the snapshot embedded in the
 //! surrounding value, never the live handle.
 
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::golem::permissions::derive as permissions_derive;
 use crate::preview2::golem::permissions::inspect as permissions_inspect;
@@ -850,7 +850,7 @@ async fn durable_now<Ctx: WorkerCtx>(
 
 async fn complete_runtime_card_creation<Ctx, Pair>(
     ctx: &mut DurableWorkerCtx<Ctx>,
-    mut handle: CallHandle<Pair, NotCancellable>,
+    mut handle: DurableCallSession<Pair, NotCancellable>,
     card: StoredCard,
     provenance: CardManagedByRuntimeDerived,
 ) -> anyhow::Result<HostResponsePermissionCardDerived>
@@ -913,7 +913,8 @@ where
     // the re-executable write class so a committed Start without an End can safely retry; the
     // generic remote-write class would make retryability depend on the guest's idempotence flag.
     let begun =
-        CallHandle::<Pair, NotCancellable>::begin(ctx, DurableFunctionType::WriteLocal).await?;
+        DurableCallSession::<Pair, NotCancellable>::begin(ctx, DurableFunctionType::WriteLocal)
+            .await?;
     let oplog_index = begun.begin_index();
     let card_id = derive_card_id(ctx, &invocation_key, oplog_index);
     let provenance = CardManagedByRuntimeDerived {
@@ -2209,7 +2210,7 @@ fn permission_error_to_revoke_error(
 }
 
 async fn complete_permission_card_revoke<Ctx: WorkerCtx>(
-    mut handle: CallHandle<GolemPermissionsRevokePersist, NotCancellable>,
+    mut handle: DurableCallSession<GolemPermissionsRevokePersist, NotCancellable>,
     ctx: &mut DurableWorkerCtx<Ctx>,
     card_handle: &Resource<PermissionCardHandleRep>,
     card_id: CardId,
@@ -2252,7 +2253,7 @@ async fn revoke_and_persist_card<Ctx: WorkerCtx>(
         }
     };
     let card_id = CardId(snapshot.card_id);
-    let (mut handle, captured_authority) = CallHandle::<
+    let (mut handle, captured_authority) = DurableCallSession::<
         GolemPermissionsRevokePersist,
         NotCancellable,
     >::start_with_agent_authority_capture(
@@ -2713,11 +2714,12 @@ impl<Ctx: WorkerCtx> permissions_wallet::Host for DurableWorkerCtx<Ctx> {
                 .state
                 .get_current_idempotency_key()
                 .ok_or_else(|| anyhow!("permission-card transfer requires an active invocation"))?;
-            let begun = CallHandle::<GolemPermissionsInstallTransfer, NotCancellable>::begin(
-                self,
-                DurableFunctionType::WriteLocal,
-            )
-            .await?;
+            let begun =
+                DurableCallSession::<GolemPermissionsInstallTransfer, NotCancellable>::begin(
+                    self,
+                    DurableFunctionType::WriteLocal,
+                )
+                .await?;
             let operation_index = begun.begin_index();
             let transfer_id = self.derive_transfer_id(&invocation_key, operation_index);
             let (installed_card, installed_card_provenance) = match &source_card {

--- a/golem-worker-executor/src/durable_host/quota/mod.rs
+++ b/golem-worker-executor/src/durable_host/quota/mod.rs
@@ -14,7 +14,7 @@
 
 pub mod types;
 
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::quota::types::{LeaseInterestHandle, QuotaTokenEntry, ReservationEntry};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::golem::quota::types::{FailedReservation, Host, HostReservation};
@@ -124,15 +124,16 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
 
         // `WriteLocal` (no external side effect): re-executable on an incomplete `Start`, so the
         // live acquire runs from one shared block for both the live and incomplete-replay paths.
-        let mut handle = CallHandle::<host_functions::GolemQuotaTokenNew, NotCancellable>::start(
-            self,
-            HostRequestQuotaTokenRequest {
-                resource_name,
-                expected_use,
-            },
-            DurableFunctionType::WriteLocal,
-        )
-        .await?;
+        let mut handle =
+            DurableCallSession::<host_functions::GolemQuotaTokenNew, NotCancellable>::start(
+                self,
+                HostRequestQuotaTokenRequest {
+                    resource_name,
+                    expected_use,
+                },
+                DurableFunctionType::WriteLocal,
+            )
+            .await?;
 
         let token_entry = 'token: {
             if !handle.is_live() {
@@ -175,7 +176,7 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         amount: u64,
     ) -> anyhow::Result<Result<Resource<ReservationEntry>, FailedReservation>> {
         let mut handle =
-            CallHandle::<host_functions::GolemQuotaTokenReserve, NotCancellable>::start(
+            DurableCallSession::<host_functions::GolemQuotaTokenReserve, NotCancellable>::start(
                 self,
                 HostRequestQuotaReserveRequest { amount },
                 DurableFunctionType::WriteRemote,
@@ -515,13 +516,15 @@ impl<Ctx: WorkerCtx> HostReservation for DurableWorkerCtx<Ctx> {
     async fn commit(&mut self, self_: Resource<ReservationEntry>, used: u64) -> anyhow::Result<()> {
         let entry = self.table().delete(self_)?;
 
-        let mut handle =
-            CallHandle::<host_functions::GolemQuotaReservationCommit, NotCancellable>::start(
-                self,
-                HostRequestQuotaCommitRequest { used },
-                DurableFunctionType::WriteRemote,
-            )
-            .await?;
+        let mut handle = DurableCallSession::<
+            host_functions::GolemQuotaReservationCommit,
+            NotCancellable,
+        >::start(
+            self,
+            HostRequestQuotaCommitRequest { used },
+            DurableFunctionType::WriteRemote,
+        )
+        .await?;
 
         if !handle.is_live() {
             match handle.replay(self).await? {

--- a/golem-worker-executor/src/durable_host/random/insecure.rs
+++ b/golem-worker-executor/src/durable_host/random/insecure.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::DurableWorkerCtx;
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::workerctx::WorkerCtx;
 use golem_common::model::oplog::{
     DurableFunctionType, HostRequestNoInput, HostRequestRandomBytes, HostResponseRandomBytes,
@@ -24,7 +24,7 @@ use wasmtime_wasi::random::WasiRandomView as _;
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_insecure_random_bytes(&mut self, length: u64) -> wasmtime::Result<Vec<u8>> {
-        let handle = CallHandle::<
+        let handle = DurableCallSession::<
             host_functions::RandomInsecureGetInsecureRandomBytes,
             NotCancellable,
         >::start(
@@ -48,13 +48,11 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn get_insecure_random_u64(&mut self) -> wasmtime::Result<u64> {
-        let handle =
-            CallHandle::<host_functions::RandomInsecureGetInsecureRandomU64, NotCancellable>::start(
-                self,
-                HostRequestNoInput {},
-                DurableFunctionType::ReadLocal,
-            )
-            .await?;
+        let handle = DurableCallSession::<
+            host_functions::RandomInsecureGetInsecureRandomU64,
+            NotCancellable,
+        >::start(self, HostRequestNoInput {}, DurableFunctionType::ReadLocal)
+        .await?;
 
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {

--- a/golem-worker-executor/src/durable_host/random/insecure_seed.rs
+++ b/golem-worker-executor/src/durable_host/random/insecure_seed.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::DurableWorkerCtx;
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::workerctx::WorkerCtx;
 use golem_common::model::oplog::{
     DurableFunctionType, HostRequestNoInput, HostResponseRandomSeed, host_functions,
@@ -23,13 +23,11 @@ use wasmtime_wasi::random::WasiRandomView as _;
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn insecure_seed(&mut self) -> wasmtime::Result<(u64, u64)> {
-        let handle =
-            CallHandle::<host_functions::RandomInsecureSeedInsecureSeed, NotCancellable>::start(
-                self,
-                HostRequestNoInput {},
-                DurableFunctionType::ReadLocal,
-            )
-            .await?;
+        let handle = DurableCallSession::<
+            host_functions::RandomInsecureSeedInsecureSeed,
+            NotCancellable,
+        >::start(self, HostRequestNoInput {}, DurableFunctionType::ReadLocal)
+        .await?;
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {
                 let result = {

--- a/golem-worker-executor/src/durable_host/random/random.rs
+++ b/golem-worker-executor/src/durable_host/random/random.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::DurableWorkerCtx;
-use crate::durable_host::concurrent::{CallHandle, NotCancellable};
+use crate::durable_host::concurrent::{DurableCallSession, NotCancellable};
 use crate::workerctx::WorkerCtx;
 use golem_common::model::oplog::{
     DurableFunctionType, HostRequestNoInput, HostRequestRandomBytes, HostResponseRandomBytes,
@@ -24,12 +24,13 @@ use wasmtime_wasi::random::WasiRandomView as _;
 
 impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     async fn get_random_bytes(&mut self, length: u64) -> wasmtime::Result<Vec<u8>> {
-        let handle = CallHandle::<host_functions::RandomGetRandomBytes, NotCancellable>::start(
-            self,
-            HostRequestRandomBytes { length },
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<host_functions::RandomGetRandomBytes, NotCancellable>::start(
+                self,
+                HostRequestRandomBytes { length },
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {
                 let bytes = {
@@ -44,12 +45,13 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
     }
 
     async fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
-        let handle = CallHandle::<host_functions::RandomGetRandomU64, NotCancellable>::start(
-            self,
-            HostRequestNoInput {},
-            DurableFunctionType::ReadLocal,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<host_functions::RandomGetRandomU64, NotCancellable>::start(
+                self,
+                HostRequestNoInput {},
+                DurableFunctionType::ReadLocal,
+            )
+            .await?;
         let result = handle
             .run(self, async |ctx| -> wasmtime::Result<_> {
                 let value = {

--- a/golem-worker-executor/src/durable_host/rdbms/mod.rs
+++ b/golem-worker-executor/src/durable_host/rdbms/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::durable_host::authorization::targets::{RdbmsEngine, rdbms_sql_targets, rdbms_target};
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::{HostFailureKind, InFunctionRetryHost};
 use crate::durable_host::keyvalue::environment_owner;
 use crate::durable_host::rdbms::serialized::RdbmsRequest;
@@ -224,7 +224,7 @@ where
     dyn RdbmsService: RdbmsTypeService<T>,
     E: From<RdbmsError>,
 {
-    let begun = CallHandle::<T::ConnBeginTransaction, NotCancellable>::begin(
+    let begun = DurableCallSession::<T::ConnBeginTransaction, NotCancellable>::begin(
         ctx,
         DurableFunctionType::ReadLocal,
     )
@@ -353,7 +353,7 @@ where
         None
     };
 
-    let mut handle = CallHandle::<T::ConnExecute, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::ConnExecute, NotCancellable>::start(
         ctx,
         request,
         DurableFunctionType::WriteRemote,
@@ -479,7 +479,7 @@ where
         None
     };
 
-    let mut handle = CallHandle::<T::ConnQuery, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::ConnQuery, NotCancellable>::start(
         ctx,
         request,
         DurableFunctionType::WriteRemote,
@@ -595,7 +595,7 @@ where
             "golem::rdbms::db-connection::query-stream",
         )
         .await?;
-    let mut handle = CallHandle::<T::ConnQueryStream, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::ConnQueryStream, NotCancellable>::start(
         ctx,
         HostRequestNoInput {},
         DurableFunctionType::WriteRemoteBatched(Some(begin_index)),
@@ -741,7 +741,7 @@ where
         DurableFunctionType::WriteRemoteBatched(Some(begin_oplog_idx))
     };
 
-    let mut handle = CallHandle::<T::StreamGetColumns, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::StreamGetColumns, NotCancellable>::start(
         ctx,
         HostRequestNoInput {},
         durable_function_type,
@@ -818,7 +818,7 @@ where
         DurableFunctionType::WriteRemoteBatched(Some(begin_oplog_idx))
     };
 
-    let mut handle = CallHandle::<T::StreamGetNext, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::StreamGetNext, NotCancellable>::start(
         ctx,
         HostRequestNoInput {},
         durable_function_type,
@@ -978,7 +978,7 @@ where
         None
     };
 
-    let mut handle = CallHandle::<T::TxnQuery, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::TxnQuery, NotCancellable>::start(
         ctx,
         request,
         DurableFunctionType::WriteRemoteTransaction(Some(begin_oplog_idx)),
@@ -1099,7 +1099,7 @@ where
         None
     };
 
-    let mut handle = CallHandle::<T::TxnExecute, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::TxnExecute, NotCancellable>::start(
         ctx,
         request,
         DurableFunctionType::WriteRemoteTransaction(Some(begin_oplog_idx)),
@@ -1176,7 +1176,7 @@ where
     } else {
         None
     };
-    let mut handle = CallHandle::<T::TxnQueryStream, NotCancellable>::start(
+    let mut handle = DurableCallSession::<T::TxnQueryStream, NotCancellable>::start(
         ctx,
         HostRequestNoInput {},
         DurableFunctionType::WriteRemoteTransaction(Some(begin_oplog_idx)),

--- a/golem-worker-executor/src/durable_host/replay_state/mod.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/mod.rs
@@ -321,7 +321,7 @@ struct CursorState {
     /// trip us up.
     pending_fork_starts: HashSet<OplogIndex>,
     /// Matches replayed `End`/`Cancelled` entries to the concurrent
-    /// [`crate::durable_host::concurrent::CallHandle`]s awaiting them, keyed by their `Start` index.
+    /// [`crate::durable_host::concurrent::DurableCallSession`]s awaiting them, keyed by their `Start` index.
     /// Fed only from the committed-consume hook. Lives under the cursor lock because awaited-terminal
     /// detection, terminal resolution, and `Start`-claim registration are all part of the cursor
     /// transaction; the rare slow-path `unregister` re-acquires the lock from outside a transaction.

--- a/golem-worker-executor/src/durable_host/replay_state/tests.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/tests.rs
@@ -1649,7 +1649,7 @@ async fn replay_resolves_cancelled_without_partial() {
 async fn replay_resolves_cancelled_with_partial_result() {
     // [NoOp, Start, Cancelled { partial: Some(..) }] — a call cancelled live with a partial
     // result replays to a `Cancelled` resolution that preserves the recorded partial
-    // response payload (the CallHandle replay path downloads and converts it).
+    // response payload (the DurableCallSession replay path downloads and converts it).
     let rs = replay_state_over(vec![noop(), start_now(), cancelled_with_partial_for(2, 42)]).await;
     let handle = rs
         .claim_concurrent_start(

--- a/golem-worker-executor/src/durable_host/secrets/mod.rs
+++ b/golem-worker-executor/src/durable_host/secrets/mod.rs
@@ -15,7 +15,7 @@
 pub mod types;
 
 use crate::durable_host::authorization::targets::secret_target;
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::HostFailureKind;
 use crate::durable_host::secrets::types::SecretEntry;
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx, InternalRetryResult};
@@ -408,7 +408,7 @@ impl<Ctx: WorkerCtx> reveal::Host for DurableWorkerCtx<Ctx> {
         } else {
             (None, None)
         };
-        let begun = CallHandle::<GolemSecretsReveal, NotCancellable>::begin(
+        let begun = DurableCallSession::<GolemSecretsReveal, NotCancellable>::begin(
             self,
             DurableFunctionType::ReadRemote,
         )

--- a/golem-worker-executor/src/durable_host/sockets/ip_name_lookup.rs
+++ b/golem-worker-executor/src/durable_host/sockets/ip_name_lookup.rs
@@ -15,7 +15,7 @@
 use wasmtime::component::Resource;
 
 use crate::durable_host::authorization::targets::dns_target;
-use crate::durable_host::concurrent::{CallHandle, CallReplayOutcome, NotCancellable};
+use crate::durable_host::concurrent::{CallReplayOutcome, DurableCallSession, NotCancellable};
 use crate::durable_host::durability::{HostFailureKind, InternalRetryResult};
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::workerctx::WorkerCtx;
@@ -71,11 +71,12 @@ impl<Ctx: WorkerCtx> Host for DurableWorkerCtx<Ctx> {
         // request name; on replay a committed `Start` without its `End` is re-executable (read), so
         // the live side effect runs from a single shared block for both the live and
         // incomplete-replay paths.
-        let begun = CallHandle::<SocketsIpNameLookupResolveAddresses, NotCancellable>::begin(
-            self,
-            DurableFunctionType::ReadRemote,
-        )
-        .await?;
+        let begun =
+            DurableCallSession::<SocketsIpNameLookupResolveAddresses, NotCancellable>::begin(
+                self,
+                DurableFunctionType::ReadRemote,
+            )
+            .await?;
 
         let result = 'resp: {
             let (mut handle, denied) = if begun.is_live() {

--- a/golem-worker-executor/src/durable_host/tool/mod.rs
+++ b/golem-worker-executor/src/durable_host/tool/mod.rs
@@ -21,7 +21,7 @@
 
 use crate::durable_host::authorization::targets::tool_target;
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, Cancellable, NotCancellable,
+    CallReplayOutcome, Cancellable, DurableCallSession, NotCancellable,
     authorize_live_permissions_at_serialized_access,
 };
 use crate::durable_host::durability::{ClassifiedHostError, HostFailureKind};
@@ -707,7 +707,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         let component_id = self.state.owned_agent_id.agent_id.component_id;
         let component_revision = self.state.component_metadata.revision;
 
-        let mut handle = CallHandle::<GolemToolGetAllTools, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemToolGetAllTools, NotCancellable>::start(
             self,
             HostRequestNoInput {},
             DurableFunctionType::ReadRemote,
@@ -777,7 +777,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         let component_id = self.state.owned_agent_id.agent_id.component_id;
         let component_revision = self.state.component_metadata.revision;
 
-        let mut handle = CallHandle::<GolemToolGetTool, NotCancellable>::start(
+        let mut handle = DurableCallSession::<GolemToolGetTool, NotCancellable>::start(
             self,
             HostRequestGolemToolGetTool {
                 name: tool_name.clone(),
@@ -892,7 +892,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
         });
         let replaying = accessor.with(|mut access| !access.get().state.is_live());
         let handle = if replaying {
-            let handle = CallHandle::<GolemToolRpcInvoke, Cancellable>::start_access(
+            let handle = DurableCallSession::<GolemToolRpcInvoke, Cancellable>::start_access(
                 accessor,
                 accessor.getter(),
                 HostRequestGolemToolInvoke {
@@ -941,7 +941,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
                 stdin,
             } => {
                 close_stdin(accessor, stdin).await?;
-                let handle = CallHandle::<GolemToolRpcInvoke, Cancellable>::start_access(
+                let handle = DurableCallSession::<GolemToolRpcInvoke, Cancellable>::start_access(
                     accessor,
                     accessor.getter(),
                     *request,
@@ -964,7 +964,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
             ToolCallPreparation::Ready(prepared) => prepared,
         };
 
-        let handle = CallHandle::<GolemToolRpcInvoke, Cancellable>::start_access(
+        let handle = DurableCallSession::<GolemToolRpcInvoke, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             prepared.request.clone(),
@@ -1000,19 +1000,20 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
         });
         let replaying = accessor.with(|mut access| !access.get().state.is_live());
         let handle = if replaying {
-            let mut handle = CallHandle::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
-                accessor,
-                accessor.getter(),
-                HostRequestGolemToolInvoke {
-                    tool_name: String::new(),
-                    command_path: Vec::new(),
-                    args: Vec::new(),
-                    input: empty_tool_input(),
-                    has_stdin: false,
-                },
-                DurableFunctionType::ReadRemote,
-            )
-            .await?;
+            let mut handle =
+                DurableCallSession::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
+                    accessor,
+                    accessor.getter(),
+                    HostRequestGolemToolInvoke {
+                        tool_name: String::new(),
+                        command_path: Vec::new(),
+                        args: Vec::new(),
+                        input: empty_tool_input(),
+                        has_stdin: false,
+                    },
+                    DurableFunctionType::ReadRemote,
+                )
+                .await?;
             match handle.replay_access(accessor, accessor.getter()).await? {
                 CallReplayOutcome::Replayed(response) => {
                     close_stdin(accessor, stdin).await?;
@@ -1054,13 +1055,14 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
                 stdin,
             } => {
                 close_stdin(accessor, stdin).await?;
-                let handle = CallHandle::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
-                    accessor,
-                    accessor.getter(),
-                    *request,
-                    DurableFunctionType::ReadRemote,
-                )
-                .await?;
+                let handle =
+                    DurableCallSession::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
+                        accessor,
+                        accessor.getter(),
+                        *request,
+                        DurableFunctionType::ReadRemote,
+                    )
+                    .await?;
                 let response = admit_tool_response_secret_holds(accessor, response).await?;
                 let response = handle
                     .complete_access(
@@ -1074,7 +1076,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
             ToolCallPreparation::Ready(prepared) => prepared,
         };
 
-        let handle = CallHandle::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
+        let handle = DurableCallSession::<GolemToolRpcInvokeAndAwait, Cancellable>::start_access(
             accessor,
             accessor.getter(),
             prepared.request.clone(),
@@ -1111,19 +1113,20 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
         });
         let replaying = accessor.with(|mut access| !access.get().state.is_live());
         let handle = if replaying {
-            let handle = CallHandle::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
-                accessor,
-                accessor.getter(),
-                HostRequestGolemToolInvoke {
-                    tool_name: String::new(),
-                    command_path: Vec::new(),
-                    args: Vec::new(),
-                    input: empty_tool_input(),
-                    has_stdin: false,
-                },
-                DurableFunctionType::ReadRemote,
-            )
-            .await?;
+            let handle =
+                DurableCallSession::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
+                    accessor,
+                    accessor.getter(),
+                    HostRequestGolemToolInvoke {
+                        tool_name: String::new(),
+                        command_path: Vec::new(),
+                        args: Vec::new(),
+                        input: empty_tool_input(),
+                        has_stdin: false,
+                    },
+                    DurableFunctionType::ReadRemote,
+                )
+                .await?;
             match handle.replay_access(accessor, accessor.getter()).await? {
                 CallReplayOutcome::Replayed(response) => {
                     close_stdin(accessor, stdin).await?;
@@ -1171,7 +1174,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
             } => {
                 close_stdin(accessor, stdin).await?;
                 let handle =
-                    CallHandle::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
+                    DurableCallSession::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
                         accessor,
                         accessor.getter(),
                         *request,
@@ -1194,13 +1197,14 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostToolRpcWithStore<U> for HasSelf<Dura
             }
             ToolCallPreparation::Ready(prepared) => prepared,
         };
-        let handle = CallHandle::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
-            accessor,
-            accessor.getter(),
-            prepared.request.clone(),
-            DurableFunctionType::ReadRemote,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<GolemToolRpcAsyncInvokeAndAwait, Cancellable>::start_access(
+                accessor,
+                accessor.getter(),
+                prepared.request.clone(),
+                DurableFunctionType::ReadRemote,
+            )
+            .await?;
         close_stdin(accessor, prepared.stdin).await?;
         let _permit = prepared.permit;
         let result = admit_tool_response_secret_holds(

--- a/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
+++ b/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
@@ -14,7 +14,7 @@
 
 use crate::durable_host::authorization::targets::agent_method_target;
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, Cancellable, DeferredCallReplayOutcome, NotCancellable,
+    CallReplayOutcome, Cancellable, DeferredCallReplayOutcome, DurableCallSession, NotCancellable,
     authorize_live_permissions_at_serialized_access, finish_span_in_memory,
     try_agent_auth_ctx_at_serialized_access,
 };
@@ -332,7 +332,7 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             let mut logical_remote_agent_id =
                 OwnedAgentId::new(self.owned_agent_id.environment_id, &logical_remote_agent_id);
 
-            let mut handle = CallHandle::<GolemRpcWasmRpcNew, NotCancellable>::start(
+            let mut handle = DurableCallSession::<GolemRpcWasmRpcNew, NotCancellable>::start(
                 self,
                 HostRequestGolemRpcCreate {
                     remote_agent_id: remote_agent_id.clone(),
@@ -383,14 +383,15 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             );
         }
 
-        let handle = CallHandle::<GolemRpcWasmRpcNew, NotCancellable>::start_with_agent_authority(
-            self,
-            HostRequestGolemRpcCreate {
-                remote_agent_id: remote_agent_id.clone(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let handle =
+            DurableCallSession::<GolemRpcWasmRpcNew, NotCancellable>::start_with_agent_authority(
+                self,
+                HostRequestGolemRpcCreate {
+                    remote_agent_id: remote_agent_id.clone(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         if !handle.is_live() {
             match handle.replay(self).await? {
@@ -492,12 +493,12 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
 
         let call = if self.state.is_live() {
             Either::Left(
-                CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::
+                DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::
                     begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                     .await?,
             )
         } else {
-            let begun = CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::
+            let begun = DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::
                 begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                 .await?;
             let begin_index = begun.begin_index();
@@ -620,7 +621,7 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
 
         let call = if self.state.is_live() {
             Either::Left(
-                CallHandle::<GolemRpcWasmRpcInvoke, NotCancellable>::begin_with_agent_authority(
+                DurableCallSession::<GolemRpcWasmRpcInvoke, NotCancellable>::begin_with_agent_authority(
                     self,
                     DurableFunctionType::WriteRemote,
                 )
@@ -628,7 +629,7 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
             )
         } else {
             let begun =
-                CallHandle::<GolemRpcWasmRpcInvoke, NotCancellable>::begin_with_agent_authority(
+                DurableCallSession::<GolemRpcWasmRpcInvoke, NotCancellable>::begin_with_agent_authority(
                     self,
                     DurableFunctionType::WriteRemote,
                 )
@@ -842,12 +843,12 @@ impl<Ctx: WorkerCtx> HostWasmRpc for DurableWorkerCtx<Ctx> {
         // at the top of this function and is re-applied by `begin`.
         let call = if self.state.is_live() {
             Either::Left(
-                CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::
+                DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::
                     begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                     .await?,
             )
         } else {
-            let begun = CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::
+            let begun = DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::
                 begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                 .await?;
             Either::Right(begun.start_replay(self).await?)
@@ -1163,7 +1164,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         }
 
         let begun =
-            CallHandle::<GolemRpcWasmRpcActivate, NotCancellable>::begin_with_agent_authority(
+            DurableCallSession::<GolemRpcWasmRpcActivate, NotCancellable>::begin_with_agent_authority(
                 self,
                 DurableFunctionType::WriteRemote,
             )
@@ -1406,12 +1407,12 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
 
         let call = if self.state.is_live() {
             Either::Left(
-                CallHandle::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::
+                DurableCallSession::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::
                     begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                     .await?,
             )
         } else {
-            let begun = CallHandle::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::
+            let begun = DurableCallSession::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::
                 begin_with_agent_authority(self, DurableFunctionType::WriteRemote)
                 .await?;
             let begin_index = begun.begin_index();
@@ -1630,7 +1631,7 @@ async fn persist_invoke_and_await_denial<Ctx: WorkerCtx>(
     error: RpcError,
 ) -> anyhow::Result<Result<InvocationResultWithMetadata, RpcError>> {
     let details = rpc_denied_details(error);
-    let begun = CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::begin(
+    let begun = DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>::begin(
         ctx,
         DurableFunctionType::WriteRemote,
     )
@@ -1659,7 +1660,7 @@ async fn persist_invoke_denial<Ctx: WorkerCtx>(
     error: RpcError,
 ) -> anyhow::Result<Result<InvocationMetadata, RpcError>> {
     let details = rpc_denied_details(error);
-    let begun = CallHandle::<GolemRpcWasmRpcInvoke, NotCancellable>::begin(
+    let begun = DurableCallSession::<GolemRpcWasmRpcInvoke, NotCancellable>::begin(
         ctx,
         DurableFunctionType::WriteRemote,
     )
@@ -1701,7 +1702,7 @@ async fn persist_async_invoke_denial<Ctx: WorkerCtx>(
             payload.span_id.clone(),
         )
     };
-    let begun = CallHandle::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::begin(
+    let begun = DurableCallSession::<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>::begin(
         ctx,
         DurableFunctionType::WriteRemote,
     )
@@ -1799,7 +1800,7 @@ async fn persist_schedule_denial<Ctx: WorkerCtx>(
     error: RpcError,
 ) -> anyhow::Result<Result<Resource<CancellationToken>, RpcError>> {
     let details = rpc_denied_details(error);
-    let begun = CallHandle::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::begin(
+    let begun = DurableCallSession::<GolemRpcWasmRpcScheduleInvocation, NotCancellable>::begin(
         ctx,
         DurableFunctionType::WriteRemote,
     )
@@ -1927,7 +1928,7 @@ async fn run_invoke_and_await<Ctx: WorkerCtx>(
     remote_agent_id: OwnedAgentId,
     idempotency_key: IdempotencyKey,
     span: Arc<InvocationContextSpan>,
-    mut handle: CallHandle<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>,
+    mut handle: DurableCallSession<GolemRpcWasmRpcInvokeAndAwaitResult, NotCancellable>,
     scope_card: Option<ScopeCard>,
 ) -> anyhow::Result<Result<SchemaValue, RpcError>> {
     let mut freshness_disposition = if known_fresh_dispatch_allowed(
@@ -2059,7 +2060,7 @@ async fn run_invoke<Ctx: WorkerCtx>(
     remote_agent_id: OwnedAgentId,
     idempotency_key: IdempotencyKey,
     span: Arc<InvocationContextSpan>,
-    mut handle: CallHandle<GolemRpcWasmRpcInvoke, NotCancellable>,
+    mut handle: DurableCallSession<GolemRpcWasmRpcInvoke, NotCancellable>,
 ) -> anyhow::Result<Result<(), RpcError>> {
     let mut freshness_disposition = if known_fresh_dispatch_allowed(
         handle.is_live(),
@@ -2156,7 +2157,7 @@ type FutureInvokeTaskResult = Result<Result<SchemaValue, InternalRpcError>, Erro
 type FutureInvokeTaskHandle =
     Arc<tokio::sync::Mutex<AbortOnDropJoinHandle<FutureInvokeTaskResult>>>;
 type FutureInvokeGetResult = Result<Result<SchemaValue, RpcError>, Error>;
-type FutureInvokeCallHandle = CallHandle<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>;
+type FutureInvokeCallHandle = DurableCallSession<GolemRpcWasmRpcInvokeAndAwaitResult, Cancellable>;
 
 async fn admit_rpc_result_secret_holds<U, Ctx>(
     accessor: &Accessor<U, HasSelf<DurableWorkerCtx<Ctx>>>,
@@ -2913,14 +2914,15 @@ impl<Ctx: WorkerCtx> HostCancellationToken for DurableWorkerCtx<Ctx> {
                 )))
             })?;
 
-        let mut handle = CallHandle::<GolemRpcCancellationTokenCancel, NotCancellable>::start(
-            self,
-            HostRequestGolemRpcScheduledInvocationCancellation {
-                schedule_id: serialized_schedule_id.clone(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut handle =
+            DurableCallSession::<GolemRpcCancellationTokenCancel, NotCancellable>::start(
+                self,
+                HostRequestGolemRpcScheduledInvocationCancellation {
+                    schedule_id: serialized_schedule_id.clone(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         'cancel: {
             if !handle.is_live() {
@@ -3010,7 +3012,7 @@ fn invocation_target_agent_id(
 
 pub async fn construct_wasm_rpc_resource<Ctx: WorkerCtx>(
     ctx: &mut DurableWorkerCtx<Ctx>,
-    handle: CallHandle<GolemRpcWasmRpcNew, NotCancellable>,
+    handle: DurableCallSession<GolemRpcWasmRpcNew, NotCancellable>,
     remote_agent_id: AgentId,
     env: &[(String, String)],
     config: Vec<AgentConfigEntryDto>,

--- a/golem-worker-executor/src/durable_host/websocket/client.rs
+++ b/golem-worker-executor/src/durable_host/websocket/client.rs
@@ -14,7 +14,7 @@
 
 use crate::durable_host::authorization::targets::websocket_target;
 use crate::durable_host::concurrent::{
-    CallHandle, CallReplayOutcome, LeaveIncompleteOnDrop, NotCancellable,
+    CallReplayOutcome, DurableCallSession, LeaveIncompleteOnDrop, NotCancellable,
 };
 use crate::durable_host::{DurabilityHost, DurableWorkerCtx};
 use crate::preview2::golem::websocket::client::{
@@ -105,11 +105,12 @@ impl<Ctx: WorkerCtx> HostWebsocketConnection for DurableWorkerCtx<Ctx> {
     ) -> anyhow::Result<Result<Resource<WebSocketConnectionEntry>, Error>> {
         self.observe_function_call("golem:websocket/client", "connect");
 
-        let begun = CallHandle::<host_functions::WebsocketClientConnect, NotCancellable>::begin(
-            self,
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let begun =
+            DurableCallSession::<host_functions::WebsocketClientConnect, NotCancellable>::begin(
+                self,
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         let mut call = if begun.is_live() {
             let denied = match websocket_target(&url) {
@@ -241,14 +242,15 @@ impl<Ctx: WorkerCtx> HostWebsocketConnection for DurableWorkerCtx<Ctx> {
     ) -> anyhow::Result<Result<(), Error>> {
         self.observe_function_call("golem:websocket/client", "send");
 
-        let mut call = CallHandle::<host_functions::WebsocketClientSend, NotCancellable>::start(
-            self,
-            HostRequestWebsocketSend {
-                message: message_to_serializable(&message),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut call =
+            DurableCallSession::<host_functions::WebsocketClientSend, NotCancellable>::start(
+                self,
+                HostRequestWebsocketSend {
+                    message: message_to_serializable(&message),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         if !call.is_live() {
             let _ = self.as_wasi_view().table().get(&self_)?;
@@ -346,15 +348,16 @@ impl<Ctx: WorkerCtx> HostWebsocketConnection for DurableWorkerCtx<Ctx> {
     ) -> anyhow::Result<Result<(), Error>> {
         self.observe_function_call("golem:websocket/client", "close");
 
-        let mut call = CallHandle::<host_functions::WebsocketClientClose, NotCancellable>::start(
-            self,
-            HostRequestWebsocketClose {
-                code,
-                reason: reason.clone(),
-            },
-            DurableFunctionType::WriteRemote,
-        )
-        .await?;
+        let mut call =
+            DurableCallSession::<host_functions::WebsocketClientClose, NotCancellable>::start(
+                self,
+                HostRequestWebsocketClose {
+                    code,
+                    reason: reason.clone(),
+                },
+                DurableFunctionType::WriteRemote,
+            )
+            .await?;
 
         let terminal_close_error =
             TerminalWebSocketError::Closed(Some(SerializableWebsocketCloseInfo {
@@ -492,7 +495,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWebsocketConnectionWithStore<U>
                 .observe_function_call("golem:websocket/client", "receive")
         });
 
-        let mut call = CallHandle::<
+        let mut call = DurableCallSession::<
             host_functions::WebsocketClientReceive,
             LeaveIncompleteOnDrop,
         >::start_access(
@@ -609,7 +612,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> HostWebsocketConnectionWithStore<U>
                 .observe_function_call("golem:websocket/client", "receive-with-timeout")
         });
 
-        let mut call = CallHandle::<
+        let mut call = DurableCallSession::<
             host_functions::WebsocketClientReceiveWithTimeout,
             LeaveIncompleteOnDrop,
         >::start_access(
@@ -769,7 +772,7 @@ async fn ensure_websocket_connection_live<Ctx: WorkerCtx>(
 
     // The read-only side-effect trap fires earlier: every caller of this helper
     // (`send` / `receive` / `receive-with-timeout` / `close`) goes through
-    // `CallHandle::start` with `WriteRemote` first, which routes through
+    // `DurableCallSession::start` with `WriteRemote` first, which routes through
     // `DurabilityHost::begin_durable_function` — the single central read-only guard.
     let request = match build_request(&info.url, info.headers.as_deref()) {
         Ok(request) => request,
@@ -871,7 +874,7 @@ async fn ensure_websocket_connection_live_access<U: Send + 'static, Ctx: WorkerC
     }
 
     // The read-only side-effect trap fires earlier: every caller of this helper goes through
-    // `CallHandle::start_access` with `WriteRemote` first, which routes through
+    // `DurableCallSession::start_access` with `WriteRemote` first, which routes through
     // `DurabilityHost::begin_durable_function` — the single central read-only guard.
     let request = match build_request(&info.url, info.headers.as_deref()) {
         Ok(request) => request,

--- a/golem-worker-executor/src/services/worker_fork.rs
+++ b/golem-worker-executor/src/services/worker_fork.rs
@@ -867,7 +867,7 @@ impl<Ctx: WorkerCtx> WorkerForkService for DefaultWorkerFork<Ctx> {
         // If the copied cutoff is the source call's outer `WriteRemote` scope `Start`, complete
         // that scope after the synthetic child call so the forked worker can replay the same shape
         // as the source call. This is a synthetic write into another worker's oplog, not an
-        // in-context host call, so it uses the atomic-pair primitive directly (no `CallHandle`);
+        // in-context host call, so it uses the atomic-pair primitive directly (no `DurableCallSession`);
         // atomicity matters because a split `Start`/`End` would corrupt the forked worker's replay.
         let request = HostRequest::NoInput(HostRequestNoInput {});
         let response = HostResponse::GolemApiFork(HostResponseGolemApiFork {

--- a/golem-worker-executor/src/worker/invocation.rs
+++ b/golem-worker-executor/src/worker/invocation.rs
@@ -295,7 +295,7 @@ fn tail_work_settled(active_spawned_tasks: usize, replay_cursor_open: bool) -> b
 /// future is dropped, no `AgentInvocationFinished` entry is written, and normal retry handling
 /// replays any calls left incomplete — the same contract as a crash at this point.
 ///
-/// The event loop future itself is never dropped while unfinished: durable `CallHandle`s owned
+/// The event loop future itself is never dropped while unfinished: durable `DurableCallSession`s owned
 /// by parked host futures are not cancellation-safe (`NotCancellable` handles panic when dropped
 /// unfinished, and even `Cancellable` drops may leave terminal oplog effects unwritten).
 /// External cancellation — worker interruption and the optional max-invocation-duration limit —


### PR DESCRIPTION
## Summary

- extract durable-call admission, authority stabilization, scope recovery, commit, and checkpoint ordering into `DurableCallCoordinator`
- carry admission state through a typed `DurableCallBoundary`
- move serialized accessor authority and replay-boundary helpers into the coordinator module
- rename `CallHandle` to `DurableCallSession` throughout the worker executor
- preserve existing oplog formats, replay claims, and terminal ordering

## Verification

- `cargo make fix`
- focused durable-call/read-only/replay tests: 7 passed, 0 failed
- `git diff --check`

`cargo make build` was also attempted from an empty Cargo target directory, but the workspace-wide all-target build exhausted the orb's 64 GiB filesystem while linking test targets. GitHub CI will run the full build in its normal environment.
