### PR TITLE
Reject streaming agent methods from MCP export

### DIFF
--- a/golem-worker-service/src/mcp/agent_mcp_capability.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_capability.rs
@@ -40,9 +40,10 @@ impl McpAgentCapability {
     /// Build an MCP tool or resource capability for a single agent method.
     ///
     /// Performs export-time validation so we never advertise a capability that
-    /// would always fail at invoke time: the constructor schema is checked to be
-    /// supplyable via MCP (no multimodal / unstructured constructor parameters),
-    /// resolving `SchemaType::Ref`s against `schema_graph`.
+    /// would always fail at invoke time: streaming methods are rejected, and the
+    /// constructor schema is checked to be supplyable via MCP (no multimodal /
+    /// unstructured constructor parameters), resolving `SchemaType::Ref`s
+    /// against `schema_graph`.
     #[allow(clippy::too_many_arguments)]
     pub fn from_agent_method(
         account_id: &AccountId,
@@ -55,6 +56,14 @@ impl McpAgentCapability {
         constructor: &AgentConstructorSchema,
         component_id: ComponentId,
     ) -> anyhow::Result<Self> {
+        if method.uses_streams(&schema_graph) {
+            anyhow::bail!(
+                "streaming method {} of agent type {} cannot be exported through MCP",
+                method.name,
+                agent_type_name.0
+            );
+        }
+
         validate_constructor_schema_for_mcp(&schema_graph, &constructor.input_schema).map_err(
             |e| {
                 anyhow::anyhow!(
@@ -71,9 +80,9 @@ impl McpAgentCapability {
             .iter()
             .any(|f| matches!(f.source, FieldSource::UserSupplied));
 
-        if has_user_input {
+        if has_user_input || method.read_only.is_none() {
             tracing::debug!(
-                "Method {} of agent type {} has input parameters, exposing as tool",
+                "Exposing method {} of agent type {} as a tool",
                 method.name,
                 agent_type_name.0
             );
@@ -109,7 +118,7 @@ impl McpAgentCapability {
             })))
         } else {
             tracing::debug!(
-                "Method {} of agent type {} has no input parameters, exposing as resource",
+                "Method {} of agent type {} is read-only and has no input parameters, exposing as resource",
                 method.name,
                 agent_type_name.0
             );
@@ -201,5 +210,181 @@ fn output_resource_mime_type(graph: &SchemaGraph, output: &OutputSchema) -> Opti
         Ok(Some(UnstructuredPayloadKind::Binary)) => None,
         Ok(None) => Some("application/json".to_string()),
         Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_common::base_model::agent::{CachePolicy, ReadOnlyConfig};
+    use golem_common::model::Empty;
+    use golem_common::schema::agent::{AutoInjectedKind, InputSchema, NamedField};
+    use golem_common::schema::schema_type::SchemaType;
+    use test_r::test;
+
+    fn constructor() -> AgentConstructorSchema {
+        AgentConstructorSchema {
+            name: None,
+            description: String::new(),
+            prompt_hint: None,
+            input_schema: InputSchema::Parameters(vec![]),
+        }
+    }
+
+    fn method(input: Vec<NamedField>, output: OutputSchema, read_only: bool) -> AgentMethodSchema {
+        AgentMethodSchema {
+            name: "method".to_string(),
+            description: String::new(),
+            prompt_hint: None,
+            input_schema: InputSchema::Parameters(input),
+            output_schema: output,
+            http_endpoint: vec![],
+            read_only: read_only.then_some(ReadOnlyConfig {
+                cache_policy: CachePolicy::NoCache(Empty {}),
+                uses_principal: false,
+            }),
+        }
+    }
+
+    fn capability(
+        graph: SchemaGraph,
+        method: &AgentMethodSchema,
+    ) -> anyhow::Result<McpAgentCapability> {
+        capability_with_constructor(graph, method, &constructor())
+    }
+
+    fn capability_with_constructor(
+        graph: SchemaGraph,
+        method: &AgentMethodSchema,
+        constructor: &AgentConstructorSchema,
+    ) -> anyhow::Result<McpAgentCapability> {
+        McpAgentCapability::from_agent_method(
+            &AccountId::new(),
+            &AccountEmail::new("mcp@golem"),
+            &EnvironmentId::new(),
+            &AgentTypeName("TestAgent".to_string()),
+            AgentMode::Durable,
+            Arc::new(graph),
+            method,
+            constructor,
+            ComponentId::new(),
+        )
+    }
+
+    #[test]
+    fn parameterless_read_only_method_is_a_resource() {
+        let capability = capability(
+            SchemaGraph::empty(),
+            &method(vec![], OutputSchema::Unit, true),
+        )
+        .unwrap();
+
+        assert!(matches!(capability, McpAgentCapability::Resource(_)));
+    }
+
+    #[test]
+    fn parameterless_non_read_only_method_is_a_tool() {
+        let capability = capability(
+            SchemaGraph::empty(),
+            &method(vec![], OutputSchema::Unit, false),
+        )
+        .unwrap();
+
+        assert!(matches!(capability, McpAgentCapability::Tool(_)));
+    }
+
+    #[test]
+    fn read_only_method_with_user_input_is_a_tool() {
+        let capability = capability(
+            SchemaGraph::empty(),
+            &method(
+                vec![NamedField::user_supplied("value", SchemaType::string())],
+                OutputSchema::Unit,
+                true,
+            ),
+        )
+        .unwrap();
+
+        assert!(matches!(capability, McpAgentCapability::Tool(_)));
+    }
+
+    #[test]
+    fn read_only_method_with_only_auto_injected_input_is_a_resource() {
+        let capability = capability(
+            SchemaGraph::empty(),
+            &method(
+                vec![NamedField::auto_injected(
+                    "principal",
+                    AutoInjectedKind::Principal,
+                    SchemaType::string(),
+                )],
+                OutputSchema::Unit,
+                true,
+            ),
+        )
+        .unwrap();
+
+        assert!(matches!(capability, McpAgentCapability::Resource(_)));
+    }
+
+    #[test]
+    fn auto_injected_constructor_input_keeps_resource_static() {
+        let constructor = AgentConstructorSchema {
+            name: None,
+            description: String::new(),
+            prompt_hint: None,
+            input_schema: InputSchema::Parameters(vec![NamedField::auto_injected(
+                "principal",
+                AutoInjectedKind::Principal,
+                SchemaType::string(),
+            )]),
+        };
+        let capability = capability_with_constructor(
+            SchemaGraph::empty(),
+            &method(vec![], OutputSchema::Unit, true),
+            &constructor,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            capability,
+            McpAgentCapability::Resource(resource)
+                if matches!(resource.kind, AgentMcpResourceKind::Static(_))
+        ));
+    }
+
+    #[test]
+    fn method_with_input_stream_is_not_exported() {
+        let error = capability(
+            SchemaGraph::empty(),
+            &method(
+                vec![NamedField::user_supplied(
+                    "values",
+                    SchemaType::stream(Some(SchemaType::string())),
+                )],
+                OutputSchema::Unit,
+                false,
+            ),
+        )
+        .err()
+        .expect("streaming method should be rejected");
+
+        assert!(error.to_string().contains("cannot be exported through MCP"));
+    }
+
+    #[test]
+    fn method_with_output_stream_is_not_exported() {
+        let error = capability(
+            SchemaGraph::empty(),
+            &method(
+                vec![],
+                OutputSchema::Single(Box::new(SchemaType::stream(Some(SchemaType::string())))),
+                true,
+            ),
+        )
+        .err()
+        .expect("streaming method should be rejected");
+
+        assert!(error.to_string().contains("cannot be exported through MCP"));
     }
 }

--- a/golem-worker-service/src/mcp/agent_mcp_server.rs
+++ b/golem-worker-service/src/mcp/agent_mcp_server.rs
@@ -157,10 +157,9 @@ pub async fn get_agent_capabilities(
         }
 
         for method in &agent_type.methods {
-            // Validate (project to the legacy invoke model) before advertising
-            // anything for this method. If the capability cannot be projected,
-            // invoking it would always fail, so we skip both the tool/resource
-            // and its prompt instead of exposing a broken method.
+            // Validate the method for MCP export before advertising anything.
+            // If the capability cannot be exported, invoking it would always
+            // fail, so skip both the tool/resource and its prompt.
             let agent_method_mcp = McpAgentCapability::from_agent_method(
                 &account_id,
                 &account_email,

--- a/integration-tests/tests/custom_api/mcp.rs
+++ b/integration-tests/tests/custom_api/mcp.rs
@@ -325,6 +325,11 @@ async fn list_tools(#[dimension(db)] ctx: &McpTestContext) -> anyhow::Result<()>
     assert!(tool_names.contains(&"WeatherAgent-get_weather_report_for_city_text".to_string()));
     assert!(tool_names.contains(&"WeatherAgent-get_snow_fall_image_for_city".to_string()));
     assert!(tool_names.contains(&"WeatherAgent-get_lat_long_for_city".to_string()));
+    assert!(
+        !tool_names.contains(&"WeatherAgent-stream_weather_report_for_city".to_string()),
+        "Streaming methods must not be exported as tools: {:?}",
+        tool_names
+    );
 
     // WeatherAgentSingleton tools (no constructor params)
     assert!(tool_names.contains(&"WeatherAgentSingleton-get_weather_report_for_city".to_string()));
@@ -338,7 +343,8 @@ async fn list_tools(#[dimension(db)] ctx: &McpTestContext) -> anyhow::Result<()>
     assert!(tool_names.contains(&"WeatherAgentSingleton-get_snow_fall_image_for_city".to_string()));
     assert!(tool_names.contains(&"WeatherAgentSingleton-get_lat_long_for_city".to_string()));
 
-    // StaticResource and DynamicResource methods have no input params -> exposed as resources, not tools
+    // StaticResource and DynamicResource methods are read-only and have no input params,
+    // so they are exposed as resources, not tools.
     assert!(!tool_names.iter().any(|n| n.starts_with("StaticResource")));
     assert!(!tool_names.iter().any(|n| n.starts_with("DynamicResource")));
 
@@ -557,6 +563,9 @@ async fn list_resources(#[dimension(db)] ctx: &McpTestContext) -> anyhow::Result
     assert!(
         resource_uris.contains(&"golem://StaticResource/get_static_now_fall_image".to_string())
     );
+    assert!(
+        !resource_uris.contains(&"golem://WeatherAgent/stream_weather_report_for_city".to_string())
+    );
 
     assert!(
         !resource_uris
@@ -593,6 +602,10 @@ async fn list_resource_templates(#[dimension(db)] ctx: &McpTestContext) -> anyho
     );
     assert!(
         template_uris.contains(&"golem://DynamicResource/get_snow_fall_image/{name}".to_string())
+    );
+    assert!(
+        !template_uris
+            .contains(&"golem://WeatherAgent/stream_weather_report_for_city/{name}".to_string())
     );
 
     Ok(())
@@ -755,6 +768,11 @@ async fn list_prompts(#[dimension(db)] ctx: &McpTestContext) -> anyhow::Result<(
     assert!(
         prompt_names.contains(&"WeatherAgent-get_weather_report_for_city".to_string()),
         "Expected WeatherAgent-get_weather_report_for_city prompt in {:?}",
+        prompt_names
+    );
+    assert!(
+        !prompt_names.contains(&"WeatherAgent-stream_weather_report_for_city".to_string()),
+        "Streaming method prompts must not be exported: {:?}",
         prompt_names
     );
 

--- a/test-components/agent-mcp/Cargo.lock
+++ b/test-components/agent-mcp/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +83,20 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+ "rayon-core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -131,10 +151,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "ctor"
@@ -368,6 +428,7 @@ dependencies = [
  "base64",
  "bigdecimal",
  "bit-vec",
+ "blake3",
  "chrono",
  "combine",
  "golem-schema-derive",
@@ -783,6 +844,16 @@ dependencies = [
  "itertools",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/test-components/agent-mcp/src/dynamic_resource.rs
+++ b/test-components/agent-mcp/src/dynamic_resource.rs
@@ -1,18 +1,22 @@
 use golem_rust::agentic::{BasicModality, Multimodal, UnstructuredBinary, UnstructuredText};
-use golem_rust::{agent_definition, agent_implementation};
+use golem_rust::{agent_definition, agent_implementation, read_only};
 
-// Agent methods that don't take any arguments becomes a resource
+// Read-only agent methods that don't take any arguments become resources.
 // However they are dynamic because it depends on agent identity (constructor)
-// and therefore becomes "resource templates" according to MCP
+// and therefore become "resource templates" according to MCP.
 
 #[agent_definition]
 pub trait DynamicResource {
     // The resource depends on the agent identity
     fn new(name: String) -> Self;
 
+    #[read_only]
     fn get_weather_report(&self) -> String;
+    #[read_only]
     fn get_weather_report_with_images(&self) -> Multimodal;
+    #[read_only]
     fn get_weather_report_text(&self) -> UnstructuredText;
+    #[read_only]
     fn get_snow_fall_image(&self) -> UnstructuredBinary<String>;
 }
 

--- a/test-components/agent-mcp/src/static_resource.rs
+++ b/test-components/agent-mcp/src/static_resource.rs
@@ -1,16 +1,20 @@
 use golem_rust::agentic::{BasicModality, Multimodal, UnstructuredBinary, UnstructuredText};
-use golem_rust::{agent_definition, agent_implementation};
+use golem_rust::{agent_definition, agent_implementation, read_only};
 
-// Agent methods that don't take any arguments becomes a resource
+// Read-only agent methods that don't take any arguments become resources.
 // However they are static because they don't depend on the agent identity,
-// and therefore becomes "static resources" according to MCP
+// and therefore become "static resources" according to MCP.
 #[agent_definition]
 pub trait StaticResource {
     // The resource is static, it doesn't depend on the agent identity
     fn new() -> Self;
+    #[read_only]
     fn get_static_weather_report(&self) -> String;
+    #[read_only]
     fn get_static_weather_report_with_images(&self) -> Multimodal;
+    #[read_only]
     fn get_static_weather_report_text(&self) -> UnstructuredText;
+    #[read_only]
     fn get_static_now_fall_image(&self) -> UnstructuredBinary<String>;
 }
 

--- a/test-components/agent-mcp/src/weather_agent.rs
+++ b/test-components/agent-mcp/src/weather_agent.rs
@@ -1,5 +1,7 @@
 use crate::location_details::LocationDetails;
-use golem_rust::agentic::{BasicModality, Multimodal, UnstructuredBinary, UnstructuredText};
+use golem_rust::agentic::{
+    AgentStream, BasicModality, Multimodal, UnstructuredBinary, UnstructuredText,
+};
 use golem_rust::{agent_definition, agent_implementation, prompt};
 
 // These agent methods are tools, since they take arguments, but with constructor params
@@ -14,6 +16,8 @@ trait WeatherAgent {
     fn get_weather_report_for_city_text(&self, city: String) -> UnstructuredText;
     fn get_snow_fall_image_for_city(&self, city: String) -> UnstructuredBinary<String>;
     fn get_lat_long_for_city(&self, city: String) -> LocationDetails;
+    #[prompt("Stream a weather report for a specific city")]
+    fn stream_weather_report_for_city(&self, city: String) -> AgentStream<String>;
 }
 
 struct MyDynamicWeatherToolImpl {
@@ -59,5 +63,10 @@ impl WeatherAgent for MyDynamicWeatherToolImpl {
             country: "Unknown".to_string(),
             population: 0,
         }
+    }
+
+    fn stream_weather_report_for_city(&self, _city: String) -> AgentStream<String> {
+        let (_writer, stream) = AgentStream::new();
+        stream
     }
 }


### PR DESCRIPTION
## Overview

- reject stream-bearing agent methods from MCP capability and prompt export
- expose parameterless methods as resources or resource templates only when they are read-only; export other non-streaming methods as tools
- add unit and end-to-end MCP listing coverage, including auto-injected parameters and recursive stream schemas

This is aligned with #3789 and does not add an MCP protocol extension or buffer streams into arrays.

## Verification

- `cargo test -p golem-worker-service --lib -- agent_mcp_capability::tests --report-time`
- `cargo clippy -p golem-worker-service --lib --tests -- -D warnings`
- `cargo check -p golem-worker-service --all-targets`
- `cargo clippy -p integration-tests --test integration --no-deps -- -D warnings`
- SQLite MCP integration tests for listing tools, resources, resource templates, and prompts
- rebuilt the `agent-mcp` test component
- package-scoped formatting and `git diff --check`

Resolves GOL-94
