### PR TITLE
Fix MoonBit multi-component embed paths

### DIFF
--- a/cli/golem-cli/src/app/template/repo.rs
+++ b/cli/golem-cli/src/app/template/repo.rs
@@ -329,7 +329,8 @@ impl AppTemplateRepo {
 
 #[cfg(test)]
 mod tests {
-    use super::AppTemplateRepo;
+    use super::{AppTemplateRepo, TEMPLATES_DIR};
+    use crate::model::app_raw::{Application, BuildCommand};
     use crate::model::language::GuestLanguage;
     use std::fs as stdfs;
     use std::path::{Path, PathBuf};
@@ -363,6 +364,80 @@ mod tests {
                 "{} common template skill drifted for {}",
                 language.name(),
                 relative_path.display(),
+            );
+        }
+    }
+
+    #[test]
+    fn moonbit_embed_commands_run_from_app_root() {
+        let template_source = TEMPLATES_DIR
+            .get_file("moonbit/common-on-demand/golem.yaml")
+            .unwrap()
+            .contents_utf8()
+            .unwrap();
+        let application = Application::from_yaml_str(template_source).unwrap();
+
+        let expected_commands = [
+            ("moonbit", "debug", "agent-guest"),
+            ("moonbit", "release", "agent-guest"),
+            ("moonbit-tool-middleware", "debug", "tool-middleware-guest"),
+            (
+                "moonbit-tool-middleware",
+                "release",
+                "tool-middleware-guest",
+            ),
+            (
+                "moonbit-agent-tool-middleware",
+                "debug",
+                "agent-tool-middleware-guest",
+            ),
+            (
+                "moonbit-agent-tool-middleware",
+                "release",
+                "agent-tool-middleware-guest",
+            ),
+        ];
+
+        let embed_command_count = application
+            .component_templates
+            .values()
+            .flat_map(|template| template.presets.values())
+            .flat_map(|preset| &preset.build)
+            .filter(|command| {
+                matches!(
+                    command,
+                    BuildCommand::External(command)
+                        if command.command.starts_with("wasm-tools component embed ")
+                )
+            })
+            .count();
+        assert_eq!(embed_command_count, expected_commands.len());
+
+        for (template_name, preset_name, world) in expected_commands {
+            let preset = &application.component_templates[template_name].presets[preset_name];
+            let embed_commands = preset
+                .build
+                .iter()
+                .filter_map(|command| match command {
+                    BuildCommand::External(command)
+                        if command.command.starts_with("wasm-tools component embed ") =>
+                    {
+                        Some(command)
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(embed_commands.len(), 1, "{template_name}.{preset_name}");
+            let embed_command = embed_commands[0];
+            assert!(
+                embed_command.command.contains(&format!("--world {world} ")),
+                "{template_name}.{preset_name} does not embed world {world}"
+            );
+            assert_eq!(
+                embed_command.dir.as_deref(),
+                Some("{{ appRootDir }}"),
+                "{template_name}.{preset_name}"
             );
         }
     }

--- a/cli/golem-cli/templates/moonbit/common-on-demand/golem.yaml
+++ b/cli/golem-cli/templates/moonbit/common-on-demand/golem.yaml
@@ -13,6 +13,7 @@ componentTemplates:
         - command: moon build --target wasm
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/debug/build/{{ moonbitBuildPackagePath }}" --world agent-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/debug"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.embed.wasm" --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.agent.wasm"
@@ -26,6 +27,7 @@ componentTemplates:
         - command: moon build --target wasm --release
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/release/build/{{ moonbitBuildPackagePath }}" --world agent-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/release"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.embed.wasm" --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.agent.wasm"
@@ -42,6 +44,7 @@ componentTemplates:
         - command: moon build --target wasm
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/debug/build/{{ moonbitBuildPackagePath }}" --world tool-middleware-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.tool-middleware.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/debug"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.tool-middleware.embed.wasm" --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.tool-middleware.wasm"
@@ -55,6 +58,7 @@ componentTemplates:
         - command: moon build --target wasm --release
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/release/build/{{ moonbitBuildPackagePath }}" --world tool-middleware-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.tool-middleware.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/release"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.tool-middleware.embed.wasm" --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.tool-middleware.wasm"
@@ -71,6 +75,7 @@ componentTemplates:
         - command: moon build --target wasm
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/debug/build/{{ moonbitBuildPackagePath }}" --world agent-tool-middleware-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.agent-tool-middleware.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/debug"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.agent-tool-middleware.embed.wasm" --output "{{ appRootDir }}/_build/wasm/debug/{{ componentName | to_snake_case }}.agent-tool-middleware.wasm"
@@ -84,6 +89,7 @@ componentTemplates:
         - command: moon build --target wasm --release
           dir: "{{ appRootDir }}"
         - command: wasm-tools component embed "GOLEM_MOONBIT_BUILD_SDK_PATH/wit" "{{ appRootDir }}/_build/wasm/release/build/{{ moonbitBuildPackagePath }}" --world agent-tool-middleware-guest --encoding utf16 --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.agent-tool-middleware.embed.wasm"
+          dir: "{{ appRootDir }}"
           mkdirs:
           - "{{ appRootDir }}/_build/wasm/release"
         - command: wasm-tools component new "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.agent-tool-middleware.embed.wasm" --output "{{ appRootDir }}/_build/wasm/release/{{ componentName | to_snake_case }}.agent-tool-middleware.wasm"


### PR DESCRIPTION
## Summary

- run every MoonBit `wasm-tools component embed` step from the application root
- cover ordinary, tool-middleware, and combined components in debug and release presets
- add an embedded-template regression test for all six commands

## Why

Published MoonBit applications resolve the SDK WIT directory through the app-relative `.mooncakes/golemcloud/golem_sdk/wit` path. External commands without an explicit `dir` run from each component directory, so multi-component applications looked for `.mooncakes` beneath `moonbit-main`, `moonbit-second`, and similar directories.

Setting the embed commands' working directory to `{{ appRootDir }}` makes the published relative path resolve correctly. Local SDK overrides remain valid because they are absolute, single-component behavior is unchanged, and the subsequent `component new` commands already use app-rooted input and output paths.

The issue was reproduced with the real official MoonBit compiler: both MoonBit packages compiled successfully, after which `wasm-tools component embed` failed to find the root `.mooncakes` path from a component directory. Running that same embed command from the application root succeeded.

## Verification

- `cargo test -p golem-cli moonbit_embed_commands_run_from_app_root -- --report-time`
- `cargo fmt -p golem-cli -- --check`
- `cargo clippy -p golem-cli --all-targets --no-deps -- -D warnings`
- `cargo check -p golem-cli --all-targets`

Resolves GOL-176