### PR TITLE
Fix CLI streaming invocation close race

### DIFF
--- a/cli/golem-cli/src/command_handler/agent/invocation_session.rs
+++ b/cli/golem-cli/src/command_handler/agent/invocation_session.rs
@@ -2575,7 +2575,9 @@ fn proto_value_to_json(
 fn is_connection_closed(error: &tungstenite::Error) -> bool {
     matches!(
         error,
-        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed
+        tungstenite::Error::ConnectionClosed
+            | tungstenite::Error::AlreadyClosed
+            | tungstenite::Error::Protocol(tungstenite::error::ProtocolError::SendAfterClosing)
     ) || matches!(error, tungstenite::Error::Io(error) if error.kind() == ErrorKind::BrokenPipe)
 }
 
@@ -3130,6 +3132,43 @@ mod tests {
         };
         assert!(response_cancels_input(&response, Some(1)));
         assert!(!response_cancels_input(&response, Some(3)));
+    }
+
+    #[test]
+    async fn peer_close_racing_with_a_send_is_connection_closed() {
+        let (client_io, server_io) = tokio::io::duplex(1024);
+        let client = tokio_tungstenite::WebSocketStream::from_raw_socket(
+            client_io,
+            tungstenite::protocol::Role::Client,
+            None,
+        )
+        .await;
+        let mut server = tokio_tungstenite::WebSocketStream::from_raw_socket(
+            server_io,
+            tungstenite::protocol::Role::Server,
+            None,
+        )
+        .await;
+        let (mut client_sink, mut client_stream) = client.split();
+
+        server.send(Message::Close(None)).await.unwrap();
+        assert!(matches!(
+            client_stream.next().await,
+            Some(Ok(Message::Close(_)))
+        ));
+
+        let error = client_sink
+            .send(Message::Binary(Vec::new().into()))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            &error,
+            tungstenite::Error::Protocol(tungstenite::error::ProtocolError::SendAfterClosing)
+        ));
+        assert!(is_connection_closed(&error));
+        assert!(!is_connection_closed(&tungstenite::Error::Protocol(
+            tungstenite::error::ProtocolError::ReceivedAfterClosing,
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A streaming agent can cancel its input while the CLI still has stdin frames queued in its independent WebSocket writer. The server then sends `StreamCancel(InputConsumer)`, `Finished(Success)`, and a normal WebSocket close.

If the CLI reader observes the close before the writer drains those queued frames, tungstenite moves the shared split socket into its closing state. The writer's next frame then returns `ProtocolError::SendAfterClosing`. The CLI did not classify that terminal local write state as a closed connection, so a successfully completed invocation could fail with a WebSocket protocol error. The same race could also mask a malformed piped-input diagnostic collected during cancellation.

## Fix

- Treat only tungstenite's `SendAfterClosing` protocol variant as a closed connection, alongside `ConnectionClosed`, `AlreadyClosed`, and broken pipe.
- Add a deterministic in-memory split-WebSocket regression that reads a peer close and then attempts a write, reproducing the exact tungstenite state transition.
- Verify that malformed peer traffic (`ReceivedAfterClosing`) remains an error.

This remains safe before protocol completion: a closed writer only stops outbound input handling, while the invocation still cannot succeed until the reader receives and validates `Finished`.

## Verification

- `cargo test -p golem-cli --lib -- peer_close_racing_with_a_send_is_connection_closed connection_truncation_before_finish_is_an_error --report-time`
- `integration::app::agents::test_streaming_invocation_cli_end_to_end` passed 5 consecutive runs
- `cargo fmt -p golem-cli -- --check`
- `cargo clippy -p golem-cli --all-targets --no-deps -- -D warnings`
- `cargo check -p golem-cli --all-targets`
- `cargo make build-cli-test-bins`