### PR TITLE
Review fixes for agent instructions improvements

### DIFF
--- a/.agents/skills/db-migration-scripts/SKILL.md
+++ b/.agents/skills/db-migration-scripts/SKILL.md
@@ -19,8 +19,41 @@ when one of these already owns the table.
 ## PostgreSQL and SQLite
 
 Every schema change must be implemented for **both** PostgreSQL and SQLite. Add matching files to
-the owning `postgres/` and `sqlite/` directories with the same numbered prefix and filename. Use
-the appropriate SQL dialect for each database; do not assume PostgreSQL DDL is accepted by SQLite.
+the owning `postgres/` and `sqlite/` directories with the same numbered prefix and filename. Do not
+assume PostgreSQL DDL is accepted by SQLite.
+
+By default, prefer one schema shape for both engines — column types included — so that a single SQL
+string can serve both. This is a preference, not a requirement. Some roots deliberately diverge
+because the two engines play genuinely different roles there. The deciding question is whether that
+root's query layer is shared:
+
+| Migration root | Query layer | Convention |
+|---|---|---|
+| `golem-registry-service/db/migration/` | one impl expanded per backend by `#[trait_gen(PostgresPool -> PostgresPool, SqlitePool)]` | converge by default |
+| `golem-shard-manager/db/migration/` | same `trait_gen` pattern (`src/quota/quota_repo.rs`, `src/sharding/persistence.rs`) | converge by default |
+| `golem-worker-executor/db/migration/{indexed,keyvalue,scheduler}/` | separate `postgres.rs` / `sqlite.rs` under `src/storage/<subsystem>/` (alongside `multi_sqlite.rs`, `redis.rs`, `memory.rs`) | diverge where the engine calls for it |
+
+### Shared-query roots
+
+In the registry service and shard manager, each SQL literal is written once and expanded for both
+pools, so a divergent schema would force the query layer to be split per dialect. Keep the resulting
+schema identical whenever possible. SQLite's type affinity accepts `UUID`, `TIMESTAMP`, `BIGINT`,
+`BYTEA`, and `NUMERIC` verbatim, so use them in both. Reach for an engine-specific type
+(`BIGSERIAL` vs `INTEGER PRIMARY KEY AUTOINCREMENT`, `TEXT[]` vs `TEXT`) only where there is no
+common alternative.
+
+DDL *mechanics* may still differ where SQLite requires it — no `ALTER COLUMN ... TYPE` (drop and
+recreate), no multi-column `ADD COLUMN` (split the statements), no `GREATEST` (use `CASE`). Converge
+on the same end-state schema regardless: after `002_code_first_routes.sql` takes either path, both
+tables have the same columns, types, and constraint names.
+
+### Per-engine roots
+
+The worker-executor storage subsystems have fully separate implementations per backend, so their
+migrations are free to diverge and already do: `BIGINT`/`BYTEA`/`DOUBLE PRECISION` against
+`INTEGER`/`BLOB`/`REAL`, different primary-key column ordering, different indexes, and
+PostgreSQL-only autovacuum tuning. Tune each engine on its own terms here rather than forcing a
+shared shape.
 
 ## File Naming
 
@@ -39,9 +72,22 @@ Check both database directories and choose the same next number in each.
 - Read neighboring migrations before choosing types, constraint names, index names, quoting, and
   DDL structure. Naming is not globally uniform across all migration roots.
 - Do not create an extra index for a primary key; both databases already index it.
-- Keep PostgreSQL and SQLite query-visible schema names aligned even when their underlying types or
-  DDL differ.
+- Keep PostgreSQL and SQLite query-visible schema names aligned.
 - Use uppercase SQL keywords and match the indentation of the neighboring files.
+
+Index and constraint naming follows the owning root:
+
+- `golem-registry-service` and `golem-shard-manager` use `<table>_<column(s)>_<idx|uk>` for indexes
+  (`_idx` regular, `_uk` unique) and `<table>_pk` for primary key constraints:
+
+  ```sql
+  CREATE INDEX accounts_deleted_at_idx ON accounts (deleted_at);
+  CREATE UNIQUE INDEX accounts_email_uk ON accounts (email) WHERE deleted_at IS NULL;
+  CONSTRAINT accounts_pk PRIMARY KEY (account_id)
+  ```
+
+- `golem-worker-executor`'s `keyvalue` and `indexed` roots use an `idx_<...>` prefix instead; its
+  `scheduler` root uses the suffix style above. Match the files you are editing.
 
 ## No Compatibility Layer
 

--- a/.agents/skills/sdk-development/SKILL.md
+++ b/.agents/skills/sdk-development/SKILL.md
@@ -11,9 +11,12 @@ The SDKs in `sdks/` are **not part of the main build flow** (`cargo make build` 
 
 ### Crates
 
-- `golem-rust` — Runtime API wrappers (transactions, durability, agentic framework, value conversions)
-- `golem-rust-macro` — Procedural macros (`#[derive(IntoSchema)]`, `#[derive(FromSchema)]`,
-  `#[agent_definition]`, etc.)
+- `golem-rust` — Runtime API wrappers (transactions, durability, agentic framework, value
+  conversions). Also re-exports the `#[derive(IntoSchema)]` / `#[derive(FromSchema)]` derives, which
+  are defined by the root-workspace `golem-schema-derive` crate, not by `golem-rust-macro`.
+- `golem-rust-macro` — Procedural macros: `#[agent_definition]`, `#[agent_implementation]`,
+  `#[tool_definition]`, `#[golem_operation]`, and the `MultimodalSchema`, `ConfigSchema`,
+  `AllowedLanguages`, `AllowedMimeTypes`, and `ToolError` derives.
 
 ### Building
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ explicitly revised, **do not perform backward-compatibility work**.
 
 - **Rust**: Latest stable toolchain via rustup, with `wasm32-wasip2` target
 - **cargo-make**: Latest version (`cargo install --force cargo-make`)
-- **cargo-test-r**: Latest version (`cargo install --force --locked cargo-test-r`)
+- **cargo-test-r**: Match the version CI installs, pinned in
+  `.github/actions/restore-binaries/action.yml` (`cargo install --force --locked cargo-test-r@<VERSION>`)
 - **redis-server**: Required by worker-executor, service-integration, and CLI integration tests that
   use spawned test dependencies; not required by every unit test
 - **docker**: Required by tests that use containerized dependencies
@@ -157,12 +158,24 @@ Load these skills for guided workflows on complex tasks:
 | `modifying-cli-manifest-schema` | Adding or changing application manifest JSON schema versions and aligning CLI schema references |
 | `modifying-cli-output-schema` | Adding or changing structured `golem-cli` output, `StructuredOutput` types, or the command output JSON schema |
 | `modifying-service-configs` | Changing service configuration structs, defaults, or adding new config fields |
+| `db-migration-scripts` | Writing PostgreSQL and SQLite migration scripts under a `db/migration/` root |
+| `logging` | Adding or reviewing `tracing` statements and following the structured logging conventions |
+| `modifying-builtin-plugins` | Changing built-in plugin source, committed WASM, descriptors, versions, or provisioning |
+| `creating-new-builtin-plugins` | Adding a new built-in WASM plugin embedded in and provisioned by the registry service |
 | `sdk-development` | Working on the Rust, TypeScript, or MoonBit SDKs in `sdks/` |
+| `migrate-ts-decorator-sdk` | Porting a TypeScript agent from the removed decorator/`BaseAgent` API to `defineAgent` |
 | `golem-scala-development` | Compile, publish, and test the Golem Scala SDK in `sdks/scala/` |
 | `golem-scala-integration-tests` | Running and debugging Scala SDK integration tests |
 | `golem-scala-base-image` | WIT folder structure and regenerating `agent_guest.wasm` for the Scala SDK |
 | `golem-scala-code-generation` | Writing Scala code generators for the Scala SDK |
+| `moonbit-agent-guide` | Writing, refactoring, and testing MoonBit projects, and using `moon` tooling |
+| `moonbit-refactoring` | Refactoring MoonBit code to be idiomatic without regressing test coverage |
+| `moonbit-c-binding` | Writing MoonBit bindings to C libraries with native FFI |
+| `moonbit-code-transform` | Source-to-source MoonBit transformations with `moonbitlang/parser` and `formatter` |
+| `moonbit-proof` | Writing proof-carrying MoonBit code with Why3-backed specifications |
 | `investigating-executor-performance` | Investigating worker-executor performance with OTLP tracing and Jaeger |
+| `investigating-benchmark-performance` | Profiling Golem benchmarks with OTLP tracing and Jaeger |
+| `analysing-ci-failures` | Diagnosing a GitHub Actions failure from a run or job URL and reproducing it locally |
 | `golem-skill-harness` | Developing, testing, and running Golem skill tests with the skill test harness |
 | `managing-docs-versions` | Cutting a new docs version, backporting fixes to older releases, and managing versioned content under `docs/src/content/` |
 | `pre-pr-checklist` | Final checks before submitting a pull request |


### PR DESCRIPTION
## Summary

- restore the pg/sqlite schema convergence rule dropped from `db-migration-scripts`, scoped per migration root: converge in the shared-query roots (registry-service, shard-manager), diverge in the worker-executor storage roots
- restore index/pk naming the same way — `<table>_<cols>_<idx|uk>` and `<table>_pk` in registry/shard-manager, `idx_*` prefix in worker-executor keyvalue/indexed
- attribute `IntoSchema`/`FromSchema` to `golem-schema-derive` re-exported via `golem-rust`, not `golem-rust-macro`
- add the 12 skills missing from the AGENTS.md table, including `logging` and `db-migration-scripts`
- point the `cargo-test-r` prerequisite at the version CI pins instead of "latest"

The convergence rule is load-bearing where the repo layer is written once and expanded by `#[trait_gen(PostgresPool -> PostgresPool, SqlitePool)]`, so divergent types would force a per-dialect split. It does not apply to `golem-worker-executor/db/migration/{indexed,keyvalue,scheduler}`, which have separate `postgres.rs`/`sqlite.rs` backends and diverge deliberately.

## Validation

- registry `001_init.sql` pg/sqlite pair is byte-identical (825 lines, 0 differing); 22 of 39 pairs identical overall
- worker-executor `keyvalue/001_init.sql` pair differs substantively by design (31 differing lines)
- 40 `trait_gen` impls across 23 files in `golem-registry-service/src/repo`, plus `golem-shard-manager/src/{quota/quota_repo.rs,sharding/persistence.rs}`
- `IntoSchema`/`FromSchema` defined in `golem-schema-derive/src/lib.rs:53,61`
- every skill named in the AGENTS.md table resolves to a directory under `.agents/skills/`

Docs only. No CI drift check covers `.agents/skills/`; only `golem-skills/skills/` feeds `cargo make check-docs-skills`.

Follow-up to #3793.
