### PR TITLE
Fix stale nightly benchmark components

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1531,7 +1531,7 @@ rm -rf build-out
 '''
 
 [tasks.build-benchmark-components]
-description = "Builds only the benchmark test WASM components"
+description = "Rebuilds only the benchmark test WASM components"
 dependencies = ["wit", "build-sdk-ts"]
 script_runner = "@duckscript"
 script = '''
@@ -1543,7 +1543,7 @@ if ${golem_cli_empty}
     set_env GOLEM_CLI ${golem_cli}
 end
 cd test-components
-exec --fail-on-error ./build-components.sh benchmarks
+exec --fail-on-error ./build-components.sh benchmarks rebuild
 '''
 
 [tasks.run-benchmark-suite-orb]

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -11,8 +11,6 @@ source_ref="$(git symbolic-ref -q HEAD || true)"
 artifact_dir="${GOLEM_BENCHMARK_ARTIFACT_DIR:-$root/tmp}"
 results_repository="${BENCHMARK_RESULTS_REPOSITORY:-https://github.com/golemcloud/benchmark-results.git}"
 generated_files=(
-    sdks/ts/packages/golem-ts-typegen/.metadata/generated-types.json
-    sdks/ts/packages/golem-ts-typegen/.metadata/generated-types.ts
     test-components/benchmarks/package-lock.json
 )
 


### PR DESCRIPTION
## Summary

- force benchmark components to clean and rebuild before nightly/CI benchmark runs, preventing cached WASMs from surviving SDK or WIT contract changes
- remove obsolete TypeScript typegen metadata paths from the nightly cleanup list so successful runs are not failed by `git restore`

## Verification

- `cargo make fix`
- `CARGO_INCREMENTAL=false cargo make build`
- `cargo make build-benchmark-components`
- `bash -n integration-tests/benchmark_suites/run_orb_nightly.sh test-components/build-components.sh`