### PR TITLE
Clean orb benchmark state before nightly runs

### DIFF
--- a/integration-tests/benchmark_suites/orb-nightly.md
+++ b/integration-tests/benchmark_suites/orb-nightly.md
@@ -10,6 +10,8 @@ It builds and runs all primary benchmarks in `ci.yaml`, keeps timestamped result
 artifacts under `tmp/`, and then uses the validated publisher from `golemcloud/benchmark-results`
 to append and push exactly that run. The analysis compares the run with the immediately preceding
 run from the same runner and suite.
+Before building, it cleans the Cargo target directory and removes leftover benchmark Postgres
+containers and unused Docker volumes so every run starts with enough disk space and a fresh database.
 Failed or partial runs are never published. Publishing is idempotent, and non-fast-forward races
 are retried from a fresh `benchmark-results` checkout.
 
@@ -54,6 +56,6 @@ than inventing one.
 
 For recovery testing or an idempotent publication retry, set `GOLEM_BENCHMARK_RESULTS_INPUT` to an
 existing JSON artifact. The artifact must match the current commit and ref. The repository URL,
-expected ref, artifact directory, and space reclamation can be overridden with
+expected ref, and artifact directory can be overridden with
 `BENCHMARK_RESULTS_REPOSITORY`, `GOLEM_BENCHMARK_EXPECTED_REF`,
-`GOLEM_BENCHMARK_ARTIFACT_DIR`, and `GOLEM_BENCHMARK_RECLAIM_SPACE` respectively.
+and `GOLEM_BENCHMARK_ARTIFACT_DIR` respectively.

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -55,10 +55,16 @@ else
     export WASM_RQUICKJS_VERSION=0.4.1
     export GOLEM_BENCHMARK_RESULTS_PATH="$results"
 
-    if [[ "${GOLEM_BENCHMARK_RECLAIM_SPACE:-true}" == "true" ]]; then
-        rm -rf target/debug
-        docker container prune --force
+    cargo clean
+
+    mapfile -t postgres_containers < <(
+        docker ps --all --quiet --filter ancestor=postgres:17.7
+    )
+    if ((${#postgres_containers[@]})); then
+        docker rm --force --volumes "${postgres_containers[@]}"
     fi
+    docker container prune --force
+    docker volume prune --force
 
     # The SDK build currently caches generated output without tracking its source revision.
     cargo make clean-sdk-ts


### PR DESCRIPTION
## Summary

- make full Cargo target cleanup mandatory before production Amp orb benchmarks
- remove leftover benchmark PostgreSQL containers and volumes before each run
- prune stopped containers and unused volumes so the fixed-size orb has enough disk space
- document the mandatory clean-run behavior and remove the obsolete cleanup opt-out

This supports running nightly benchmarks reliably in Amp orbs. A previous run exhausted disk while PostgreSQL was writing WAL; the mandatory cleanup increased free disk from under 1 GiB to 28 GiB and ensured the database started fresh.

## Validation

- `bash -n integration-tests/benchmark_suites/run_orb_nightly.sh`
- `git diff --check HEAD^ HEAD`
- full `cargo make run-benchmark-suite-orb` spawned suite with all 11 CI benchmark definitions: passed in 48m 51.89s, including the previously failing `latency-medium` PostgreSQL workload
- successful result published idempotently to `golemcloud/benchmark-results` at `66a8873520bdbc2377525f29f7da71f65f89f015`