### PR TITLE
tool-invoke review nits

### DIFF
--- a/golem-schema/wit/deps/golem-tool/common.wit
+++ b/golem-schema/wit/deps/golem-tool/common.wit
@@ -375,7 +375,7 @@ interface common {
     body:  string,
   }
 
-  // Invocation contract — shared between guest and host
+  // Invocation contract — shared between guest and host.
   variant tool-error {
     invalid-tool-name(string),
     invalid-command-path(list<string>),

--- a/golem-worker-executor/src/durable_host/tool/mod.rs
+++ b/golem-worker-executor/src/durable_host/tool/mod.rs
@@ -2664,6 +2664,9 @@ where
                             let _ = operation.begin_cancel();
                             operation.resolve_cancel(true).await;
                             operation.settle().await;
+                            if let Some(stdout) = &stdout_controller {
+                                stdout.publish_completion();
+                            }
                             return decode_tool_terminal(*response).map_err(Into::into);
                         }
                         Err(error) => {

--- a/golem-worker-executor/src/durable_host/tool/operation.rs
+++ b/golem-worker-executor/src/durable_host/tool/operation.rs
@@ -648,6 +648,7 @@ impl Drop for ProvisionalOwnerToolOperation {
         let mut state = operation.owner.state.lock().unwrap();
         if state.operations[&operation.id].invocation_id.is_none() {
             state.operations.remove(&operation.id);
+            operation.owner.changed.notify_waiters();
             tracing::debug!(
                 operation_id = operation.id,
                 "Removed unaccepted tool operation"

--- a/sdks/moonbit/golem_sdk/tool/attachments.mbt
+++ b/sdks/moonbit/golem_sdk/tool/attachments.mbt
@@ -141,7 +141,7 @@ pub fn byte_stream(
           }
       }
     }
-  })
+  }, on_unstarted_drop=fn() { source.drop_sync() })
 }
 
 ///|
@@ -162,6 +162,7 @@ fn stdin_byte_stream(
         }
         match chunk {
           None => return
+          Some(bytes) if bytes.length() == 0 => continue
           Some(bytes) => {
             let item : Result[FixedArray[Byte], @toolHost.ByteStreamFailure] = Ok(
               bytes,

--- a/sdks/moonbit/golem_sdk/tool/client.mbt
+++ b/sdks/moonbit/golem_sdk/tool/client.mbt
@@ -199,8 +199,14 @@ pub fn[E] ToolClient::start(
   decode_error : (@model.TypedSchemaValue) -> Result[E, String],
 ) -> Result[ToolInvocation[E], ToolError[E]] {
   let wire_input = @model.typed_schema_value_to_wit(input) catch {
-    e =>
+    e => {
+      release_failed_tool_input(input, @model_host.resource_drops())
+      match stdin {
+        Some(stdin) => stdin.drop_sync()
+        None => ()
+      }
       return Err(tool_protocol_error("failed to encode tool input: \{Repr(e)}"))
+    }
   }
   let wire_stdin = prepare_stdin(stdin)
   let (wire_stdout, output, stdout_source) = if stdout {

--- a/sdks/rust/golem-rust-macro/src/tool/client.rs
+++ b/sdks/rust/golem-rust-macro/src/tool/client.rs
@@ -166,7 +166,7 @@ fn synthesize_leaf_method(
     };
     let value_inserts = value_inserts(ir, cmd, &inherited_params, tool_name, omitted_names);
     let result_ty = client_result_type(&cmd.output, has_stdout);
-    let decode_result = decode_client_result(&cmd.output, has_stdout);
+    let decode_result = decode_client_result(&cmd.output);
     let invoke = invoke_call(&cmd.output, stdin_expr.clone());
     let input_expr = input_build_expr(&descriptor_fn_ident, quote! { __golem_param_values });
 
@@ -279,7 +279,7 @@ fn synthesize_leaf_method_dynamic(
         None => quote! { ::std::option::Option::None },
     };
     let result_ty = client_result_type(&cmd.output, has_stdout);
-    let decode_result = decode_client_result(&cmd.output, has_stdout);
+    let decode_result = decode_client_result(&cmd.output);
     let invoke = invoke_call(&cmd.output, stdin_expr.clone());
     let input_expr = input_build_expr(&descriptor_fn_ident, param_values.clone());
 
@@ -1262,19 +1262,15 @@ fn invoke_call(output: &ReturnType, stdin_expr: TokenStream) -> TokenStream {
     }
 }
 
-fn decode_client_result(output: &ReturnType, has_stdout: bool) -> TokenStream {
+/// Only reached for commands without stdout; a stdout-bearing command returns a
+/// started invocation before this is used.
+fn decode_client_result(output: &ReturnType) -> TokenStream {
     let (ok, _) = split_result(output);
-    match (ok, has_stdout) {
-        (Some(ok), true) => quote! {
-            golem_rust::agentic::decode_result_with_stdout::<#ok, _>(__result)
-        },
-        (None, true) => quote! {
-            golem_rust::agentic::decode_result_stdout_only(__result)
-        },
-        (Some(ok), false) => quote! {
+    match ok {
+        Some(ok) => quote! {
             golem_rust::agentic::decode_result_value::<#ok, _>(__result)
         },
-        (None, false) => quote! {
+        None => quote! {
             golem_rust::agentic::decode_result_empty(__result)
         },
     }

--- a/sdks/rust/golem-rust-macro/src/tool/helpers.rs
+++ b/sdks/rust/golem-rust-macro/src/tool/helpers.rs
@@ -505,7 +505,12 @@ pub fn to_kebab_case(ident: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{StreamKind, stream_type, to_kebab_case};
+    use super::{
+        StreamKind, fresh_internal_ident, normalize_sdk_paths_in_item_trait, replace_ident,
+        resolve_generated_sdk_paths, stream_type, to_kebab_case,
+    };
+    use proc_macro2::{Ident, Span};
+    use quote::quote;
 
     #[test]
     fn kebab_cases() {
@@ -530,5 +535,122 @@ mod tests {
             Some((StreamKind::Output, false))
         );
         assert_eq!(stream_type(&nested_optional), None);
+    }
+
+    #[test]
+    fn replaces_sdk_identifiers_inside_nested_generated_tokens() {
+        let from = Ident::new("golem_rust", Span::call_site());
+        let to = Ident::new("sdk_alias", Span::call_site());
+        let replaced = replace_ident(
+            quote! {
+                fn generated(value: golem_rust::TypedSchemaValue) {
+                    let _ = golem_rust::tool::ToolInvokeError::InvalidInput("x".to_string());
+                }
+            },
+            &from,
+            &to,
+        )
+        .to_string();
+
+        assert!(replaced.contains("sdk_alias :: TypedSchemaValue"));
+        assert!(replaced.contains("sdk_alias :: tool :: ToolInvokeError"));
+        assert!(!replaced.contains("golem_rust"));
+    }
+
+    #[test]
+    fn generated_sdk_paths_skip_rewriting_for_the_canonical_dependency_name() {
+        let canonical = Ident::new("golem_rust", Span::call_site());
+        let preserved = Ident::new("__preserved_golem_rust", Span::call_site());
+        let tokens = quote! {
+            fn generated(value: golem_rust::TypedSchemaValue) {
+                let __preserved_golem_rust = value;
+            }
+        };
+
+        let resolved =
+            resolve_generated_sdk_paths(tokens.clone(), &canonical, &canonical, &preserved);
+
+        assert_eq!(resolved.to_string(), tokens.to_string());
+    }
+
+    #[test]
+    fn sdk_path_normalization_preserves_authored_names_and_local_canonical_paths() {
+        let resolved = Ident::new("sdk_alias", Span::call_site());
+        let canonical = Ident::new("golem_rust", Span::call_site());
+        let preserved = Ident::new("__preserved_golem_rust", Span::call_site());
+        let mut item: syn::ItemTrait = syn::parse_quote! {
+            trait Example {
+                fn sdk_alias(
+                    &self,
+                    principal: sdk_alias::tool::Principal,
+                    payload: golem_rust::Payload,
+                );
+
+                fn golem_rust(&self, golem_rust: String);
+            }
+        };
+
+        normalize_sdk_paths_in_item_trait(&mut item, &resolved, &canonical, &preserved);
+        let normalized = quote! { #item }.to_string();
+        assert!(normalized.contains("fn sdk_alias"));
+        assert!(normalized.contains("principal : golem_rust :: tool :: Principal"));
+        assert!(normalized.contains("payload : __preserved_golem_rust :: Payload"));
+        assert!(normalized.contains("fn __preserved_golem_rust"));
+        assert!(normalized.contains("__preserved_golem_rust : String"));
+
+        let emitted =
+            resolve_generated_sdk_paths(quote! { #item }, &resolved, &canonical, &preserved)
+                .to_string();
+        assert!(emitted.contains("principal : sdk_alias :: tool :: Principal"));
+        assert!(emitted.contains("payload : golem_rust :: Payload"));
+        assert!(emitted.contains("fn golem_rust"));
+        assert!(emitted.contains("golem_rust : String"));
+    }
+
+    #[test]
+    fn internal_identifier_is_fresh_against_authored_tokens() {
+        let tokens = quote! {
+            fn __golem_preserved() {
+                let __golem_preserved_ = 1;
+                let GolemPreserved1 = 2;
+            }
+        };
+        assert_eq!(
+            fresh_internal_ident(&tokens, "__golem_preserved", proc_macro2::Span::call_site())
+                .to_string(),
+            "__golem_preserved_2"
+        );
+    }
+
+    #[test]
+    fn escaped_authored_marker_literal_is_not_restored() {
+        let tokens: proc_macro2::TokenStream = r#"
+            const AUTHORED: &str =
+                "__golem_preserved_golem_rust_identifier_for_\u{45}xample";
+        "#
+        .parse()
+        .unwrap();
+        let preferred = "__golem_preserved_golem_rust_identifier_for_Example";
+        let preserved = fresh_internal_ident(&tokens, preferred, proc_macro2::Span::call_site());
+        assert_eq!(preserved.to_string(), format!("{preferred}_1"));
+
+        let resolved = resolve_generated_sdk_paths(
+            tokens,
+            &Ident::new("sdk_alias", Span::call_site()),
+            &Ident::new("golem_rust", Span::call_site()),
+            &preserved,
+        );
+        let file = syn::parse2::<syn::File>(resolved).unwrap();
+        let syn::Item::Const(item) = &file.items[0] else {
+            panic!("expected authored const item");
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(value),
+            ..
+        }) = item.expr.as_ref()
+        else {
+            panic!("expected authored string literal");
+        };
+        assert_eq!(value.value(), preferred);
     }
 }

--- a/sdks/scala/core/js/src/main/scala/golem/runtime/tool/ToolImplementationRuntime.scala
+++ b/sdks/scala/core/js/src/main/scala/golem/runtime/tool/ToolImplementationRuntime.scala
@@ -56,7 +56,8 @@ final class JsToolOutputStream(val underlying: ToolHostApi.RawToolStdoutWriter) 
   private var terminal: Option[Future[Either[StreamWriteError, Unit]]] = None
 
   override def write(bytes: Array[Byte]): Future[Either[StreamWriteError, Unit]] =
-    call(underlying.write(js.typedarray.Uint8Array.from(bytes.map(_.toShort).toJSArray)))
+    if (bytes.isEmpty) Future.successful(Right(()))
+    else call(underlying.write(js.typedarray.Uint8Array.from(bytes.map(_.toShort).toJSArray)))
   override def finish(): Future[Either[StreamWriteError, Unit]] =
     selectTerminal(underlying.finish())
   override def fail(reason: ByteStreamFailure): Future[Either[StreamWriteError, Unit]] =
@@ -116,6 +117,7 @@ object JsToolOutputStream {
     case "abandoned"          => ByteStreamFailure.Abandoned
     case "resource-exhausted" => ByteStreamFailure.ResourceExhausted
     case "failed"             => ByteStreamFailure.Failed(value.`val`.asInstanceOf[String])
+    case other                => ByteStreamFailure.Failed(s"unknown byte-stream failure: $other")
   }
 }
 

--- a/sdks/scala/model/src/main/scala/golem/tool/ToolClient.scala
+++ b/sdks/scala/model/src/main/scala/golem/tool/ToolClient.scala
@@ -392,13 +392,18 @@ object ToolClientRuntime {
   )(decode: ToolInvokeResult => Either[ToolError[E], T]): Either[ToolError[E], ToolInvocation[E, T]] =
     input.left.map(identity[ToolError[E]]).flatMap { record =>
       rpc.start(commandPath, record, stdin, stdout = true).left.map(mapRpcFailure(_, decodeError)).flatMap { started =>
-        started.stdout.toRight(protocolError("tool invocation did not create declared stdout stream")).map { stream =>
-          ToolInvocation(
-            stream,
-            started.result.map(_.left.map(mapRpcFailure(_, decodeError)).flatMap(decode)),
-            started.cancel
-          )
-        }
+        started.stdout
+          .toRight {
+            started.cancel()
+            protocolError("tool invocation did not create declared stdout stream")
+          }
+          .map { stream =>
+            ToolInvocation(
+              stream,
+              started.result.map(_.left.map(mapRpcFailure(_, decodeError)).flatMap(decode)),
+              started.cancel
+            )
+          }
       }
     }
 

--- a/sdks/ts/packages/golem-ts-sdk/src/bridge/tool.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/bridge/tool.ts
@@ -10,7 +10,6 @@ import {
   type FutureInvokeResult,
   type RpcError,
   type ToolError,
-  type ToolStdin,
 } from 'golem:tool/host@0.1.0';
 import {
   preflightWitTypedSchemaValue,
@@ -58,7 +57,7 @@ export function createToolClientTransport(toolName: string): ToolClientTransport
         inputEndpoints?.[1],
         outputEndpoints?.[0],
       );
-      if (inputEndpoints) void pumpToolStdin(stdin!, ...inputEndpoints);
+      if (inputEndpoints) void pumpToolStdin(stdin!, inputEndpoints[0], inputEndpoints[2]);
       return {
         stdout: outputEndpoints?.[1],
         result: future.get(),
@@ -71,7 +70,6 @@ export function createToolClientTransport(toolName: string): ToolClientTransport
 async function pumpToolStdin(
   source: ToolInputStream,
   writer: ReturnType<typeof createStdin>[0],
-  _capability: ToolStdin,
   closed: ReturnType<typeof createStdin>[2],
 ): Promise<void> {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;

--- a/sdks/ts/packages/golem-ts-sdk/src/index.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/index.ts
@@ -569,6 +569,7 @@ function createToolOutputStream(writer: ToolStdoutWriter): ToolOutputStreamAdapt
           if (!(contents instanceof Uint8Array)) {
             throw new TypeError('tool stdout accepts only Uint8Array chunks');
           }
+          if (contents.byteLength === 0) return;
           return writer.write(contents);
         }),
       );

--- a/test-components/tool-streaming/rust-caller/src/lib.rs
+++ b/test-components/tool-streaming/rust-caller/src/lib.rs
@@ -147,8 +147,9 @@ fn evidence(
 async fn read_all(mut stdout: InputStream) -> Vec<u8> {
     let mut output = Vec::new();
     while let Some(item) = stdout.next().await {
-        if let Ok(chunk) = item {
-            output.extend(chunk);
+        match item {
+            Ok(chunk) => output.extend(chunk),
+            Err(failure) => panic!("tool stdout failed: {failure:?}"),
         }
     }
     output

--- a/test-components/tool-streaming/rust-provider/src/lib.rs
+++ b/test-components/tool-streaming/rust-provider/src/lib.rs
@@ -183,7 +183,9 @@ fn nested_input(bytes: Vec<u8>) -> InputStream {
     let (mut writer, reader) =
         golem_rust::golem_agentic::wit_stream::new::<Result<Vec<u8>, ByteStreamFailure>>();
     spawn_local(async move {
-        let _ = writer.write_all(vec![Ok(bytes)]).await;
+        if !bytes.is_empty() {
+            let _ = writer.write_all(vec![Ok(bytes)]).await;
+        }
     });
     reader
 }


### PR DESCRIPTION
- mechanical review nits on top of #3787, one commit each so any can be dropped
- restores the five sdk-path helper tests dropped from `helpers.rs`, and deletes the unreachable stdout arms in `decode_client_result` (the `(Some, true)` arm called the two-arg `agentic::decode_result_with_stdout` with one argument)
- skips empty stdout/stdin chunks in the ts, scala and moonbit guest writers, which the wit forbids and the client readers reject
- releases resources on paths that returned early without them: moonbit `ToolClient::start` on encode failure, moonbit `byte_stream` dropped unstarted, scala `start` when declared stdout is missing
- publishes staged stdout on the cancelled no-body tool terminal, and notifies waiters when an unaccepted tool operation is removed, both mirroring the adjacent path
- makes the rust test caller fail on a stdout failure item instead of skipping it, so 31 assertions stop passing regardless of how stdout closed
- verified locally: `cargo check -p golem-worker-executor`, `cargo test -p golem-rust-macro` (121 pass), `cargo fmt --check`; ts/scala/moonbit rely on CI
- discussion-level findings are separate review comments rather than commits here
