### PR TITLE
Keep Amp orb benchmark toolchain in sync

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -76,8 +76,13 @@ if [[ ! -f /opt/wasi-sdk/VERSION ]] || ! grep -q '^25\.0$' /opt/wasi-sdk/VERSION
     rm -f "$wasi_archive"
 fi
 
-if ! wasm-rquickjs --version 2>/dev/null | grep -q '0.4.1'; then
-    cargo binstall --force --locked wasm-rquickjs-cli@0.4.1
+wasm_rquickjs_version="$(awk -F'"' '/^[[:space:]]*WASM_RQUICKJS_VERSION: / { print $2; exit }' .github/workflows/benchmark.yaml)"
+if [[ -z "$wasm_rquickjs_version" ]]; then
+    echo "Failed to read WASM_RQUICKJS_VERSION from .github/workflows/benchmark.yaml" >&2
+    exit 1
+fi
+if [[ "$(wasm-rquickjs --version 2>/dev/null || true)" != "wasm-rquickjs-cli $wasm_rquickjs_version" ]]; then
+    cargo binstall --force --locked "wasm-rquickjs-cli@$wasm_rquickjs_version"
 fi
 
 if ! cargo component --version 2>/dev/null | grep -q '0.21.1'; then
@@ -93,7 +98,6 @@ if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
 export PATH="/opt/node24/bin:$HOME/.cargo/bin:$PATH"
 export WASI_SDK_VERSION=25
 export WASI_SDK_PATH=/opt/wasi-sdk
-export WASM_RQUICKJS_VERSION=0.4.1
 EOF
 fi
 

--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -12,6 +12,7 @@ artifact_dir="${GOLEM_BENCHMARK_ARTIFACT_DIR:-$root/tmp}"
 results_repository="${BENCHMARK_RESULTS_REPOSITORY:-https://github.com/golemcloud/benchmark-results.git}"
 generated_files=(
     test-components/benchmarks/package-lock.json
+    test-components/benchmarks/Cargo.lock
 )
 
 if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
@@ -52,7 +53,15 @@ else
     export PATH="/opt/node24/bin:$HOME/.cargo/bin:$PATH"
     export WASI_SDK_VERSION=25
     export WASI_SDK_PATH=/opt/wasi-sdk
-    export WASM_RQUICKJS_VERSION=0.4.1
+    WASM_RQUICKJS_VERSION="$(awk -F'"' '/^[[:space:]]*WASM_RQUICKJS_VERSION: / { print $2; exit }' .github/workflows/benchmark.yaml)"
+    if [[ -z "$WASM_RQUICKJS_VERSION" ]]; then
+        echo "Failed to read WASM_RQUICKJS_VERSION from .github/workflows/benchmark.yaml" >&2
+        exit 1
+    fi
+    export WASM_RQUICKJS_VERSION
+    if [[ "$(wasm-rquickjs --version 2>/dev/null || true)" != "wasm-rquickjs-cli $WASM_RQUICKJS_VERSION" ]]; then
+        cargo binstall --force --locked "wasm-rquickjs-cli@$WASM_RQUICKJS_VERSION"
+    fi
     export GOLEM_BENCHMARK_RESULTS_PATH="$results"
 
     cargo clean


### PR DESCRIPTION
## Summary
- derive the orb's wasm-rquickjs requirement from the benchmark workflow instead of keeping a stale independent pin
- install the required wasm-rquickjs version automatically when an existing orb is outdated
- treat the benchmark Cargo lockfile as generated output and restore it before publication checks

## Validation
- `bash -n .agents/setup integration-tests/benchmark_suites/run_orb_nightly.sh`
- verified the workflow requirement resolves to wasm-rquickjs 0.4.2 and matches the installed binary
- ran the full orb benchmark suite successfully with wasm-rquickjs 0.4.2; publication was intentionally blocked by the newly observed generated Cargo.lock change, which this PR fixes
- `git diff --check`

The failed/partial attempts were not published.