### PR TITLE
Fix P3 HTTP replay after missing consume-body scope start

### DIFF
--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -758,6 +758,17 @@ impl TestWorkerExecutor {
             .await
     }
 
+    /// Arms a one-shot gate immediately before the next discriminated p3 HTTP consume-body scope
+    /// `Start` is appended for `agent_id`.
+    pub async fn gate_next_consume_body_scope_start(
+        &self,
+        agent_id: &AgentId,
+    ) -> ConsumeBodyScopeStartGateHandle {
+        self.additional_test_deps
+            .gate_next_consume_body_scope_start(agent_id.clone())
+            .await
+    }
+
     /// Defers the first ready consume-body reply until the matching guest read
     /// is polled again, allowing a test to initiate `stream.cancel-read` while
     /// the reply is queued. Must be armed before the invocation creates its
@@ -2847,6 +2858,36 @@ impl TestOplog {
         permit.forget();
     }
 
+    fn is_consume_body_scope_start(entry: &OplogEntry) -> bool {
+        matches!(entry, OplogEntry::Start {
+            function_name: HostFunctionName::Custom(function_name),
+            ..
+        } if function_name.starts_with("<scope:batched-write:consume-body:"))
+    }
+
+    async fn pause_before_consume_body_scope_start(&self) -> bool {
+        let Some(gate) = self
+            .additional_test_deps
+            .consume_body_scope_start_gate(&self.owned_agent_id.agent_id)
+            .await
+        else {
+            return false;
+        };
+        if !gate.armed.swap(false, Ordering::SeqCst) {
+            return false;
+        }
+        if let Some(reached_tx) = gate.reached_tx.lock().unwrap().take() {
+            let _ = reached_tx.send(());
+        }
+        let permit = gate
+            .release
+            .acquire()
+            .await
+            .expect("the consume-body scope Start gate semaphore was closed");
+        permit.forget();
+        gate.abort_append.load(Ordering::SeqCst)
+    }
+
     async fn check_oplog_add(&self, entry: &OplogEntry) -> Result<(), String> {
         let entry_name = match entry {
             OplogEntry::BeginRemoteTransaction { .. } => "BeginRemoteTransaction",
@@ -2905,6 +2946,11 @@ impl TestOplog {
 #[async_trait]
 impl Oplog for TestOplog {
     async fn add(&self, entry: OplogEntry) -> OplogIndex {
+        if Self::is_consume_body_scope_start(&entry)
+            && self.pause_before_consume_body_scope_start().await
+        {
+            return std::future::pending().await;
+        }
         let gated = self.is_consume_body_chunk_data_end(&entry);
         let index = self.oplog.add(entry).await;
         if gated {
@@ -3291,6 +3337,7 @@ pub struct AdditionalTestDeps {
     /// to deterministically race a guest-side body-reader drop against an
     /// already-persisted chunk delivery.
     consume_body_chunk_end_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyChunkEndGate>>>,
+    consume_body_scope_start_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeStartGate>>>,
     consume_body_reply_defer_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyReplyDeferGate>>>,
     /// Captured once on first call to [`TestWorkerCtx::create`]. Used by the
     /// read-only test helpers (`worker_is_loaded`,
@@ -3315,6 +3362,7 @@ impl AdditionalTestDeps {
             oplog_call_counts: Arc::new(std::sync::Mutex::new(HashMap::new())),
             rdbms_tx_failures,
             consume_body_chunk_end_gates: Arc::new(scc::HashMap::new()),
+            consume_body_scope_start_gates: Arc::new(scc::HashMap::new()),
             consume_body_reply_defer_gates: Arc::new(scc::HashMap::new()),
             active_agents: Arc::new(std::sync::OnceLock::new()),
         }
@@ -3350,6 +3398,34 @@ impl AdditionalTestDeps {
         agent_id: &AgentId,
     ) -> Option<Arc<ConsumeBodyChunkEndGate>> {
         self.consume_body_chunk_end_gates
+            .read_async(agent_id, |_, gate| gate.clone())
+            .await
+    }
+
+    pub async fn gate_next_consume_body_scope_start(
+        &self,
+        agent_id: AgentId,
+    ) -> ConsumeBodyScopeStartGateHandle {
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let gate = Arc::new(ConsumeBodyScopeStartGate {
+            armed: AtomicBool::new(true),
+            abort_append: AtomicBool::new(false),
+            reached_tx: std::sync::Mutex::new(Some(reached_tx)),
+            release: tokio::sync::Semaphore::new(0),
+        });
+        self.consume_body_scope_start_gates
+            .entry_async(agent_id)
+            .await
+            .and_modify(|existing| *existing = gate.clone())
+            .or_insert_with(|| gate.clone());
+        ConsumeBodyScopeStartGateHandle { reached_rx, gate }
+    }
+
+    async fn consume_body_scope_start_gate(
+        &self,
+        agent_id: &AgentId,
+    ) -> Option<Arc<ConsumeBodyScopeStartGate>> {
+        self.consume_body_scope_start_gates
             .read_async(agent_id, |_, gate| gate.clone())
             .await
     }
@@ -3503,6 +3579,43 @@ impl Drop for ConsumeBodyChunkEndGateHandle {
     /// not leave the gated producer blocked in `Oplog::add` forever, so dropping
     /// releases the gate. The extra permit is harmless after an explicit
     /// release because the gate fires at most once.
+    fn drop(&mut self) {
+        self.gate.release.add_permits(1);
+    }
+}
+
+struct ConsumeBodyScopeStartGate {
+    armed: AtomicBool,
+    abort_append: AtomicBool,
+    reached_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: tokio::sync::Semaphore,
+}
+
+pub struct ConsumeBodyScopeStartGateHandle {
+    reached_rx: tokio::sync::oneshot::Receiver<()>,
+    gate: Arc<ConsumeBodyScopeStartGate>,
+}
+
+impl ConsumeBodyScopeStartGateHandle {
+    pub async fn reached(&mut self) {
+        (&mut self.reached_rx)
+            .await
+            .expect("the consume-body scope Start gate was dropped without firing");
+    }
+
+    pub fn release(&self) {
+        self.gate.release.add_permits(1);
+    }
+
+    /// Leaves the append future pending after the gate is released, so dropping the executor
+    /// simulates process loss without ever writing the scope `Start` to the underlying oplog.
+    pub fn abort_append(&self) {
+        self.gate.abort_append.store(true, Ordering::SeqCst);
+        self.gate.release.add_permits(1);
+    }
+}
+
+impl Drop for ConsumeBodyScopeStartGateHandle {
     fn drop(&mut self) {
         self.gate.release.add_permits(1);
     }

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -769,6 +769,18 @@ impl TestWorkerExecutor {
             .await
     }
 
+    /// Arms a one-shot gate immediately before the next discriminated p3 HTTP consume-body scope
+    /// `End` is appended for `agent_id`. Must be armed before the invocation appends the scope's
+    /// `Start` (the gate is consulted when tracking scope `Start` appends too).
+    pub async fn gate_next_consume_body_scope_end(
+        &self,
+        agent_id: &AgentId,
+    ) -> ConsumeBodyScopeEndGateHandle {
+        self.additional_test_deps
+            .gate_next_consume_body_scope_end(agent_id.clone())
+            .await
+    }
+
     /// Defers the first ready consume-body reply until the matching guest read
     /// is polled again, allowing a test to initiate `stream.cancel-read` while
     /// the reply is queued. Must be armed before the invocation creates its
@@ -2798,6 +2810,10 @@ struct TestOplog {
     /// chunk reads, so the gated append below can recognize their matching `End`
     /// appends (an `End` only carries its `start_index`).
     consume_body_chunk_starts: Arc<std::sync::Mutex<HashSet<OplogIndex>>>,
+    /// Indices of discriminated consume-body scope `Start` entries this agent
+    /// appended, so the scope `End` gate below can recognize their matching
+    /// `End` appends (an `End` only carries its `start_index`).
+    consume_body_scope_starts: Arc<std::sync::Mutex<HashSet<OplogIndex>>>,
 }
 
 impl TestOplog {
@@ -2811,6 +2827,7 @@ impl TestOplog {
             oplog,
             additional_test_deps,
             consume_body_chunk_starts: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            consume_body_scope_starts: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 
@@ -2888,6 +2905,45 @@ impl TestOplog {
         gate.abort_append.load(Ordering::SeqCst)
     }
 
+    /// Recognizes the `End` of a tracked consume-body scope `Start`.
+    fn is_consume_body_scope_end(&self, entry: &OplogEntry) -> bool {
+        let OplogEntry::End { start_index, .. } = entry else {
+            return false;
+        };
+        self.consume_body_scope_starts
+            .lock()
+            .unwrap()
+            .contains(start_index)
+    }
+
+    /// Pauses at an armed consume-body scope `End` gate before the entry is
+    /// appended: signals the test that the append was reached, then blocks
+    /// until the test releases the gate. Fires at most once per gate. Returns
+    /// whether the append must be aborted (left pending forever) to simulate a
+    /// crash before the scope `End` became durable.
+    async fn pause_before_consume_body_scope_end(&self) -> bool {
+        let Some(gate) = self
+            .additional_test_deps
+            .consume_body_scope_end_gate(&self.owned_agent_id.agent_id)
+            .await
+        else {
+            return false;
+        };
+        if !gate.armed.swap(false, Ordering::SeqCst) {
+            return false;
+        }
+        if let Some(reached_tx) = gate.reached_tx.lock().unwrap().take() {
+            let _ = reached_tx.send(());
+        }
+        let permit = gate
+            .release
+            .acquire()
+            .await
+            .expect("the consume-body scope End gate semaphore was closed");
+        permit.forget();
+        gate.abort_append.load(Ordering::SeqCst)
+    }
+
     async fn check_oplog_add(&self, entry: &OplogEntry) -> Result<(), String> {
         let entry_name = match entry {
             OplogEntry::BeginRemoteTransaction { .. } => "BeginRemoteTransaction",
@@ -2951,8 +3007,23 @@ impl Oplog for TestOplog {
         {
             return std::future::pending().await;
         }
+        if self.is_consume_body_scope_end(&entry)
+            && self.pause_before_consume_body_scope_end().await
+        {
+            return std::future::pending().await;
+        }
+        let track_scope_start = Self::is_consume_body_scope_start(&entry);
         let gated = self.is_consume_body_chunk_data_end(&entry);
         let index = self.oplog.add(entry).await;
+        if track_scope_start
+            && self
+                .additional_test_deps
+                .consume_body_scope_end_gate(&self.owned_agent_id.agent_id)
+                .await
+                .is_some()
+        {
+            self.consume_body_scope_starts.lock().unwrap().insert(index);
+        }
         if gated {
             self.pause_at_consume_body_chunk_end_gate().await;
         }
@@ -3338,6 +3409,7 @@ pub struct AdditionalTestDeps {
     /// already-persisted chunk delivery.
     consume_body_chunk_end_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyChunkEndGate>>>,
     consume_body_scope_start_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeStartGate>>>,
+    consume_body_scope_end_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeEndGate>>>,
     consume_body_reply_defer_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyReplyDeferGate>>>,
     /// Captured once on first call to [`TestWorkerCtx::create`]. Used by the
     /// read-only test helpers (`worker_is_loaded`,
@@ -3363,6 +3435,7 @@ impl AdditionalTestDeps {
             rdbms_tx_failures,
             consume_body_chunk_end_gates: Arc::new(scc::HashMap::new()),
             consume_body_scope_start_gates: Arc::new(scc::HashMap::new()),
+            consume_body_scope_end_gates: Arc::new(scc::HashMap::new()),
             consume_body_reply_defer_gates: Arc::new(scc::HashMap::new()),
             active_agents: Arc::new(std::sync::OnceLock::new()),
         }
@@ -3426,6 +3499,34 @@ impl AdditionalTestDeps {
         agent_id: &AgentId,
     ) -> Option<Arc<ConsumeBodyScopeStartGate>> {
         self.consume_body_scope_start_gates
+            .read_async(agent_id, |_, gate| gate.clone())
+            .await
+    }
+
+    pub async fn gate_next_consume_body_scope_end(
+        &self,
+        agent_id: AgentId,
+    ) -> ConsumeBodyScopeEndGateHandle {
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let gate = Arc::new(ConsumeBodyScopeEndGate {
+            armed: AtomicBool::new(true),
+            abort_append: AtomicBool::new(false),
+            reached_tx: std::sync::Mutex::new(Some(reached_tx)),
+            release: tokio::sync::Semaphore::new(0),
+        });
+        self.consume_body_scope_end_gates
+            .entry_async(agent_id)
+            .await
+            .and_modify(|existing| *existing = gate.clone())
+            .or_insert_with(|| gate.clone());
+        ConsumeBodyScopeEndGateHandle { reached_rx, gate }
+    }
+
+    async fn consume_body_scope_end_gate(
+        &self,
+        agent_id: &AgentId,
+    ) -> Option<Arc<ConsumeBodyScopeEndGate>> {
+        self.consume_body_scope_end_gates
             .read_async(agent_id, |_, gate| gate.clone())
             .await
     }
@@ -3616,6 +3717,43 @@ impl ConsumeBodyScopeStartGateHandle {
 }
 
 impl Drop for ConsumeBodyScopeStartGateHandle {
+    fn drop(&mut self) {
+        self.gate.release.add_permits(1);
+    }
+}
+
+struct ConsumeBodyScopeEndGate {
+    armed: AtomicBool,
+    abort_append: AtomicBool,
+    reached_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: tokio::sync::Semaphore,
+}
+
+pub struct ConsumeBodyScopeEndGateHandle {
+    reached_rx: tokio::sync::oneshot::Receiver<()>,
+    gate: Arc<ConsumeBodyScopeEndGate>,
+}
+
+impl ConsumeBodyScopeEndGateHandle {
+    pub async fn reached(&mut self) {
+        (&mut self.reached_rx)
+            .await
+            .expect("the consume-body scope End gate was dropped without firing");
+    }
+
+    pub fn release(&self) {
+        self.gate.release.add_permits(1);
+    }
+
+    /// Leaves the append future pending after the gate is released, so dropping the executor
+    /// simulates process loss without ever writing the scope `End` to the underlying oplog.
+    pub fn abort_append(&self) {
+        self.gate.abort_append.store(true, Ordering::SeqCst);
+        self.gate.release.add_permits(1);
+    }
+}
+
+impl Drop for ConsumeBodyScopeEndGateHandle {
     fn drop(&mut self) {
         self.gate.release.add_permits(1);
     }

--- a/golem-worker-executor/src/durable_host/concurrent/call.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/call.rs
@@ -374,10 +374,14 @@ impl ScopeReplayRecovery {
         match self {
             Self::Default => assume_idempotence,
             Self::Forbidden => false,
-            // `Reexecute` authorizes only recovery of a missing synthetic scope Start after its
-            // readiness proof. An existing but incomplete scope cannot poll that proof without
-            // risking a duplex upload/response deadlock, so it must not re-execute.
-            Self::Reexecute { .. } => false,
+            // `Reexecute` is only constructed for an effectively idempotent replayed
+            // request (idempotent method or the `assume_idempotence` override) with
+            // recorded resend metadata, so an existing but incomplete scope may
+            // re-execute (jump to live) — the same authorization the missing-`Start`
+            // recovery relies on. The readiness proof guards only the missing-`Start`
+            // path; request-body replayability is validated lazily before any network
+            // re-issue, refusing (retry-exempt) if the recording is incomplete.
+            Self::Reexecute { .. } => true,
         }
     }
 
@@ -399,10 +403,17 @@ mod scope_replay_recovery_tests {
     use test_r::test;
 
     #[test]
-    fn reexecute_policy_does_not_authorize_existing_incomplete_scope() {
+    fn reexecute_policy_authorizes_existing_incomplete_scope() {
         let recovery = ScopeReplayRecovery::reexecute_when(async { Ok(()) });
 
-        assert!(!recovery.can_reexecute_incomplete(true));
+        assert!(recovery.can_reexecute_incomplete(true));
+        assert!(recovery.can_reexecute_incomplete(false));
+    }
+
+    #[test]
+    fn forbidden_policy_does_not_authorize_existing_incomplete_scope() {
+        assert!(!ScopeReplayRecovery::Forbidden.can_reexecute_incomplete(true));
+        assert!(!ScopeReplayRecovery::Forbidden.can_reexecute_incomplete(false));
     }
 }
 

--- a/golem-worker-executor/src/durable_host/concurrent/call.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/call.rs
@@ -308,7 +308,7 @@ struct PreparedAccessStart<Pair: HostPayloadPair, P: DropPolicy, Ctx: WorkerCtx>
 }
 
 impl<Pair: HostPayloadPair, P: DropPolicy, Ctx: WorkerCtx> PreparedAccessStart<Pair, P, Ctx> {
-    async fn switch_to_live(&self) {
+    async fn switch_to_live(&mut self) {
         self.replay_state.switch_to_live().await;
         self.linear_memory.switch_to_live();
     }
@@ -346,6 +346,64 @@ pub(crate) struct AccessClaimOptions {
     /// Ownership propagated from a resource created by an earlier observational call. When absent,
     /// initiation captures the current custom-invocation task context.
     pub(crate) observational_owner: Option<OplogIndex>,
+    pub(crate) scope_replay_recovery: ScopeReplayRecovery,
+}
+
+type ScopeReplayReadiness = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
+
+#[derive(Default)]
+pub(crate) enum ScopeReplayRecovery {
+    #[default]
+    Default,
+    Forbidden,
+    Reexecute {
+        readiness: Option<ScopeReplayReadiness>,
+    },
+}
+
+impl ScopeReplayRecovery {
+    pub(crate) fn reexecute_when(
+        readiness: impl Future<Output = Result<(), String>> + Send + 'static,
+    ) -> Self {
+        Self::Reexecute {
+            readiness: Some(Box::pin(readiness)),
+        }
+    }
+
+    fn can_reexecute_incomplete(&self, assume_idempotence: bool) -> bool {
+        match self {
+            Self::Default => assume_idempotence,
+            Self::Forbidden => false,
+            // `Reexecute` authorizes only recovery of a missing synthetic scope Start after its
+            // readiness proof. An existing but incomplete scope cannot poll that proof without
+            // risking a duplex upload/response deadlock, so it must not re-execute.
+            Self::Reexecute { .. } => false,
+        }
+    }
+
+    async fn await_readiness(&mut self) -> Result<(), WorkerExecutorError> {
+        match self {
+            Self::Reexecute { readiness } => readiness
+                .take()
+                .expect("scope recovery readiness is awaited at most once")
+                .await
+                .map_err(WorkerExecutorError::runtime),
+            Self::Default | Self::Forbidden => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod scope_replay_recovery_tests {
+    use super::ScopeReplayRecovery;
+    use test_r::test;
+
+    #[test]
+    fn reexecute_policy_does_not_authorize_existing_incomplete_scope() {
+        let recovery = ScopeReplayRecovery::reexecute_when(async { Ok(()) });
+
+        assert!(!recovery.can_reexecute_incomplete(true));
+    }
 }
 
 struct ExecutedAccessStart<Pair: HostPayloadPair, P: DropPolicy> {
@@ -1007,7 +1065,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
             prepared.unpersisted,
         );
         let scope_start = if starts_scope {
-            Some(Self::execute_access_scope_start(&prepared).await?)
+            Some(Self::execute_access_scope_start(&mut prepared).await?)
         } else {
             None
         };
@@ -1237,7 +1295,7 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
     }
 
     async fn execute_access_scope_start<Ctx: WorkerCtx>(
-        prepared: &PreparedAccessStart<Pair, P, Ctx>,
+        prepared: &mut PreparedAccessStart<Pair, P, Ctx>,
     ) -> Result<AccessOpenedScope, (WorkerExecutorError, AccessStartCleanup)> {
         let function_type = prepared.retry.function_type().clone();
         // A caller-supplied discriminator makes the synthetic scope name unique among concurrent
@@ -1251,20 +1309,80 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
             None => HostFunctionName::Custom("<scope:batched-write>".to_string()),
         };
         if prepared.is_live {
-            let entry = OplogEntry::Start {
-                timestamp: Timestamp::now_utc(),
-                parent_start_index: prepared.entity_parent_start_index,
-                function_name: scope_name,
-                invocation_id: None,
-                observational_owner: prepared.execution_scope.observational_owner,
-                request: None,
-                durable_function_type: function_type,
-            };
-            let begin_index = prepared
-                .public_state
-                .worker()
-                .add_and_commit_oplog(entry)
-                .await;
+            match &mut prepared.claim_options.scope_replay_recovery {
+                ScopeReplayRecovery::Forbidden => {
+                    return Err((
+                        WorkerExecutorError::runtime(
+                            "Recorded remote write scope was not completed and cannot be safely recovered",
+                        ),
+                        AccessStartCleanup {
+                            atomic_lease: prepared.atomic_lease.clone(),
+                        },
+                    ));
+                }
+                ScopeReplayRecovery::Reexecute { .. } => {
+                    if prepared.execution_scope.atomic_region.is_some()
+                        || prepared.execution_scope.observational_owner.is_some()
+                        || prepared.entity_parent_start_index.is_some()
+                    {
+                        return Err((
+                            WorkerExecutorError::runtime(
+                                "Recorded remote write scope cannot be recovered inside another durable scope",
+                            ),
+                            AccessStartCleanup {
+                                atomic_lease: prepared.atomic_lease.clone(),
+                            },
+                        ));
+                    }
+                    prepared
+                        .claim_options
+                        .scope_replay_recovery
+                        .await_readiness()
+                        .await
+                        .map_err(|err| {
+                            (
+                                err,
+                                AccessStartCleanup {
+                                    atomic_lease: prepared.atomic_lease.clone(),
+                                },
+                            )
+                        })?;
+                    match prepared
+                        .replay_state
+                        .claim_scope_start_or_recover_missing(
+                            &scope_name,
+                            &function_type,
+                            prepared.entity_parent_start_index,
+                        )
+                        .await
+                        .map_err(|err| {
+                            (
+                                err,
+                                AccessStartCleanup {
+                                    atomic_lease: prepared.atomic_lease.clone(),
+                                },
+                            )
+                        })? {
+                        ScopeStartClaimOutcome::MissingSwitchedToLive => {}
+                        ScopeStartClaimOutcome::Missing => unreachable!(
+                            "missing-scope recovery either claims the scope or switches live"
+                        ),
+                        ScopeStartClaimOutcome::Claimed { .. } => {
+                            return Err((
+                                WorkerExecutorError::runtime(
+                                    "Recorded remote write scope was already claimed after replay completed",
+                                ),
+                                AccessStartCleanup {
+                                    atomic_lease: prepared.atomic_lease.clone(),
+                                },
+                            ));
+                        }
+                    }
+                }
+                ScopeReplayRecovery::Default => {}
+            }
+            let begin_index =
+                Self::append_access_scope_start(prepared, scope_name, function_type).await;
             Ok(AccessOpenedScope {
                 begin_index,
                 replay_handle: None,
@@ -1275,22 +1393,69 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
             // discriminator suffix). There is no plain-name fallback: a discriminated claim must
             // never steal a plain sibling scope, and P3 deploys on a clean database so every
             // replayed oplog was recorded with the discriminators already in place.
-            let (begin_index, replay_handle) = prepared
-                .replay_state
-                .claim_scope_start(
-                    &scope_name,
-                    &function_type,
-                    prepared.entity_parent_start_index,
-                )
-                .await
-                .map_err(|err| {
-                    (
-                        err,
-                        AccessStartCleanup {
-                            atomic_lease: prepared.atomic_lease.clone(),
-                        },
+            let can_recover_missing = matches!(
+                &prepared.claim_options.scope_replay_recovery,
+                ScopeReplayRecovery::Reexecute { .. }
+            ) && prepared.execution_scope.atomic_region.is_none()
+                && prepared.execution_scope.observational_owner.is_none()
+                && prepared.entity_parent_start_index.is_none();
+            let claim_result = if can_recover_missing {
+                prepared
+                    .replay_state
+                    .claim_scope_start_or_recover_missing_when_ready(
+                        &scope_name,
+                        &function_type,
+                        prepared.entity_parent_start_index,
+                        prepared
+                            .claim_options
+                            .scope_replay_recovery
+                            .await_readiness(),
                     )
-                })?;
+                    .await
+                    .map(|outcome| match outcome {
+                        ScopeStartClaimOutcome::Claimed {
+                            begin_index,
+                            handle,
+                        } => Some((begin_index, handle)),
+                        ScopeStartClaimOutcome::MissingSwitchedToLive => None,
+                        ScopeStartClaimOutcome::Missing => unreachable!(
+                            "missing-scope recovery either claims the scope or switches live"
+                        ),
+                    })
+            } else {
+                prepared
+                    .replay_state
+                    .claim_scope_start(
+                        &scope_name,
+                        &function_type,
+                        prepared.entity_parent_start_index,
+                    )
+                    .await
+                    .map(Some)
+            };
+            let claimed_scope = claim_result.map_err(|err| {
+                (
+                    err,
+                    AccessStartCleanup {
+                        atomic_lease: prepared.atomic_lease.clone(),
+                    },
+                )
+            })?;
+            let Some((begin_index, replay_handle)) = claimed_scope else {
+                prepared.linear_memory.switch_to_live();
+                let begin_index =
+                    Self::append_access_scope_start(prepared, scope_name, function_type).await;
+                prepared
+                    .public_state
+                    .worker()
+                    .reattach_worker_status()
+                    .await;
+                return Ok(AccessOpenedScope {
+                    begin_index,
+                    replay_handle: None,
+                    switched_to_live: true,
+                });
+            };
 
             if function_type == DurableFunctionType::WriteRemote
                 && !prepared.retry.durable_execution_state().assume_idempotence
@@ -1337,7 +1502,13 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
                     }),
                     OplogEntryLookupResult::NotFound {
                         violates_for_all: false,
-                    } if prepared.retry.durable_execution_state().assume_idempotence => {
+                    } if prepared
+                        .claim_options
+                        .scope_replay_recovery
+                        .can_reexecute_incomplete(
+                            prepared.retry.durable_execution_state().assume_idempotence,
+                        ) =>
+                    {
                         prepared.switch_to_live().await;
                         let deleted_region = OplogRegion {
                             start: begin_index.next(),
@@ -1379,6 +1550,26 @@ impl<Pair: HostPayloadPair, P: DropPolicy> DurableCallSession<Pair, P> {
                 })
             }
         }
+    }
+
+    async fn append_access_scope_start<Ctx: WorkerCtx>(
+        prepared: &mut PreparedAccessStart<Pair, P, Ctx>,
+        scope_name: HostFunctionName,
+        function_type: DurableFunctionType,
+    ) -> OplogIndex {
+        prepared
+            .public_state
+            .worker()
+            .add_and_commit_oplog(OplogEntry::Start {
+                timestamp: Timestamp::now_utc(),
+                parent_start_index: prepared.entity_parent_start_index,
+                function_name: scope_name,
+                invocation_id: None,
+                observational_owner: prepared.execution_scope.observational_owner,
+                request: None,
+                durable_function_type: function_type,
+            })
+            .await
     }
 
     fn finish_access_start<Ctx: WorkerCtx>(

--- a/golem-worker-executor/src/durable_host/concurrent/mod.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/mod.rs
@@ -55,7 +55,9 @@ use crate::durable_host::durability::{
     TaskRetryContext, TerminalCallError, mark_durable_call_trap_context,
     try_trigger_host_trap_retry,
 };
-use crate::durable_host::replay_state::{OplogEntryLookupResult, ReplayState};
+use crate::durable_host::replay_state::{
+    OplogEntryLookupResult, ReplayState, ScopeStartClaimOutcome,
+};
 use crate::durable_host::{
     AtomicRegionLease, DurableScopeKind, DurableWorkerCtx, PublicDurableWorkerState,
 };

--- a/golem-worker-executor/src/durable_host/concurrent/replay.rs
+++ b/golem-worker-executor/src/durable_host/concurrent/replay.rs
@@ -263,6 +263,10 @@ impl ConcurrentReplayResolver {
         self.pending.contains_key(&start_idx) || self.prefetched_terminals.contains_key(&start_idx)
     }
 
+    pub fn has_any_claims(&self) -> bool {
+        !self.pending.is_empty() || !self.prefetched_terminals.is_empty()
+    }
+
     /// Returns whether the registered resolution receiver is still alive. A dropped replay handle
     /// remains pending so its eventual terminal can be drained, but it cannot make further body
     /// progress and therefore is not an active consumer for structural-divergence detection.

--- a/golem-worker-executor/src/durable_host/p3/http/rebuild.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/rebuild.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::replay::ReplayedRequestBodyDrainReadiness;
 use super::request_body::{
     DurableRequestBody, DurableRequestBodyDrainOutcome, RecordedRequestBodyTerminal,
     recorded_request_body_replay, scan_recorded_request_body_frames,
@@ -47,6 +48,10 @@ pub(crate) struct P3HttpSendRebuild {
     /// the oplog yet; after a restart the body is reconstructed from the
     /// recorded frames instead.
     pub(super) durable_body: Option<DurableRequestBody>,
+    /// Completion of replay's request-body drain when the recorded frame stream was incomplete at
+    /// the send terminal. It proves the final reproduced body length and trailer presence after
+    /// healing; missing-scope recovery must validate the recording against it before re-issuing.
+    pub(super) replayed_request_body_drain: Option<ReplayedRequestBodyDrainReadiness>,
 }
 
 /// Aborts the spawned I/O task of a re-issued request when dropped, bounding
@@ -93,6 +98,79 @@ pub(super) enum ResendOutcome {
     /// The recorded request body cannot be reconstructed; the reason describes
     /// why (without any caller-specific context prefix).
     Refused(String),
+}
+
+/// Builds the readiness check used only after replay has proved the response-body scope is missing.
+/// It verifies that the replayed send has a complete request-body recording before recovery may
+/// re-issue it. The check performs no network I/O and writes no oplog entries.
+pub(super) fn recorded_request_body_replayability<Ctx: WorkerCtx, U: 'static>(
+    accessor: &Accessor<U, DurableP3<Ctx>>,
+    rebuild: &mut P3HttpSendRebuild,
+) -> impl std::future::Future<Output = Result<(), String>> + Send + 'static {
+    let durable_body_present = rebuild.durable_body.is_some();
+    let replayed_request_body_drain = rebuild.replayed_request_body_drain.take();
+    let send_start_index = rebuild.recorded_request_body;
+    let oplog = accessor.with(|mut access| {
+        durable_worker_ctx::<Ctx, U>(access.data_mut())
+            .state
+            .oplog
+            .clone()
+    });
+    async move {
+        if durable_body_present {
+            return Ok(());
+        }
+
+        let reproduced = match replayed_request_body_drain {
+            Some(drain) => Some(drain.proof.await.map_err(|_| {
+                "the replayed request-body drain ended before proving recording health".to_string()
+            })??),
+            None => None,
+        };
+        let scan = scan_recorded_request_body_frames(oplog, send_start_index)
+            .await
+            .map_err(|error| {
+                format!("the recorded request-body frames could not be read: {error}")
+            })?;
+        match &scan.terminal {
+            Some(RecordedRequestBodyTerminal::End) => {}
+            Some(RecordedRequestBodyTerminal::Error(error)) => Err(format!(
+                "the recorded request body ended with a guest body error: {error:?}"
+            ))?,
+            None => {
+                return Err(
+                    "the recorded request body is incomplete (no terminal frame was recorded)"
+                        .to_string(),
+                );
+            }
+        }
+        if let Some(reproduced) = reproduced {
+            if scan.covered_len != reproduced.final_length {
+                return Err(format!(
+                    "the healed request-body recording covers {} bytes, but replay reproduced {} bytes",
+                    scan.covered_len, reproduced.final_length
+                ));
+            }
+            if scan
+                .data_frames
+                .iter()
+                .any(|frame| frame.offset.saturating_add(frame.len) > reproduced.final_length)
+            {
+                return Err(
+                    "the request-body recording contains data beyond the length reproduced during replay"
+                        .to_string(),
+                );
+            }
+            if scan.trailers_recorded() != reproduced.trailers_present {
+                return Err(format!(
+                    "the healed request-body recording's trailer presence does not match replay (recorded: {}, reproduced: {})",
+                    scan.trailers_recorded(),
+                    reproduced.trailers_present
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Reconstructs the p3 request resource-equivalent from the recorded head:
@@ -412,6 +490,7 @@ mod tests {
             recorded_status: 200,
             recorded_request_body: OplogIndex::INITIAL,
             durable_body: None,
+            replayed_request_body_drain: None,
         };
 
         let request = build_rebuilt_request(

--- a/golem-worker-executor/src/durable_host/p3/http/replay.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/replay.rs
@@ -27,12 +27,16 @@ use golem_common::model::oplog::payload::types::{
 };
 use golem_common::model::oplog::{DurableFunctionType, OplogIndex};
 use http::{HeaderMap, HeaderName, HeaderValue};
+use http_body::Body as _;
 use http_body_util::BodyExt as _;
 use http_body_util::Empty;
 use http_body_util::combinators::UnsyncBoxBody;
+use std::future::poll_fn;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use tokio::sync::oneshot;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::Poll;
+use tokio::sync::{Notify, oneshot};
 use tracing::warn;
 use wasmtime::AsContextMut;
 use wasmtime::component::{Accessor, AccessorTask, Resource};
@@ -49,11 +53,49 @@ pub(super) struct ReplayedRequestBodyRecording {
     pub(super) recording_complete_at_end: bool,
 }
 
+pub(super) struct ReplayedRequestBodyDrainReadiness {
+    pub(super) proof: oneshot::Receiver<Result<ReplayedRequestBodyRecordingProof, String>>,
+    pub(super) progress: Arc<ReplayedRequestBodyDrainProgress>,
+}
+
+#[derive(Default)]
+pub(super) struct ReplayedRequestBodyDrainProgress {
+    waiting_for_guest_body: AtomicBool,
+    changed: Notify,
+}
+
+impl ReplayedRequestBodyDrainProgress {
+    pub(super) fn set_waiting_for_guest_body(&self, waiting: bool) {
+        if self.waiting_for_guest_body.swap(waiting, Ordering::AcqRel) != waiting {
+            self.changed.notify_one();
+        }
+    }
+
+    pub(super) fn is_waiting_for_guest_body(&self) -> bool {
+        self.waiting_for_guest_body.load(Ordering::Acquire)
+    }
+
+    pub(super) async fn wait_for_change(&self, previous: bool) {
+        loop {
+            let changed = self.changed.notified();
+            if self.is_waiting_for_guest_body() != previous {
+                return;
+            }
+            changed.await;
+        }
+    }
+}
+
 pub(super) async fn consume_replayed_request<Ctx: WorkerCtx, U: Send + 'static>(
     store: &Accessor<U, DurableP3<Ctx>>,
     req: Resource<Request>,
     recorded_body: Option<ReplayedRequestBodyRecording>,
-) -> HttpResult<()> {
+) -> HttpResult<Option<ReplayedRequestBodyDrainReadiness>> {
+    let await_recording = recorded_body
+        .as_ref()
+        .is_some_and(|recorded| !recorded.recording_complete_at_end);
+    let (recording_finished_tx, recording_finished_rx) = oneshot::channel();
+    let progress = Arc::new(ReplayedRequestBodyDrainProgress::default());
     let (drain_result_tx, drain_result_rx) = oneshot::channel::<Result<(), ErrorCode>>();
     let http_store = store.with_getter::<WasiHttp>(wasi_http_view::<Ctx, U>);
     let body = http_store.with(
@@ -85,9 +127,16 @@ pub(super) async fn consume_replayed_request<Ctx: WorkerCtx, U: Send + 'static>(
         body,
         recorded_body,
         drain_result_tx,
+        recording_finished_tx,
+        progress.clone(),
         activity,
     ));
-    Ok(())
+    Ok(
+        await_recording.then_some(ReplayedRequestBodyDrainReadiness {
+            proof: recording_finished_rx,
+            progress,
+        }),
+    )
 }
 
 /// Spawns a [`ReplayedRequestLeakGuard`] for the replayed send's request
@@ -225,6 +274,8 @@ pub(super) struct ReplayRequestBodyDrain<Ctx> {
     body: UnsyncBoxBody<Bytes, ErrorCode>,
     recorded_body: Option<ReplayedRequestBodyRecording>,
     result_tx: oneshot::Sender<Result<(), ErrorCode>>,
+    recording_finished_tx: oneshot::Sender<Result<ReplayedRequestBodyRecordingProof, String>>,
+    progress: Arc<ReplayedRequestBodyDrainProgress>,
     activity: TailActivity,
     _phantom: PhantomData<fn() -> Ctx>,
 }
@@ -234,12 +285,16 @@ impl<Ctx> ReplayRequestBodyDrain<Ctx> {
         body: UnsyncBoxBody<Bytes, ErrorCode>,
         recorded_body: Option<ReplayedRequestBodyRecording>,
         result_tx: oneshot::Sender<Result<(), ErrorCode>>,
+        recording_finished_tx: oneshot::Sender<Result<ReplayedRequestBodyRecordingProof, String>>,
+        progress: Arc<ReplayedRequestBodyDrainProgress>,
         activity: TailActivity,
     ) -> Self {
         Self {
             body,
             recorded_body,
             result_tx,
+            recording_finished_tx,
+            progress,
             activity,
             _phantom: PhantomData,
         }
@@ -256,52 +311,91 @@ where
             body,
             recorded_body,
             result_tx,
+            recording_finished_tx,
+            progress,
             activity,
             _phantom,
         } = self;
-        let result = match recorded_body.filter(|recorded| !recorded.recording_complete_at_end) {
-            None => activity.park(drain_request_body(body)).await,
+        let (result, recording_result) = match recorded_body
+            .filter(|recorded| !recorded.recording_complete_at_end)
+        {
+            None => (activity.park(drain_request_body(body)).await, None),
             Some(recorded_body) => {
                 let (oplog, recording_enabled) = accessor.with(|mut access| {
                     let ctx = durable_worker_ctx::<Ctx, U>(access.data_mut());
                     (ctx.state.oplog.clone(), !ctx.state.snapshotting_mode)
                 });
                 if recording_enabled {
-                    drain_replayed_request_body_completing_recording(
+                    let outcome = drain_replayed_request_body_completing_recording_with_progress(
                         body,
                         oplog,
                         recorded_body.send_start_index,
                         &activity,
+                        &progress,
                     )
-                    .await
+                    .await;
+                    (outcome.transmission, Some(outcome.recording))
                 } else {
-                    activity.park(drain_request_body(body)).await
+                    (
+                        activity
+                            .park(drain_request_body_with_progress(body, &progress))
+                            .await,
+                        Some(Err(
+                            "the incomplete request-body recording cannot be healed while snapshotting"
+                                .to_string(),
+                        )),
+                    )
                 }
             }
         };
+        if let Some(recording_result) = recording_result {
+            let _ = recording_finished_tx.send(recording_result);
+        }
         let _ = result_tx.send(result);
         Ok(())
     }
+}
+
+pub(super) struct ReplayRequestBodyDrainOutcome {
+    pub(super) transmission: Result<(), ErrorCode>,
+    pub(super) recording: Result<ReplayedRequestBodyRecordingProof, String>,
 }
 
 /// Drains a replayed request body whose oplog recording may be incomplete,
 /// completing the recording as it goes: the recorded frames are summarized
 /// (merged by offset — frame recordings are appended by concurrent tasks, so
 /// oplog order is not pull order, and crash/re-exec generations may overlap),
-/// and if no terminal frame was recorded, the guest's re-produced bytes past
-/// the covered prefix are appended as new frames. Bytes inside the covered
-/// prefix are discarded by byte count, because the guest's frame boundaries
-/// can differ between runs.
+/// and the guest's re-produced bytes past the covered prefix are appended as
+/// new frames. The body is always fully driven even if an old terminal exists:
+/// independently appended frames can land out of order, so that terminal does
+/// not prove that an earlier data or trailers append succeeded.
 ///
-/// Scan or append failures never fail the drain: the guest's transmission
-/// result must not depend on recording health. They only leave the recording
-/// incomplete, which a later rebuild detects and refuses.
+/// Scan or append failures do not change the guest's transmission result, but
+/// they fail the separate recording proof and prevent a physical re-issue.
+#[cfg(test)]
 pub(super) async fn drain_replayed_request_body_completing_recording(
     body: UnsyncBoxBody<Bytes, ErrorCode>,
     oplog: Arc<dyn Oplog>,
     send_start_index: OplogIndex,
     activity: &TailActivity,
-) -> Result<(), ErrorCode> {
+) -> ReplayRequestBodyDrainOutcome {
+    drain_replayed_request_body_completing_recording_with_progress(
+        body,
+        oplog,
+        send_start_index,
+        activity,
+        &Arc::new(ReplayedRequestBodyDrainProgress::default()),
+    )
+    .await
+}
+
+async fn drain_replayed_request_body_completing_recording_with_progress(
+    body: UnsyncBoxBody<Bytes, ErrorCode>,
+    oplog: Arc<dyn Oplog>,
+    send_start_index: OplogIndex,
+    activity: &TailActivity,
+    progress: &Arc<ReplayedRequestBodyDrainProgress>,
+) -> ReplayRequestBodyDrainOutcome {
     let scan = match scan_recorded_request_body_frames(oplog.clone(), send_start_index).await {
         Ok(scan) => scan,
         Err(error) => {
@@ -311,36 +405,70 @@ pub(super) async fn drain_replayed_request_body_completing_recording(
                 "Failed to scan the recorded p3 HTTP request-body frames; draining the replayed request body without completing its recording"
             );
             // Safe park: the fallback drain appends nothing (guest-driven only).
-            return activity.park(drain_request_body(body)).await;
+            return ReplayRequestBodyDrainOutcome {
+                transmission: activity
+                    .park(drain_request_body_with_progress(body, progress))
+                    .await,
+                recording: Err(format!(
+                    "the recorded request-body frames could not be scanned: {error}"
+                )),
+            };
         }
     };
-    if scan.terminal_recorded() {
-        // The recording completed after the send result was recorded (its
-        // terminal frame just landed later in the oplog): nothing to append.
-        // Safe park: this drain appends nothing (guest-driven only).
-        return activity.park(drain_request_body(body)).await;
+    drain_past_recorded_prefix(body, oplog, send_start_index, scan, activity, progress).await
+}
+
+async fn next_replayed_request_body_frame(
+    body: &mut UnsyncBoxBody<Bytes, ErrorCode>,
+    progress: &Arc<ReplayedRequestBodyDrainProgress>,
+) -> Option<Result<http_body::Frame<Bytes>, ErrorCode>> {
+    poll_fn(|cx| match std::pin::Pin::new(&mut *body).poll_frame(cx) {
+        Poll::Ready(frame) => {
+            progress.set_waiting_for_guest_body(false);
+            Poll::Ready(frame)
+        }
+        Poll::Pending => {
+            progress.set_waiting_for_guest_body(true);
+            Poll::Pending
+        }
+    })
+    .await
+}
+
+async fn drain_request_body_with_progress(
+    mut body: UnsyncBoxBody<Bytes, ErrorCode>,
+    progress: &Arc<ReplayedRequestBodyDrainProgress>,
+) -> Result<(), ErrorCode> {
+    while let Some(frame) = next_replayed_request_body_frame(&mut body, progress).await {
+        frame?;
     }
-    drain_past_recorded_prefix(body, oplog, send_start_index, scan, activity).await
+    Ok(())
 }
 
 /// The incomplete-recording drain core: discards the guest's re-produced bytes
 /// up to `scan.covered_len` (splitting a frame that straddles the boundary),
 /// records everything past it — data at its byte offset, trailers unless
-/// already recorded, and always a terminal frame — and returns the guest
-/// body's terminal result.
+/// already recorded, and a terminal frame when one is missing — and returns
+/// the guest body's terminal result plus the recording-health proof.
 async fn drain_past_recorded_prefix(
     mut body: UnsyncBoxBody<Bytes, ErrorCode>,
     oplog: Arc<dyn Oplog>,
     send_start_index: OplogIndex,
     scan: RecordedRequestBodyScan,
     activity: &TailActivity,
-) -> Result<(), ErrorCode> {
+    progress: &Arc<ReplayedRequestBodyDrainProgress>,
+) -> ReplayRequestBodyDrainOutcome {
     let mut recording = true;
     let mut trailers_recorded = scan.trailers_recorded();
+    let terminal_recorded = scan.terminal_recorded();
+    let mut reproduced_trailers = false;
     let mut pos: u64 = 0;
     // Safe park: each frame is guest-(re)produced body data; the appends
     // between frames stay active.
-    while let Some(frame) = activity.park(body.frame()).await {
+    while let Some(frame) = activity
+        .park(next_replayed_request_body_frame(&mut body, progress))
+        .await
+    {
         match frame {
             Ok(frame) => match frame.into_data().map_err(http_body::Frame::into_trailers) {
                 Ok(data) => {
@@ -360,6 +488,7 @@ async fn drain_past_recorded_prefix(
                     pos = end;
                 }
                 Err(Ok(trailers)) => {
+                    reproduced_trailers = true;
                     if recording && !trailers_recorded {
                         recording = record_frame_or_warn(
                             &oplog,
@@ -383,19 +512,38 @@ async fn drain_past_recorded_prefix(
                     )
                     .await;
                 }
-                return Err(error);
+                return ReplayRequestBodyDrainOutcome {
+                    transmission: Err(error),
+                    recording: Err(
+                        "the deterministically reproduced guest request body ended with an error"
+                            .to_string(),
+                    ),
+                };
             }
         }
     }
-    if recording {
-        record_frame_or_warn(
+    if recording && !terminal_recorded {
+        recording = record_frame_or_warn(
             &oplog,
             send_start_index,
             SerializableP3HttpRequestBodyFrame::End,
         )
         .await;
     }
-    Ok(())
+    ReplayRequestBodyDrainOutcome {
+        transmission: Ok(()),
+        recording: if recording {
+            Ok(ReplayedRequestBodyRecordingProof {
+                final_length: pos,
+                trailers_present: reproduced_trailers,
+            })
+        } else {
+            Err(
+                "a required request-body frame could not be appended while healing the recording"
+                    .to_string(),
+            )
+        },
+    }
 }
 
 /// Appends one frame to the send's recording, returning whether recording may
@@ -481,6 +629,25 @@ mod tests {
 
     fn test_activity() -> TailActivity {
         crate::durable_host::tail_work::TailWorkTracker::new().activity()
+    }
+
+    fn assert_clean_recording(
+        outcome: ReplayRequestBodyDrainOutcome,
+        final_length: u64,
+        trailers_present: bool,
+    ) {
+        assert!(
+            matches!(&outcome.transmission, Ok(())),
+            "drain failed: {:?}",
+            outcome.transmission
+        );
+        assert_eq!(
+            outcome.recording,
+            Ok(ReplayedRequestBodyRecordingProof {
+                final_length,
+                trailers_present,
+            })
+        );
     }
 
     struct TrackedChunk {
@@ -863,16 +1030,16 @@ mod tests {
             &test_activity(),
         )
         .await;
-        assert!(matches!(result, Ok(())), "drain failed: {result:?}");
+        assert_clean_recording(result, 11, false);
         let (bytes, trailers, ends, errors) =
             summarize_recording(oplog.recorded_frames_for(PARENT));
         assert_eq!(bytes, b"hello world");
         assert_eq!((trailers, ends, errors), (0, 1, 0));
     }
 
-    /// A recording whose terminal frame landed in the oplog (even after the
-    /// send result) is complete: the drain must only discard the guest's
-    /// re-produced body and append nothing.
+    /// A recording whose terminal frame landed after the send result still has
+    /// its reproduced length verified. When all earlier frames are present,
+    /// the drain appends nothing.
     #[test]
     #[timeout("10s")]
     async fn replay_drain_leaves_complete_recording_untouched() {
@@ -891,8 +1058,77 @@ mod tests {
             &test_activity(),
         )
         .await;
-        assert!(matches!(result, Ok(())), "drain failed: {result:?}");
+        assert_clean_recording(result, 3, false);
         assert_eq!(oplog.entry_count(), entries_before);
+    }
+
+    /// A terminal can overtake an independently appended data frame. The old
+    /// terminal must not hide that gap: replay fills it from the reproduced
+    /// body and proves the final contiguous length before recovery may resend.
+    #[test]
+    #[timeout("10s")]
+    async fn replay_drain_heals_gap_even_when_end_is_already_recorded() {
+        let oplog = FrameTestOplog::new();
+        record(&oplog, PARENT, data(0, b"ab")).await;
+        record(&oplog, PARENT, data(4, b"ef")).await;
+        record(&oplog, PARENT, SerializableP3HttpRequestBodyFrame::End).await;
+        let body = frame_body(
+            vec![http_body::Frame::data(Bytes::from_static(b"abcdef"))],
+            None,
+        );
+
+        let outcome = drain_replayed_request_body_completing_recording(
+            body,
+            oplog.clone(),
+            PARENT,
+            &test_activity(),
+        )
+        .await;
+
+        assert_clean_recording(outcome, 6, false);
+        let scan = scan_recorded_request_body_frames(oplog, PARENT)
+            .await
+            .expect("scan failed");
+        assert_eq!(scan.covered_len, 6);
+        assert!(matches!(
+            scan.terminal,
+            Some(RecordedRequestBodyTerminal::End)
+        ));
+    }
+
+    /// If healing a gap fails, an old terminal is insufficient proof and the
+    /// recording must remain ineligible for a physical recovery request.
+    #[test]
+    #[timeout("10s")]
+    async fn replay_drain_rejects_failed_healing_despite_recorded_end() {
+        let oplog = FrameTestOplog::new();
+        record(&oplog, PARENT, data(0, b"ab")).await;
+        record(&oplog, PARENT, data(4, b"ef")).await;
+        record(&oplog, PARENT, SerializableP3HttpRequestBodyFrame::End).await;
+        oplog.fail_uploads();
+        let body = frame_body(
+            vec![http_body::Frame::data(Bytes::from_static(b"abcdef"))],
+            None,
+        );
+
+        let outcome = drain_replayed_request_body_completing_recording(
+            body,
+            oplog.clone(),
+            PARENT,
+            &test_activity(),
+        )
+        .await;
+
+        assert!(matches!(&outcome.transmission, Ok(())));
+        assert!(outcome.recording.is_err());
+        let scan = scan_recorded_request_body_frames(oplog, PARENT)
+            .await
+            .expect("scan failed");
+        assert_eq!(scan.covered_len, 2);
+        assert!(matches!(
+            scan.terminal,
+            Some(RecordedRequestBodyTerminal::End)
+        ));
     }
 
     /// Guest trailers past the covered prefix are recorded when the recording
@@ -918,7 +1154,7 @@ mod tests {
             &test_activity(),
         )
         .await;
-        assert!(matches!(result, Ok(())), "drain failed: {result:?}");
+        assert_clean_recording(result, 3, true);
         let (bytes, trailers, ends, errors) =
             summarize_recording(oplog.recorded_frames_for(PARENT));
         assert_eq!(bytes, b"abc");
@@ -958,7 +1194,7 @@ mod tests {
             &test_activity(),
         )
         .await;
-        assert!(matches!(result, Ok(())), "drain failed: {result:?}");
+        assert_clean_recording(result, 3, true);
         let (bytes, trailers, ends, errors) =
             summarize_recording(oplog.recorded_frames_for(PARENT));
         assert_eq!(bytes, b"abc");
@@ -985,9 +1221,11 @@ mod tests {
         )
         .await;
         assert!(
-            matches!(result, Err(ErrorCode::HttpProtocolError)),
-            "drain must surface the guest body error, got {result:?}"
+            matches!(&result.transmission, Err(ErrorCode::HttpProtocolError)),
+            "drain must surface the guest body error, got {:?}",
+            result.transmission
         );
+        assert!(result.recording.is_err());
         let (bytes, trailers, ends, errors) =
             summarize_recording(oplog.recorded_frames_for(PARENT));
         assert_eq!(bytes, b"ab");
@@ -1009,7 +1247,7 @@ mod tests {
             &test_activity(),
         )
         .await;
-        assert!(matches!(result, Ok(())), "drain failed: {result:?}");
+        assert_clean_recording(result, 0, false);
         let (bytes, trailers, ends, errors) =
             summarize_recording(oplog.recorded_frames_for(PARENT));
         assert!(bytes.is_empty());

--- a/golem-worker-executor/src/durable_host/p3/http/request_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/request_body.rs
@@ -545,6 +545,14 @@ pub(super) enum RecordedRequestBodyTerminal {
     Error(SerializableHttpErrorCode),
 }
 
+/// Facts observed while fully draining the deterministically reproduced guest request body.
+/// Recovery compares them with the healed recording before physically re-issuing the request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ReplayedRequestBodyRecordingProof {
+    pub(super) final_length: u64,
+    pub(super) trailers_present: bool,
+}
+
 impl RecordedRequestBodyScan {
     pub(super) fn trailers_recorded(&self) -> bool {
         self.trailers_index.is_some()
@@ -1175,6 +1183,7 @@ where
                 request_identity: None,
                 parent_start_index: None,
                 observational_owner,
+                ..Default::default()
             },
             async |_| Ok(HostRequestNoInput {}),
         )

--- a/golem-worker-executor/src/durable_host/p3/http/response_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/response_body.rs
@@ -1212,13 +1212,14 @@ where
                     let read_frame = async {
                         if pending_reissue {
                             // First live read of a replayed response's placeholder body:
-                            // the durable consume-body scope turned out to be incomplete
-                            // (the original run was interrupted mid-body-stream, so the
-                            // scope claim jumped to live), and the placeholder carries no
-                            // data. Re-issue the recorded request now and stream the
-                            // fresh body instead. This only fires on a real guest demand:
-                            // a dropped stream or a cleanly replaying scope never
-                            // re-issues.
+                            // the durable consume-body scope was either missing entirely
+                            // (the crash happened before its `Start` was committed, so a
+                            // synthetic scope was recovered live) or incomplete (the
+                            // original run was interrupted mid-body-stream, so the scope
+                            // claim jumped to live), and the placeholder carries no data.
+                            // Re-issue the recorded request now and stream the fresh body
+                            // instead. This only fires on a real guest demand: a dropped
+                            // stream or a cleanly replaying scope never re-issues.
                             pending_reissue = false;
                             match resend.as_ref() {
                                 Some(resend) => {

--- a/golem-worker-executor/src/durable_host/p3/http/response_body.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/response_body.rs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::rebuild::resend_recorded_request;
 use super::rebuild::{AbortOnDropIoTask, P3HttpSendRebuild};
 use super::rebuild::{RebuildOutcome, ResendOutcome, reissue_recorded_request};
+use super::rebuild::{recorded_request_body_replayability, resend_recorded_request};
+use super::replay::ReplayedRequestBodyDrainProgress;
 use super::serialization::{deserialize_error_code, serialize_error_code};
 use super::serialization::{deserialize_headers, serialize_headers};
 use super::*;
 use crate::durable_host::concurrent::{
     AccessClaimOptions, CompletionDelivery, DemandDelivery, DemandDeliveryMode, DropEvent,
-    DurableDemandItem, DurableDemandStream, demand_channel,
+    DurableDemandItem, DurableDemandStream, ScopeReplayRecovery, demand_channel,
 };
 use crate::durable_host::durability::{
     AsyncRetryDecision, DurabilityHost, DurableCallTrapContext, HostFailureKind,
@@ -56,9 +57,10 @@ use http_body_util::combinators::UnsyncBoxBody;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tracing::debug;
 use wasmtime::component::{
     Access, Accessor, AccessorTask, Destination, FutureProducer, FutureReader, Resource,
@@ -127,12 +129,6 @@ pub(super) fn register_open_response<Ctx: WorkerCtx, U: Send>(
     });
 }
 
-/// Whether the recorded request head declares a request body: a positive (or
-/// unparseable) `content-length`, or any `transfer-encoding`. The oplog does
-/// not record request body bytes, so such a request cannot be faithfully
-/// re-issued after a restart. This is best-effort detection from the head
-/// only — a streamed upload without `content-length` is indistinguishable
-/// from no body and slips through.
 impl<Ctx: WorkerCtx> types::HostResponse for DurableP3View<'_, Ctx> {
     fn get_status_code(&mut self, res: Resource<Response>) -> wasmtime::Result<StatusCode> {
         observe_function_call(&*self.0, "http::types::response", "get-status-code");
@@ -192,6 +188,65 @@ pub(super) enum HttpBodyChunkReply {
         message: String,
         trap_context: DurableCallTrapContext,
     },
+}
+
+#[derive(Default)]
+struct HttpBodyDemandSignal {
+    observed: AtomicBool,
+    notify: Notify,
+}
+
+impl HttpBodyDemandSignal {
+    fn observe(&self) {
+        self.observed.store(true, Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    async fn observed(&self) {
+        while !self.observed.load(Ordering::Acquire) {
+            self.notify.notified().await;
+        }
+    }
+}
+
+async fn require_recording_before_response_demand(
+    readiness: impl Future<Output = Result<(), String>>,
+    demand_signal: Arc<HttpBodyDemandSignal>,
+    request_body_progress: Option<Arc<ReplayedRequestBodyDrainProgress>>,
+) -> Result<(), String> {
+    let Some(request_body_progress) = request_body_progress else {
+        return readiness.await;
+    };
+    tokio::pin!(readiness);
+    let mut response_demanded = demand_signal.observed.load(Ordering::Acquire);
+    loop {
+        let request_body_waiting = request_body_progress.is_waiting_for_guest_body();
+        if response_demanded && request_body_waiting {
+            tokio::select! {
+                biased;
+                result = &mut readiness => return result,
+                () = std::future::ready(()) => return Err(
+                    "response-body demand arrived while replay was waiting for more guest request-body data"
+                        .to_string(),
+                )
+            }
+        }
+
+        if response_demanded {
+            tokio::select! {
+                biased;
+                result = &mut readiness => return result,
+                () = request_body_progress.wait_for_change(request_body_waiting) => {}
+            }
+        } else {
+            tokio::select! {
+                biased;
+                result = &mut readiness => return result,
+                () = demand_signal.observed() => response_demanded = true,
+                () = request_body_progress.wait_for_change(request_body_waiting) => {}
+            }
+        }
+    }
 }
 
 /// Settles a persisted chunk completion at the producer's observation boundary rather than when
@@ -367,6 +422,7 @@ impl Drop for HttpTrailersDeliveryGuard {
 /// replay.
 pub(super) struct DurableHttpBodyProducer {
     demand_tx: mpsc::Sender<HttpBodyDemand>,
+    demand_signal: Arc<HttpBodyDemandSignal>,
     hook: Option<Arc<dyn P3HttpBodyProducerHook>>,
     pending: Option<PendingHttpBodyRead>,
     pending_cancel: Option<oneshot::Receiver<()>>,
@@ -384,10 +440,12 @@ pub(super) struct PendingHttpBodyRead {
 impl DurableHttpBodyProducer {
     fn new(
         demand_tx: mpsc::Sender<HttpBodyDemand>,
+        demand_signal: Arc<HttpBodyDemandSignal>,
         hook: Option<Arc<dyn P3HttpBodyProducerHook>>,
     ) -> Self {
         Self {
             demand_tx,
+            demand_signal,
             hook,
             pending: None,
             pending_cancel: None,
@@ -550,7 +608,7 @@ impl<D> StreamProducer<D> for DurableHttpBodyProducer {
                 // oplog and fail on replay.
                 let (tx, rx) = oneshot::channel();
                 match self.demand_tx.try_send(HttpBodyDemand::Cancel(tx)) {
-                    Ok(()) => {}
+                    Ok(()) => self.demand_signal.observe(),
                     Err(mpsc::error::TrySendError::Closed(_)) => {
                         self.finished = true;
                         return Poll::Ready(Ok(StreamResult::Cancelled));
@@ -576,7 +634,7 @@ impl<D> StreamProducer<D> for DurableHttpBodyProducer {
                 cancel: cancel_rx,
                 cancel_ack: cancel_ack_tx,
             }) {
-                Ok(()) => {}
+                Ok(()) => self.demand_signal.observe(),
                 Err(mpsc::error::TrySendError::Closed(_)) => {
                     self.finished = true;
                     return Poll::Ready(Err(wasmtime::Error::msg(
@@ -882,6 +940,7 @@ pub(super) async fn skip_body_prefix(
 pub(super) struct HttpConsumeBodyTask<Ctx> {
     body: UnsyncBoxBody<Bytes, ErrorCode>,
     demand_rx: mpsc::Receiver<HttpBodyDemand>,
+    demand_signal: Arc<HttpBodyDemandSignal>,
     trailers_tx: oneshot::Sender<HttpTrailersResolution>,
     trailers_delivery: Arc<HttpTrailersDelivery>,
     /// Open-response state of the send that produced this response (its
@@ -899,6 +958,7 @@ impl<Ctx> HttpConsumeBodyTask<Ctx> {
     fn new(
         body: UnsyncBoxBody<Bytes, ErrorCode>,
         demand_rx: mpsc::Receiver<HttpBodyDemand>,
+        demand_signal: Arc<HttpBodyDemandSignal>,
         trailers_tx: oneshot::Sender<HttpTrailersResolution>,
         trailers_delivery: Arc<HttpTrailersDelivery>,
         response_state: Option<OpenP3HttpResponseState>,
@@ -907,6 +967,7 @@ impl<Ctx> HttpConsumeBodyTask<Ctx> {
         Self {
             body,
             demand_rx,
+            demand_signal,
             trailers_tx,
             trailers_delivery,
             response_state,
@@ -925,12 +986,36 @@ where
         let HttpConsumeBodyTask {
             mut body,
             demand_rx,
+            demand_signal,
             trailers_tx,
             trailers_delivery,
-            response_state,
+            mut response_state,
             activity,
             ..
         } = self;
+
+        let scope_replay_recovery = match response_state.as_mut() {
+            Some(state) if state.body_is_placeholder && state.is_idempotent => {
+                match state.resend.as_mut() {
+                    Some(rebuild) => {
+                        let request_body_progress = rebuild
+                            .replayed_request_body_drain
+                            .as_ref()
+                            .map(|drain| drain.progress.clone());
+                        ScopeReplayRecovery::reexecute_when(
+                            require_recording_before_response_demand(
+                                recorded_request_body_replayability(accessor, rebuild),
+                                demand_signal.clone(),
+                                request_body_progress,
+                            ),
+                        )
+                    }
+                    None => ScopeReplayRecovery::Forbidden,
+                }
+            }
+            Some(state) if state.body_is_placeholder => ScopeReplayRecovery::Forbidden,
+            _ => ScopeReplayRecovery::Default,
+        };
 
         let (
             response_span,
@@ -994,6 +1079,7 @@ where
                 request_identity: None,
                 parent_start_index: None,
                 observational_owner,
+                scope_replay_recovery,
             },
             DemandDeliveryMode::Deferred,
             async |_| Ok(HostRequestNoInput {}),
@@ -1732,6 +1818,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostResponseWithStore<U> for Dura
         // Capacity 1 suffices (and bounds memory as defense in depth): the
         // producer keeps at most one demand in flight at a time.
         let (demand_tx, demand_rx) = demand_channel();
+        let demand_signal = Arc::new(HttpBodyDemandSignal::default());
         let (trailers_tx, trailers_rx) = oneshot::channel();
         let trailers_delivery = HttpTrailersDelivery::new();
         let producer_hook = {
@@ -1746,7 +1833,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostResponseWithStore<U> for Dura
         // handle construction fails.
         let mut stream = StreamReader::new(
             &mut store,
-            DurableHttpBodyProducer::new(demand_tx, producer_hook),
+            DurableHttpBodyProducer::new(demand_tx, demand_signal.clone(), producer_hook),
         )?;
         let mut trailers = match FutureReader::new(
             &mut store,
@@ -1776,6 +1863,7 @@ impl<U: Send + 'static, Ctx: WorkerCtx> types::HostResponseWithStore<U> for Dura
         store.spawn(HttpConsumeBodyTask::<Ctx>::new(
             body,
             demand_rx,
+            demand_signal,
             trailers_tx,
             trailers_delivery,
             response_state,
@@ -1825,6 +1913,66 @@ mod tests {
         DurableFunctionType, HostRequest, HostResponse, OplogEntry, OplogIndex, OplogPayload,
     };
     use test_r::{test, timeout};
+
+    #[test]
+    #[timeout("10s")]
+    async fn missing_scope_readiness_refuses_pending_proof_after_response_demand() {
+        let demand_signal = Arc::new(HttpBodyDemandSignal::default());
+        demand_signal.observe();
+        let request_body_progress = Arc::new(ReplayedRequestBodyDrainProgress::default());
+        request_body_progress.set_waiting_for_guest_body(true);
+
+        let error = require_recording_before_response_demand(
+            std::future::pending::<Result<(), String>>(),
+            demand_signal,
+            Some(request_body_progress),
+        )
+        .await
+        .expect_err("response demand must bound a pending recording proof");
+
+        assert!(error.contains("response-body demand"));
+    }
+
+    #[test]
+    async fn missing_scope_readiness_prefers_an_already_completed_proof() {
+        let demand_signal = Arc::new(HttpBodyDemandSignal::default());
+        demand_signal.observe();
+        let request_body_progress = Arc::new(ReplayedRequestBodyDrainProgress::default());
+        request_body_progress.set_waiting_for_guest_body(true);
+
+        require_recording_before_response_demand(
+            async { Ok(()) },
+            demand_signal,
+            Some(request_body_progress),
+        )
+        .await
+        .expect("a completed recording proof must win over concurrent response demand");
+    }
+
+    #[test]
+    async fn missing_scope_readiness_ignores_demand_for_storage_only_validation() {
+        let demand_signal = Arc::new(HttpBodyDemandSignal::default());
+        demand_signal.observe();
+        let request_body_progress = Arc::new(ReplayedRequestBodyDrainProgress::default());
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let mut check = Box::pin(require_recording_before_response_demand(
+            async move {
+                ready_rx.await.expect("readiness sender dropped");
+                Ok(())
+            },
+            demand_signal,
+            Some(request_body_progress),
+        ));
+
+        assert!(
+            futures::poll!(check.as_mut()).is_pending(),
+            "response demand alone must not refuse bounded storage-only validation"
+        );
+        ready_tx.send(()).expect("readiness receiver dropped");
+        check
+            .await
+            .expect("storage-only validation must complete after becoming ready");
+    }
 
     /// Seeds `oplog` with the durable prefix a live consume-body loop leaves behind right before
     /// the guest-facing transfer of its first chunk: the parent consume-body `Start`, the child

--- a/golem-worker-executor/src/durable_host/p3/http/send.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/send.rs
@@ -220,6 +220,7 @@ where
         request_identity: Some(HostRequest::from(host_request.clone())),
         parent_start_index: None,
         observational_owner: None,
+        ..Default::default()
     };
     let mut handle = DurableCallSession::<P3HttpClientSend, P>::start_access_with_options(
         store,
@@ -293,7 +294,8 @@ where
                     }),
                     SerializableP3HttpClientSendResult::HttpError(_) => None,
                 };
-                consume_replayed_request::<Ctx, U>(store, req, recorded_request_body).await?;
+                let replayed_request_body_drain =
+                    consume_replayed_request::<Ctx, U>(store, req, recorded_request_body).await?;
                 let recorded_status = match &response.result {
                     SerializableP3HttpClientSendResult::SuccessWithRecordedRequestBody {
                         headers,
@@ -342,6 +344,7 @@ where
                                     recorded_status,
                                     recorded_request_body: send_start_index,
                                     durable_body: None,
+                                    replayed_request_body_drain,
                                 }),
                                 body_is_placeholder: true,
                                 observational_owner,
@@ -411,7 +414,7 @@ where
     }
 
     if authorization_denied {
-        consume_replayed_request::<Ctx, U>(store, req, None).await?;
+        let _ = consume_replayed_request::<Ctx, U>(store, req, None).await?;
         let error_code = ErrorCode::HttpRequestDenied;
         let result =
             SerializableP3HttpClientSendResult::HttpError(serialize_error_code(&error_code));
@@ -825,6 +828,7 @@ where
                         recorded_status: response_status,
                         recorded_request_body: send_start_index,
                         durable_body: Some(physical.body.clone()),
+                        replayed_request_body_drain: None,
                     }),
                     body_is_placeholder: false,
                     observational_owner,

--- a/golem-worker-executor/src/durable_host/p3/http/test_support.rs
+++ b/golem-worker-executor/src/durable_host/p3/http/test_support.rs
@@ -66,6 +66,10 @@ impl FrameTestOplog {
         self.upload_gate.add_permits(n);
     }
 
+    pub(super) fn fail_uploads(&self) {
+        self.upload_gate.close();
+    }
+
     pub(super) fn entry_count(&self) -> usize {
         self.entries.lock().unwrap().len()
     }

--- a/golem-worker-executor/src/durable_host/replay_state/claims.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/claims.rs
@@ -385,6 +385,138 @@ impl ReplayState {
         Ok((handle.start_idx(), handle))
     }
 
+    /// Claims an exact synthetic scope `Start`. If no such entry was committed, atomically proves
+    /// that the remaining replay suffix has no competing claim, matching discriminator, delivery
+    /// boundary, or concurrent side effect before switching replay to live mode.
+    pub(crate) async fn claim_scope_start_or_recover_missing(
+        &self,
+        expected_function_name: &HostFunctionName,
+        expected_function_type: &DurableFunctionType,
+        parent_start_index: Option<OplogIndex>,
+    ) -> Result<ScopeStartClaimOutcome, WorkerExecutorError> {
+        self.claim_scope_start_with_missing_recovery(
+            expected_function_name,
+            expected_function_type,
+            parent_start_index,
+            true,
+        )
+        .await
+    }
+
+    /// Claims an exact synthetic scope `Start`, reporting absence without switching replay to live.
+    pub(crate) async fn claim_scope_start_if_present(
+        &self,
+        expected_function_name: &HostFunctionName,
+        expected_function_type: &DurableFunctionType,
+        parent_start_index: Option<OplogIndex>,
+    ) -> Result<ScopeStartClaimOutcome, WorkerExecutorError> {
+        self.claim_scope_start_with_missing_recovery(
+            expected_function_name,
+            expected_function_type,
+            parent_start_index,
+            false,
+        )
+        .await
+    }
+
+    /// Claims an exact synthetic scope `Start` without polling `readiness` when the scope exists.
+    /// If it is missing, waits for the caller's recovery precondition and then atomically repeats
+    /// the exact claim and missing-scope safety checks before switching replay to live.
+    pub(crate) async fn claim_scope_start_or_recover_missing_when_ready(
+        &self,
+        expected_function_name: &HostFunctionName,
+        expected_function_type: &DurableFunctionType,
+        parent_start_index: Option<OplogIndex>,
+        readiness: impl Future<Output = Result<(), WorkerExecutorError>>,
+    ) -> Result<ScopeStartClaimOutcome, WorkerExecutorError> {
+        match self
+            .claim_scope_start_if_present(
+                expected_function_name,
+                expected_function_type,
+                parent_start_index,
+            )
+            .await?
+        {
+            claimed @ ScopeStartClaimOutcome::Claimed { .. } => Ok(claimed),
+            ScopeStartClaimOutcome::Missing => {
+                readiness.await?;
+                self.claim_scope_start_or_recover_missing(
+                    expected_function_name,
+                    expected_function_type,
+                    parent_start_index,
+                )
+                .await
+            }
+            ScopeStartClaimOutcome::MissingSwitchedToLive => {
+                unreachable!("presence-only scope claim never switches replay to live")
+            }
+        }
+    }
+
+    async fn claim_scope_start_with_missing_recovery(
+        &self,
+        expected_function_name: &HostFunctionName,
+        expected_function_type: &DurableFunctionType,
+        parent_start_index: Option<OplogIndex>,
+        recover_missing: bool,
+    ) -> Result<ScopeStartClaimOutcome, WorkerExecutorError> {
+        let claim = StartClaim::scope(
+            expected_function_name,
+            expected_function_type,
+            parent_start_index,
+        );
+        loop {
+            let progress = self.cursor.progress.notified();
+            tokio::pin!(progress);
+            progress.as_mut().enable();
+
+            let owned_claim = claim.clone();
+            let (outcome, blocked_on_completion_delivery) = self
+                .run_owned_cursor_op(move |state| async move {
+                    let result = state
+                        .with_tx(async |tx| {
+                            let outcome = tx
+                                .claim_scope_start_with_missing_recovery(
+                                    &owned_claim,
+                                    recover_missing,
+                                )
+                                .await?;
+                            Ok((outcome, tx.blocked_on_completion_delivery))
+                        })
+                        .await?;
+                    if recover_missing && matches!(&result.0, StartClaimAttempt::Missing) {
+                        state
+                            .cursor
+                            .oplog
+                            .on_replay_progress(state.cursor.replay_target())
+                            .await;
+                    }
+                    Ok(result)
+                })
+                .await?;
+
+            match outcome {
+                StartClaimAttempt::Claimed(handle, _) => {
+                    return Ok(ScopeStartClaimOutcome::Claimed {
+                        begin_index: handle.start_idx(),
+                        handle,
+                    });
+                }
+                StartClaimAttempt::Missing => {
+                    return Ok(if recover_missing {
+                        ScopeStartClaimOutcome::MissingSwitchedToLive
+                    } else {
+                        ScopeStartClaimOutcome::Missing
+                    });
+                }
+                StartClaimAttempt::Blocked => {
+                    debug_assert!(blocked_on_completion_delivery);
+                    progress.await;
+                }
+            }
+        }
+    }
+
     /// Claims the next top-level (unowned) durable-call `Start` whose identity **and recorded
     /// request payload** match. Payload matching is what disambiguates concurrent durable calls
     /// that share the same function name and durable function type but were issued with different
@@ -602,19 +734,30 @@ impl ReplayState {
                                     ));
                                 }
 
-                                tx.claim_start_matching(
+                                match tx
+                                    .claim_start_matching(
                                     |entry| matches!(entry, OplogEntry::Start {
                                         invocation_id: Some(invocation_id),
                                         observational_owner: None,
                                         ..
                                     } if *invocation_id == expected_invocation_id),
-                                    || {
-                                        format!(
-                                            "custom durable Start {{ invocation_id: {expected_invocation_id} }}"
-                                        )
-                                    },
                                 )
-                                .await?
+                                    .await?
+                                {
+                                    StartClaimAttempt::Claimed(handle, entry) => {
+                                        Some((handle, entry))
+                                    }
+                                    StartClaimAttempt::Blocked => None,
+                                    StartClaimAttempt::Missing => {
+                                        return Err(WorkerExecutorError::unexpected_oplog_entry(
+                                            format!(
+                                                "custom durable Start {{ invocation_id: {expected_invocation_id} }}"
+                                            ),
+                                            "no matching Start between the replay cursor and the replay target"
+                                                .to_string(),
+                                        ));
+                                    }
+                                }
                             }
                             OplogEntryLookupResult::NotFound { .. } => {
                                 return Err(WorkerExecutorError::unexpected_oplog_entry(

--- a/golem-worker-executor/src/durable_host/replay_state/cursor.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/cursor.rs
@@ -1169,7 +1169,7 @@ impl CursorTx<'_> {
         Ok(ReplayCallHandle::new(start_idx, receiver))
     }
 
-    /// Claims the first not-yet-claimed `Start` entry matching `matches_identity`, registering a
+    /// Looks for the first not-yet-claimed `Start` entry matching `matches_identity`, registering a
     /// resolver receiver keyed by the `Start`'s index and returning the registered handle together
     /// with the claimed entry. Shared core of every concurrent-replay `Start` claim.
     ///
@@ -1194,21 +1194,20 @@ impl CursorTx<'_> {
     /// `End`/`Cancelled` is reached only after the cursor has consumed the claimed `Start`, so
     /// terminal routing is unaffected. Matching `Start`s that share the same identity are claimed
     /// in oplog order, preserving the deterministic per-task/per-parent chain order. A replay
-    /// divergence (no matching `Start` recorded at all) surfaces as a `NotFound` claim error
-    /// instead of an immediate head mismatch.
+    /// divergence (no matching `Start` recorded at all) is reported to the caller instead of as an
+    /// immediate head mismatch.
     pub(super) async fn claim_start_matching(
         &mut self,
         matches_identity: impl Fn(&OplogEntry) -> bool,
-        expected: impl FnOnce() -> String,
-    ) -> Result<Option<(ReplayCallHandle, Box<OplogEntry>)>, WorkerExecutorError> {
+    ) -> Result<StartClaimAttempt, WorkerExecutorError> {
         // Head fast path: auto-drains awaited terminals and already-claimed `Start`s, then
         // consumes the head iff it matches this claim's identity.
         if let Some((start_idx, entry)) = self.try_get_oplog_entry(&matches_identity).await? {
             let handle = self.register_claimed_start(start_idx).await?;
-            return Ok(Some((handle, Box::new(entry))));
+            return Ok(StartClaimAttempt::Claimed(handle, Box::new(entry)));
         }
         if self.blocked_on_completion_delivery {
-            return Ok(None);
+            return Ok(StartClaimAttempt::Blocked);
         }
 
         // The head belongs to someone else: scan ahead for the first not-yet-claimed matching
@@ -1244,18 +1243,13 @@ impl CursorTx<'_> {
             OplogEntryLookupResult::Found { index, entry, .. } => {
                 if matches!(entry.as_ref(), OplogEntry::CompletionDelivered { .. }) {
                     self.blocked_on_completion_delivery = true;
-                    return Ok(None);
+                    return Ok(StartClaimAttempt::Blocked);
                 }
                 self.st.claimed_starts.insert(index);
                 let handle = self.register_claimed_start(index).await?;
-                Ok(Some((handle, entry)))
+                Ok(StartClaimAttempt::Claimed(handle, entry))
             }
-            OplogEntryLookupResult::NotFound { .. } => {
-                Err(WorkerExecutorError::unexpected_oplog_entry(
-                    expected(),
-                    "no matching Start between the replay cursor and the replay target".to_string(),
-                ))
-            }
+            OplogEntryLookupResult::NotFound { .. } => Ok(StartClaimAttempt::Missing),
         }
     }
 
@@ -1380,10 +1374,17 @@ impl CursorTx<'_> {
                 self.claim_start_matching_request(matches_identity, expected_request, expected)
                     .await?
             }
-            None => {
-                self.claim_start_matching(matches_identity, expected)
-                    .await?
-            }
+            None => match self.claim_start_matching(matches_identity).await? {
+                StartClaimAttempt::Claimed(handle, entry) => Some((handle, entry)),
+                StartClaimAttempt::Blocked => None,
+                StartClaimAttempt::Missing => {
+                    return Err(WorkerExecutorError::unexpected_oplog_entry(
+                        expected(),
+                        "no matching Start between the replay cursor and the replay target"
+                            .to_string(),
+                    ));
+                }
+            },
         };
         let Some((handle, entry)) = claimed else {
             return Ok(None);
@@ -1399,6 +1400,122 @@ impl CursorTx<'_> {
             handle.start_idx()
         );
         Ok(Some((handle, entry)))
+    }
+
+    /// Claims an exact scope `Start`. When `recover_missing` is set, a missing scope switches to
+    /// live mode only after proving that doing so cannot abandon another concurrent operation.
+    pub(super) async fn claim_scope_start_with_missing_recovery(
+        &mut self,
+        claim: &StartClaim,
+        recover_missing: bool,
+    ) -> Result<StartClaimAttempt, WorkerExecutorError> {
+        debug_assert!(!claim.carries_request());
+        let outcome = self
+            .claim_start_matching(|entry| {
+                matches!(entry, OplogEntry::Start {
+                    function_name,
+                    invocation_id,
+                    observational_owner,
+                    request,
+                    durable_function_type,
+                    parent_start_index,
+                    ..
+                } if claim
+                    .expected_function_name()
+                    .is_some_and(|expected| function_name == expected)
+                    && claim
+                        .expected_function_type()
+                        .is_some_and(|expected| durable_function_type == expected)
+                    && invocation_id.is_none()
+                    && observational_owner.is_none()
+                    && request.is_none()
+                    && *parent_start_index == claim.expected_parent_start_index())
+            })
+            .await?;
+        if !matches!(outcome, StartClaimAttempt::Missing) {
+            return Ok(outcome);
+        }
+        if !recover_missing {
+            return Ok(StartClaimAttempt::Missing);
+        }
+
+        if self.st.concurrent_resolver.has_any_claims()
+            || !self.st.claimed_starts.is_empty()
+            || !self.st.claimed_custom_invocation_ids.is_empty()
+            || !self.st.custom_subtrees.is_empty()
+        {
+            return Err(WorkerExecutorError::unexpected_oplog_entry(
+                claim.expected_description(),
+                "the scope Start is missing while another concurrent replay claim is active"
+                    .to_string(),
+            ));
+        }
+
+        let expected_name = claim
+            .expected_function_name()
+            .expect("a recoverable scope claim always has an exact function name");
+        let replay_target = self.cursor.replay_target();
+        let name_collision = self
+            .cursor
+            .scan_oplog(
+                OplogIndex::INITIAL,
+                replay_target.next(),
+                &self.st.skipped_regions,
+                self.st
+                    .skipped_regions
+                    .find_next_deleted_region(OplogIndex::INITIAL),
+                OplogIndex::NONE,
+                |entry, _, _| {
+                    matches!(entry, OplogEntry::Start { function_name, .. }
+                        if function_name == expected_name)
+                },
+                |_, _, _| true,
+                (),
+                |_, _, _| {},
+            )
+            .await;
+        if matches!(name_collision, OplogEntryLookupResult::Found { .. }) {
+            return Err(WorkerExecutorError::unexpected_oplog_entry(
+                claim.expected_description(),
+                "a scope Start with the same discriminator exists but cannot be claimed"
+                    .to_string(),
+            ));
+        }
+
+        let suffix_start = self.cursor.last_replayed_index().next();
+        let unsafe_suffix = self
+            .cursor
+            .scan_oplog(
+                suffix_start,
+                replay_target.next(),
+                &self.st.skipped_regions,
+                self.st
+                    .skipped_regions
+                    .find_next_deleted_region(suffix_start),
+                OplogIndex::NONE,
+                |entry, begin_idx, state| {
+                    matches!(entry, OplogEntry::CompletionDelivered { .. })
+                        || !entry.no_concurrent_side_effect(begin_idx, state)
+                },
+                |_, _, _| true,
+                ScopeScanState {
+                    root: OplogIndex::NONE,
+                    descendants: HashSet::new(),
+                    current_is_descendant_scope: false,
+                },
+                |entry, idx, state| entry.track_scope_membership(idx, state),
+            )
+            .await;
+        if matches!(unsafe_suffix, OplogEntryLookupResult::Found { .. }) {
+            return Err(WorkerExecutorError::unexpected_oplog_entry(
+                claim.expected_description(),
+                "the scope Start is missing before an unsafe concurrent side effect or delivery boundary"
+                    .to_string(),
+            ));
+        }
+
+        self.switch_to_live();
+        Ok(StartClaimAttempt::Missing)
     }
 
     /// Switches the cursor to live mode: records `ReplayFinished` if replay was still in progress,

--- a/golem-worker-executor/src/durable_host/replay_state/mod.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/mod.rs
@@ -22,7 +22,7 @@ use golem_common::model::invocation_context::InvocationContextStack;
 use golem_common::model::oplog::host_functions::HostFunctionName;
 use golem_common::model::oplog::{
     AtomicOplogIndex, DurableFunctionType, HostRequest, HostResponse, HostResponseGolemApiFork,
-    LogLevel, OplogEntry, OplogIndex, OplogPayload, OplogScopeProjection,
+    LogLevel, OplogEntry, OplogIndex, OplogPayload, OplogScopeProjection, ScopeScanState,
 };
 use golem_common::model::regions::{DeletedRegions, OplogRegion};
 use golem_common::model::{
@@ -117,6 +117,21 @@ pub struct ClaimedConcurrentStart {
     pub function_name: HostFunctionName,
     pub durable_function_type: DurableFunctionType,
     pub timestamp: Timestamp,
+}
+
+pub(crate) enum ScopeStartClaimOutcome {
+    Claimed {
+        begin_index: OplogIndex,
+        handle: ReplayCallHandle,
+    },
+    Missing,
+    MissingSwitchedToLive,
+}
+
+enum StartClaimAttempt {
+    Claimed(ReplayCallHandle, Box<OplogEntry>),
+    Blocked,
+    Missing,
 }
 
 mod abandoned;

--- a/golem-worker-executor/src/durable_host/replay_state/tests.rs
+++ b/golem-worker-executor/src/durable_host/replay_state/tests.rs
@@ -4632,6 +4632,157 @@ async fn plain_scope_claim_never_matches_discriminated_scope_start() {
 }
 
 #[test]
+async fn missing_scope_recovery_switches_live_over_benign_suffix() {
+    let rs = replay_state_over(vec![noop(), noop()]).await;
+    let scope_name = HostFunctionName::Custom("<scope:batched-write:consume-body:7>".to_string());
+
+    let outcome = rs
+        .claim_scope_start_or_recover_missing(
+            &scope_name,
+            &DurableFunctionType::WriteRemoteBatched(None),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        outcome,
+        ScopeStartClaimOutcome::MissingSwitchedToLive
+    ));
+    assert!(rs.is_live());
+}
+
+#[test]
+async fn missing_scope_presence_check_does_not_switch_live() {
+    let foreign_start = OplogEntry::Start {
+        timestamp: Timestamp::now_utc(),
+        parent_start_index: None,
+        function_name: HostFunctionName::MonotonicClockNow,
+        invocation_id: None,
+        observational_owner: None,
+        request: Some(OplogPayload::Inline(Box::new(HostRequest::NoInput(
+            HostRequestNoInput {},
+        )))),
+        durable_function_type: DurableFunctionType::ReadLocal,
+    };
+    let rs = replay_state_over(vec![noop(), foreign_start]).await;
+    let scope_name = HostFunctionName::Custom("<scope:batched-write:consume-body:7>".to_string());
+
+    let outcome = rs
+        .claim_scope_start_if_present(
+            &scope_name,
+            &DurableFunctionType::WriteRemoteBatched(None),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(matches!(outcome, ScopeStartClaimOutcome::Missing));
+    assert!(!rs.is_live());
+}
+
+#[test]
+async fn existing_scope_claim_does_not_wait_for_missing_scope_recovery_readiness() {
+    let scope_name = HostFunctionName::Custom("<scope:batched-write:consume-body:7>".to_string());
+    let scope_start = OplogEntry::Start {
+        timestamp: Timestamp::now_utc(),
+        parent_start_index: None,
+        function_name: scope_name.clone(),
+        invocation_id: None,
+        observational_owner: None,
+        request: None,
+        durable_function_type: DurableFunctionType::WriteRemoteBatched(None),
+    };
+    let rs = replay_state_over(vec![noop(), scope_start, batched_scope_end(2)]).await;
+
+    let outcome = rs
+        .claim_scope_start_or_recover_missing_when_ready(
+            &scope_name,
+            &DurableFunctionType::WriteRemoteBatched(None),
+            None,
+            async { panic!("recovery readiness must not be polled for an existing scope") },
+        )
+        .await
+        .unwrap();
+
+    let ScopeStartClaimOutcome::Claimed {
+        begin_index,
+        handle,
+    } = outcome
+    else {
+        panic!("expected the existing scope to be claimed")
+    };
+    assert_eq!(begin_index, OplogIndex::from_u64(2));
+    assert!(matches!(
+        rs.await_resolution_outcome(handle).await.unwrap(),
+        ResolutionOutcome::Resolved(Resolution::Completed { .. })
+    ));
+    assert!(rs.is_live());
+}
+
+#[test]
+async fn missing_scope_recovery_rejects_foreign_remote_write() {
+    let foreign_write = OplogEntry::Start {
+        timestamp: Timestamp::now_utc(),
+        parent_start_index: None,
+        function_name: HostFunctionName::MonotonicClockNow,
+        invocation_id: None,
+        observational_owner: None,
+        request: Some(OplogPayload::Inline(Box::new(HostRequest::NoInput(
+            HostRequestNoInput {},
+        )))),
+        durable_function_type: DurableFunctionType::WriteRemote,
+    };
+    let rs = replay_state_over(vec![noop(), foreign_write]).await;
+    let scope_name = HostFunctionName::Custom("<scope:batched-write:consume-body:7>".to_string());
+
+    let result = rs
+        .claim_scope_start_or_recover_missing(
+            &scope_name,
+            &DurableFunctionType::WriteRemoteBatched(None),
+            None,
+        )
+        .await;
+    let error = match result {
+        Ok(_) => panic!("a foreign remote write must prevent missing-scope recovery"),
+        Err(error) => error,
+    };
+
+    assert!(format!("{error}").contains("unsafe concurrent side effect"));
+    assert!(!rs.is_live());
+}
+
+#[test]
+async fn missing_scope_recovery_rejects_discriminator_collision() {
+    let scope_name = HostFunctionName::Custom("<scope:batched-write:consume-body:7>".to_string());
+    let conflicting_start = OplogEntry::Start {
+        timestamp: Timestamp::now_utc(),
+        parent_start_index: None,
+        function_name: scope_name.clone(),
+        invocation_id: None,
+        observational_owner: None,
+        request: None,
+        durable_function_type: DurableFunctionType::ReadLocal,
+    };
+    let rs = replay_state_over(vec![noop(), conflicting_start]).await;
+
+    let result = rs
+        .claim_scope_start_or_recover_missing(
+            &scope_name,
+            &DurableFunctionType::WriteRemoteBatched(None),
+            None,
+        )
+        .await;
+    let error = match result {
+        Ok(_) => panic!("a same-name scope Start must not be treated as absent"),
+        Err(error) => error,
+    };
+
+    assert!(format!("{error}").contains("same discriminator exists"));
+    assert!(!rs.is_live());
+}
+
+#[test]
 async fn entity_owned_scope_claim_requires_the_recorded_parent() {
     let parent = OplogIndex::from_u64(7);
     let scope_start = OplogEntry::Start {

--- a/golem-worker-executor/tests/api.rs
+++ b/golem-worker-executor/tests/api.rs
@@ -4453,6 +4453,10 @@ async fn invocation_queue_is_persistent(
 
     let response = Arc::new(Mutex::new("initial".to_string()));
     let response_clone = response.clone();
+    let first_poll_release = Arc::new(tokio::sync::Semaphore::new(0));
+    let first_poll_release_clone = first_poll_release.clone();
+    let (first_poll_entered_tx, first_poll_entered_rx) = tokio::sync::oneshot::channel();
+    let first_poll_entered_tx = Arc::new(Mutex::new(Some(first_poll_entered_tx)));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
 
@@ -4462,9 +4466,18 @@ async fn invocation_queue_is_persistent(
         async move {
             let route = Router::new().route(
                 "/poll",
-                get(move || async move {
-                    let body = response_clone.lock().unwrap();
-                    body.clone()
+                get(move || {
+                    let first_poll_release = first_poll_release_clone.clone();
+                    let first_poll_entered_tx = first_poll_entered_tx.clone();
+                    async move {
+                        let first_poll = first_poll_entered_tx.lock().unwrap().take();
+                        if let Some(entered) = first_poll {
+                            let _ = entered.send(());
+                            let permit = first_poll_release.acquire().await.unwrap();
+                            permit.forget();
+                        }
+                        response_clone.lock().unwrap().clone()
+                    }
                 }),
             );
 
@@ -4491,9 +4504,7 @@ async fn invocation_queue_is_persistent(
         .invoke_agent(&component, &agent_id, "start_polling", data_value!("done"))
         .await?;
 
-    executor
-        .wait_for_status(&worker_id, AgentStatus::Running, Duration::from_secs(10))
-        .await?;
+    tokio::time::timeout(Duration::from_secs(10), first_poll_entered_rx).await??;
 
     executor
         .invoke_agent(&component, &agent_id, "increment", data_value!())
@@ -4506,6 +4517,17 @@ async fn invocation_queue_is_persistent(
     executor
         .invoke_agent(&component, &agent_id, "increment", data_value!())
         .await?;
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let metadata = executor.get_worker_metadata(&worker_id).await?;
+            if metadata.pending_invocation_count == 3 {
+                break Ok::<(), WorkerExecutorError>(());
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await??;
 
     executor.interrupt(&worker_id).await?;
 
@@ -4515,22 +4537,18 @@ async fn invocation_queue_is_persistent(
 
     executor.check_oplog_is_queryable(&worker_id).await?;
 
+    {
+        let mut response = response.lock().unwrap();
+        *response = "done".to_string();
+    }
+    first_poll_release.add_permits(1);
+
     drop(executor);
     let executor = start(deps, &context).await?;
 
     executor
         .invoke_agent(&component, &agent_id, "increment", data_value!())
         .await?;
-
-    // executor.log_output(&worker_id).await?;
-
-    executor
-        .wait_for_status(&worker_id, AgentStatus::Running, Duration::from_secs(10))
-        .await?;
-    {
-        let mut response = response.lock().unwrap();
-        *response = "done".to_string();
-    }
 
     let result = executor
         .invoke_and_await_agent(&component, &agent_id, "get_count", data_value!())

--- a/golem-worker-executor/tests/http.rs
+++ b/golem-worker-executor/tests/http.rs
@@ -1336,6 +1336,316 @@ async fn drive_gated_body_discard_round(
     Ok(())
 }
 
+/// A restart after the send completed but before its spawned consume-body task committed the scope
+/// `Start` must safely re-issue an idempotent request and continue the recorded invocation.
+#[test]
+#[tracing::instrument]
+async fn outgoing_http_recovers_missing_consume_body_scope_start(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const RESPONSE: &str = "recovered-body";
+
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let host_http_port = listener.local_addr()?.port();
+    let http_server = spawn({
+        let request_count = request_count.clone();
+        async move {
+            let route = Router::new().route(
+                "/",
+                axum::routing::get(move || {
+                    let request_count = request_count.clone();
+                    async move {
+                        request_count.fetch_add(1, Ordering::SeqCst);
+                        RESPONSE
+                    }
+                }),
+            );
+            axum::serve(listener, route).await.unwrap();
+        }
+        .in_current_span()
+    });
+
+    let component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+    let mut env = HashMap::new();
+    env.insert("PORT".to_string(), host_http_port.to_string());
+    let agent_id = agent_id!("HttpClient4");
+    let worker_id = executor
+        .start_agent_with(&component.id, agent_id.clone(), env, Vec::new())
+        .await?;
+    let key = IdempotencyKey::fresh();
+    let mut gate = executor
+        .gate_next_consume_body_scope_start(&worker_id)
+        .await;
+
+    executor
+        .invoke_agent_with_key(&component, &agent_id, &key, "get_idempotent", data_value!())
+        .await?;
+    timeout(Duration::from_secs(20), gate.reached()).await?;
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+    let before_restart = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    assert_eq!(
+        partition_starts(&before_restart, "http::client::send").counts(),
+        (0, 1, 0)
+    );
+    assert_eq!(
+        partition_starts(&before_restart, "http::types::response::consume-body").counts(),
+        (0, 0, 0)
+    );
+
+    gate.abort_append();
+    drop(gate);
+    drop(executor);
+    let executor = start(deps, &context).await?;
+    let result = timeout(
+        Duration::from_secs(60),
+        executor.invoke_and_await_agent_with_key(
+            &component,
+            &agent_id,
+            &key,
+            "get_idempotent",
+            data_value!(),
+        ),
+    )
+    .await??
+    .into_typed::<String>()?;
+
+    assert_eq!(result, format!("200 {RESPONSE}"));
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        2,
+        "recovery must perform exactly one body re-issue"
+    );
+    let oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    assert_eq!(
+        partition_starts(&oplog, "http::client::send").counts(),
+        (0, 1, 0),
+        "the body re-issue must not record a second guest-visible send"
+    );
+    assert_eq!(
+        partition_starts(&oplog, "http::types::response::consume-body").counts(),
+        (0, 1, 0)
+    );
+    executor.check_oplog_is_queryable(&worker_id).await?;
+
+    drop(executor);
+    http_server.abort();
+    Ok(())
+}
+
+/// The same missing-scope crash window must never duplicate a non-idempotent POST.
+#[test]
+#[tracing::instrument]
+async fn outgoing_http_does_not_reissue_non_idempotent_missing_consume_body_scope(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let host_http_port = listener.local_addr()?.port();
+    let http_server = spawn({
+        let request_count = request_count.clone();
+        async move {
+            let route = Router::new().route(
+                "/",
+                post(move |body: Bytes| {
+                    let request_count = request_count.clone();
+                    async move {
+                        assert_eq!(body, Bytes::from_static(b"test-body"));
+                        request_count.fetch_add(1, Ordering::SeqCst);
+                        "post-response"
+                    }
+                }),
+            );
+            axum::serve(listener, route).await.unwrap();
+        }
+        .in_current_span()
+    });
+
+    let component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+    let mut env = HashMap::new();
+    env.insert("PORT".to_string(), host_http_port.to_string());
+    let agent_id = agent_id!("HttpClient4");
+    let worker_id = executor
+        .start_agent_with(&component.id, agent_id.clone(), env, Vec::new())
+        .await?;
+    let key = IdempotencyKey::fresh();
+    let mut gate = executor
+        .gate_next_consume_body_scope_start(&worker_id)
+        .await;
+
+    executor
+        .invoke_agent_with_key(
+            &component,
+            &agent_id,
+            &key,
+            "post_non_idempotent",
+            data_value!(),
+        )
+        .await?;
+    timeout(Duration::from_secs(20), gate.reached()).await?;
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+    gate.abort_append();
+    drop(gate);
+    drop(executor);
+
+    let executor = start(deps, &context).await?;
+    let invocation = spawn({
+        let executor = executor.clone();
+        let component = component.clone();
+        let agent_id = agent_id.clone();
+        async move {
+            executor
+                .invoke_and_await_agent_with_key(
+                    &component,
+                    &agent_id,
+                    &key,
+                    "post_non_idempotent",
+                    data_value!(),
+                )
+                .await
+        }
+        .in_current_span()
+    });
+    executor
+        .wait_for_status(&worker_id, AgentStatus::Retrying, Duration::from_secs(20))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        1,
+        "a non-idempotent request must not be re-issued"
+    );
+    invocation.abort();
+    let _ = invocation.await;
+
+    drop(executor);
+    http_server.abort();
+    Ok(())
+}
+
+/// Missing-scope recovery must refuse instead of deadlocking or resending when the guest keeps
+/// its request body open until it can read the response body.
+#[test]
+#[tracing::instrument]
+async fn outgoing_http_missing_consume_scope_refuses_full_duplex_body_cycle(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let host_http_port = listener.local_addr()?.port();
+    let http_server = spawn({
+        let request_count = request_count.clone();
+        async move {
+            let route = Router::new().route(
+                "/early-response",
+                axum::routing::put(move || {
+                    let request_count = request_count.clone();
+                    async move {
+                        request_count.fetch_add(1, Ordering::SeqCst);
+                        "early-body"
+                    }
+                }),
+            );
+            axum::serve(listener, route).await.unwrap();
+        }
+        .in_current_span()
+    });
+
+    let component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+    let mut env = HashMap::new();
+    env.insert("PORT".to_string(), host_http_port.to_string());
+    let agent_id = agent_id!("HttpClient4");
+    let worker_id = executor
+        .start_agent_with(&component.id, agent_id.clone(), env, Vec::new())
+        .await?;
+    let key = IdempotencyKey::fresh();
+    let mut gate = executor
+        .gate_next_consume_body_scope_start(&worker_id)
+        .await;
+
+    executor
+        .invoke_agent_with_key(
+            &component,
+            &agent_id,
+            &key,
+            "put_with_p3_body_open_until_response_read",
+            data_value!(),
+        )
+        .await?;
+    timeout(Duration::from_secs(20), gate.reached()).await?;
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+    gate.abort_append();
+    drop(gate);
+    drop(executor);
+
+    let executor = start(deps, &context).await?;
+    let invocation = spawn({
+        let executor = executor.clone();
+        let component = component.clone();
+        let agent_id = agent_id.clone();
+        async move {
+            executor
+                .invoke_and_await_agent_with_key(
+                    &component,
+                    &agent_id,
+                    &key,
+                    "put_with_p3_body_open_until_response_read",
+                    data_value!(),
+                )
+                .await
+        }
+        .in_current_span()
+    });
+    executor
+        .wait_for_status(&worker_id, AgentStatus::Retrying, Duration::from_secs(20))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        1,
+        "full-duplex recovery refusal must not re-issue the request"
+    );
+    invocation.abort();
+    let _ = invocation.await;
+
+    drop(executor);
+    http_server.abort();
+    Ok(())
+}
+
 /// A response-body chunk whose durable `End(Data)` is already persisted when
 /// the guest drops the body reader must not be delivered — live or on replay.
 /// The test pauses the consume-body producer between the chunk's durable `End`

--- a/golem-worker-executor/tests/http.rs
+++ b/golem-worker-executor/tests/http.rs
@@ -1444,6 +1444,172 @@ async fn outgoing_http_recovers_missing_consume_body_scope_start(
     Ok(())
 }
 
+/// A restart after the consume-body scope `Start` and some chunk children committed, but before
+/// the scope `End` did (a crash mid-response-body-stream), must jump the incomplete scope to live
+/// and safely re-issue the idempotent request instead of failing the replay.
+#[test]
+#[tracing::instrument]
+async fn outgoing_http_reissues_incomplete_consume_body_scope_after_restart(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    _tracing: &Tracing,
+    #[tagged_as("http_tests")] http_tests: &PrecompiledComponent,
+) -> anyhow::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const BODY_FIRST: &[u8] = b"streamed";
+    const BODY_REST: &[u8] = b"-body";
+    const RESPONSE: &str = "streamed-body";
+
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let host_http_port = listener.local_addr()?.port();
+    let (first_chunk_tx, mut first_chunk_rx) = mpsc::unbounded_channel();
+    let rest_release = Arc::new(tokio::sync::Semaphore::new(0));
+
+    let http_server = spawn({
+        let request_count = request_count.clone();
+        let rest_release = rest_release.clone();
+        async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let request_count = request_count.clone();
+                let rest_release = rest_release.clone();
+                let first_chunk_tx = first_chunk_tx.clone();
+                spawn(
+                    async move {
+                        let result = async {
+                            let request = read_request_headers(&mut stream).await?;
+                            anyhow::ensure!(
+                                request.starts_with(b"GET / "),
+                                "unexpected request: {}",
+                                String::from_utf8_lossy(&request)
+                            );
+                            let count = request_count.fetch_add(1, Ordering::SeqCst) + 1;
+                            stream
+                                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 13\r\n\r\n")
+                                .await?;
+                            if count == 1 {
+                                // Trickle the body in two flushes so at least one chunk's
+                                // durable record forces the scope `Start` to become durable
+                                // before the gated scope `End`. (The two flushes do not
+                                // guarantee two distinct recorded chunks; the parent-scope
+                                // shape asserted below does not depend on chunk count.)
+                                stream.write_all(BODY_FIRST).await?;
+                                stream.flush().await?;
+                                let _ = first_chunk_tx.send(Ok(()));
+                                let _permit = rest_release.acquire().await?;
+                                stream.write_all(BODY_REST).await?;
+                            } else {
+                                stream.write_all(BODY_FIRST).await?;
+                                stream.write_all(BODY_REST).await?;
+                            }
+                            stream.flush().await?;
+                            Ok(())
+                        }
+                        .await;
+                        if let Err(error) = result {
+                            let _ = first_chunk_tx.send(Err(error));
+                        }
+                    }
+                    .in_current_span(),
+                );
+            }
+        }
+        .in_current_span()
+    });
+
+    let component = executor
+        .component_dep(&context.default_environment_id, http_tests)
+        .store()
+        .await?;
+    let mut env = HashMap::new();
+    env.insert("PORT".to_string(), host_http_port.to_string());
+    let agent_id = agent_id!("HttpClient4");
+    let worker_id = executor
+        .start_agent_with(&component.id, agent_id.clone(), env, Vec::new())
+        .await?;
+    let key = IdempotencyKey::fresh();
+    let mut gate = executor.gate_next_consume_body_scope_end(&worker_id).await;
+
+    executor
+        .invoke_agent_with_key(&component, &agent_id, &key, "get_idempotent", data_value!())
+        .await?;
+    recv_request_event(&mut first_chunk_rx).await?;
+    rest_release.add_permits(1);
+    timeout(Duration::from_secs(20), gate.reached()).await?;
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+    let before_restart = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    assert_eq!(
+        partition_starts(&before_restart, "http::client::send").counts(),
+        (0, 1, 0)
+    );
+    assert_eq!(
+        partition_starts(&before_restart, "http::types::response::consume-body").counts(),
+        (0, 0, 1),
+        "the consume-body scope must have a committed Start but no End before the crash"
+    );
+
+    gate.abort_append();
+    drop(gate);
+    drop(executor);
+    let executor = start(deps, &context).await?;
+    let result = timeout(
+        Duration::from_secs(60),
+        executor.invoke_and_await_agent_with_key(
+            &component,
+            &agent_id,
+            &key,
+            "get_idempotent",
+            data_value!(),
+        ),
+    )
+    .await??
+    .into_typed::<String>()?;
+
+    assert_eq!(result, format!("200 {RESPONSE}"));
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        2,
+        "recovery must perform exactly one body re-issue"
+    );
+    let oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    assert_eq!(
+        partition_starts(&oplog, "http::client::send").counts(),
+        (0, 1, 0),
+        "the body re-issue must not record a second guest-visible send"
+    );
+    let bodies = partition_starts(&oplog, "http::types::response::consume-body");
+    assert_eq!(
+        bodies.counts(),
+        (0, 1, 1),
+        "the re-issued live consume-body must complete with an End, while the pre-crash \
+         Start stays physically recorded inside the jumped region: {bodies:?}"
+    );
+    let jump_regions: Vec<_> = oplog
+        .iter()
+        .filter_map(|entry| match &entry.entry {
+            golem_common::model::oplog::PublicOplogEntry::Jump(params) => Some(params.jump.clone()),
+            _ => None,
+        })
+        .collect();
+    let incomplete_start = bodies.incomplete[0];
+    assert!(
+        jump_regions
+            .iter()
+            .any(|region| region.contains(incomplete_start)),
+        "the incomplete pre-crash consume-body Start at {incomplete_start} must be covered \
+         by a Jump's deleted region so it is skipped on any later replay: {jump_regions:?}"
+    );
+    executor.check_oplog_is_queryable(&worker_id).await?;
+
+    drop(executor);
+    http_server.abort();
+    Ok(())
+}
+
 /// The same missing-scope crash window must never duplicate a non-idempotent POST.
 #[test]
 #[tracing::instrument]

--- a/test-components/http-tests/Cargo.lock
+++ b/test-components/http-tests/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +83,20 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+ "rayon-core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -131,10 +151,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "ctor"
@@ -451,6 +511,7 @@ dependencies = [
  "base64",
  "bigdecimal",
  "bit-vec",
+ "blake3",
  "chrono",
  "combine",
  "golem-schema-derive",
@@ -966,6 +1027,16 @@ dependencies = [
  "itertools",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/test-components/http-tests/src/http_client_4.rs
+++ b/test-components/http-tests/src/http_client_4.rs
@@ -21,6 +21,10 @@ pub trait HttpClient4 {
     /// while awaiting response headers.
     async fn put_with_p3_small_body_open_until_response(&self) -> String;
 
+    /// Sends a raw wasip3 PUT request and keeps the body stream open until the first
+    /// response-body read completes.
+    async fn put_with_p3_body_open_until_response_read(&self) -> String;
+
     /// Sends a raw wasip3 PUT request with a declared small content-length but keeps the
     /// body stream open while awaiting response headers.
     async fn put_with_p3_declared_small_body_open_until_response(&self) -> String;
@@ -169,6 +173,10 @@ impl HttpClient4 for HttpClient4Impl {
 
     async fn put_with_p3_small_body_open_until_response(&self) -> String {
         do_put_with_p3_small_body_open_until_response().await
+    }
+
+    async fn put_with_p3_body_open_until_response_read(&self) -> String {
+        do_put_with_p3_body_open_until_response_read().await
     }
 
     async fn put_with_p3_declared_small_body_open_until_response(&self) -> String {
@@ -986,6 +994,65 @@ async fn do_put_with_p3_small_body_open_until_response() -> String {
     };
 
     (send, hold_body_open).race().await
+}
+
+async fn do_put_with_p3_body_open_until_response_read() -> String {
+    use futures_concurrency::prelude::*;
+    use golem_rust::wasip3::http::{client, types};
+    use golem_rust::wasip3::wit_bindgen::StreamResult;
+    use golem_rust::wasip3::{wit_future, wit_stream};
+
+    let port = std::env::var("PORT").unwrap_or("9999".to_string());
+    let headers =
+        types::Fields::from_list(&[("x-test".to_string(), b"open-until-response-read".to_vec())])
+            .unwrap();
+    let (mut body_tx, body_rx) = wit_stream::new();
+    let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+    let (request, transmit) = types::Request::new(headers, Some(body_rx), trailers_rx, None);
+    request.set_method(&types::Method::Put).unwrap();
+    request.set_scheme(Some(&types::Scheme::Http)).unwrap();
+    request
+        .set_authority(Some(&format!("localhost:{port}")))
+        .unwrap();
+    request
+        .set_path_with_query(Some("/early-response"))
+        .unwrap();
+
+    let (send_result, remaining) = (async { client::send(request).await }, async {
+        body_tx.write_all(b"hello".to_vec()).await
+    })
+        .join()
+        .await;
+    assert!(remaining.is_empty(), "request body receiver closed early");
+
+    let response = send_result.expect("Request failed");
+    let status = response.get_status_code();
+    let (response_done_tx, response_done_rx) = wit_future::new(|| Ok(()));
+    let (mut body, response_trailers) = types::Response::consume_body(response, response_done_rx);
+    let (read_result, buffer) = body.read(Vec::with_capacity(1024)).await;
+    let response_bytes = match read_result {
+        StreamResult::Complete(len) => buffer[..len].to_vec(),
+        StreamResult::Dropped => Vec::new(),
+        StreamResult::Cancelled => panic!("response body read was cancelled"),
+    };
+
+    drop(body_tx);
+    trailers_tx
+        .write(Ok(None))
+        .await
+        .expect("failed to finish request trailers");
+    let transmit_result = transmit.await;
+    drop(body);
+    response_trailers.await.expect("response trailers failed");
+    response_done_tx
+        .write(Ok(()))
+        .await
+        .expect("failed to acknowledge response body");
+
+    format!(
+        "{status} {} transmit={transmit_result:?}",
+        String::from_utf8_lossy(&response_bytes)
+    )
 }
 
 async fn do_put_with_p3_declared_small_body_open_until_response() -> String {


### PR DESCRIPTION
## Problem

The failure in [GitHub Actions run 33170218282, job 98848659586](https://github.com/golemcloud/golem/actions/runs/33170218282/job/98848659586) exposed a valid production interruption window in P3 outgoing HTTP replay.

The outgoing `client::send` result (including the response status and headers) can become durable before the separately spawned response `consume-body` task appends its synthetic batched-write scope `Start`. If the executor is interrupted or the process is lost in that window, the oplog contains the completed send but no scope for the response-body continuation.

On replay:

1. `client::send` returns the recorded response head with a placeholder body.
2. The deterministic guest calls `response.consume-body` again.
3. Replay tries to claim the exact discriminated scope, such as `<scope:batched-write:consume-body:39>`.
4. No matching `Start` exists before the replay target, so replay reports structural divergence rather than completing the invocation.

Using the exact component artifact from the failing CI run reproduced that signature immediately. Repeating the original test before the fix produced 3 failures in 10 runs.

The failing `invocation_queue_is_persistent` test also had an independent synchronization weakness. `AgentStatus::Running` only showed that the worker was executing; it did not prove that the first `/poll` request had reached a controlled blocking point or that all three `increment` invocations were durably represented in the pending queue before interruption. The production fix addresses the observed replay failure, but the queue test still needed deterministic coordination.

## Solution

### Recover an exactly identified missing scope

The concurrent replay API now supports a narrowly scoped missing-`Start` recovery policy.

Recovery first attempts to claim the exact scope by its deterministic discriminator, durable function type, parent, ownership, and empty scope request. Existing scopes always win before any recovery readiness check is polled. This preserves normal replay for completed scopes and avoids waiting on request-body production unnecessarily.

If the exact scope is absent, replay only transitions to live after atomically revalidating that:

- there are no active concurrent replay claims;
- no scope with the same discriminator exists elsewhere in the replayable oplog;
- no completion-delivery boundary would be crossed;
- the remaining suffix contains no unsafe concurrent side effect; and
- recovery is not nested in an atomic, observational, or entity-owned scope.

After those checks, replay switches to live, appends the missing synthetic scope `Start`, switches linear memory to live, and reattaches worker status. Existing-but-incomplete scopes are deliberately not authorized by this policy; only a genuinely absent `Start` can use it.

### Reissue only when HTTP recovery is safe

A replayed placeholder response enables missing-scope recovery only when the request is effectively idempotent. Non-idempotent requests use a forbidden policy and fail without another physical request.

A physical reissue also requires a proven reconstructable request body:

- replay fully drains the deterministically reproduced guest request body;
- recorded frames are merged by byte offset because their concurrent appends may land out of order;
- missing coverage is healed from the reproduced body;
- an already recorded `End` is not treated as proof that earlier independent frame appends succeeded;
- scan, append, snapshot, cancellation, or guest-body failures make recovery ineligible; and
- a final rescan verifies a clean terminal, exact contiguous length, no bytes beyond the reproduced length, and matching trailer presence.

The reissue is recovery of the recorded send, not a second guest-visible host call: it writes no new send entry, starts no new span, and does not count against HTTP call limits. The recorded response status and headers remain authoritative; the fresh request supplies only a replacement response body. A differing fresh status is logged but not exposed to the guest.

### Avoid full-duplex recovery cycles

A replayed upload can be genuinely full duplex: the guest may keep producing the request body only after it reads the response body. Waiting for the complete request-body proof before starting the recovered response-body scope would then deadlock.

The replay drain now publishes whether it is actually blocked waiting for more guest request-body data. Recovery refuses promptly only when that state overlaps with guest response-body demand. Response demand by itself is not an error, so an empty GET whose terminal frame is merely waiting on storage can still finish validation and recover.

### Make the queue test deterministic

`invocation_queue_is_persistent` now:

1. blocks the first `/poll` request before responding;
2. waits until the handler has definitely been entered;
3. submits the three increments;
4. polls worker metadata until `pending_invocation_count == 3`;
5. interrupts the worker;
6. changes the response to `done` and releases the handler; and
7. restarts the executor, adds a fourth increment, and verifies the final count is four.

This tests the intended persistence boundary directly instead of using `Running` as a proxy.

## Regression coverage

A one-shot test oplog gate pauses immediately before the underlying append of the next discriminated P3 consume-body scope `Start`. Its abort mode leaves that append permanently pending, so dropping the executor deterministically models process loss without writing the `Start`.

New integration coverage verifies:

- an idempotent GET recovers from the exact missing-scope window with exactly one physical reissue, one guest-visible send, and one completed consume-body scope;
- a non-idempotent POST is never duplicated; and
- a full-duplex PUT whose request body stays open until the first response-body read is refused promptly without deadlock or reissue.

Unit regressions additionally cover discriminator collisions, unsafe replay suffixes, claim-before-readiness ordering, existing incomplete scopes, old `End` entries hiding body gaps, failed gap healing, and the distinction between guest-body blocking and storage-only validation.

## Verification

Before the fix:

- exact CI artifact / original test: **3 failures in 10 repeated runs**

After the fix, on the final revision:

- idempotent missing-scope recovery: **10/10 passed**
- non-idempotent refusal: **5/5 passed**
- full-duplex refusal: **10/10 passed**
- original `api::invocation_queue_is_persistent --exact`: **20/20 passed**

Additional checks:

```text
cargo test -p golem-worker-executor --lib -- replay_drain_ --report-time
cargo test -p golem-worker-executor --lib -- missing_scope_ --report-time
cargo test -p golem-worker-executor --lib -- existing_scope_claim_does_not_wait --report-time
cargo test -p golem-worker-executor --lib -- reexecute_policy_does_not_authorize --report-time
cargo check -p golem-worker-executor --lib
cargo clippy -p golem-worker-executor -p golem-worker-executor-test-utils --all-targets -- --no-deps -Dwarnings
cargo fmt --all -- --check
git diff --check
```

The targeted HTTP test component was rebuilt before running the integration tests. Repository-wide worker/integration suites are left to CI.
