### PR TITLE
Clean benchmark object store before Amp orb runs

### DIFF
--- a/integration-tests/benchmark_suites/run_orb_nightly.sh
+++ b/integration-tests/benchmark_suites/run_orb_nightly.sh
@@ -65,6 +65,7 @@ else
     export GOLEM_BENCHMARK_RESULTS_PATH="$results"
 
     cargo clean
+    rm -rf /tmp/ittest-local-object-store
 
     mapfile -t postgres_containers < <(
         docker ps --all --quiet --filter ancestor=postgres:17.7


### PR DESCRIPTION
## Summary
- remove the shared integration-test object store before each nightly benchmark run
- prevent artifacts from prior runs from exhausting the Amp orb disk

## Validation
- `bash -n integration-tests/benchmark_suites/run_orb_nightly.sh`
- `git diff --check`