### PR TITLE
Optimize Amp orb setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,12 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+setup_started=$SECONDS
+step_started=$SECONDS
+step_name=""
+
+start_step() {
+    if [[ -n "$step_name" ]]; then
+        printf '<== %s (%ss)\n' "$step_name" "$((SECONDS - step_started))"
+    fi
+    step_name="$1"
+    step_started=$SECONDS
+    printf '==> %s\n' "$step_name"
+}
+
+start_step "Install system packages"
+
 packages=(
     build-essential
     clang
     cmake
     curl
-    docker.io
     jq
     libssl-dev
     lld
@@ -22,21 +36,32 @@ for package in "${packages[@]}"; do
         missing_packages+=("$package")
     fi
 done
+if ! command -v dockerd >/dev/null 2>&1; then
+    missing_packages+=(docker.io)
+fi
 
 if ((${#missing_packages[@]})); then
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing_packages[@]}"
 fi
 
+start_step "Install Rust toolchain"
+
+export PATH="$HOME/.cargo/bin:$PATH"
+rustup_installed=false
 if ! command -v rustup >/dev/null 2>&1; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+    rustup_installed=true
 fi
-export PATH="$HOME/.cargo/bin:$PATH"
 
-rustup update stable --no-self-update
+if [[ "$rustup_installed" == false ]]; then
+    rustup update stable --no-self-update
+fi
 rustup default stable
 rustup component add clippy rustfmt
 rustup target add wasm32-wasip1 wasm32-wasip2
+
+start_step "Install Rust development tools"
 
 if ! command -v cargo-binstall >/dev/null 2>&1; then
     curl --proto '=https' --tlsv1.2 -sSfL \
@@ -44,8 +69,11 @@ if ! command -v cargo-binstall >/dev/null 2>&1; then
 fi
 
 if ! cargo make --version 2>/dev/null | grep -q 'cargo-make 0.37.24'; then
-    cargo install --force --locked cargo-make --version 0.37.24
+    cargo binstall --force --locked --no-confirm --disable-telemetry \
+        --targets x86_64-unknown-linux-musl cargo-make@0.37.24
 fi
+
+start_step "Install Node.js and pnpm"
 
 node_version="24.19.0"
 node_home="/opt/node24"
@@ -65,6 +93,8 @@ if ! pnpm --version 2>/dev/null | grep -q '^11\.22\.0$'; then
     sudo "$node_home/bin/npm" install --global pnpm@11.22.0
 fi
 
+start_step "Install WASI SDK"
+
 if [[ ! -f /opt/wasi-sdk/VERSION ]] || ! grep -q '^25\.0$' /opt/wasi-sdk/VERSION; then
     wasi_archive="$(mktemp)"
     curl -sSfL \
@@ -76,17 +106,20 @@ if [[ ! -f /opt/wasi-sdk/VERSION ]] || ! grep -q '^25\.0$' /opt/wasi-sdk/VERSION
     rm -f "$wasi_archive"
 fi
 
+start_step "Install WebAssembly development tools"
+
 wasm_rquickjs_version="$(awk -F'"' '/^[[:space:]]*WASM_RQUICKJS_VERSION: / { print $2; exit }' .github/workflows/benchmark.yaml)"
 if [[ -z "$wasm_rquickjs_version" ]]; then
     echo "Failed to read WASM_RQUICKJS_VERSION from .github/workflows/benchmark.yaml" >&2
     exit 1
 fi
 if [[ "$(wasm-rquickjs --version 2>/dev/null || true)" != "wasm-rquickjs-cli $wasm_rquickjs_version" ]]; then
-    cargo binstall --force --locked "wasm-rquickjs-cli@$wasm_rquickjs_version"
+    cargo binstall --force --locked --no-confirm --disable-telemetry \
+        "wasm-rquickjs-cli@$wasm_rquickjs_version"
 fi
 
 if ! cargo component --version 2>/dev/null | grep -q '0.21.1'; then
-    cargo binstall --force cargo-component@0.21.1
+    cargo binstall --force --no-confirm --disable-telemetry cargo-component@0.21.1
 fi
 
 profile_marker="# Golem Amp orb toolchain"
@@ -101,4 +134,9 @@ export WASI_SDK_PATH=/opt/wasi-sdk
 EOF
 fi
 
+start_step "Start orb services"
+
 amp orb services ensure
+
+printf '<== %s (%ss)\n' "$step_name" "$((SECONDS - step_started))"
+printf 'Setup completed in %ss\n' "$((SECONDS - setup_started))"


### PR DESCRIPTION
## Summary

- avoid installing Debian's `docker.io` when the orb already provides `dockerd`
- make Rust tool detection idempotent and skip the redundant update after a fresh rustup install
- install a compatible static `cargo-make` binary instead of compiling it from source
- make binary installs noninteractive and add per-stage setup timing

## Verification

- `bash -n .agents/setup .agents/resume`
- `git diff --check`
- fresh diagnostic-orb setup completed in 62s
- repeated warm setup completed in about 2s
- `.agents/resume` completed in 0.74s
- verified pinned Rust, Node.js, pnpm, WASI SDK, wasm-rquickjs, cargo-component, and cargo-make versions