### PR TITLE
Stop durable stream reconciler before deleting oplog

### DIFF
--- a/golem-worker-executor/src/services/oplog/tests.rs
+++ b/golem-worker-executor/src/services/oplog/tests.rs
@@ -3849,6 +3849,64 @@ async fn deleting_ephemeral_worker_fences_in_flight_archive_transfers(_tracing: 
     deleting_worker_fences_in_flight_archive_transfers_impl(AgentMode::Ephemeral).await;
 }
 
+#[test]
+async fn open_multilayer_oplog_retains_stale_index_after_service_deletion(_tracing: &Tracing) {
+    let indexed_storage = Arc::new(InMemoryIndexedStorage::new());
+    let blob_storage = Arc::new(InMemoryBlobStorage::new());
+    let primary = Arc::new(
+        PrimaryOplogService::new(
+            indexed_storage.clone(),
+            blob_storage,
+            1,
+            1,
+            100,
+            RetryConfig::default(),
+        )
+        .await,
+    );
+    let archive = Arc::new(CompressedOplogArchiveService::new(
+        indexed_storage,
+        1,
+        RetryConfig::default(),
+    ));
+    let service = MultiLayerOplogService::new(primary, nev![archive], 100, 1);
+    let account_id = AccountId::new();
+    let environment_id = EnvironmentId::new();
+    let agent_id = AgentId {
+        component_id: ComponentId::new(),
+        agent_id: "delete-with-open-oplog".to_string(),
+    };
+    let owned_agent_id = OwnedAgentId::new(environment_id, &agent_id);
+    let oplog = service
+        .create(
+            &owned_agent_id,
+            AgentMode::Durable,
+            OplogEntry::no_op(),
+            make_agent_metadata(agent_id, account_id, environment_id),
+            default_last_known_status(),
+            default_execution_status(AgentMode::Durable),
+        )
+        .await;
+    let current = oplog.current_oplog_index().await;
+
+    service.delete(&owned_agent_id, AgentMode::Durable).await;
+
+    assert_eq!(oplog.current_oplog_index().await, current);
+    assert!(!service.exists(&owned_agent_id, AgentMode::Durable).await);
+    let panic = AssertUnwindSafe(oplog.read_exact(OplogIndex::INITIAL, current.as_u64()))
+        .catch_unwind()
+        .await
+        .expect_err("exact read from the deleted storage must panic");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied());
+    assert_eq!(
+        message,
+        Some("Oplog read failed: missing oplog entries in range [1..=1]")
+    );
+}
+
 async fn deleting_worker_fences_in_flight_archive_transfers_impl(agent_mode: AgentMode) {
     let indexed_storage = Arc::new(InMemoryIndexedStorage::new());
     let blob_storage = Arc::new(InMemoryBlobStorage::new());

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -132,6 +132,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex, MutexGuard, OnceCell, OwnedMutexGuard, RwLock};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level, debug, info, span, warn};
 use uuid::Uuid;
 use wasmtime::Store;
@@ -433,6 +434,44 @@ pub struct Worker<Ctx: WorkerCtx> {
     /// are invalidated lazily on the next lookup.
     read_only_cache_epoch: Arc<AtomicU64>,
     durable_stream_producer: OnceCell<Arc<DurableStreamProducer>>,
+    durable_stream_attachment_reconciler: DurableStreamAttachmentReconciler,
+}
+
+/// Owns the periodic task so worker deletion can join it before removing oplog storage.
+#[derive(Default)]
+struct DurableStreamAttachmentReconciler {
+    shutdown: CancellationToken,
+    handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl DurableStreamAttachmentReconciler {
+    fn start(&self, handle: JoinHandle<()>) {
+        let mut stored = self
+            .handle
+            .try_lock()
+            .expect("durable stream reconciler started while stopping");
+        assert!(
+            stored.is_none(),
+            "durable stream reconciler already started"
+        );
+        *stored = Some(handle);
+    }
+
+    async fn stop(&self) {
+        self.shutdown.cancel();
+        let mut stored = self.handle.lock().await;
+        if let Some(handle) = stored.as_mut() {
+            let _ = handle.await;
+        }
+        stored.take();
+    }
+}
+
+impl Drop for DurableStreamAttachmentReconciler {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        self.handle.get_mut().take();
+    }
 }
 
 struct WorkerDurableStreamConsumerJournal<Ctx: WorkerCtx> {
@@ -907,6 +946,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             read_only_cache,
             read_only_cache_epoch: Arc::new(AtomicU64::new(0)),
             durable_stream_producer: OnceCell::new(),
+            durable_stream_attachment_reconciler: DurableStreamAttachmentReconciler::default(),
         };
 
         // Wire the worker event service into the forwarding oplog so plugin errors
@@ -1221,6 +1261,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             PendingLiveInvocationDisposition::Fail,
         )
         .await;
+        self.durable_stream_attachment_reconciler.stop().await;
         self.finalize_durable_stream_consumer_dependencies().await?;
         self.reconcile_durable_stream_attachments().await?;
         let probe = DbDirectStreamAttachmentConsumerProbe::new_routed(
@@ -4606,17 +4647,25 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     pub(crate) fn start_durable_stream_attachment_reconciler(this: &Arc<Self>) {
         let worker = Arc::downgrade(this);
+        let shutdown = this.durable_stream_attachment_reconciler.shutdown.clone();
         let interval_duration = this
             .deps
             .config()
             .durable_stream
             .renewal_interval
             .min(this.deps.config().durable_stream.reconciliation_interval);
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             tokio::task::yield_now().await;
             let mut interval = tokio::time::interval(interval_duration);
             loop {
-                interval.tick().await;
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => break,
+                    _ = interval.tick() => {}
+                }
+                if shutdown.is_cancelled() {
+                    break;
+                }
                 let Some(worker) = worker.upgrade() else {
                     break;
                 };
@@ -4636,6 +4685,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 }
             }
         });
+        this.durable_stream_attachment_reconciler.start(handle);
     }
 
     /// Appends an oplog entry without forcing a durable commit. Callers that
@@ -6892,6 +6942,94 @@ fn lookup_result_from_cached_result(
 mod tests {
     use super::*;
     use test_r::test;
+
+    #[test]
+    async fn stopping_durable_stream_reconciler_waits_for_in_flight_pass() {
+        let reconciler = Arc::new(DurableStreamAttachmentReconciler::default());
+        let shutdown = reconciler.shutdown.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let (completed_tx, completed_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            finish_rx.await.unwrap();
+            completed_tx.send(()).unwrap();
+            shutdown.cancelled().await;
+        });
+        reconciler.start(handle);
+        started_rx.await.unwrap();
+
+        let mut stopping = tokio::spawn({
+            let reconciler = reconciler.clone();
+            async move { reconciler.stop().await }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut stopping)
+                .await
+                .is_err(),
+            "stop returned before the in-flight pass completed"
+        );
+        finish_tx.send(()).unwrap();
+
+        completed_rx
+            .await
+            .expect("in-flight reconciliation pass did not complete");
+        tokio::time::timeout(Duration::from_secs(1), stopping)
+            .await
+            .expect("stop did not return after the in-flight pass completed")
+            .expect("stop task failed");
+        assert!(reconciler.handle.lock().await.is_none());
+    }
+
+    #[test]
+    async fn cancelled_reconciler_stop_retains_the_in_flight_pass_barrier() {
+        let reconciler = Arc::new(DurableStreamAttachmentReconciler::default());
+        let shutdown = reconciler.shutdown.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            started_tx.send(()).unwrap();
+            finish_rx.await.unwrap();
+            shutdown.cancelled().await;
+        });
+        reconciler.start(handle);
+        started_rx.await.unwrap();
+
+        let first_stop = tokio::spawn({
+            let reconciler = reconciler.clone();
+            async move { reconciler.stop().await }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if reconciler.handle.try_lock().is_err() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first stop did not acquire the handle barrier");
+        first_stop.abort();
+        first_stop.await.expect_err("first stop was not cancelled");
+
+        let mut second_stop = tokio::spawn({
+            let reconciler = reconciler.clone();
+            async move { reconciler.stop().await }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut second_stop)
+                .await
+                .is_err(),
+            "retrying stop lost the in-flight pass barrier"
+        );
+        finish_tx.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), second_stop)
+            .await
+            .expect("retrying stop did not return after the in-flight pass completed")
+            .expect("retrying stop task failed");
+        assert!(reconciler.handle.lock().await.is_none());
+    }
 
     #[test]
     fn allocated_memory_sums_unique_untouched_backings() -> anyhow::Result<()> {

--- a/test-components/agent-counters/Cargo.lock
+++ b/test-components/agent-counters/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +83,20 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+ "rayon-core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -131,10 +151,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "ctor"
@@ -368,6 +428,7 @@ dependencies = [
  "base64",
  "bigdecimal",
  "bit-vec",
+ "blake3",
  "chrono",
  "combine",
  "golem-schema-derive",
@@ -784,6 +845,16 @@ dependencies = [
  "itertools",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- own and gracefully stop each worker's durable-stream attachment reconciler before worker oplog storage is removed
- preserve the join barrier across cancelled, concurrent, or retried deletion attempts
- add deterministic coverage for the stale open-oplog index panic and reconciler shutdown races

## Root cause

Worker deletion removed every oplog tier while a detached durable-stream reconciliation pass could still hold the worker alive. The open primary oplog actor continued reporting its pre-delete index, so topology recovery requested an exact range from storage that had already been deleted and fail-stopped on the resulting gap.

The shutdown is graceful rather than aborting an in-flight pass because durable-stream mutations may commit an oplog entry before publishing the corresponding in-memory index update.

## Testing

- `cargo fmt -p golem-worker-executor -- --check`
- `cargo clippy -p golem-worker-executor --all-targets --no-deps -- -D warnings`
- `cargo check -p golem-worker-executor --all-targets`
- targeted reconciler/oplog unit tests: 3 passed
- `cargo test -p golem-worker-executor --test integration -- api::delete_worker --exact --report-time --nocapture`: 1 passed

Resolves GOL-515