### PR TITLE
Update Desert to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "desert_core"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e561700fe8c3a51189d8f8b5e83344fb1747b88cc0343e14d3c22842459624"
+checksum = "623ecd066d1ec74037f703e5a5833304a5621a0c0201ad72ea04a80054483fc7"
 dependencies = [
  "bigdecimal",
  "bit-vec 0.6.3",
@@ -2658,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "desert_macro"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e622883bc90493a0921717f5363f8adf7cb5307419abda5126bfd624379ca785"
+checksum = "d9ed06e04bc6899b2609b595a931e84d79a5f4187225d6f4cd942b2ebf54db81"
 dependencies = [
  "bytes",
  "desert_core",
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "desert_rust"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94677f3ac0a0b303a8b3dd01576348652c85e55da1b71a60f6b92f25180b66dd"
+checksum = "0fd78c31bbbee1a0cd9203362cb1b00306344759d064fc1e8636d5c8c64bfc61"
 dependencies = [
  "desert_core",
  "desert_macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ crossterm = "0.29"
 darling = "0.20.11"
 dashmap = "7.0.0-rc2"
 derive_more = { version = "2.0.1", features = ["display", "into", "from_str"] }
-desert_rust = { version = "0.1.9", features = ["bigdecimal", "uuid", "chrono", "nonempty-collections", "serde-json", "bit-vec", "url", "mac_address"] }
+desert_rust = { version = "0.1.10", features = ["bigdecimal", "uuid", "chrono", "nonempty-collections", "serde-json", "bit-vec", "url", "mac_address"] }
 dir-diff = "0.3.3"
 dirs = "6.0.0"
 dotenvy = "0.15.7"


### PR DESCRIPTION
## Summary

- update `desert_rust` from 0.1.9 to 0.1.10
- update the lockfile to `desert_macro` 0.1.10 and `desert_core` 0.2.1
- pick up the large-enum deserializer stack-frame fix from [vigoo/desert-rust#36](https://github.com/vigoo/desert-rust/issues/36)

This addresses the stack overflow observed in [worker-executor group 4](https://github.com/golemcloud/golem/actions/runs/33170067176/job/98848187558). In the `dev-ci` integration binary, the generated `HostFunctionName` and `OplogEntry` deserializer dispatcher frames are now 1,528 bytes each, down from 390,888 and 353,752 bytes respectively. Variant work is isolated in small helper frames.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p golem-common --all-targets -- --no-deps -Dwarnings`
- `cargo build -p golem`
- `cargo test -p golem-common --lib -- --report-time` — 1,153 passed, 1 ignored
- `env -u RUST_MIN_STACK cargo test --profile dev-ci --package golem-worker-executor --test integration scope_card_delivery_and_cleanup_survive_crash_replay -- --test-threads=1 --report-time --nocapture` — 1 passed on the default thread stack