### PR TITLE
Fix snapshot recovery across automatic updates

### DIFF
--- a/golem-common/src/model/mod.rs
+++ b/golem-common/src/model/mod.rs
@@ -733,6 +733,8 @@ pub struct AgentStatusRecord {
     pub last_automatic_snapshot_index: Option<OplogIndex>,
     /// Timestamp of the last automatic snapshot entry in the oplog.
     pub last_automatic_snapshot_timestamp: Option<Timestamp>,
+    /// Component revision that created the last automatic snapshot.
+    pub last_automatic_snapshot_component_revision: Option<ComponentRevision>,
     /// The agent mode the worker was created with. Decided at create time and persisted in the
     /// `Create` oplog entry; immutable for the life of the worker. `#[transient]`: it is not part
     /// of the serialized record (it is persisted separately) and defaults to `Durable` on
@@ -770,6 +772,7 @@ impl Default for AgentStatusRecord {
             last_manual_update_snapshot_index: None,
             last_automatic_snapshot_index: None,
             last_automatic_snapshot_timestamp: None,
+            last_automatic_snapshot_component_revision: None,
             agent_mode: AgentMode::Durable,
         }
     }

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -604,6 +604,24 @@ impl TestWorkerExecutor {
         )
     }
 
+    pub fn fail_next_oplog_download(&self, agent_id: &AgentId) {
+        self.additional_test_deps
+            .fail_next_oplog_download(agent_id.clone());
+    }
+
+    pub fn return_no_op_after_oplog_reads(
+        &self,
+        agent_id: &AgentId,
+        oplog_index: OplogIndex,
+        reads_to_skip: usize,
+    ) {
+        self.additional_test_deps.return_no_op_after_oplog_reads(
+            agent_id.clone(),
+            oplog_index,
+            reads_to_skip,
+        );
+    }
+
     pub async fn commit_oplog_entry_bypassing_worker_status(
         &self,
         agent_id: &AgentId,
@@ -2971,6 +2989,12 @@ impl Oplog for TestOplog {
     }
 
     async fn read(&self, oplog_index: OplogIndex) -> OplogEntry {
+        if self
+            .additional_test_deps
+            .take_no_op_oplog_read(&self.owned_agent_id.agent_id, oplog_index)
+        {
+            return OplogEntry::no_op();
+        }
         self.oplog.read(oplog_index).await
     }
 
@@ -3005,6 +3029,12 @@ impl Oplog for TestOplog {
         payload_id: PayloadId,
         md5_hash: Vec<u8>,
     ) -> Result<Vec<u8>, String> {
+        if self
+            .additional_test_deps
+            .take_oplog_download_failure(&self.owned_agent_id.agent_id)
+        {
+            return Err("injected oplog payload download failure".to_string());
+        }
         self.oplog.download_raw_payload(payload_id, md5_hash).await
     }
 
@@ -3284,6 +3314,8 @@ impl<T: RdbmsType> Rdbms<T> for TestRdms<T> {
 pub struct AdditionalTestDeps {
     oplog_failures: Arc<scc::HashMap<AgentId, scc::HashMap<String, usize>>>,
     oplog_call_counts: Arc<std::sync::Mutex<HashMap<(OwnedAgentId, &'static str), usize>>>,
+    oplog_download_failures: Arc<std::sync::Mutex<HashSet<AgentId>>>,
+    no_op_oplog_reads: Arc<std::sync::Mutex<HashMap<(AgentId, OplogIndex), usize>>>,
     rdbms_tx_failures: Arc<scc::HashMap<AgentId, scc::HashMap<String, usize>>>,
     /// One-shot gates pausing the first consume-body chunk `End` append of an
     /// agent inside the [`TestOplog`] wrapper — after the entry is durable in
@@ -3313,6 +3345,8 @@ impl AdditionalTestDeps {
         Self {
             oplog_failures,
             oplog_call_counts: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            oplog_download_failures: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            no_op_oplog_reads: Arc::new(std::sync::Mutex::new(HashMap::new())),
             rdbms_tx_failures,
             consume_body_chunk_end_gates: Arc::new(scc::HashMap::new()),
             consume_body_reply_defer_gates: Arc::new(scc::HashMap::new()),
@@ -3401,6 +3435,48 @@ impl AdditionalTestDeps {
             .get(&(owned_agent_id.clone(), api))
             .copied()
             .unwrap_or_default()
+    }
+
+    fn fail_next_oplog_download(&self, agent_id: AgentId) {
+        self.oplog_download_failures
+            .lock()
+            .unwrap()
+            .insert(agent_id);
+    }
+
+    fn take_oplog_download_failure(&self, agent_id: &AgentId) -> bool {
+        self.oplog_download_failures
+            .lock()
+            .unwrap()
+            .remove(agent_id)
+    }
+
+    fn return_no_op_after_oplog_reads(
+        &self,
+        agent_id: AgentId,
+        oplog_index: OplogIndex,
+        reads_to_skip: usize,
+    ) {
+        self.no_op_oplog_reads
+            .lock()
+            .unwrap()
+            .insert((agent_id, oplog_index), reads_to_skip);
+    }
+
+    fn take_no_op_oplog_read(&self, agent_id: &AgentId, oplog_index: OplogIndex) -> bool {
+        let key = (agent_id.clone(), oplog_index);
+        let mut reads = self.no_op_oplog_reads.lock().unwrap();
+        match reads.get_mut(&key) {
+            Some(0) => {
+                reads.remove(&key);
+                true
+            }
+            Some(reads_to_skip) => {
+                *reads_to_skip -= 1;
+                false
+            }
+            None => false,
+        }
     }
 
     /// Stores the executor's `ActiveAgents` registry on first call. Subsequent

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -62,7 +62,8 @@ use crate::metrics::storage::{
 use crate::metrics::wasm::{record_number_of_replayed_functions, record_resume_worker};
 use crate::model::event::InternalWorkerEvent;
 use crate::model::{
-    AgentConfig, ExecutionStatus, InvocationContext, LastError, ReadFileResult, TrapType,
+    AgentConfig, ExecutionStatus, InvocationContext, LastError, ReadFileResult, SnapshotSource,
+    TrapType,
 };
 use crate::services::active_agents::MemoryGrant;
 use crate::services::agent_storage_meter::AgentStorageMeter;
@@ -1058,6 +1059,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
             pending_update,
             original_phantom_id,
             worker_config.last_snapshot_index,
+            worker_config.last_snapshot_source,
             per_invocation_http_call_limit,
             per_invocation_rpc_call_limit,
             resource_limits.clone(),
@@ -3804,12 +3806,10 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         store: &mut (impl AsContextMut<Data = Ctx> + Send),
         instance: &Instance,
     ) -> SnapshotRecoveryResult {
-        let snapshot_index = store
-            .as_context()
-            .data()
-            .durable_ctx()
-            .state
-            .last_snapshot_index;
+        let (snapshot_index, snapshot_source) = {
+            let state = &store.as_context().data().durable_ctx().state;
+            (state.last_snapshot_index, state.last_snapshot_source)
+        };
 
         let snapshot_index = match snapshot_index {
             Some(idx) => idx,
@@ -3843,6 +3843,9 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
                 );
                 warn!("{error}");
                 Self::emit_snapshot_recovery_event(store, snapshot_index, false, Some(error));
+                if snapshot_source == Some(SnapshotSource::Automatic) {
+                    return SnapshotRecoveryResult::Failed;
+                }
                 if let Err(err) = store
                     .as_context_mut()
                     .data_mut()
@@ -3872,6 +3875,9 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
                 );
                 warn!("{error}");
                 Self::emit_snapshot_recovery_event(store, snapshot_index, false, Some(error));
+                if snapshot_source == Some(SnapshotSource::Automatic) {
+                    return SnapshotRecoveryResult::Failed;
+                }
                 if let Err(err) = store
                     .as_context_mut()
                     .data_mut()
@@ -9509,6 +9515,7 @@ struct PrivateDurableWorkerState {
     /// Stores the phantom ID associated with the currently replayed oplog region. Forks can change it
     current_phantom_id: Option<Uuid>,
     last_snapshot_index: Option<OplogIndex>,
+    last_snapshot_source: Option<SnapshotSource>,
 
     /// Number of outgoing HTTP calls made in the current invocation (live only, not replayed).
     /// Reset to 0 at the start of each exported function invocation.
@@ -9612,6 +9619,7 @@ impl PrivateDurableWorkerState {
         pending_update: Option<TimestampedUpdateDescription>,
         original_phantom_id: Option<Uuid>,
         last_snapshot_index: Option<OplogIndex>,
+        last_snapshot_source: Option<SnapshotSource>,
         per_invocation_http_call_limit: u64,
         per_invocation_rpc_call_limit: u64,
         resource_limit_entry: Arc<AtomicResourceEntry>,
@@ -9775,6 +9783,7 @@ impl PrivateDurableWorkerState {
             min_exposed_marker: None,
             current_phantom_id: original_phantom_id,
             last_snapshot_index,
+            last_snapshot_source,
             resource_limit_entry,
         })
     }

--- a/golem-worker-executor/src/model/mod.rs
+++ b/golem-worker-executor/src/model/mod.rs
@@ -64,6 +64,12 @@ impl ShardAssignmentCheck for ShardAssignment {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SnapshotSource {
+    Automatic,
+    ManualUpdate,
+}
+
 /// Worker-specific configuration. These values are used to initialize the worker, and they can
 /// be different for each worker.
 #[derive(Clone, Debug)]
@@ -76,6 +82,7 @@ pub struct AgentConfig {
     pub created_by_email: AccountEmail,
     pub initial_agent_config: Vec<TypedAgentConfigEntry>,
     pub last_snapshot_index: Option<OplogIndex>,
+    pub last_snapshot_source: Option<SnapshotSource>,
     pub agent_effective_surface: EffectiveSurface,
     pub owner_component_metadata: Option<Arc<Component>>,
 }
@@ -90,6 +97,7 @@ impl AgentConfig {
         created_by_email: AccountEmail,
         initial_agent_config: Vec<TypedAgentConfigEntry>,
         last_snapshot_index: Option<OplogIndex>,
+        last_snapshot_source: Option<SnapshotSource>,
         agent_effective_surface: EffectiveSurface,
         owner_component_metadata: Option<Arc<Component>>,
     ) -> AgentConfig {
@@ -102,6 +110,7 @@ impl AgentConfig {
             created_by_email,
             initial_agent_config,
             last_snapshot_index,
+            last_snapshot_source,
             agent_effective_surface,
             owner_component_metadata,
         }

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -47,7 +47,9 @@ use crate::durable_host::{
 };
 use crate::metrics::storage::record_filesystem_pool_released;
 use crate::metrics::workers::AdmissionPhase;
-use crate::model::{AgentConfig, ExecutionStatus, LookupResult, ReadFileResult, TrapType};
+use crate::model::{
+    AgentConfig, ExecutionStatus, LookupResult, ReadFileResult, SnapshotSource, TrapType,
+};
 use crate::services::active_agents::{
     FilesystemStoragePermit, MemoryGrant, RegisteredConcurrentAccount, WorkerComponentCharge,
 };
@@ -1038,6 +1040,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 worker_metadata.created_by,
                 worker_metadata.created_by_email,
                 initial_agent_config,
+                None,
                 None,
                 agent_effective_surface,
                 Some(owner_component_metadata),
@@ -6529,6 +6532,7 @@ impl RunningWorker {
         let mut last_snapshot_index = worker_metadata
             .last_known_status
             .last_manual_update_snapshot_index;
+        let mut last_snapshot_source = last_snapshot_index.map(|_| SnapshotSource::ManualUpdate);
 
         // Automatic snapshots are only considered until the first failure and while they match
         // the active component revision. Pending updates temporarily ignore them so compatibility
@@ -6542,6 +6546,7 @@ impl RunningWorker {
             skipped_regions.set_override(snapshot_skip);
 
             last_snapshot_index = Some(snapshot_idx);
+            last_snapshot_source = Some(SnapshotSource::Automatic);
         }
 
         let context = Ctx::create(
@@ -6579,6 +6584,7 @@ impl RunningWorker {
                 worker_metadata.created_by_email,
                 worker_metadata.config,
                 last_snapshot_index,
+                last_snapshot_source,
                 agent_effective_surface,
                 None,
             ),

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -6471,19 +6471,40 @@ impl RunningWorker {
             .current_component
             .store(Arc::new(component_metadata.clone()));
 
-        let component_version_for_replay = worker_metadata
+        let automatic_snapshot = worker_metadata
             .last_known_status
-            .pending_updates
-            .front()
-            .and_then(|update| match update.kind {
-                PendingUpdateKind::SnapshotBased => Some(update.target_revision),
-                PendingUpdateKind::Automatic => None,
-            })
-            .unwrap_or(
+            .last_automatic_snapshot_index
+            .zip(
                 worker_metadata
                     .last_known_status
-                    .component_revision_for_replay,
-            );
+                    .last_automatic_snapshot_component_revision,
+            )
+            .filter(|(_, snapshot_revision)| {
+                *snapshot_revision == worker_metadata.last_known_status.component_revision
+            })
+            .filter(|_| {
+                pending_update.is_none()
+                    && !parent.snapshot_recovery_disabled.load(Ordering::Acquire)
+            });
+
+        let component_version_for_replay = automatic_snapshot.map_or_else(
+            || {
+                worker_metadata
+                    .last_known_status
+                    .pending_updates
+                    .front()
+                    .and_then(|update| match update.kind {
+                        PendingUpdateKind::SnapshotBased => Some(update.target_revision),
+                        PendingUpdateKind::Automatic => None,
+                    })
+                    .unwrap_or(
+                        worker_metadata
+                            .last_known_status
+                            .component_revision_for_replay,
+                    )
+            },
+            |(_, snapshot_revision)| snapshot_revision,
+        );
 
         let component_metadata_for_replay =
             if component_metadata.revision == component_version_for_replay {
@@ -6509,14 +6530,10 @@ impl RunningWorker {
             .last_known_status
             .last_manual_update_snapshot_index;
 
-        // automatic snapshots are only considered until the first failure.
-        // additionally, if there are updates, the automatic snapshot is temporarily ignored to catch issues earlier
-        if let Some(snapshot_idx) = worker_metadata
-            .last_known_status
-            .last_automatic_snapshot_index
-            && pending_update.is_none()
-            && !parent.snapshot_recovery_disabled.load(Ordering::Acquire)
-        {
+        // Automatic snapshots are only considered until the first failure and while they match
+        // the active component revision. Pending updates temporarily ignore them so compatibility
+        // is established by replaying from the authoritative manual-update baseline.
+        if let Some((snapshot_idx, _)) = automatic_snapshot {
             let snapshot_skip =
                 DeletedRegionsBuilder::from_regions(vec![OplogRegion::from_index_range(
                     OplogIndex::INITIAL.next()..=snapshot_idx,

--- a/golem-worker-executor/src/worker/status.rs
+++ b/golem-worker-executor/src/worker/status.rs
@@ -285,6 +285,7 @@ pub fn update_status_with_new_entries(
         last_manual_update_snapshot_index,
         last_automatic_snapshot_index,
         last_automatic_snapshot_timestamp,
+        last_automatic_snapshot_component_revision,
     ) = calculate_update_fields(
         last_known.pending_updates,
         last_known.failed_updates,
@@ -295,6 +296,7 @@ pub fn update_status_with_new_entries(
         last_known.last_manual_update_snapshot_index,
         last_known.last_automatic_snapshot_index,
         last_known.last_automatic_snapshot_timestamp,
+        last_known.last_automatic_snapshot_component_revision,
         &deleted_regions,
         &new_entries,
     );
@@ -363,6 +365,7 @@ pub fn update_status_with_new_entries(
         last_manual_update_snapshot_index,
         last_automatic_snapshot_index,
         last_automatic_snapshot_timestamp,
+        last_automatic_snapshot_component_revision,
         agent_mode,
     };
 
@@ -938,6 +941,7 @@ fn calculate_update_fields(
     initial_last_manual_update_snapshot_index: Option<OplogIndex>,
     initial_last_automatic_snapshot_index: Option<OplogIndex>,
     initial_last_automatic_snapshot_timestamp: Option<Timestamp>,
+    initial_last_automatic_snapshot_component_revision: Option<ComponentRevision>,
     deleted_regions: &DeletedRegions,
     entries: &BTreeMap<OplogIndex, OplogEntry>,
 ) -> (
@@ -950,6 +954,7 @@ fn calculate_update_fields(
     Option<OplogIndex>,
     Option<OplogIndex>,
     Option<Timestamp>,
+    Option<ComponentRevision>,
 ) {
     let mut pending_updates = initial_pending_updates;
     let mut failed_updates = initial_failed_updates;
@@ -960,6 +965,8 @@ fn calculate_update_fields(
     let mut last_manual_update_snapshot_index = initial_last_manual_update_snapshot_index;
     let mut last_automatic_snapshot_index = initial_last_automatic_snapshot_index;
     let mut last_automatic_snapshot_timestamp = initial_last_automatic_snapshot_timestamp;
+    let mut last_automatic_snapshot_component_revision =
+        initial_last_automatic_snapshot_component_revision;
 
     for (oplog_idx, entry) in entries {
         // Skipping entries in deleted regions (by revert)
@@ -1018,21 +1025,25 @@ fn calculate_update_fields(
                 revision = *target_revision;
                 size = *new_component_size;
 
+                let applied_update = pending_updates.pop_front();
+                last_automatic_snapshot_index = None;
+                last_automatic_snapshot_timestamp = None;
+                last_automatic_snapshot_component_revision = None;
+
                 if let Some(PendingUpdateRef {
                     kind: PendingUpdateKind::SnapshotBased,
                     oplog_index: applied_update_oplog_index,
                     ..
-                }) = pending_updates.pop_front()
+                }) = applied_update
                 {
                     component_revision_for_replay = *target_revision;
                     last_manual_update_snapshot_index = Some(applied_update_oplog_index);
-                    last_automatic_snapshot_index = None;
-                    last_automatic_snapshot_timestamp = None;
                 }
             }
             OplogEntry::Snapshot { timestamp, .. } => {
                 last_automatic_snapshot_index = Some(*oplog_idx);
                 last_automatic_snapshot_timestamp = Some(*timestamp);
+                last_automatic_snapshot_component_revision = Some(revision);
             }
             _ => {}
         }
@@ -1047,6 +1058,7 @@ fn calculate_update_fields(
         last_manual_update_snapshot_index,
         last_automatic_snapshot_index,
         last_automatic_snapshot_timestamp,
+        last_automatic_snapshot_component_revision,
     )
 }
 
@@ -2114,6 +2126,48 @@ mod test {
     }
 
     #[test]
+    async fn successful_auto_update_invalidates_automatic_snapshot() {
+        let update = UpdateDescription::Automatic {
+            target_revision: ComponentRevision::new(2).unwrap(),
+        };
+
+        let test_case = TestCase::builder(1)
+            .snapshot()
+            .pending_update(&update, |_| {})
+            .successful_update(update, 2000, &HashSet::new())
+            .build();
+        let final_status = &test_case.entries.last().unwrap().expected_status;
+
+        assert_eq!(final_status.last_automatic_snapshot_index, None);
+        assert_eq!(final_status.last_automatic_snapshot_timestamp, None);
+        assert_eq!(
+            final_status.last_automatic_snapshot_component_revision,
+            None
+        );
+        run_test_case(test_case).await;
+    }
+
+    #[test]
+    async fn failed_auto_update_keeps_automatic_snapshot() {
+        let update = UpdateDescription::Automatic {
+            target_revision: ComponentRevision::new(2).unwrap(),
+        };
+
+        let test_case = TestCase::builder(1)
+            .snapshot()
+            .pending_update(&update, |_| {})
+            .failed_update(update)
+            .build();
+        let final_status = &test_case.entries.last().unwrap().expected_status;
+
+        assert_eq!(
+            final_status.last_automatic_snapshot_component_revision,
+            Some(ComponentRevision::new(1).unwrap())
+        );
+        run_test_case(test_case).await;
+    }
+
+    #[test]
     async fn snapshot_tracking_with_revert() {
         let k1 = IdempotencyKey::fresh();
 
@@ -2473,6 +2527,8 @@ mod test {
                 move |mut status| {
                     status.last_automatic_snapshot_index = Some(oplog_idx);
                     status.last_automatic_snapshot_timestamp = Some(timestamp);
+                    status.last_automatic_snapshot_component_revision =
+                        Some(status.component_revision);
                     status
                 },
             )
@@ -2531,6 +2587,8 @@ mod test {
                 status.last_automatic_snapshot_index = old_status.last_automatic_snapshot_index;
                 status.last_automatic_snapshot_timestamp =
                     old_status.last_automatic_snapshot_timestamp;
+                status.last_automatic_snapshot_component_revision =
+                    old_status.last_automatic_snapshot_component_revision;
 
                 status
             })
@@ -2653,6 +2711,9 @@ mod test {
                 status.component_size = new_component_size;
                 status.component_revision = *update_description.target_revision();
                 status.active_plugins = new_active_plugins.clone();
+                status.last_automatic_snapshot_index = None;
+                status.last_automatic_snapshot_timestamp = None;
+                status.last_automatic_snapshot_component_revision = None;
 
                 if status.skipped_regions.is_overridden() {
                     status.skipped_regions.merge_override();
@@ -2667,8 +2728,6 @@ mod test {
                     status.component_revision_for_replay = target_revision;
                     status.last_manual_update_snapshot_index =
                         applied_update.map(|au| au.oplog_index);
-                    status.last_automatic_snapshot_index = None;
-                    status.last_automatic_snapshot_timestamp = None;
                 };
 
                 status

--- a/golem-worker-executor/tests/durability.rs
+++ b/golem-worker-executor/tests/durability.rs
@@ -86,6 +86,32 @@ pub(crate) async fn assert_snapshot_recovery_loaded(events: &mut UnboundedReceiv
     .expect("Timed out waiting for snapshot recovery event");
 }
 
+pub(crate) async fn assert_snapshot_recovery_failed(
+    events: &mut UnboundedReceiver<LogEvent>,
+    expected_error: &str,
+) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(event) = events.recv().await {
+            match AgentEvent::try_from(event) {
+                Ok(AgentEvent::SnapshotRecoveryFailed { error, .. }) => {
+                    assert!(
+                        error.contains(expected_error),
+                        "Snapshot recovery failed with unexpected error: {error}"
+                    );
+                    return;
+                }
+                Ok(AgentEvent::SnapshotRecoverySucceeded { snapshot_index, .. }) => {
+                    panic!("Snapshot recovery from {snapshot_index} unexpectedly succeeded");
+                }
+                _ => {}
+            }
+        }
+        panic!("Worker event stream ended before snapshot recovery event");
+    })
+    .await
+    .expect("Timed out waiting for snapshot recovery event");
+}
+
 #[test]
 #[tracing::instrument]
 async fn custom_durability_1(

--- a/golem-worker-executor/tests/hot_update.rs
+++ b/golem-worker-executor/tests/hot_update.rs
@@ -13,17 +13,21 @@
 // limitations under the License.
 
 use crate::Tracing;
+use crate::durability::assert_snapshot_recovery_loaded;
 use async_lock::Mutex;
 use axum::Router;
 use axum::routing::post;
 use bytes::Bytes;
 use golem_common::model::AgentStatus;
 use golem_common::model::component::ComponentRevision;
+use golem_common::model::oplog::{OplogIndex, PublicOplogEntry};
 use golem_common::{agent_id, data_value, phantom_agent_id};
 use golem_test_framework::dsl::{TestDsl, update_counts};
 
+use golem_worker_executor::services::golem_config::SnapshotPolicy;
 use golem_worker_executor_test_utils::{
     LastUniqueId, PrecompiledComponent, TestContext, WorkerExecutorTestDependencies, start,
+    start_with_snapshot_policy,
 };
 use http::StatusCode;
 use log::info;
@@ -31,7 +35,7 @@ use pretty_assertions::{assert_eq, assert_ne};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use test_r::{inherit_test_dep, test};
+use test_r::{inherit_test_dep, test, timeout};
 use tokio::spawn;
 use tokio::task::JoinHandle;
 use tracing::{Instrument, debug};
@@ -278,6 +282,192 @@ async fn auto_update_on_idle(
     assert_eq!(result.into_typed::<u64>()?, 0);
     assert_eq!(metadata.component_revision, updated_component.revision);
     assert_eq!(update_counts(&metadata), (0, 1, 0));
+    Ok(())
+}
+
+#[test]
+#[timeout("120s")]
+#[tracing::instrument]
+async fn auto_update_invalidates_snapshot_from_previous_revision(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("agent_update_v1")] agent_update_v1: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let executor = start_with_snapshot_policy(
+        deps,
+        &context,
+        SnapshotPolicy::EveryNInvocation { count: 1 },
+    )
+    .await?;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, agent_update_v1)
+        .store()
+        .await?;
+    let agent_id = agent_id!("SnapshotUpdateTest");
+    let worker_id = executor
+        .start_agent(&component.id, agent_id.clone())
+        .await?;
+
+    let initial = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "loaded_snapshot_revision",
+            data_value!(),
+        )
+        .await?;
+    assert_eq!(initial.into_typed::<u32>()?, 0);
+
+    let snapshots_before_update = executor
+        .get_oplog(&worker_id, OplogIndex::INITIAL)
+        .await?
+        .iter()
+        .filter(|entry| matches!(&entry.entry, PublicOplogEntry::Snapshot(_)))
+        .count();
+    assert!(snapshots_before_update > 0);
+
+    let updated_component = executor
+        .update_component(&component.id, "it_agent_update_v2_release")
+        .await?;
+    executor
+        .auto_update_worker(&worker_id, updated_component.revision, false)
+        .await?;
+    executor
+        .wait_for_component_revision(
+            &worker_id,
+            updated_component.revision,
+            Duration::from_secs(30),
+        )
+        .await?;
+
+    let snapshots_after_update = executor
+        .get_oplog(&worker_id, OplogIndex::INITIAL)
+        .await?
+        .iter()
+        .filter(|entry| matches!(&entry.entry, PublicOplogEntry::Snapshot(_)))
+        .count();
+    assert_eq!(snapshots_after_update, snapshots_before_update);
+
+    drop(executor);
+    let executor = start_with_snapshot_policy(
+        deps,
+        &context,
+        SnapshotPolicy::EveryNInvocation { count: 1 },
+    )
+    .await?;
+
+    let loaded_snapshot_revision = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "loaded_snapshot_revision",
+            data_value!(),
+        )
+        .await?;
+    let metadata = executor.get_worker_metadata(&worker_id).await?;
+
+    assert_eq!(loaded_snapshot_revision.into_typed::<u32>()?, 0);
+    assert_eq!(metadata.component_revision, updated_component.revision);
+    assert_eq!(update_counts(&metadata), (0, 1, 0));
+    executor.check_oplog_is_queryable(&worker_id).await?;
+    Ok(())
+}
+
+#[test]
+#[timeout("120s")]
+#[tracing::instrument]
+async fn snapshot_after_auto_update_recovers_with_updated_component_context(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("agent_update_v1")] agent_update_v1: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let executor = start_with_snapshot_policy(
+        deps,
+        &context,
+        SnapshotPolicy::EveryNInvocation { count: 1 },
+    )
+    .await?;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, agent_update_v1)
+        .store()
+        .await?;
+    let agent_id = agent_id!("SnapshotUpdateTest");
+    let worker_id = executor
+        .start_agent(&component.id, agent_id.clone())
+        .await?;
+
+    let updated_component = executor
+        .update_component(&component.id, "it_agent_update_v2_release")
+        .await?;
+    executor
+        .auto_update_worker(&worker_id, updated_component.revision, false)
+        .await?;
+    executor
+        .wait_for_component_revision(
+            &worker_id,
+            updated_component.revision,
+            Duration::from_secs(30),
+        )
+        .await?;
+
+    let snapshots_before_invocation = executor
+        .get_oplog(&worker_id, OplogIndex::INITIAL)
+        .await?
+        .iter()
+        .filter(|entry| matches!(&entry.entry, PublicOplogEntry::Snapshot(_)))
+        .count();
+    let before_snapshot = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "loaded_snapshot_revision",
+            data_value!(),
+        )
+        .await?;
+    assert_eq!(before_snapshot.into_typed::<u32>()?, 0);
+
+    let snapshot_count = executor
+        .get_oplog(&worker_id, OplogIndex::INITIAL)
+        .await?
+        .iter()
+        .filter(|entry| matches!(&entry.entry, PublicOplogEntry::Snapshot(_)))
+        .count();
+    assert_eq!(snapshot_count, snapshots_before_invocation + 1);
+
+    drop(executor);
+    let executor = start_with_snapshot_policy(
+        deps,
+        &context,
+        SnapshotPolicy::EveryNInvocation { count: 1 },
+    )
+    .await?;
+    let mut events = executor.capture_output(&worker_id).await?;
+
+    let revision = executor
+        .invoke_and_await_agent(&component, &agent_id, "revision_two_only", data_value!())
+        .await?;
+    assert_snapshot_recovery_loaded(&mut events).await;
+    let loaded_snapshot_revision = executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "loaded_snapshot_revision",
+            data_value!(),
+        )
+        .await?;
+    let metadata = executor.get_worker_metadata(&worker_id).await?;
+
+    assert_eq!(revision.into_typed::<u32>()?, 2);
+    assert_eq!(loaded_snapshot_revision.into_typed::<u32>()?, 2);
+    assert_eq!(metadata.component_revision, updated_component.revision);
+    assert_eq!(update_counts(&metadata), (0, 1, 0));
+    executor.check_oplog_is_queryable(&worker_id).await?;
     Ok(())
 }
 

--- a/golem-worker-executor/tests/hot_update.rs
+++ b/golem-worker-executor/tests/hot_update.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::Tracing;
-use crate::durability::assert_snapshot_recovery_loaded;
+use crate::durability::{assert_snapshot_recovery_failed, assert_snapshot_recovery_loaded};
 use async_lock::Mutex;
 use axum::Router;
 use axum::routing::post;
@@ -24,10 +24,10 @@ use golem_common::model::oplog::{OplogIndex, PublicOplogEntry};
 use golem_common::{agent_id, data_value, phantom_agent_id};
 use golem_test_framework::dsl::{TestDsl, update_counts};
 
-use golem_worker_executor::services::golem_config::SnapshotPolicy;
+use golem_worker_executor::services::golem_config::{OplogConfig, SnapshotPolicy};
 use golem_worker_executor_test_utils::{
     LastUniqueId, PrecompiledComponent, TestContext, WorkerExecutorTestDependencies, start,
-    start_with_snapshot_policy,
+    start_customized, start_with_snapshot_policy,
 };
 use http::StatusCode;
 use log::info;
@@ -469,6 +469,156 @@ async fn snapshot_after_auto_update_recovers_with_updated_component_context(
     assert_eq!(update_counts(&metadata), (0, 1, 0));
     executor.check_oplog_is_queryable(&worker_id).await?;
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum AutomaticSnapshotLoadFailure {
+    InvalidEntry,
+    PayloadDownload,
+}
+
+async fn assert_automatic_snapshot_load_failure_recreates_replay_context(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    agent_update_v1: &PrecompiledComponent,
+    failure: AutomaticSnapshotLoadFailure,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let oplog_config = OplogConfig {
+        max_payload_size: 0,
+        default_snapshotting: SnapshotPolicy::EveryNInvocation { count: 1 },
+        ..Default::default()
+    };
+    let executor = start_customized(
+        deps,
+        &context,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(oplog_config.clone()),
+    )
+    .await?;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, agent_update_v1)
+        .store()
+        .await?;
+    let agent_id = agent_id!("SnapshotUpdateTest");
+    let worker_id = executor
+        .start_agent(&component.id, agent_id.clone())
+        .await?;
+
+    let updated_component = executor
+        .update_component(&component.id, "it_agent_update_v2_release")
+        .await?;
+    executor
+        .auto_update_worker(&worker_id, updated_component.revision, false)
+        .await?;
+    executor
+        .wait_for_component_revision(
+            &worker_id,
+            updated_component.revision,
+            Duration::from_secs(30),
+        )
+        .await?;
+
+    executor
+        .invoke_and_await_agent(
+            &component,
+            &agent_id,
+            "loaded_snapshot_revision",
+            data_value!(),
+        )
+        .await?;
+    let snapshot_index = executor
+        .get_oplog(&worker_id, OplogIndex::INITIAL)
+        .await?
+        .iter()
+        .rev()
+        .find_map(|entry| {
+            matches!(&entry.entry, PublicOplogEntry::Snapshot(_)).then_some(entry.oplog_index)
+        })
+        .expect("Expected an automatic snapshot after the post-update invocation");
+
+    drop(executor);
+    let executor = start_customized(
+        deps,
+        &context,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(oplog_config),
+    )
+    .await?;
+
+    let expected_error = match failure {
+        AutomaticSnapshotLoadFailure::InvalidEntry => {
+            // Context initialization reads the snapshot boundary once before recovery loads it.
+            executor.return_no_op_after_oplog_reads(&worker_id, snapshot_index, 1);
+            "Expected Snapshot entry"
+        }
+        AutomaticSnapshotLoadFailure::PayloadDownload => {
+            executor.fail_next_oplog_download(&worker_id);
+            "Failed to download snapshot payload"
+        }
+    };
+    let mut events = executor.capture_output(&worker_id).await?;
+
+    let replay_revision = executor
+        .invoke_and_await_agent(&component, &agent_id, "replay_revision", data_value!())
+        .await?;
+    assert_snapshot_recovery_failed(&mut events, expected_error).await;
+    let revision_two_only = executor
+        .invoke_and_await_agent(&component, &agent_id, "revision_two_only", data_value!())
+        .await?;
+    let metadata = executor.get_worker_metadata(&worker_id).await?;
+
+    assert_eq!(replay_revision.into_typed::<u32>()?, 0);
+    assert_eq!(revision_two_only.into_typed::<u32>()?, 2);
+    assert_eq!(metadata.component_revision, updated_component.revision);
+    assert_eq!(update_counts(&metadata), (0, 1, 0));
+    executor.check_oplog_is_queryable(&worker_id).await?;
+    Ok(())
+}
+
+#[test]
+#[timeout("120s")]
+#[tracing::instrument]
+async fn automatic_snapshot_invalid_entry_fallback_recreates_replay_context(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("agent_update_v1")] agent_update_v1: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    assert_automatic_snapshot_load_failure_recreates_replay_context(
+        last_unique_id,
+        deps,
+        agent_update_v1,
+        AutomaticSnapshotLoadFailure::InvalidEntry,
+    )
+    .await
+}
+
+#[test]
+#[timeout("120s")]
+#[tracing::instrument]
+async fn automatic_snapshot_download_failure_recreates_replay_context(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("agent_update_v1")] agent_update_v1: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    assert_automatic_snapshot_load_failure_recreates_replay_context(
+        last_unique_id,
+        deps,
+        agent_update_v1,
+        AutomaticSnapshotLoadFailure::PayloadDownload,
+    )
+    .await
 }
 
 #[test]

--- a/test-components/agent-updates-v1/src/lib.rs
+++ b/test-components/agent-updates-v1/src/lib.rs
@@ -134,6 +134,42 @@ impl RevisionEnvAgent for RevisionEnvAgentImpl {
     }
 }
 
+#[agent_definition(snapshotting = "enabled")]
+pub trait SnapshotUpdateTest {
+    fn new() -> Self;
+    fn loaded_snapshot_revision(&self) -> u32;
+}
+
+struct SnapshotUpdateTestImpl {
+    loaded_snapshot_revision: u32,
+}
+
+#[agent_implementation]
+impl SnapshotUpdateTest for SnapshotUpdateTestImpl {
+    fn new() -> Self {
+        Self {
+            loaded_snapshot_revision: 0,
+        }
+    }
+
+    fn loaded_snapshot_revision(&self) -> u32 {
+        self.loaded_snapshot_revision
+    }
+
+    async fn save_snapshot(&self) -> Result<Vec<u8>, String> {
+        Ok(vec![1])
+    }
+
+    async fn load_snapshot(&mut self, bytes: Vec<u8>) -> Result<(), String> {
+        self.loaded_snapshot_revision = bytes
+            .first()
+            .copied()
+            .map(u32::from)
+            .ok_or_else(|| "Missing snapshot revision".to_string())?;
+        Ok(())
+    }
+}
+
 async fn report_f1(current: u64) {
     let port = std::env::var("PORT").unwrap_or("9999".to_string());
 

--- a/test-components/agent-updates-v1/src/lib.rs
+++ b/test-components/agent-updates-v1/src/lib.rs
@@ -138,10 +138,12 @@ impl RevisionEnvAgent for RevisionEnvAgentImpl {
 pub trait SnapshotUpdateTest {
     fn new() -> Self;
     fn loaded_snapshot_revision(&self) -> u32;
+    fn replay_revision(&self) -> u32;
 }
 
 struct SnapshotUpdateTestImpl {
     loaded_snapshot_revision: u32,
+    replay_revision: u32,
 }
 
 #[agent_implementation]
@@ -149,11 +151,19 @@ impl SnapshotUpdateTest for SnapshotUpdateTestImpl {
     fn new() -> Self {
         Self {
             loaded_snapshot_revision: 0,
+            replay_revision: std::env::var("GOLEM_COMPONENT_REVISION")
+                .ok()
+                .and_then(|revision| revision.parse().ok())
+                .unwrap_or_default(),
         }
     }
 
     fn loaded_snapshot_revision(&self) -> u32 {
         self.loaded_snapshot_revision
+    }
+
+    fn replay_revision(&self) -> u32 {
+        self.replay_revision
     }
 
     async fn save_snapshot(&self) -> Result<Vec<u8>, String> {

--- a/test-components/agent-updates-v2/src/lib.rs
+++ b/test-components/agent-updates-v2/src/lib.rs
@@ -164,6 +164,47 @@ impl RevisionEnvAgent for RevisionEnvAgentImpl {
     }
 }
 
+#[agent_definition(snapshotting = "enabled")]
+pub trait SnapshotUpdateTest {
+    fn new() -> Self;
+    fn loaded_snapshot_revision(&self) -> u32;
+    fn revision_two_only(&self) -> u32;
+}
+
+struct SnapshotUpdateTestImpl {
+    loaded_snapshot_revision: u32,
+}
+
+#[agent_implementation]
+impl SnapshotUpdateTest for SnapshotUpdateTestImpl {
+    fn new() -> Self {
+        Self {
+            loaded_snapshot_revision: 0,
+        }
+    }
+
+    fn loaded_snapshot_revision(&self) -> u32 {
+        self.loaded_snapshot_revision
+    }
+
+    fn revision_two_only(&self) -> u32 {
+        2
+    }
+
+    async fn save_snapshot(&self) -> Result<Vec<u8>, String> {
+        Ok(vec![2])
+    }
+
+    async fn load_snapshot(&mut self, bytes: Vec<u8>) -> Result<(), String> {
+        self.loaded_snapshot_revision = bytes
+            .first()
+            .copied()
+            .map(u32::from)
+            .ok_or_else(|| "Missing snapshot revision".to_string())?;
+        Ok(())
+    }
+}
+
 async fn report_f1(current: u64) {
     let port = std::env::var("PORT").unwrap_or("9999".to_string());
 

--- a/test-components/agent-updates-v2/src/lib.rs
+++ b/test-components/agent-updates-v2/src/lib.rs
@@ -168,11 +168,13 @@ impl RevisionEnvAgent for RevisionEnvAgentImpl {
 pub trait SnapshotUpdateTest {
     fn new() -> Self;
     fn loaded_snapshot_revision(&self) -> u32;
+    fn replay_revision(&self) -> u32;
     fn revision_two_only(&self) -> u32;
 }
 
 struct SnapshotUpdateTestImpl {
     loaded_snapshot_revision: u32,
+    replay_revision: u32,
 }
 
 #[agent_implementation]
@@ -180,11 +182,19 @@ impl SnapshotUpdateTest for SnapshotUpdateTestImpl {
     fn new() -> Self {
         Self {
             loaded_snapshot_revision: 0,
+            replay_revision: std::env::var("GOLEM_COMPONENT_REVISION")
+                .ok()
+                .and_then(|revision| revision.parse().ok())
+                .unwrap_or_default(),
         }
     }
 
     fn loaded_snapshot_revision(&self) -> u32 {
         self.loaded_snapshot_revision
+    }
+
+    fn replay_revision(&self) -> u32 {
+        self.replay_revision
     }
 
     fn revision_two_only(&self) -> u32 {


### PR DESCRIPTION
## Summary
- track the component revision that produced each automatic snapshot
- invalidate pre-update snapshots after successful updates and recover post-update snapshots with matching component metadata
- add worker-executor regressions for stale snapshots and stale durable context

## Testing
- `cargo clippy -p golem-common -p golem-worker-executor --all-targets -- --no-deps -Dwarnings`
- targeted worker-executor integration and status reducer tests
- release builds and WASM-target clippy for both updated test components

Resolves GOL-182