### PR TITLE
Unify account usage reporting across API and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "serde_yaml",
  "shadow-rs",
  "shlex 1.3.0",
+ "sqlx",
  "strip-ansi-escapes",
  "strum",
  "strum_macros",

--- a/cli/golem-cli/Cargo.toml
+++ b/cli/golem-cli/Cargo.toml
@@ -136,6 +136,7 @@ pretty_assertions = { workspace = true }
 pretty_env_logger = { workspace = true }
 proptest = { workspace = true }
 reqwest = { workspace = true }
+sqlx = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing"] }
 test-r = { workspace = true }
 wat = { workspace = true }

--- a/cli/golem-cli/command-output-schema/command-output.schema.json
+++ b/cli/golem-cli/command-output-schema/command-output.schema.json
@@ -709,7 +709,9 @@
         "memoryGbSeconds",
         "durableStorageGbMonth",
         "ephemeralStorageGbMonth",
-        "period"
+        "period",
+        "asOf",
+        "metering"
       ],
       "properties": {
         "$type": {
@@ -731,7 +733,15 @@
           "type": "number"
         },
         "period": {
-          "$ref": "#/definitions/StorageUsagePeriod"
+          "$ref": "#/definitions/AccountUsagePeriod"
+        },
+        "asOf": {
+          "description": "When the registry last received a usage snapshot for this period, or when it produced an empty snapshot.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "metering": {
+          "$ref": "#/definitions/AccountUsageMetering"
         }
       },
       "additionalProperties": false
@@ -751,8 +761,42 @@
         }
       ]
     },
-    "StorageUsagePeriod": {
+    "AccountUsageMetering": {
       "type": "object",
+      "description": "Collection state for each customer-visible usage dimension. Both storage dimensions use the filesystem meter.",
+      "required": [
+        "compute",
+        "memory",
+        "durableStorage",
+        "ephemeralStorage"
+      ],
+      "properties": {
+        "compute": {
+          "$ref": "#/definitions/MeteringStatus"
+        },
+        "memory": {
+          "$ref": "#/definitions/MeteringStatus"
+        },
+        "durableStorage": {
+          "$ref": "#/definitions/MeteringStatus"
+        },
+        "ephemeralStorage": {
+          "$ref": "#/definitions/MeteringStatus"
+        }
+      },
+      "additionalProperties": false
+    },
+    "MeteringStatus": {
+      "type": "string",
+      "enum": [
+        "enabled",
+        "disabled",
+        "unknown"
+      ]
+    },
+    "AccountUsagePeriod": {
+      "type": "object",
+      "description": "A UTC calendar month in YYYY-MM form.",
       "required": [
         "year",
         "month"

--- a/cli/golem-cli/src/command.rs
+++ b/cli/golem-cli/src/command.rs
@@ -2327,28 +2327,28 @@ pub mod account {
     use crate::command::shared_args::AccountIdOptionalArg;
     use clap::{Args, Subcommand};
     use golem_common::model::account_usage::{
-        DEFAULT_STORAGE_USAGE_HISTORY_PERIODS, StorageUsagePeriod,
+        AccountUsagePeriod, DEFAULT_ACCOUNT_USAGE_HISTORY_PERIODS,
     };
     use golem_common::model::permission_share::PermissionShareId;
 
     #[derive(Debug, Subcommand)]
     pub enum AccountUsageSubcommand {
-        /// Show storage usage for current or selected billing period.
+        /// Show account usage for the current or selected UTC billing period.
         Show {
             #[command(flatten)]
             account_id: AccountIdOptionalArg,
 
             /// Billing period in YYYY-MM format.
             #[arg(long)]
-            period: Option<StorageUsagePeriod>,
+            period: Option<AccountUsagePeriod>,
         },
-        /// Show storage usage for closed billing periods.
+        /// Show sparse account usage for closed UTC billing periods, newest first.
         History {
             #[command(flatten)]
             account_id: AccountIdOptionalArg,
 
             /// Number of closed periods to show.
-            #[arg(long, default_value_t = DEFAULT_STORAGE_USAGE_HISTORY_PERIODS)]
+            #[arg(long, default_value_t = DEFAULT_ACCOUNT_USAGE_HISTORY_PERIODS)]
             last: usize,
         },
     }
@@ -2513,7 +2513,7 @@ pub mod account {
             #[command(flatten)]
             account_id: AccountIdOptionalArg,
         },
-        /// Show current or historical account storage usage.
+        /// Show current or historical account usage.
         Usage {
             #[command(subcommand)]
             subcommand: AccountUsageSubcommand,

--- a/cli/golem-cli/src/command_handler/account.rs
+++ b/cli/golem-cli/src/command_handler/account.rs
@@ -32,7 +32,7 @@ use golem_client::model::{
     PermissionShareUpdate,
 };
 use golem_common::model::account::{AccountEmail, AccountId};
-use golem_common::model::account_usage::{SetMemoryLimit, SetStorageLimit, StorageUsagePeriod};
+use golem_common::model::account_usage::{AccountUsagePeriod, SetMemoryLimit, SetStorageLimit};
 use golem_common::model::permission_share::{
     PermissionShareData, PermissionShareId, PermissionShareName,
 };
@@ -251,7 +251,7 @@ impl AccountCommandHandler {
     async fn cmd_usage_show(
         &self,
         account_id: Option<AccountId>,
-        period: Option<StorageUsagePeriod>,
+        period: Option<AccountUsagePeriod>,
     ) -> anyhow::Result<()> {
         let account_id = self.select_account_id_or_err(account_id).await?;
         let period = period.map(|period| period.to_string());
@@ -260,7 +260,7 @@ impl AccountCommandHandler {
             .golem_clients()
             .await?
             .account
-            .get_account_storage_usage(&account_id.0, period.as_deref())
+            .get_account_usage(&account_id.0, period.as_deref())
             .await
             .map_service_error()?;
         self.ctx
@@ -281,7 +281,7 @@ impl AccountCommandHandler {
             .golem_clients()
             .await?
             .account
-            .get_account_storage_usage_history(&account_id.0, Some(last))
+            .get_account_usage_history(&account_id.0, Some(last))
             .await
             .map_service_error()?
             .into_iter()

--- a/cli/golem-cli/src/model/account.rs
+++ b/cli/golem-cli/src/model/account.rs
@@ -16,11 +16,11 @@ use crate::model::cli_output::StructuredOutput;
 use crate::model::grant::{format_grants, grant_count};
 use crate::model::masking::Masked;
 use crate::model::text_format::*;
+use chrono::SecondsFormat;
 use golem_client::model::{Account, PermissionShare};
 use golem_common::model::account::AccountId;
 use golem_common::model::account_usage::{
-    MemoryLimit, StorageLimit, StorageUsage, StorageUsageHistory, StorageUsageMetrics,
-    StorageUsagePeriod,
+    AccountUsage, AccountUsageMetrics, MemoryLimit, StorageLimit,
 };
 use golem_common::model::permission_share::PermissionShareId;
 use serde::{Deserialize, Serialize};
@@ -130,44 +130,30 @@ impl StructuredOutput for AccountDeleteView {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountUsageView {
-    pub compute_gcu: f64,
-    pub memory_gb_seconds: u64,
-    pub durable_storage_gb_month: f64,
-    pub ephemeral_storage_gb_month: f64,
-    pub period: StorageUsagePeriod,
+    #[serde(flatten)]
+    pub usage: AccountUsageMetrics,
 }
 
 impl Masked for AccountUsageView {}
 
-impl From<StorageUsage> for AccountUsageView {
-    fn from(usage: StorageUsage) -> Self {
-        usage.usage.into()
+impl From<AccountUsage> for AccountUsageView {
+    fn from(usage: AccountUsage) -> Self {
+        Self { usage: usage.usage }
     }
 }
 
-impl From<StorageUsageHistory> for AccountUsageView {
-    fn from(usage: StorageUsageHistory) -> Self {
-        usage.usage.into()
-    }
-}
-
-impl From<StorageUsageMetrics> for AccountUsageView {
-    fn from(usage: StorageUsageMetrics) -> Self {
-        Self {
-            period: usage.period,
-            compute_gcu: usage.compute_gcu,
-            memory_gb_seconds: usage.memory_gb_seconds,
-            durable_storage_gb_month: usage.durable_storage_gb_month,
-            ephemeral_storage_gb_month: usage.ephemeral_storage_gb_month,
-        }
+impl From<AccountUsageMetrics> for AccountUsageView {
+    fn from(usage: AccountUsageMetrics) -> Self {
+        Self { usage }
     }
 }
 
 /// Column headings for the history table, which needs them even when there are no rows
 /// to take them from. Kept in step with [`AccountUsageView::rendered_fields`] by
 /// `account_usage_always_renders_the_same_labels_in_order`.
-const ACCOUNT_USAGE_LABELS: [&str; 5] = [
+const ACCOUNT_USAGE_LABELS: [&str; 6] = [
     "Period",
+    "As of",
     "Compute",
     "Memory",
     "Durable storage",
@@ -179,26 +165,26 @@ impl AccountUsageView {
     /// detail view and the history table render through this, so the same usage can never
     /// be reported two different ways. Each label sits next to the value it names, so a
     /// figure cannot end up under the wrong heading.
-    fn rendered_fields(&self) -> [(&'static str, String); 5] {
+    fn rendered_fields(&self) -> [(&'static str, String); 6] {
         [
-            ("Period", self.period.to_string()),
-            ("Compute", format!("{} GCU", self.compute_gcu)),
-            ("Memory", format!("{} GB-seconds", self.memory_gb_seconds)),
+            ("Period", self.usage.period.to_string()),
             (
-                "Durable storage",
-                format!("{} GB-month", self.durable_storage_gb_month),
+                "As of",
+                self.usage
+                    .as_of
+                    .to_rfc3339_opts(SecondsFormat::Millis, true),
             ),
-            (
-                "Ephemeral storage",
-                format!("{} GB-month", self.ephemeral_storage_gb_month),
-            ),
+            ("Compute", self.usage.format_compute()),
+            ("Memory", self.usage.format_memory()),
+            ("Durable storage", self.usage.format_durable_storage()),
+            ("Ephemeral storage", self.usage.format_ephemeral_storage()),
         ]
     }
 }
 
 impl MessageWithFields for AccountUsageView {
     fn message(&self) -> String {
-        format!("Account usage for {}", self.period)
+        format!("Account usage for {}", self.usage.period)
     }
 
     fn fields(&self) -> Vec<(String, String)> {
@@ -488,7 +474,10 @@ impl StructuredOutput for PermissionShareListView {
 #[cfg(test)]
 mod tests {
     use super::{ACCOUNT_USAGE_LABELS, AccountUsageView, MessageWithFields};
-    use golem_common::model::account_usage::StorageUsagePeriod;
+    use chrono::{TimeZone, Utc};
+    use golem_common::model::account_usage::{
+        AccountUsageMetering, AccountUsageMetrics, AccountUsagePeriod, MeteringStatus,
+    };
     use proptest::prelude::*;
     use test_r::test;
 
@@ -503,8 +492,8 @@ mod tests {
         ]
     }
 
-    fn arb_period() -> impl Strategy<Value = StorageUsagePeriod> {
-        (1970i32..=9999, 1u32..=12).prop_map(|(year, month)| StorageUsagePeriod { year, month })
+    fn arb_period() -> impl Strategy<Value = AccountUsagePeriod> {
+        (1970i32..=9999, 1u32..=12).prop_map(|(year, month)| AccountUsagePeriod { year, month })
     }
 
     fn arb_usage() -> impl Strategy<Value = AccountUsageView> {
@@ -524,11 +513,20 @@ mod tests {
                     period,
                 )| {
                     AccountUsageView {
-                        compute_gcu,
-                        memory_gb_seconds,
-                        durable_storage_gb_month,
-                        ephemeral_storage_gb_month,
-                        period,
+                        usage: AccountUsageMetrics {
+                            compute_gcu,
+                            memory_gb_seconds,
+                            durable_storage_gb_month,
+                            ephemeral_storage_gb_month,
+                            period,
+                            as_of: Utc.with_ymd_and_hms(2026, 4, 2, 3, 4, 5).unwrap(),
+                            metering: AccountUsageMetering {
+                                compute: MeteringStatus::Enabled,
+                                memory: MeteringStatus::Enabled,
+                                durable_storage: MeteringStatus::Enabled,
+                                ephemeral_storage: MeteringStatus::Enabled,
+                            },
+                        },
                     }
                 },
             )
@@ -536,13 +534,22 @@ mod tests {
 
     fn sample_usage() -> AccountUsageView {
         AccountUsageView {
-            compute_gcu: 1.5,
-            memory_gb_seconds: 4,
-            durable_storage_gb_month: 2.5,
-            ephemeral_storage_gb_month: 3.5,
-            period: StorageUsagePeriod {
-                year: 2026,
-                month: 4,
+            usage: AccountUsageMetrics {
+                compute_gcu: 1.5,
+                memory_gb_seconds: 4,
+                durable_storage_gb_month: 2.5,
+                ephemeral_storage_gb_month: 3.5,
+                period: AccountUsagePeriod {
+                    year: 2026,
+                    month: 4,
+                },
+                as_of: Utc.with_ymd_and_hms(2026, 4, 2, 3, 4, 5).unwrap(),
+                metering: AccountUsageMetering {
+                    compute: MeteringStatus::Enabled,
+                    memory: MeteringStatus::Enabled,
+                    durable_storage: MeteringStatus::Enabled,
+                    ephemeral_storage: MeteringStatus::Enabled,
+                },
             },
         }
     }
@@ -555,6 +562,7 @@ mod tests {
             fields,
             vec![
                 ("Period".to_string(), "2026-04".to_string()),
+                ("As of".to_string(), "2026-04-02T03:04:05.000Z".to_string()),
                 ("Compute".to_string(), "1.5 GCU".to_string()),
                 ("Memory".to_string(), "4 GB-seconds".to_string()),
                 ("Durable storage".to_string(), "2.5 GB-month".to_string()),
@@ -605,9 +613,9 @@ mod tests {
         fn account_usage_metrics_round_trip_with_their_units(usage in arb_usage()) {
             let fields = usage.fields();
             let expected: [(&str, &str, f64); 3] = [
-                ("Compute", " GCU", usage.compute_gcu),
-                ("Durable storage", " GB-month", usage.durable_storage_gb_month),
-                ("Ephemeral storage", " GB-month", usage.ephemeral_storage_gb_month),
+                ("Compute", " GCU", usage.usage.compute_gcu),
+                ("Durable storage", " GB-month", usage.usage.durable_storage_gb_month),
+                ("Ephemeral storage", " GB-month", usage.usage.ephemeral_storage_gb_month),
             ];
 
             for (label, unit, value) in expected {
@@ -643,8 +651,8 @@ mod tests {
 
             prop_assert_eq!(year.len(), 4, "year must be zero-padded, got '{}'", period);
             prop_assert_eq!(month.len(), 2, "month must be zero-padded, got '{}'", period);
-            prop_assert_eq!(year.parse::<i32>().ok(), Some(usage.period.year));
-            prop_assert_eq!(month.parse::<u32>().ok(), Some(usage.period.month));
+            prop_assert_eq!(year.parse::<i32>().ok(), Some(usage.usage.period.year));
+            prop_assert_eq!(month.parse::<u32>().ok(), Some(usage.usage.period.month));
         }
     }
 }

--- a/cli/golem-cli/src/model/cli_output/tests.rs
+++ b/cli/golem-cli/src/model/cli_output/tests.rs
@@ -4,6 +4,7 @@ use crate::model::cli_output::{
 };
 use crate::model::deploy::DeployPlanView;
 use crate::model::masking::MaskingConfig;
+use chrono::{TimeZone, Utc};
 use golem_common::model::card::{CardId, PolymorphicCard};
 use proptest::prelude::*;
 use quote::ToTokens;
@@ -3290,6 +3291,11 @@ fn arb_account_usage_view() -> BoxedStrategy<crate::model::account::AccountUsage
         0.0f64..1_000_000.0,
         1900i32..=2200,
         1u32..=12,
+        prop_oneof![
+            Just(golem_common::model::account_usage::MeteringStatus::Enabled),
+            Just(golem_common::model::account_usage::MeteringStatus::Disabled),
+            Just(golem_common::model::account_usage::MeteringStatus::Unknown),
+        ],
     )
         .prop_map(
             |(
@@ -3299,13 +3305,26 @@ fn arb_account_usage_view() -> BoxedStrategy<crate::model::account::AccountUsage
                 ephemeral_storage_gb_month,
                 year,
                 month,
+                metering_status,
             )| {
                 crate::model::account::AccountUsageView {
-                    compute_gcu,
-                    memory_gb_seconds,
-                    durable_storage_gb_month,
-                    ephemeral_storage_gb_month,
-                    period: golem_common::model::account_usage::StorageUsagePeriod { year, month },
+                    usage: golem_common::model::account_usage::AccountUsageMetrics {
+                        compute_gcu,
+                        memory_gb_seconds,
+                        durable_storage_gb_month,
+                        ephemeral_storage_gb_month,
+                        period: golem_common::model::account_usage::AccountUsagePeriod {
+                            year,
+                            month,
+                        },
+                        as_of: Utc.with_ymd_and_hms(2026, 4, 2, 3, 4, 5).unwrap(),
+                        metering: golem_common::model::account_usage::AccountUsageMetering {
+                            compute: metering_status,
+                            memory: metering_status,
+                            durable_storage: metering_status,
+                            ephemeral_storage: metering_status,
+                        },
+                    },
                 }
             },
         )

--- a/cli/golem-cli/tests/app/account.rs
+++ b/cli/golem-cli/tests/app/account.rs
@@ -1,11 +1,16 @@
 use crate::Tracing;
 use crate::app::{TestContext, cmd, flag};
+use chrono::{DateTime, Datelike, Utc};
 use golem_cli::{fs, versions};
-use golem_common::model::account_usage::StorageUsagePeriod;
+use golem_common::model::account_usage::{
+    AccountUsageMetering, AccountUsagePeriod, MeteringStatus,
+};
 use indoc::{formatdoc, indoc};
 use serde::Deserialize;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use std::time::Duration;
 use test_r::{inherit_test_dep, test, timeout};
+use uuid::Uuid;
 
 inherit_test_dep!(Tracing);
 
@@ -25,7 +30,9 @@ struct AccountUsageItemView {
     memory_gb_seconds: u64,
     durable_storage_gb_month: f64,
     ephemeral_storage_gb_month: f64,
-    period: StorageUsagePeriod,
+    period: AccountUsagePeriod,
+    as_of: DateTime<Utc>,
+    metering: AccountUsageMetering,
 }
 
 #[derive(Debug, Deserialize)]
@@ -47,17 +54,117 @@ struct AccountLimitsView {
     user_configurable: bool,
 }
 
+fn previous_period(period: AccountUsagePeriod) -> AccountUsagePeriod {
+    if period.month == 1 {
+        AccountUsagePeriod {
+            year: period.year - 1,
+            month: 12,
+        }
+    } else {
+        AccountUsagePeriod {
+            year: period.year,
+            month: period.month - 1,
+        }
+    }
+}
+
+async fn seed_account_usage(
+    ctx: &TestContext,
+) -> (AccountUsagePeriod, AccountUsagePeriod, AccountUsagePeriod) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(ctx.data_dir.path().join("registry.db"))
+                .journal_mode(SqliteJournalMode::Wal)
+                .foreign_keys(true),
+        )
+        .await
+        .expect("failed to open registry database");
+    let account_id = sqlx::query_scalar::<_, Uuid>(
+        "SELECT account_id FROM accounts WHERE email = 'initial@user'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("initial account is missing");
+
+    let now = Utc::now();
+    let current = AccountUsagePeriod {
+        year: now.year(),
+        month: now.month(),
+    };
+    let previous = previous_period(current);
+    let zero_period = previous_period(previous);
+    let gb_month = 1024_i64.pow(3) * 730 * 3600;
+
+    for (period, values, metering) in [
+        (
+            current,
+            [(2, 1_500_000), (10, gb_month), (11, 2 * gb_month), (12, 14)],
+            (true, true, true),
+        ),
+        (
+            previous,
+            [
+                (2, 2_500_000),
+                (10, 3 * gb_month),
+                (11, 4 * gb_month),
+                (12, 21),
+            ],
+            (true, false, true),
+        ),
+        (
+            zero_period,
+            [(2, 0), (10, 0), (11, 0), (12, 0)],
+            (false, true, false),
+        ),
+    ] {
+        let usage_key = period.to_string();
+        for (usage_type, value) in values {
+            sqlx::query(
+                "INSERT INTO account_usage_stats \
+                 (account_id, usage_type, usage_key, value, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(account_id)
+            .bind(usage_type)
+            .bind(&usage_key)
+            .bind(value)
+            .bind(now)
+            .execute(&pool)
+            .await
+            .expect("failed to seed account usage");
+        }
+        sqlx::query(
+            "INSERT INTO account_usage_metering_state \
+             (account_id, usage_key, compute_enabled, memory_enabled, \
+              filesystem_enabled, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(account_id)
+        .bind(usage_key)
+        .bind(metering.0)
+        .bind(metering.1)
+        .bind(metering.2)
+        .bind(now)
+        .execute(&pool)
+        .await
+        .expect("failed to seed account usage metering state");
+    }
+
+    (current, previous, zero_period)
+}
+
 #[test]
 #[timeout("1m")]
-async fn account_storage_usage_and_limits_use_live_cli_wire_path(_tracing: &Tracing) {
+async fn account_usage_and_limits_use_live_cli_wire_path(_tracing: &Tracing) {
     let mut ctx = TestContext::new();
     ctx.start_server().await;
+    let (current_period, previous_period, zero_period) = seed_account_usage(&ctx).await;
 
-    let period_before_request = StorageUsagePeriod::current();
     let output = ctx
         .cli([cmd::ACCOUNT, "usage", "show", flag::FORMAT, "json"])
         .await;
-    let period_after_request = StorageUsagePeriod::current();
     assert!(output.success_or_dump());
     let usage = output
         .stdout_json::<AccountUsageView>()
@@ -65,14 +172,29 @@ async fn account_storage_usage_and_limits_use_live_cli_wire_path(_tracing: &Trac
         .next()
         .expect("account usage show produced no JSON output");
     assert_eq!(usage.kind, "account.usage.show");
-    assert_eq!(usage.usage.compute_gcu, 0.0);
-    assert_eq!(usage.usage.memory_gb_seconds, 0);
-    assert_eq!(usage.usage.durable_storage_gb_month, 0.0);
-    assert_eq!(usage.usage.ephemeral_storage_gb_month, 0.0);
-    assert!(
-        usage.usage.period == period_before_request || usage.usage.period == period_after_request,
-        "usage period should match the current period during the request"
+    assert_eq!(usage.usage.compute_gcu, 1.5);
+    assert_eq!(usage.usage.memory_gb_seconds, 14);
+    assert_eq!(usage.usage.durable_storage_gb_month, 1.0);
+    assert_eq!(usage.usage.ephemeral_storage_gb_month, 2.0);
+    assert!(usage.usage.as_of <= Utc::now());
+    assert_eq!(usage.usage.metering.compute, MeteringStatus::Enabled);
+    assert_eq!(usage.usage.metering.memory, MeteringStatus::Enabled);
+    assert_eq!(
+        usage.usage.metering.durable_storage,
+        MeteringStatus::Enabled
     );
+    assert_eq!(
+        usage.usage.metering.ephemeral_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(usage.usage.period, current_period);
+
+    let output = ctx.cli([cmd::ACCOUNT, "usage", "show"]).await;
+    assert!(output.success_or_dump());
+    assert!(output.stdout_contains("1.5 GCU"));
+    assert!(output.stdout_contains("14 GB-seconds"));
+    assert!(output.stdout_contains("1 GB-month"));
+    assert!(output.stdout_contains("2 GB-month"));
 
     let output = ctx
         .cli([cmd::ACCOUNT, "usage", "history", flag::FORMAT, "json"])
@@ -84,7 +206,50 @@ async fn account_storage_usage_and_limits_use_live_cli_wire_path(_tracing: &Trac
         .next()
         .expect("account usage history produced no JSON output");
     assert_eq!(history.kind, "account.usage.history");
-    assert!(history.usage.is_empty());
+    assert_eq!(history.usage.len(), 2);
+    assert_eq!(history.usage[0].period, previous_period);
+    assert_eq!(history.usage[0].compute_gcu, 2.5);
+    assert_eq!(history.usage[0].memory_gb_seconds, 21);
+    assert_eq!(history.usage[0].durable_storage_gb_month, 3.0);
+    assert_eq!(history.usage[0].ephemeral_storage_gb_month, 4.0);
+    assert_eq!(history.usage[0].metering.compute, MeteringStatus::Enabled);
+    assert_eq!(history.usage[0].metering.memory, MeteringStatus::Disabled);
+    assert_eq!(
+        history.usage[0].metering.durable_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(
+        history.usage[0].metering.ephemeral_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(history.usage[1].period, zero_period);
+    assert_eq!(history.usage[1].compute_gcu, 0.0);
+    assert_eq!(history.usage[1].memory_gb_seconds, 0);
+    assert_eq!(history.usage[1].durable_storage_gb_month, 0.0);
+    assert_eq!(history.usage[1].ephemeral_storage_gb_month, 0.0);
+    assert_eq!(history.usage[1].metering.compute, MeteringStatus::Disabled);
+    assert_eq!(history.usage[1].metering.memory, MeteringStatus::Enabled);
+    assert_eq!(
+        history.usage[1].metering.durable_storage,
+        MeteringStatus::Disabled
+    );
+    assert_eq!(
+        history.usage[1].metering.ephemeral_storage,
+        MeteringStatus::Disabled
+    );
+
+    let output = ctx.cli([cmd::ACCOUNT, "usage", "history"]).await;
+    assert!(output.success_or_dump());
+    assert!(output.stdout_contains("2.5 GCU"));
+    assert!(
+        output.stdout_contains_ordered(["21", "GB-seconds", "(metering", "disabled)"]),
+        "disabled metering must not hide accrued usage"
+    );
+    assert!(output.stdout_contains("3 GB-month"));
+    assert!(output.stdout_contains("4 GB-month"));
+    assert!(output.stdout_contains(zero_period.to_string()));
+    assert!(output.stdout_contains_ordered(["0 GCU", "(metering", "disabled)"]));
+    assert!(output.stdout_contains_ordered([zero_period.to_string(), "GB-seconds".to_string()]));
 
     let output = ctx
         .cli([cmd::ACCOUNT, "limits", "show", flag::FORMAT, "json"])

--- a/docs/src/content/next/rest-api/account.mdx
+++ b/docs/src/content/next/rest-api/account.mdx
@@ -255,18 +255,23 @@ The response not only contains the token data but also the secret which can be p
 }
 ```
 
-## Get current durable and ephemeral storage usage and storage limit.
+## Get account usage for a UTC calendar month.
 Path|Method|Protected
 ---|---|---
 `/v1/accounts/{account_id}/usage`|GET|Yes
 
-
+Compute is reported in GCU, memory in allocated linear-memory GB-seconds, and durable and
+ephemeral storage in GB-month using byte-seconds / (1024^3 * 730 * 3600). `asOf` is when
+the registry last received a usage snapshot for the period, or the response time if no
+snapshot exists. Metering status distinguishes enabled meters that measured zero from
+disabled meters. `unknown` means no usage producer has reported metering state for the
+period. Durable and ephemeral storage both reflect the shared filesystem meter.
 
 **Query Parameters**
 
 Name|Type|Required|Description
 ---|---|---|---
-period|string|No|-
+period|string|No|Billing period in YYYY-MM format. Defaults to the current UTC calendar month.
 
 
 
@@ -275,48 +280,33 @@ period|string|No|-
 ```json copy
 {
   "accountId": "3d07c219-0a88-45be-9cfc-91e9d095a1e9",
-  "planId": "b3f60ba2-c1fd-4b3a-a23d-8e876e0ef75d",
-  "planName": "string",
   "usage": {
     "period": {
       "year": 0,
-      "month": 0
+      "month": 1
     },
+    "asOf": "2019-08-24T14:15:22Z",
     "computeGcu": 0.1,
     "memoryGbSeconds": 0,
     "durableStorageGbMonth": 0.1,
-    "ephemeralStorageGbMonth": 0.1
-  },
-  "maxStoragePerAgent": {
-    "effectiveValue": 0,
-    "planDefault": 0,
-    "overrideValue": 0,
-    "ceiling": 0,
-    "userConfigurable": true
-  },
-  "maxMemoryPerAgent": {
-    "effectiveValue": 0,
-    "planDefault": 0,
-    "overrideValue": 0,
-    "ceiling": 0,
-    "userConfigurable": true
-  },
-  "monthlyMemoryGbSeconds": {
-    "effectiveValue": 0,
-    "planDefault": 0,
-    "overrideValue": 0,
-    "ceiling": 0,
-    "userConfigurable": true
+    "ephemeralStorageGbMonth": 0.1,
+    "metering": {
+      "compute": "enabled",
+      "memory": "enabled",
+      "durableStorage": "enabled",
+      "ephemeralStorage": "enabled"
+    }
   }
 }
 ```
 
-## Get storage usage for closed billing periods, newest first.
+## Get sparse account usage for closed UTC calendar months, newest first.
 Path|Method|Protected
 ---|---|---
 `/v1/accounts/{account_id}/usage/history`|GET|Yes
 
-
+Each item uses the same metrics and metering-status contract as current usage. The response
+does not include plan or limit metadata because historical limits are not snapshotted.
 
 **Query Parameters**
 
@@ -335,12 +325,19 @@ last|integer|No|-
     "usage": {
       "period": {
         "year": 0,
-        "month": 0
+        "month": 1
       },
+      "asOf": "2019-08-24T14:15:22Z",
       "computeGcu": 0.1,
       "memoryGbSeconds": 0,
       "durableStorageGbMonth": 0.1,
-      "ephemeralStorageGbMonth": 0.1
+      "ephemeralStorageGbMonth": 0.1,
+      "metering": {
+        "compute": "enabled",
+        "memory": "enabled",
+        "durableStorage": "enabled",
+        "ephemeralStorage": "enabled"
+      }
     }
   }
 ]

--- a/golem-api-grpc/proto/golem/registry/resource_usage_update.proto
+++ b/golem-api-grpc/proto/golem/registry/resource_usage_update.proto
@@ -12,4 +12,7 @@ message ResourceUsageUpdate {
   int64 durable_storage_byte_seconds_delta = 5;
   int64 ephemeral_storage_byte_seconds_delta = 6;
   int64 memory_gb_seconds_delta = 7;
+  bool compute_metering_enabled = 8;
+  bool memory_metering_enabled = 9;
+  bool filesystem_metering_enabled = 10;
 }

--- a/golem-client/build.rs
+++ b/golem-client/build.rs
@@ -51,16 +51,20 @@ fn generate(yaml_path: PathBuf, out_dir: OsString) {
             ),
             // account usage
             (
-                "StorageUsage",
-                "golem_common::model::account_usage::StorageUsage",
+                "AccountUsage",
+                "golem_common::model::account_usage::AccountUsage",
             ),
             (
-                "StorageUsageHistory",
-                "golem_common::model::account_usage::StorageUsageHistory",
+                "AccountUsageMetrics",
+                "golem_common::model::account_usage::AccountUsageMetrics",
             ),
             (
-                "StorageUsageMetrics",
-                "golem_common::model::account_usage::StorageUsageMetrics",
+                "AccountUsageMetering",
+                "golem_common::model::account_usage::AccountUsageMetering",
+            ),
+            (
+                "MeteringStatus",
+                "golem_common::model::account_usage::MeteringStatus",
             ),
             (
                 "StorageLimit",
@@ -71,8 +75,8 @@ fn generate(yaml_path: PathBuf, out_dir: OsString) {
                 "golem_common::model::account_usage::SetStorageLimit",
             ),
             (
-                "StorageUsagePeriod",
-                "golem_common::model::account_usage::StorageUsagePeriod",
+                "AccountUsagePeriod",
+                "golem_common::model::account_usage::AccountUsagePeriod",
             ),
             (
                 "MemoryLimit",

--- a/golem-common/src/base_model/account_usage.rs
+++ b/golem-common/src/base_model/account_usage.rs
@@ -13,45 +13,53 @@
 // limitations under the License.
 
 use crate::base_model::account::AccountId;
-use crate::base_model::plan::{PlanId, PlanName};
-use crate::declare_structs;
+use crate::{declare_enums, declare_structs};
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 pub const BYTE_SECONDS_PER_GB_MONTH: f64 = 1024.0 * 1024.0 * 1024.0 * 730.0 * 3600.0;
 pub const FUEL_PER_GCU: u64 = 1_000_000;
-pub const DEFAULT_STORAGE_USAGE_HISTORY_PERIODS: usize = 6;
+pub const DEFAULT_ACCOUNT_USAGE_HISTORY_PERIODS: usize = 6;
 const PERIOD_FORMAT_ERROR: &str = "period must use YYYY-MM format";
+
+declare_enums! {
+    pub enum MeteringStatus {
+        Enabled,
+        Disabled,
+        /// No usage producer has reported the metering state for this period yet.
+        Unknown,
+    }
+}
 
 declare_structs! {
     #[derive(Copy, Eq, PartialOrd, Ord)]
-    pub struct StorageUsagePeriod {
+    pub struct AccountUsagePeriod {
         pub year: i32,
+        #[cfg_attr(feature = "full", oai(validator(minimum(value = "1"), maximum(value = "12"))))]
         pub month: u32,
     }
 
-    pub struct StorageUsageMetrics {
-        pub period: StorageUsagePeriod,
+    pub struct AccountUsageMetering {
+        pub compute: MeteringStatus,
+        pub memory: MeteringStatus,
+        pub durable_storage: MeteringStatus,
+        pub ephemeral_storage: MeteringStatus,
+    }
+
+    pub struct AccountUsageMetrics {
+        pub period: AccountUsagePeriod,
+        pub as_of: DateTime<Utc>,
         pub compute_gcu: f64,
         pub memory_gb_seconds: u64,
         pub durable_storage_gb_month: f64,
         pub ephemeral_storage_gb_month: f64,
+        pub metering: AccountUsageMetering,
     }
 
-    pub struct StorageUsage {
+    pub struct AccountUsage {
         pub account_id: AccountId,
-        pub plan_id: PlanId,
-        pub plan_name: PlanName,
-        pub usage: StorageUsageMetrics,
-        pub max_storage_per_agent: StorageLimit,
-        pub max_memory_per_agent: MemoryLimit,
-        pub monthly_memory_gb_seconds: MemoryLimit,
-    }
-
-    pub struct StorageUsageHistory {
-        pub account_id: AccountId,
-        pub usage: StorageUsageMetrics,
+        pub usage: AccountUsageMetrics,
     }
 
     #[derive(Eq)]
@@ -83,13 +91,13 @@ declare_structs! {
     }
 }
 
-impl Display for StorageUsagePeriod {
+impl Display for AccountUsagePeriod {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:04}-{:02}", self.year, self.month)
     }
 }
 
-impl StorageUsagePeriod {
+impl AccountUsagePeriod {
     pub fn current() -> Self {
         let now = Utc::now();
         Self {
@@ -133,7 +141,7 @@ impl MemoryLimit {
     }
 }
 
-impl FromStr for StorageUsagePeriod {
+impl FromStr for AccountUsagePeriod {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -157,17 +165,63 @@ impl FromStr for StorageUsagePeriod {
     }
 }
 
+pub fn fuel_to_gcu(fuel: u64) -> f64 {
+    fuel as f64 / FUEL_PER_GCU as f64
+}
+
+pub fn byte_seconds_to_gb_month(byte_seconds: u64) -> f64 {
+    byte_seconds as f64 / BYTE_SECONDS_PER_GB_MONTH
+}
+
+impl AccountUsageMetrics {
+    pub fn format_compute(&self) -> String {
+        format_metered(self.compute_gcu, "GCU", self.metering.compute)
+    }
+
+    pub fn format_memory(&self) -> String {
+        format_metered(self.memory_gb_seconds, "GB-seconds", self.metering.memory)
+    }
+
+    pub fn format_durable_storage(&self) -> String {
+        format_metered(
+            self.durable_storage_gb_month,
+            "GB-month",
+            self.metering.durable_storage,
+        )
+    }
+
+    pub fn format_ephemeral_storage(&self) -> String {
+        format_metered(
+            self.ephemeral_storage_gb_month,
+            "GB-month",
+            self.metering.ephemeral_storage,
+        )
+    }
+}
+
+fn format_metered(value: impl Display, unit: &str, status: MeteringStatus) -> String {
+    match status {
+        MeteringStatus::Enabled => format!("{value} {unit}"),
+        MeteringStatus::Disabled => format!("{value} {unit} (metering disabled)"),
+        MeteringStatus::Unknown => format!("{value} {unit} (metering state unknown)"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{MemoryLimit, StorageUsagePeriod};
+    use super::{
+        AccountUsageMetering, AccountUsageMetrics, AccountUsagePeriod, FUEL_PER_GCU, MemoryLimit,
+        MeteringStatus, byte_seconds_to_gb_month, fuel_to_gcu,
+    };
+    use chrono::Utc;
     use std::str::FromStr;
     use test_r::test;
 
     #[test]
-    fn storage_usage_period_parses_year_and_month() {
+    fn account_usage_period_parses_year_and_month() {
         assert_eq!(
-            StorageUsagePeriod::from_str("2026-04").unwrap(),
-            StorageUsagePeriod {
+            AccountUsagePeriod::from_str("2026-04").unwrap(),
+            AccountUsagePeriod {
                 year: 2026,
                 month: 4,
             }
@@ -175,9 +229,9 @@ mod tests {
     }
 
     #[test]
-    fn storage_usage_period_rejects_invalid_month() {
+    fn account_usage_period_rejects_invalid_month() {
         assert_eq!(
-            StorageUsagePeriod::from_str("2026-13").unwrap_err(),
+            AccountUsagePeriod::from_str("2026-13").unwrap_err(),
             "period month must be between 01 and 12"
         );
     }
@@ -193,6 +247,45 @@ mod tests {
                 ceiling: 200,
                 user_configurable: true,
             }
+        );
+    }
+
+    #[test]
+    fn account_usage_uses_canonical_customer_unit_conversions() {
+        assert_eq!(fuel_to_gcu(FUEL_PER_GCU * 2), 2.0);
+        let byte_seconds_per_gb_month = 1024_u64.pow(3) * 730 * 3600;
+        assert_eq!(byte_seconds_to_gb_month(byte_seconds_per_gb_month * 2), 2.0);
+    }
+
+    #[test]
+    fn account_usage_formatting_distinguishes_metering_state_from_zero() {
+        let usage = AccountUsageMetrics {
+            period: AccountUsagePeriod {
+                year: 2026,
+                month: 4,
+            },
+            as_of: Utc::now(),
+            compute_gcu: 0.0,
+            memory_gb_seconds: 0,
+            durable_storage_gb_month: 0.0,
+            ephemeral_storage_gb_month: 0.0,
+            metering: AccountUsageMetering {
+                compute: MeteringStatus::Enabled,
+                memory: MeteringStatus::Disabled,
+                durable_storage: MeteringStatus::Unknown,
+                ephemeral_storage: MeteringStatus::Unknown,
+            },
+        };
+
+        assert_eq!(usage.format_compute(), "0 GCU");
+        assert_eq!(usage.format_memory(), "0 GB-seconds (metering disabled)");
+        assert_eq!(
+            usage.format_durable_storage(),
+            "0 GB-month (metering state unknown)"
+        );
+        assert_eq!(
+            usage.format_ephemeral_storage(),
+            "0 GB-month (metering state unknown)"
         );
     }
 }

--- a/golem-registry-service/db/migration/postgres/034_account_usage_metering_state.sql
+++ b/golem-registry-service/db/migration/postgres/034_account_usage_metering_state.sql
@@ -1,0 +1,13 @@
+CREATE TABLE account_usage_metering_state
+(
+    account_id        UUID      NOT NULL,
+    usage_key         TEXT      NOT NULL,
+    compute_enabled   BOOLEAN   NOT NULL,
+    memory_enabled    BOOLEAN   NOT NULL,
+    filesystem_enabled BOOLEAN  NOT NULL,
+    updated_at        TIMESTAMP NOT NULL,
+    CONSTRAINT account_usage_metering_state_pk
+        PRIMARY KEY (account_id, usage_key),
+    CONSTRAINT account_usage_metering_state_accounts_fk
+        FOREIGN KEY (account_id) REFERENCES accounts
+);

--- a/golem-registry-service/db/migration/sqlite/034_account_usage_metering_state.sql
+++ b/golem-registry-service/db/migration/sqlite/034_account_usage_metering_state.sql
@@ -1,0 +1,13 @@
+CREATE TABLE account_usage_metering_state
+(
+    account_id        UUID      NOT NULL,
+    usage_key         TEXT      NOT NULL,
+    compute_enabled   BOOLEAN   NOT NULL,
+    memory_enabled    BOOLEAN   NOT NULL,
+    filesystem_enabled BOOLEAN  NOT NULL,
+    updated_at        TIMESTAMP NOT NULL,
+    CONSTRAINT account_usage_metering_state_pk
+        PRIMARY KEY (account_id, usage_key),
+    CONSTRAINT account_usage_metering_state_accounts_fk
+        FOREIGN KEY (account_id) REFERENCES accounts
+);

--- a/golem-registry-service/src/api/account_usage.rs
+++ b/golem-registry-service/src/api/account_usage.rs
@@ -20,8 +20,8 @@ use crate::services::auth::AuthService;
 use golem_common::base_model::api;
 use golem_common::model::account::AccountId;
 use golem_common::model::account_usage::{
-    DEFAULT_STORAGE_USAGE_HISTORY_PERIODS, MemoryLimit, SetMemoryLimit, SetStorageLimit,
-    StorageLimit, StorageUsage, StorageUsageHistory,
+    AccountUsage, DEFAULT_ACCOUNT_USAGE_HISTORY_PERIODS, MemoryLimit, SetMemoryLimit,
+    SetStorageLimit, StorageLimit,
 };
 use golem_common::recorded_http_api_request;
 use golem_service_base::api_tags::ApiTags;
@@ -57,22 +57,28 @@ impl AccountUsageApi {
         }
     }
 
-    /// Get current durable and ephemeral storage usage and storage limit.
+    /// Get account usage for a UTC calendar month.
+    ///
+    /// Compute is reported in GCU, memory in allocated linear-memory GB-seconds, and durable and
+    /// ephemeral storage in GB-month using byte-seconds / (1024^3 * 730 * 3600). `asOf` is when
+    /// the registry last received a usage snapshot for the period, or the response time if no
+    /// snapshot exists. Metering status distinguishes enabled meters that measured zero from
+    /// disabled meters. `unknown` means no usage producer has reported metering state for the
+    /// period. Durable and ephemeral storage both reflect the shared filesystem meter.
     #[oai(
         path = "/:account_id/usage",
         method = "get",
-        operation_id = "get_account_storage_usage"
+        operation_id = "get_account_usage"
     )]
     async fn get_usage(
         &self,
         account_id: Path<AccountId>,
+        /// Billing period in YYYY-MM format. Defaults to the current UTC calendar month.
         period: Query<Option<String>>,
         token: GolemSecurityScheme,
-    ) -> ApiResult<Json<StorageUsage>> {
-        let record = recorded_http_api_request!(
-            "get_account_storage_usage",
-            account_id = account_id.0.to_string()
-        );
+    ) -> ApiResult<Json<AccountUsage>> {
+        let record =
+            recorded_http_api_request!("get_account_usage", account_id = account_id.0.to_string());
         let auth = self.auth_service.authenticate_token(token.secret()).await?;
         let response = match period.0 {
             Some(period) => {
@@ -80,13 +86,13 @@ impl AccountUsageApi {
                     ApiError::bad_request(api::error_code::INVALID_USAGE_PERIOD, message)
                 })?;
                 self.account_usage_service
-                    .get_storage_usage_for_period(account_id.0, period, &auth)
+                    .get_usage_for_period(account_id.0, period, &auth)
                     .instrument(record.span.clone())
                     .await?
             }
             None => {
                 self.account_usage_service
-                    .get_storage_usage(account_id.0, &auth)
+                    .get_usage(account_id.0, &auth)
                     .instrument(record.span.clone())
                     .await?
             }
@@ -95,28 +101,31 @@ impl AccountUsageApi {
         record.result(Ok(Json(response)))
     }
 
-    /// Get storage usage for closed billing periods, newest first.
+    /// Get sparse account usage for closed UTC calendar months, newest first.
+    ///
+    /// Each item uses the same metrics and metering-status contract as current usage. The response
+    /// does not include plan or limit metadata because historical limits are not snapshotted.
     #[oai(
         path = "/:account_id/usage/history",
         method = "get",
-        operation_id = "get_account_storage_usage_history"
+        operation_id = "get_account_usage_history"
     )]
     async fn get_usage_history(
         &self,
         account_id: Path<AccountId>,
         last: Query<Option<usize>>,
         token: GolemSecurityScheme,
-    ) -> ApiResult<Json<Vec<StorageUsageHistory>>> {
+    ) -> ApiResult<Json<Vec<AccountUsage>>> {
         let record = recorded_http_api_request!(
-            "get_account_storage_usage_history",
+            "get_account_usage_history",
             account_id = account_id.0.to_string()
         );
         let auth = self.auth_service.authenticate_token(token.secret()).await?;
         let response = self
             .account_usage_service
-            .get_storage_usage_history(
+            .get_usage_history(
                 account_id.0,
-                last.0.unwrap_or(DEFAULT_STORAGE_USAGE_HISTORY_PERIODS),
+                last.0.unwrap_or(DEFAULT_ACCOUNT_USAGE_HISTORY_PERIODS),
                 &auth,
             )
             .instrument(record.span.clone())

--- a/golem-registry-service/src/grpc/api_impl.rs
+++ b/golem-registry-service/src/grpc/api_impl.rs
@@ -218,6 +218,11 @@ impl RegistryServiceGrpcApi {
                         ephemeral_storage_byte_seconds_delta: u
                             .ephemeral_storage_byte_seconds_delta,
                         memory_gb_seconds_delta: u.memory_gb_seconds_delta,
+                        metering: golem_service_base::clients::registry::ResourceUsageMetering {
+                            compute: u.compute_metering_enabled,
+                            memory: u.memory_metering_enabled,
+                            filesystem: u.filesystem_metering_enabled,
+                        },
                     },
                 ))
             })

--- a/golem-registry-service/src/repo/account_usage.rs
+++ b/golem-registry-service/src/repo/account_usage.rs
@@ -15,15 +15,14 @@
 pub use crate::repo::model::account::AccountRecord;
 use crate::repo::model::account_resource_override::AccountResourceOverrideDimension;
 use crate::repo::model::account_usage::{
-    AccountUsage, AccountUsagePlan, StorageUsageHistoryRecord, UsageGrouping, UsageTracking,
-    UsageType,
+    AccountUsage, AccountUsagePlan, AccountUsageRecord, UsageGrouping, UsageTracking, UsageType,
 };
 use async_trait::async_trait;
 use chrono::Datelike;
 use conditional_trait_gen::trait_gen;
 use futures::FutureExt;
 use futures::future::BoxFuture;
-use golem_common::model::account_usage::{MemoryLimit, StorageLimit, StorageUsagePeriod};
+use golem_common::model::account_usage::{AccountUsagePeriod, MemoryLimit, StorageLimit};
 use golem_service_base::db::postgres::PostgresPool;
 use golem_service_base::db::sqlite::SqlitePool;
 use golem_service_base::db::{LabelledPoolApi, LabelledPoolTransaction, Pool, PoolApi};
@@ -31,10 +30,41 @@ use golem_service_base::repo::NumericU64;
 use golem_service_base::repo::RepoResult;
 use golem_service_base::repo::SqlDateTime;
 use indoc::indoc;
-use sqlx::{Database, QueryBuilder, Row};
+use sqlx::{Database, FromRow, QueryBuilder, Row};
 use std::collections::BTreeMap;
 use tracing::{Instrument, Span, info_span};
 use uuid::Uuid;
+
+#[derive(sqlx::FromRow)]
+struct AccountUsageReportRow {
+    usage_type: Option<UsageType>,
+    value: Option<NumericU64>,
+    updated_at: SqlDateTime,
+    compute_enabled: Option<bool>,
+    memory_enabled: Option<bool>,
+    filesystem_enabled: Option<bool>,
+}
+
+impl AccountUsageReportRow {
+    fn apply_to(self, report: &mut AccountUsageRecord) {
+        let updated_at = self.updated_at.into_utc();
+        match (
+            self.usage_type,
+            self.value,
+            self.compute_enabled,
+            self.memory_enabled,
+            self.filesystem_enabled,
+        ) {
+            (Some(usage_type), Some(value), _, _, _) => {
+                report.apply(usage_type, value.get(), updated_at)
+            }
+            (None, None, Some(compute), Some(memory), Some(filesystem)) => {
+                report.apply_metering(compute, memory, filesystem, updated_at)
+            }
+            _ => {}
+        }
+    }
+}
 
 #[async_trait]
 pub trait AccountUsageRepo: Send + Sync {
@@ -47,12 +77,18 @@ pub trait AccountUsageRepo: Send + Sync {
         usage_type: UsageType,
     ) -> RepoResult<Option<AccountUsage>>;
 
-    async fn get_storage_history(
+    async fn get_usage_report(
         &self,
         account_id: Uuid,
-        before: StorageUsagePeriod,
+        period: AccountUsagePeriod,
+    ) -> RepoResult<AccountUsageRecord>;
+
+    async fn get_usage_history(
+        &self,
+        account_id: Uuid,
+        before: AccountUsagePeriod,
         last: usize,
-    ) -> RepoResult<Vec<StorageUsageHistoryRecord>>;
+    ) -> RepoResult<Vec<AccountUsageRecord>>;
 
     async fn add(&self, account_usage: &AccountUsage) -> RepoResult<()>;
 }
@@ -94,14 +130,25 @@ impl<Repo: AccountUsageRepo> AccountUsageRepo for LoggedAccountUsageRepo<Repo> {
             .await
     }
 
-    async fn get_storage_history(
+    async fn get_usage_report(
         &self,
         account_id: Uuid,
-        before: StorageUsagePeriod,
-        last: usize,
-    ) -> RepoResult<Vec<StorageUsageHistoryRecord>> {
+        period: AccountUsagePeriod,
+    ) -> RepoResult<AccountUsageRecord> {
         self.repo
-            .get_storage_history(account_id, before, last)
+            .get_usage_report(account_id, period)
+            .instrument(Self::span_account_id(account_id))
+            .await
+    }
+
+    async fn get_usage_history(
+        &self,
+        account_id: Uuid,
+        before: AccountUsagePeriod,
+        last: usize,
+    ) -> RepoResult<Vec<AccountUsageRecord>> {
+        self.repo
+            .get_usage_history(account_id, before, last)
             .instrument(Self::span_account_id(account_id))
             .await
     }
@@ -222,6 +269,7 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
             storage_limit: storage_limit(&account_plan),
             max_memory_per_worker: max_memory_per_worker(&account_plan),
             monthly_memory_gb_seconds: monthly_memory_gb_seconds(&account_plan),
+            metering: None,
             plan: account_plan.plan,
             changes: Default::default(),
         }))
@@ -355,36 +403,107 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
             storage_limit: storage_limit(&account_plan),
             max_memory_per_worker: max_memory_per_worker(&account_plan),
             monthly_memory_gb_seconds: monthly_memory_gb_seconds(&account_plan),
+            metering: None,
             plan: account_plan.plan,
             changes: Default::default(),
         }))
     }
 
-    async fn get_storage_history(
+    async fn get_usage_report(
         &self,
         account_id: Uuid,
-        before: StorageUsagePeriod,
-        last: usize,
-    ) -> RepoResult<Vec<StorageUsageHistoryRecord>> {
+        period: AccountUsagePeriod,
+    ) -> RepoResult<AccountUsageRecord> {
         let rows = self
-            .with_ro("get_storage_history")
+            .with_ro("get_usage_report")
+            .fetch_all(
+                sqlx::query(indoc! { r#"
+                    SELECT
+                        usage_type,
+                        value,
+                        updated_at,
+                        NULL AS compute_enabled,
+                        NULL AS memory_enabled,
+                        NULL AS filesystem_enabled
+                    FROM account_usage_stats
+                    WHERE account_id = $1
+                        AND usage_key = $2
+                        AND usage_type IN ($3, $4, $5, $6)
+                    UNION ALL
+                    SELECT
+                        NULL AS usage_type,
+                        NULL AS value,
+                        updated_at,
+                        compute_enabled,
+                        memory_enabled,
+                        filesystem_enabled
+                    FROM account_usage_metering_state
+                    WHERE account_id = $1 AND usage_key = $2
+                "#})
+                .bind(account_id)
+                .bind(year_and_month_to_usage_key(period.year, period.month))
+                .bind(UsageType::MonthlyDurableAgentStorageByteSeconds)
+                .bind(UsageType::MonthlyEphemeralStorageByteSeconds)
+                .bind(UsageType::MonthlyGasLimit)
+                .bind(UsageType::MonthlyMemoryGbSeconds),
+            )
+            .await?;
+
+        let mut report = AccountUsageRecord::new(period);
+        for row in rows {
+            AccountUsageReportRow::from_row(&row)?.apply_to(&mut report);
+        }
+        Ok(report)
+    }
+
+    async fn get_usage_history(
+        &self,
+        account_id: Uuid,
+        before: AccountUsagePeriod,
+        last: usize,
+    ) -> RepoResult<Vec<AccountUsageRecord>> {
+        let rows = self
+            .with_ro("get_usage_history")
             .fetch_all(
                 sqlx::query(indoc! { r#"
                     WITH periods AS (
-                        SELECT DISTINCT usage_key
+                        SELECT usage_key
                         FROM account_usage_stats
                         WHERE account_id = $1
                             AND usage_key < $2
                             AND usage_type IN ($3, $4, $5, $6)
-                        ORDER BY usage_key DESC
+                        UNION
+                        SELECT usage_key
+                        FROM account_usage_metering_state
+                        WHERE account_id = $1 AND usage_key < $2
+                        ORDER BY 1 DESC
                         LIMIT $7
                     )
-                    SELECT stats.usage_key, stats.usage_type, stats.value
+                    SELECT
+                        stats.usage_key,
+                        stats.usage_type,
+                        stats.value,
+                        stats.updated_at,
+                        NULL AS compute_enabled,
+                        NULL AS memory_enabled,
+                        NULL AS filesystem_enabled
                     FROM account_usage_stats stats
                     JOIN periods ON periods.usage_key = stats.usage_key
                     WHERE stats.account_id = $1
                         AND stats.usage_type IN ($3, $4, $5, $6)
-                    ORDER BY stats.usage_key DESC
+                    UNION ALL
+                    SELECT
+                        state.usage_key,
+                        NULL AS usage_type,
+                        NULL AS value,
+                        state.updated_at,
+                        state.compute_enabled,
+                        state.memory_enabled,
+                        state.filesystem_enabled
+                    FROM account_usage_metering_state state
+                    JOIN periods ON periods.usage_key = state.usage_key
+                    WHERE state.account_id = $1
+                    ORDER BY 1 DESC
                 "#})
                 .bind(account_id)
                 .bind(year_and_month_to_usage_key(before.year, before.month))
@@ -396,7 +515,7 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
             )
             .await?;
 
-        let mut periods = BTreeMap::<StorageUsagePeriod, (u64, u64, u64, u64)>::new();
+        let mut periods = BTreeMap::<AccountUsagePeriod, AccountUsageRecord>::new();
         for row in rows {
             let usage_key: String = row.try_get("usage_key")?;
             let Some((year, month)) = usage_key.split_once('-') else {
@@ -405,30 +524,17 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
             let (Ok(year), Ok(month)) = (year.parse(), month.parse()) else {
                 continue;
             };
-            let period = StorageUsagePeriod { year, month };
-            let values = periods.entry(period).or_default();
-            let value = row.try_get::<NumericU64, _>("value")?.get();
-            match row.try_get("usage_type")? {
-                UsageType::MonthlyDurableAgentStorageByteSeconds => values.0 = value,
-                UsageType::MonthlyEphemeralStorageByteSeconds => values.1 = value,
-                UsageType::MonthlyGasLimit => values.2 = value,
-                UsageType::MonthlyMemoryGbSeconds => values.3 = value,
-                _ => continue,
-            }
+            let period = AccountUsagePeriod { year, month };
+            let report = periods
+                .entry(period)
+                .or_insert_with(|| AccountUsageRecord::new(period));
+            AccountUsageReportRow::from_row(&row)?.apply_to(report);
         }
 
         Ok(periods
             .into_iter()
             .rev()
-            .map(
-                |(period, (durable, ephemeral, compute, memory))| StorageUsageHistoryRecord {
-                    period,
-                    durable_storage_byte_seconds: durable,
-                    ephemeral_storage_byte_seconds: ephemeral,
-                    compute_fuel: compute,
-                    memory_gb_seconds: memory,
-                },
-            )
+            .map(|(_, report)| report)
             .collect())
     }
 
@@ -449,25 +555,27 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
                 (*usage_type, usage_key, *change)
             })
             .collect::<Vec<_>>();
+        let metering = account_usage.metering;
 
-        if changes.is_empty() {
+        if changes.is_empty() && metering.is_none() {
             return Ok(());
         }
 
         self.with_tx("change_usage", |tx| {
             async move {
                 let updated_at = SqlDateTime::now();
-                let mut query = QueryBuilder::<<PostgresPool as Pool>::Db>::new(indoc! { r#"
-                    WITH changes (account_id, usage_type, usage_key, delta, updated_at) AS (
-                "#});
-                query.push_values(changes, |mut row, (usage_type, usage_key, change)| {
-                    row.push_bind(account_id)
-                        .push_bind(usage_type)
-                        .push_bind(usage_key)
-                        .push_bind(change)
-                        .push_bind(updated_at.clone());
-                });
-                query.push(indoc! { r#"
+                if !changes.is_empty() {
+                    let mut query = QueryBuilder::<<PostgresPool as Pool>::Db>::new(indoc! { r#"
+                        WITH changes (account_id, usage_type, usage_key, delta, updated_at) AS (
+                    "#});
+                    query.push_values(changes, |mut row, (usage_type, usage_key, change)| {
+                        row.push_bind(account_id)
+                            .push_bind(usage_type)
+                            .push_bind(usage_key)
+                            .push_bind(change)
+                            .push_bind(updated_at.clone());
+                    });
+                    query.push(indoc! { r#"
                     )
                     INSERT INTO account_usage_stats (
                         account_id,
@@ -512,9 +620,42 @@ impl AccountUsageRepo for DbAccountUsageRepo<PostgresPool> {
                             )
                         END,
                         updated_at = excluded.updated_at;
-                "#});
+                    "#});
 
-                tx.execute(query.build()).await?;
+                    tx.execute(query.build()).await?;
+                }
+
+                if let Some(metering) = metering {
+                    let usage_key = date_usage_key;
+                    let mut query = QueryBuilder::<<PostgresPool as Pool>::Db>::new(indoc! { r#"
+                        INSERT INTO account_usage_metering_state (
+                            account_id,
+                            usage_key,
+                            compute_enabled,
+                            memory_enabled,
+                            filesystem_enabled,
+                            updated_at
+                        )
+                    "#});
+                    query.push_values([metering], |mut row, metering| {
+                        row.push_bind(account_id)
+                            .push_bind(&usage_key)
+                            .push_bind(metering.compute)
+                            .push_bind(metering.memory)
+                            .push_bind(metering.filesystem)
+                            .push_bind(updated_at.clone());
+                    });
+                    query.push(indoc! { r#"
+                        ON CONFLICT (account_id, usage_key) DO UPDATE
+                        SET
+                            compute_enabled = excluded.compute_enabled,
+                            memory_enabled = excluded.memory_enabled,
+                            filesystem_enabled = excluded.filesystem_enabled,
+                            updated_at = excluded.updated_at
+                    "#});
+
+                    tx.execute(query.build()).await?;
+                }
 
                 Ok(())
             }

--- a/golem-registry-service/src/repo/model/account_usage.rs
+++ b/golem-registry-service/src/repo/model/account_usage.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::repo::model::plan::PlanRecord;
-use golem_common::model::account_usage::{
-    BYTE_SECONDS_PER_GB_MONTH, FUEL_PER_GCU, StorageLimit, StorageUsagePeriod,
-};
+use chrono::{DateTime, Utc};
+use golem_common::model::account_usage::{AccountUsagePeriod, StorageLimit};
+use golem_service_base::clients::registry::ResourceUsageMetering;
 use golem_service_base::model::ResourceLimits;
 use golem_service_base::repo::NumericU64;
 use sqlx::FromRow;
@@ -92,14 +92,6 @@ impl UsageType {
     }
 }
 
-pub fn byte_seconds_to_gb_month(byte_seconds: u64) -> f64 {
-    byte_seconds as f64 / BYTE_SECONDS_PER_GB_MONTH
-}
-
-pub fn fuel_to_gcu(fuel: u64) -> f64 {
-    fuel as f64 / FUEL_PER_GCU as f64
-}
-
 #[derive(FromRow, Debug, Clone, PartialEq)]
 pub struct AccountUsageStatsRecord {
     pub account_id: Uuid,
@@ -120,6 +112,7 @@ pub struct AccountUsage {
     pub storage_limit: StorageLimit,
     pub max_memory_per_worker: golem_common::model::account_usage::MemoryLimit,
     pub monthly_memory_gb_seconds: golem_common::model::account_usage::MemoryLimit,
+    pub metering: Option<ResourceUsageMetering>,
     pub changes: BTreeMap<UsageType, i64>,
 }
 
@@ -133,12 +126,62 @@ pub struct AccountUsagePlan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StorageUsageHistoryRecord {
-    pub period: StorageUsagePeriod,
+pub struct AccountUsageRecord {
+    pub period: AccountUsagePeriod,
+    pub as_of: Option<DateTime<Utc>>,
     pub durable_storage_byte_seconds: u64,
     pub ephemeral_storage_byte_seconds: u64,
     pub compute_fuel: u64,
     pub memory_gb_seconds: u64,
+    pub metering: Option<ResourceUsageMetering>,
+}
+
+impl AccountUsageRecord {
+    pub fn new(period: AccountUsagePeriod) -> Self {
+        Self {
+            period,
+            as_of: None,
+            durable_storage_byte_seconds: 0,
+            ephemeral_storage_byte_seconds: 0,
+            compute_fuel: 0,
+            memory_gb_seconds: 0,
+            metering: None,
+        }
+    }
+
+    pub fn apply(&mut self, usage_type: UsageType, value: u64, updated_at: DateTime<Utc>) {
+        if self.as_of.is_none_or(|as_of| updated_at > as_of) {
+            self.as_of = Some(updated_at);
+        }
+        match usage_type {
+            UsageType::MonthlyDurableAgentStorageByteSeconds => {
+                self.durable_storage_byte_seconds = value
+            }
+            UsageType::MonthlyEphemeralStorageByteSeconds => {
+                self.ephemeral_storage_byte_seconds = value
+            }
+            UsageType::MonthlyGasLimit => self.compute_fuel = value,
+            UsageType::MonthlyMemoryGbSeconds => self.memory_gb_seconds = value,
+            _ => {}
+        }
+    }
+
+    pub fn apply_metering(
+        &mut self,
+        compute: bool,
+        memory: bool,
+        filesystem: bool,
+        updated_at: DateTime<Utc>,
+    ) {
+        if self.as_of.is_none_or(|as_of| updated_at > as_of) {
+            self.as_of = Some(updated_at);
+        }
+        self.metering = Some(ResourceUsageMetering {
+            compute,
+            memory,
+            filesystem,
+        });
+    }
 }
 
 impl AccountUsage {
@@ -204,19 +247,44 @@ impl AccountUsage {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{AccountUsageRecord, UsageType};
+    use chrono::{DateTime, Utc};
+    use golem_common::model::account_usage::AccountUsagePeriod;
     use test_r::test;
 
-    #[test]
-    fn converts_byte_seconds_to_gb_month() {
-        assert_eq!(
-            byte_seconds_to_gb_month(BYTE_SECONDS_PER_GB_MONTH as u64),
-            1.0
-        );
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(seconds, 0).unwrap()
     }
 
     #[test]
-    fn converts_fuel_to_gcu() {
-        assert_eq!(fuel_to_gcu(FUEL_PER_GCU), 1.0);
+    fn account_usage_record_keeps_latest_usage_timestamp() {
+        let mut record = AccountUsageRecord::new(AccountUsagePeriod {
+            year: 2026,
+            month: 4,
+        });
+
+        record.apply(UsageType::MonthlyGasLimit, 1, timestamp(100));
+        record.apply(UsageType::MonthlyMemoryGbSeconds, 2, timestamp(200));
+        record.apply(
+            UsageType::MonthlyDurableAgentStorageByteSeconds,
+            3,
+            timestamp(150),
+        );
+
+        assert_eq!(record.as_of, Some(timestamp(200)));
+    }
+
+    #[test]
+    fn account_usage_record_keeps_latest_metering_timestamp() {
+        let mut record = AccountUsageRecord::new(AccountUsagePeriod {
+            year: 2026,
+            month: 4,
+        });
+
+        record.apply_metering(true, true, true, timestamp(100));
+        record.apply_metering(false, false, false, timestamp(200));
+        record.apply_metering(true, false, true, timestamp(150));
+
+        assert_eq!(record.as_of, Some(timestamp(200)));
     }
 }

--- a/golem-registry-service/src/services/account_usage/mod.rs
+++ b/golem-registry-service/src/services/account_usage/mod.rs
@@ -18,21 +18,20 @@ use self::error::LimitExceededError;
 use super::account::{AccountError, AccountService};
 use crate::repo::account_usage::AccountUsageRepo;
 use crate::repo::model::account_usage::{
-    AccountUsage as RepoAccountUsage, StorageUsageHistoryRecord, UsageType,
-    byte_seconds_to_gb_month, fuel_to_gcu,
+    AccountUsage as RepoAccountUsage, AccountUsageRecord, UsageType,
 };
-use crate::repo::model::plan::PlanRecord;
 use crate::services::account_usage::error::AccountUsageError;
 use chrono::{TimeZone, Utc};
 use golem_common::model::account::{AccountEmail, AccountId};
 use golem_common::model::account_usage::{
-    StorageLimit, StorageUsage, StorageUsageHistory, StorageUsageMetrics, StorageUsagePeriod,
+    AccountUsage, AccountUsageMetering, AccountUsageMetrics, AccountUsagePeriod, MeteringStatus,
+    byte_seconds_to_gb_month, fuel_to_gcu,
 };
 use golem_common::model::card::owner::AccountOwnerPattern;
 use golem_common::model::card::{
     AccountUsageResourcePattern, AccountUsageVerb, ClassPermissionTarget, PermissionTarget,
 };
-use golem_common::model::plan::PlanName;
+use golem_service_base::clients::registry::ResourceUsageMetering;
 use golem_service_base::model::auth::AuthCtx;
 use golem_service_base::model::auth::AuthorizationError;
 use golem_service_base::model::{AccountResourceLimits, ResourceLimits};
@@ -48,6 +47,7 @@ pub struct ResourceUsageUpdate {
     pub durable_storage_byte_seconds_delta: i64,
     pub ephemeral_storage_byte_seconds_delta: i64,
     pub memory_gb_seconds_delta: i64,
+    pub metering: ResourceUsageMetering,
 }
 
 pub struct AccountUsageService {
@@ -216,6 +216,7 @@ impl AccountUsageService {
                         UsageType::MonthlyMemoryGbSeconds,
                         update.memory_gb_seconds_delta,
                     );
+                    account_usage.metering = Some(update.metering);
 
                     tracing::debug!(
                         %account_id,
@@ -295,61 +296,49 @@ impl AccountUsageService {
         Ok(account_usage.resource_limits())
     }
 
-    pub async fn get_storage_usage(
+    pub async fn get_usage(
         &self,
         account_id: AccountId,
         auth: &AuthCtx,
-    ) -> Result<StorageUsage, AccountUsageError> {
-        self.get_storage_usage_for_period(account_id, StorageUsagePeriod::current(), auth)
+    ) -> Result<AccountUsage, AccountUsageError> {
+        self.get_usage_for_period(account_id, AccountUsagePeriod::current(), auth)
             .await
     }
 
-    pub async fn get_storage_usage_for_period(
+    pub async fn get_usage_for_period(
         &self,
         account_id: AccountId,
-        period: StorageUsagePeriod,
+        period: AccountUsagePeriod,
         auth: &AuthCtx,
-    ) -> Result<StorageUsage, AccountUsageError> {
-        self.authorize_storage_usage(account_id, auth).await?;
-        let account_usage = self.get_account_usage_at(account_id, None, period).await?;
-        Ok(Self::storage_usage(
-            account_id,
-            &account_usage.plan,
-            account_usage.storage_limit.clone(),
-            account_usage.max_memory_per_worker.clone(),
-            account_usage.monthly_memory_gb_seconds.clone(),
-            StorageUsageHistoryRecord {
-                period,
-                compute_fuel: account_usage.usage(UsageType::MonthlyGasLimit),
-                memory_gb_seconds: account_usage.usage(UsageType::MonthlyMemoryGbSeconds),
-                durable_storage_byte_seconds: account_usage
-                    .usage(UsageType::MonthlyDurableAgentStorageByteSeconds),
-                ephemeral_storage_byte_seconds: account_usage
-                    .usage(UsageType::MonthlyEphemeralStorageByteSeconds),
-            },
-        ))
+    ) -> Result<AccountUsage, AccountUsageError> {
+        self.authorize_usage(account_id, auth).await?;
+        let report = self
+            .account_usage_repo
+            .get_usage_report(account_id.0, period)
+            .await?;
+        Ok(Self::usage(account_id, report))
     }
 
-    pub async fn get_storage_usage_history(
+    pub async fn get_usage_history(
         &self,
         account_id: AccountId,
         last: usize,
         auth: &AuthCtx,
-    ) -> Result<Vec<StorageUsageHistory>, AccountUsageError> {
-        let current_period = StorageUsagePeriod::current();
-        self.authorize_storage_usage(account_id, auth).await?;
+    ) -> Result<Vec<AccountUsage>, AccountUsageError> {
+        let current_period = AccountUsagePeriod::current();
+        self.authorize_usage(account_id, auth).await?;
         let history = self
             .account_usage_repo
-            .get_storage_history(account_id.0, current_period, last)
+            .get_usage_history(account_id.0, current_period, last)
             .await?;
 
         Ok(history
             .into_iter()
-            .map(|history| Self::storage_usage_history(account_id, history))
+            .map(|report| Self::usage(account_id, report))
             .collect())
     }
 
-    async fn authorize_storage_usage(
+    async fn authorize_usage(
         &self,
         account_id: AccountId,
         auth: &AuthCtx,
@@ -363,44 +352,39 @@ impl AccountUsageService {
         Ok(())
     }
 
-    fn storage_usage(
-        account_id: AccountId,
-        plan: &PlanRecord,
-        storage_limit: StorageLimit,
-        max_memory_per_agent: golem_common::model::account_usage::MemoryLimit,
-        monthly_memory_gb_seconds: golem_common::model::account_usage::MemoryLimit,
-        usage: StorageUsageHistoryRecord,
-    ) -> StorageUsage {
-        StorageUsage {
+    fn usage(account_id: AccountId, report: AccountUsageRecord) -> AccountUsage {
+        let metering = report.metering.map_or_else(
+            || AccountUsageMetering {
+                compute: MeteringStatus::Unknown,
+                memory: MeteringStatus::Unknown,
+                durable_storage: MeteringStatus::Unknown,
+                ephemeral_storage: MeteringStatus::Unknown,
+            },
+            |metering| {
+                let filesystem = metering_status(metering.filesystem);
+                AccountUsageMetering {
+                    compute: metering_status(metering.compute),
+                    memory: metering_status(metering.memory),
+                    durable_storage: filesystem,
+                    ephemeral_storage: filesystem,
+                }
+            },
+        );
+        AccountUsage {
             account_id,
-            plan_id: plan.plan_id.into(),
-            plan_name: PlanName(plan.name.clone()),
-            usage: Self::storage_usage_metrics(usage),
-            max_storage_per_agent: storage_limit,
-            max_memory_per_agent,
-            monthly_memory_gb_seconds,
-        }
-    }
-
-    fn storage_usage_history(
-        account_id: AccountId,
-        usage: StorageUsageHistoryRecord,
-    ) -> StorageUsageHistory {
-        StorageUsageHistory {
-            account_id,
-            usage: Self::storage_usage_metrics(usage),
-        }
-    }
-
-    fn storage_usage_metrics(usage: StorageUsageHistoryRecord) -> StorageUsageMetrics {
-        StorageUsageMetrics {
-            period: usage.period,
-            compute_gcu: fuel_to_gcu(usage.compute_fuel),
-            memory_gb_seconds: usage.memory_gb_seconds,
-            durable_storage_gb_month: byte_seconds_to_gb_month(usage.durable_storage_byte_seconds),
-            ephemeral_storage_gb_month: byte_seconds_to_gb_month(
-                usage.ephemeral_storage_byte_seconds,
-            ),
+            usage: AccountUsageMetrics {
+                period: report.period,
+                as_of: report.as_of.unwrap_or_else(Utc::now),
+                compute_gcu: fuel_to_gcu(report.compute_fuel),
+                memory_gb_seconds: report.memory_gb_seconds,
+                durable_storage_gb_month: byte_seconds_to_gb_month(
+                    report.durable_storage_byte_seconds,
+                ),
+                ephemeral_storage_gb_month: byte_seconds_to_gb_month(
+                    report.ephemeral_storage_byte_seconds,
+                ),
+                metering,
+            },
         }
     }
 
@@ -409,7 +393,7 @@ impl AccountUsageService {
         account_id: AccountId,
         usage_type: Option<UsageType>,
     ) -> Result<RepoAccountUsage, AccountUsageError> {
-        self.get_account_usage_at(account_id, usage_type, StorageUsagePeriod::current())
+        self.get_account_usage_at(account_id, usage_type, AccountUsagePeriod::current())
             .await
     }
 
@@ -417,12 +401,12 @@ impl AccountUsageService {
         &self,
         account_id: AccountId,
         usage_type: Option<UsageType>,
-        period: StorageUsagePeriod,
+        period: AccountUsagePeriod,
     ) -> Result<RepoAccountUsage, AccountUsageError> {
         let date = SqlDateTime::new(
             Utc.with_ymd_and_hms(period.year, period.month, 1, 0, 0, 0)
                 .single()
-                .expect("validated storage usage period"),
+                .expect("validated account usage period"),
         );
         let usage = match usage_type {
             Some(usage_type) => {
@@ -454,6 +438,14 @@ impl AccountUsageService {
         }
 
         Ok(())
+    }
+}
+
+fn metering_status(enabled: bool) -> MeteringStatus {
+    if enabled {
+        MeteringStatus::Enabled
+    } else {
+        MeteringStatus::Disabled
     }
 }
 
@@ -494,6 +486,7 @@ mod tests {
     use super::*;
     use crate::repo::model::account_usage::{AccountUsage, UsageType};
     use crate::repo::model::plan::PlanRecord;
+    use golem_common::model::account_usage::StorageLimit;
     use golem_service_base::repo::NumericU64;
     use std::collections::BTreeMap;
     use test_r::test;
@@ -557,6 +550,7 @@ mod tests {
                 ceiling: u64::MAX,
                 user_configurable: false,
             },
+            metering: None,
             changes: BTreeMap::new(),
         }
     }

--- a/golem-registry-service/tests/repo/common.rs
+++ b/golem-registry-service/tests/repo/common.rs
@@ -111,6 +111,7 @@ use golem_registry_service::services::{
     permission_share::PermissionShareService,
     plan::PlanService,
 };
+use golem_service_base::clients::registry::ResourceUsageMetering;
 use golem_service_base::db::{LabelledPoolApi, LabelledPoolTransaction, Pool, PoolApi};
 use golem_service_base::db::{postgres::PostgresPool, sqlite::SqlitePool};
 use golem_service_base::model::auth::{AuthCtx, AuthorizationError};
@@ -4275,7 +4276,9 @@ pub async fn test_account_usage(deps: &Deps) {
     }
 }
 
-pub async fn test_storage_usage_history(deps: &Deps) {
+pub async fn test_account_usage_history(deps: &Deps) {
+    use golem_service_base::model::auth::AuthCtx;
+
     let account = deps.create_account().await;
     let previous_month = SqlDateTime::new(Utc::now() - chrono::Duration::days(40));
     let older_month = SqlDateTime::new(Utc::now() - chrono::Duration::days(80));
@@ -4288,6 +4291,14 @@ pub async fn test_storage_usage_history(deps: &Deps) {
     usage.add_change(UsageType::MonthlyDurableAgentStorageByteSeconds, 123);
     usage.add_change(UsageType::MonthlyEphemeralStorageByteSeconds, 456);
     usage.add_change(UsageType::MonthlyGasLimit, 789);
+    usage.add_change(UsageType::MonthlyMemoryGbSeconds, 321);
+    usage.metering = Some(
+        golem_service_base::clients::registry::ResourceUsageMetering {
+            compute: true,
+            memory: false,
+            filesystem: true,
+        },
+    );
     deps.account_usage_repo.add(&usage).await.unwrap();
 
     let mut older_usage = deps
@@ -4301,9 +4312,9 @@ pub async fn test_storage_usage_history(deps: &Deps) {
 
     let history = deps
         .account_usage_repo
-        .get_storage_history(
+        .get_usage_history(
             account.revision.account_id,
-            golem_common::model::account_usage::StorageUsagePeriod {
+            golem_common::model::account_usage::AccountUsagePeriod {
                 year: Utc::now().year(),
                 month: Utc::now().month(),
             },
@@ -4316,6 +4327,27 @@ pub async fn test_storage_usage_history(deps: &Deps) {
     assert_eq!(history[0].durable_storage_byte_seconds, 123);
     assert_eq!(history[0].ephemeral_storage_byte_seconds, 456);
     assert_eq!(history[0].compute_fuel, 789);
+    assert_eq!(history[0].memory_gb_seconds, 321);
+    assert_eq!(
+        history[0].metering,
+        Some(ResourceUsageMetering {
+            compute: true,
+            memory: false,
+            filesystem: true,
+        })
+    );
+
+    let service_history = deps
+        .account_usage_service()
+        .get_usage_history(AccountId(account.revision.account_id), 1, &AuthCtx::System)
+        .await
+        .unwrap();
+    assert_eq!(service_history.len(), 1);
+    assert_eq!(service_history[0].usage.memory_gb_seconds, 321);
+    assert_eq!(
+        service_history[0].usage.metering.memory,
+        golem_common::model::account_usage::MeteringStatus::Disabled
+    );
 }
 
 fn compare_created_to_requested_account(
@@ -5474,6 +5506,7 @@ pub async fn test_update_http_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5507,6 +5540,7 @@ pub async fn test_update_http_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5531,6 +5565,7 @@ pub async fn test_update_http_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5554,6 +5589,7 @@ pub async fn test_update_http_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 123,
             ephemeral_storage_byte_seconds_delta: 456,
             memory_gb_seconds_delta: 12,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     svc.update_resource_usage(updates, &AuthCtx::System)
@@ -5570,6 +5606,7 @@ pub async fn test_update_http_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 10,
             ephemeral_storage_byte_seconds_delta: 20,
             memory_gb_seconds_delta: 3,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     svc.update_resource_usage(updates, &AuthCtx::System)
@@ -5628,6 +5665,7 @@ pub async fn test_update_rpc_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5661,6 +5699,7 @@ pub async fn test_update_rpc_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5685,6 +5724,7 @@ pub async fn test_update_rpc_call_counts(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5722,6 +5762,7 @@ pub async fn test_update_call_counts_batch(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     http_updates.insert(
@@ -5733,6 +5774,7 @@ pub async fn test_update_call_counts_batch(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc
@@ -5764,6 +5806,7 @@ pub async fn test_update_call_counts_batch(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     rpc_updates.insert(
@@ -5775,6 +5818,7 @@ pub async fn test_update_call_counts_batch(deps: &Deps) {
             durable_storage_byte_seconds_delta: 0,
             ephemeral_storage_byte_seconds_delta: 0,
             memory_gb_seconds_delta: 0,
+            metering: golem_service_base::clients::registry::ResourceUsageMetering::all_enabled(),
         },
     );
     let result = svc

--- a/golem-registry-service/tests/repo/postgres.rs
+++ b/golem-registry-service/tests/repo/postgres.rs
@@ -504,8 +504,8 @@ async fn test_account_usage(#[dimension(postgres_variant)] deps: &Deps) {
 }
 
 #[test]
-async fn test_storage_usage_history(#[dimension(postgres_variant)] deps: &Deps) {
-    crate::repo::common::test_storage_usage_history(deps).await;
+async fn test_account_usage_history(#[dimension(postgres_variant)] deps: &Deps) {
+    crate::repo::common::test_account_usage_history(deps).await;
 }
 
 #[test]

--- a/golem-registry-service/tests/repo/sqlite.rs
+++ b/golem-registry-service/tests/repo/sqlite.rs
@@ -288,8 +288,8 @@ async fn test_account_usage(deps: &Deps) {
 }
 
 #[test]
-async fn test_storage_usage_history(deps: &Deps) {
-    crate::repo::common::test_storage_usage_history(deps).await;
+async fn test_account_usage_history(deps: &Deps) {
+    crate::repo::common::test_account_usage_history(deps).await;
 }
 
 #[test]

--- a/golem-service-base/src/clients/registry.rs
+++ b/golem-service-base/src/clients/registry.rs
@@ -80,6 +80,23 @@ pub trait RegistryInvalidationHandler: Send + Sync {
     async fn on_event(&self, event: RegistryInvalidationEvent);
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ResourceUsageMetering {
+    pub compute: bool,
+    pub memory: bool,
+    pub filesystem: bool,
+}
+
+impl ResourceUsageMetering {
+    pub const fn all_enabled() -> Self {
+        Self {
+            compute: true,
+            memory: true,
+            filesystem: true,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResourceUsageUpdate {
     pub fuel_delta: i64,
@@ -88,6 +105,7 @@ pub struct ResourceUsageUpdate {
     pub durable_storage_byte_seconds_delta: i64,
     pub ephemeral_storage_byte_seconds_delta: i64,
     pub memory_gb_seconds_delta: i64,
+    pub metering: ResourceUsageMetering,
 }
 
 #[async_trait]
@@ -589,6 +607,9 @@ impl RegistryService for GrpcRegistryService {
                 durable_storage_byte_seconds_delta: v.durable_storage_byte_seconds_delta,
                 ephemeral_storage_byte_seconds_delta: v.ephemeral_storage_byte_seconds_delta,
                 memory_gb_seconds_delta: v.memory_gb_seconds_delta,
+                compute_metering_enabled: v.metering.compute,
+                memory_metering_enabled: v.metering.memory,
+                filesystem_metering_enabled: v.metering.filesystem,
             })
             .collect();
 

--- a/golem-worker-executor/src/services/resource_limits.rs
+++ b/golem-worker-executor/src/services/resource_limits.rs
@@ -796,6 +796,11 @@ impl AtomicResourceEntry {
                 rpc_call_count_delta: rpc_count,
                 durable_storage_byte_seconds_delta,
                 ephemeral_storage_byte_seconds_delta,
+                metering: golem_service_base::clients::registry::ResourceUsageMetering {
+                    compute: self.metering.compute,
+                    memory: self.metering.memory,
+                    filesystem: self.metering.filesystem,
+                },
             },
             durable_memory_gb_seconds_delta,
             ephemeral_memory_gb_seconds_delta,
@@ -1592,6 +1597,38 @@ mod tests {
         assert_eq!(captured.update.memory_gb_seconds_delta, 0);
         assert_eq!(captured.update.durable_storage_byte_seconds_delta, 0);
         assert_eq!(captured.update.ephemeral_storage_byte_seconds_delta, 0);
+        assert!(!captured.update.metering.compute);
+        assert!(!captured.update.metering.memory);
+        assert!(!captured.update.metering.filesystem);
+    }
+
+    #[test]
+    fn usage_update_reports_configured_metering_state() {
+        let entry = AtomicResourceEntry::new_with_all_limits_and_metering(
+            u64::MAX,
+            usize::MAX,
+            usize::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            AtomicResourceEntry::UNLIMITED_CONCURRENT_AGENTS,
+            AtomicResourceEntry::UNLIMITED_OPLOG_WRITES_PER_SECOND,
+            ResourceUsageMeteringConfig {
+                compute: true,
+                memory: false,
+                filesystem: true,
+            },
+        );
+
+        let captured = entry
+            .capture_usage_update(0)
+            .expect("stale limit refresh still produces an update");
+
+        assert!(captured.update.metering.compute);
+        assert!(!captured.update.metering.memory);
+        assert!(captured.update.metering.filesystem);
     }
 
     #[test]

--- a/integration-tests/tests/api/account_usage.rs
+++ b/integration-tests/tests/api/account_usage.rs
@@ -12,91 +12,350 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{Duration, Utc};
+use anyhow::Context;
+use chrono::{DateTime, Duration, Utc};
 use golem_client::api::{
     RegistryServiceClearAccountStorageOverrideError, RegistryServiceClient,
     RegistryServiceGetAccountStorageOverrideError, RegistryServiceSetAccountStorageOverrideError,
 };
 use golem_common::model::account::{AccountId, AccountRevision, AccountSetPlan};
 use golem_common::model::account_usage::{
-    BYTE_SECONDS_PER_GB_MONTH, MemoryLimit, SetMemoryLimit, SetStorageLimit, StorageLimit,
+    AccountUsagePeriod, MemoryLimit, MeteringStatus, SetMemoryLimit, SetStorageLimit, StorageLimit,
 };
 use golem_service_base::clients::registry::{
-    GrpcRegistryService, GrpcRegistryServiceConfig, RegistryService as _, ResourceUsageUpdate,
+    GrpcRegistryService, GrpcRegistryServiceConfig, RegistryService as _, ResourceUsageMetering,
+    ResourceUsageUpdate,
 };
 use golem_service_base::grpc::client::GrpcClientConfig;
+use golem_test_framework::components::rdb::DbInfo;
 use golem_test_framework::config::{EnvBasedTestDependencies, TestDependencies};
 use golem_test_framework::dsl::TestDslExtended;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use std::collections::HashMap;
 use test_r::{inherit_test_dep, test};
 
 inherit_test_dep!(EnvBasedTestDependencies);
 
-#[test]
-#[tracing::instrument]
-async fn account_storage_usage_accumulates_grpc_updates(
-    deps: &EnvBasedTestDependencies,
-) -> anyhow::Result<()> {
-    let user = deps.user().await?;
+fn previous_period(period: AccountUsagePeriod) -> AccountUsagePeriod {
+    if period.month == 1 {
+        AccountUsagePeriod {
+            year: period.year - 1,
+            month: 12,
+        }
+    } else {
+        AccountUsagePeriod {
+            year: period.year,
+            month: period.month - 1,
+        }
+    }
+}
+
+fn registry_client(deps: &EnvBasedTestDependencies) -> GrpcRegistryService {
     let registry_service = deps.registry_service();
-    let registry_client = GrpcRegistryService::new(&GrpcRegistryServiceConfig {
+    GrpcRegistryService::new(&GrpcRegistryServiceConfig {
         host: registry_service.grpc_host(),
         port: registry_service.grpc_port(),
         client_config: GrpcClientConfig::default(),
         invalidation_event_subscriber: Default::default(),
-    });
+    })
+}
 
-    for (durable_storage_byte_seconds_delta, ephemeral_storage_byte_seconds_delta) in
-        [(133, 476), (7, 24)]
+async fn insert_usage_for_period(
+    deps: &EnvBasedTestDependencies,
+    account_id: AccountId,
+    period: AccountUsagePeriod,
+) -> anyhow::Result<DateTime<Utc>> {
+    let usage_key = period.to_string();
+    let updated_at = DateTime::<Utc>::from_timestamp_micros(Utc::now().timestamp_micros())
+        .expect("current timestamp is representable at database precision");
+    const VALUES: [(i32, i64); 4] = [(2, 1_500_000), (10, 140), (11, 500), (12, 14)];
+    match deps.rdb().info() {
+        DbInfo::Sqlite(root) => {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    SqliteConnectOptions::new()
+                        .filename(root.join("golem_registry.db"))
+                        .journal_mode(SqliteJournalMode::Wal)
+                        .foreign_keys(true),
+                )
+                .await?;
+            for (usage_type, value) in VALUES {
+                sqlx::query(
+                    "INSERT INTO account_usage_stats \
+                     (account_id, usage_type, usage_key, value, updated_at) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(account_id.0)
+                .bind(usage_type)
+                .bind(&usage_key)
+                .bind(value)
+                .bind(updated_at)
+                .execute(&pool)
+                .await
+                .with_context(|| format!("failed to seed SQLite usage type {usage_type}"))?;
+            }
+            sqlx::query(
+                "INSERT INTO account_usage_metering_state \
+                 (account_id, usage_key, compute_enabled, memory_enabled, \
+                  filesystem_enabled, updated_at) \
+                 VALUES ($1, $2, TRUE, TRUE, TRUE, $3)",
+            )
+            .bind(account_id.0)
+            .bind(&usage_key)
+            .bind(updated_at)
+            .execute(&pool)
+            .await
+            .context("failed to seed SQLite metering state")?;
+        }
+        DbInfo::Postgres(postgres) => {
+            let pool = PgPoolOptions::new()
+                .max_connections(1)
+                .connect_with(postgres.to_connect_options())
+                .await?;
+            for (usage_type, value) in VALUES {
+                sqlx::query(
+                    "INSERT INTO golem_registry.account_usage_stats \
+                     (account_id, usage_type, usage_key, value, updated_at) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(account_id.0)
+                .bind(usage_type)
+                .bind(&usage_key)
+                .bind(value)
+                .bind(updated_at)
+                .execute(&pool)
+                .await
+                .with_context(|| format!("failed to seed PostgreSQL usage type {usage_type}"))?;
+            }
+            sqlx::query(
+                "INSERT INTO golem_registry.account_usage_metering_state \
+                 (account_id, usage_key, compute_enabled, memory_enabled, \
+                  filesystem_enabled, updated_at) \
+                 VALUES ($1, $2, TRUE, TRUE, TRUE, $3)",
+            )
+            .bind(account_id.0)
+            .bind(&usage_key)
+            .bind(updated_at)
+            .execute(&pool)
+            .await
+            .context("failed to seed PostgreSQL metering state")?;
+        }
+        DbInfo::Mysql(_) => anyhow::bail!("registry service does not support MySQL"),
+    }
+
+    Ok(updated_at)
+}
+
+#[test]
+#[tracing::instrument]
+async fn account_usage_reports_all_customer_dimensions(
+    deps: &EnvBasedTestDependencies,
+) -> anyhow::Result<()> {
+    let user = deps.user().await?;
+    let registry_service = deps.registry_service();
+    let registry_client = registry_client(deps);
+    let byte_seconds_per_gb_month = (1024_u64.pow(3) * 730 * 3600) as f64;
+
+    let updates_started_at = Utc::now();
+    for (fuel_delta, durable_storage_byte_seconds_delta, ephemeral_storage_byte_seconds_delta) in
+        [(1_000_000, 133, 476), (500_000, 7, 24)]
     {
         registry_client
             .batch_update_resource_usage(HashMap::from([(
                 AccountId(user.account_id.0),
                 ResourceUsageUpdate {
-                    fuel_delta: 0,
+                    fuel_delta,
                     http_call_count_delta: 0,
                     rpc_call_count_delta: 0,
                     durable_storage_byte_seconds_delta,
                     ephemeral_storage_byte_seconds_delta,
                     memory_gb_seconds_delta: 7,
+                    metering: ResourceUsageMetering::all_enabled(),
                 },
             )]))
             .await?;
     }
+    let updates_finished_at = Utc::now();
 
     let usage = registry_service
         .client(&user.token)
         .await
-        .get_account_storage_usage(&user.account_id.0, None)
+        .get_account_usage(&user.account_id.0, None)
         .await?;
 
     assert_eq!(usage.account_id, user.account_id);
-    assert_eq!(usage.usage.compute_gcu, 0.0);
+    assert_eq!(usage.usage.compute_gcu, 1.5);
     assert_eq!(usage.usage.memory_gb_seconds, 14);
     assert_eq!(
         usage.usage.durable_storage_gb_month,
-        140.0 / BYTE_SECONDS_PER_GB_MONTH
+        140.0 / byte_seconds_per_gb_month
     );
     assert_eq!(
         usage.usage.ephemeral_storage_gb_month,
-        500.0 / BYTE_SECONDS_PER_GB_MONTH
+        500.0 / byte_seconds_per_gb_month
     );
+    assert_eq!(usage.usage.metering.compute, MeteringStatus::Enabled);
+    assert_eq!(usage.usage.metering.memory, MeteringStatus::Enabled);
+    assert_eq!(
+        usage.usage.metering.durable_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(
+        usage.usage.metering.ephemeral_storage,
+        MeteringStatus::Enabled
+    );
+    assert!(usage.usage.as_of >= updates_started_at);
+    assert!(usage.usage.as_of <= updates_finished_at);
+
+    let historical_period = previous_period(usage.usage.period);
+    let historical_as_of =
+        insert_usage_for_period(deps, user.account_id, historical_period).await?;
+    let history = registry_service
+        .client(&user.token)
+        .await
+        .get_account_usage_history(&user.account_id.0, Some(6))
+        .await?;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].account_id, user.account_id);
+    assert_eq!(history[0].usage.period, historical_period);
+    assert_eq!(history[0].usage.compute_gcu, 1.5);
+    assert_eq!(history[0].usage.memory_gb_seconds, 14);
+    assert_eq!(
+        history[0].usage.durable_storage_gb_month,
+        140.0 / byte_seconds_per_gb_month
+    );
+    assert_eq!(
+        history[0].usage.ephemeral_storage_gb_month,
+        500.0 / byte_seconds_per_gb_month
+    );
+    assert_eq!(history[0].usage.metering.compute, MeteringStatus::Enabled);
+    assert_eq!(history[0].usage.metering.memory, MeteringStatus::Enabled);
+    assert_eq!(
+        history[0].usage.metering.durable_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(
+        history[0].usage.metering.ephemeral_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(history[0].usage.as_of, historical_as_of);
 
     Ok(())
 }
 
 #[test]
 #[tracing::instrument]
-async fn account_storage_usage_history_is_authenticated_and_empty_for_new_account(
+async fn account_usage_history_is_authenticated_and_empty_for_new_account(
     deps: &EnvBasedTestDependencies,
 ) -> anyhow::Result<()> {
     let user = deps.user().await?;
+    let request_started_at = Utc::now();
+
+    let current = deps
+        .registry_service()
+        .client(&user.token)
+        .await
+        .get_account_usage(&user.account_id.0, None)
+        .await?;
+    let request_finished_at = Utc::now();
+
+    assert_eq!(current.usage.compute_gcu, 0.0);
+    assert_eq!(current.usage.memory_gb_seconds, 0);
+    assert_eq!(current.usage.durable_storage_gb_month, 0.0);
+    assert_eq!(current.usage.ephemeral_storage_gb_month, 0.0);
+    assert_eq!(current.usage.metering.compute, MeteringStatus::Unknown);
+    assert_eq!(current.usage.metering.memory, MeteringStatus::Unknown);
+    assert_eq!(
+        current.usage.metering.durable_storage,
+        MeteringStatus::Unknown
+    );
+    assert_eq!(
+        current.usage.metering.ephemeral_storage,
+        MeteringStatus::Unknown
+    );
+    assert!(current.usage.as_of >= request_started_at);
+    assert!(current.usage.as_of <= request_finished_at);
+
+    let registry_client = registry_client(deps);
+    registry_client
+        .batch_update_resource_usage(HashMap::from([(
+            AccountId(user.account_id.0),
+            ResourceUsageUpdate {
+                fuel_delta: 0,
+                http_call_count_delta: 0,
+                rpc_call_count_delta: 0,
+                durable_storage_byte_seconds_delta: 0,
+                ephemeral_storage_byte_seconds_delta: 0,
+                memory_gb_seconds_delta: 0,
+                metering: ResourceUsageMetering::default(),
+            },
+        )]))
+        .await?;
+
+    let disabled = deps
+        .registry_service()
+        .client(&user.token)
+        .await
+        .get_account_usage(&user.account_id.0, None)
+        .await?;
+    assert_eq!(disabled.usage.compute_gcu, 0.0);
+    assert_eq!(disabled.usage.memory_gb_seconds, 0);
+    assert_eq!(disabled.usage.durable_storage_gb_month, 0.0);
+    assert_eq!(disabled.usage.ephemeral_storage_gb_month, 0.0);
+    assert_eq!(disabled.usage.metering.compute, MeteringStatus::Disabled);
+    assert_eq!(disabled.usage.metering.memory, MeteringStatus::Disabled);
+    assert_eq!(
+        disabled.usage.metering.durable_storage,
+        MeteringStatus::Disabled
+    );
+    assert_eq!(
+        disabled.usage.metering.ephemeral_storage,
+        MeteringStatus::Disabled
+    );
+
+    registry_client
+        .batch_update_resource_usage(HashMap::from([(
+            AccountId(user.account_id.0),
+            ResourceUsageUpdate {
+                fuel_delta: 0,
+                http_call_count_delta: 0,
+                rpc_call_count_delta: 0,
+                durable_storage_byte_seconds_delta: 0,
+                ephemeral_storage_byte_seconds_delta: 0,
+                memory_gb_seconds_delta: 0,
+                metering: ResourceUsageMetering::all_enabled(),
+            },
+        )]))
+        .await?;
+
+    let enabled = deps
+        .registry_service()
+        .client(&user.token)
+        .await
+        .get_account_usage(&user.account_id.0, None)
+        .await?;
+    assert_eq!(enabled.usage.compute_gcu, 0.0);
+    assert_eq!(enabled.usage.memory_gb_seconds, 0);
+    assert_eq!(enabled.usage.durable_storage_gb_month, 0.0);
+    assert_eq!(enabled.usage.ephemeral_storage_gb_month, 0.0);
+    assert_eq!(enabled.usage.metering.compute, MeteringStatus::Enabled);
+    assert_eq!(enabled.usage.metering.memory, MeteringStatus::Enabled);
+    assert_eq!(
+        enabled.usage.metering.durable_storage,
+        MeteringStatus::Enabled
+    );
+    assert_eq!(
+        enabled.usage.metering.ephemeral_storage,
+        MeteringStatus::Enabled
+    );
 
     let history = deps
         .registry_service()
         .client(&user.token)
         .await
-        .get_account_storage_usage_history(&user.account_id.0, Some(6))
+        .get_account_usage_history(&user.account_id.0, Some(6))
         .await?;
 
     assert!(history.is_empty());

--- a/integration-tests/tests/memory_billing.rs
+++ b/integration-tests/tests/memory_billing.rs
@@ -82,7 +82,7 @@ mod tests {
             .registry_service()
             .client(&user.token)
             .await
-            .get_account_storage_usage(&user.account_id.0, None)
+            .get_account_usage(&user.account_id.0, None)
             .await?;
         Ok(usage.usage.memory_gb_seconds)
     }
@@ -95,7 +95,7 @@ mod tests {
             .registry_service()
             .client(&user.token)
             .await
-            .get_account_storage_usage(&user.account_id.0, None)
+            .get_account_usage(&user.account_id.0, None)
             .await?;
         Ok(usage.usage.durable_storage_gb_month * BYTE_SECONDS_PER_GB_MONTH)
     }

--- a/openapi/golem-registry-service.yaml
+++ b/openapi/golem-registry-service.yaml
@@ -643,7 +643,14 @@ paths:
       tags:
       - RegistryService
       - Account
-      summary: Get current durable and ephemeral storage usage and storage limit.
+      summary: Get account usage for a UTC calendar month.
+      description: |-
+        Compute is reported in GCU, memory in allocated linear-memory GB-seconds, and durable and
+        ephemeral storage in GB-month using byte-seconds / (1024^3 * 730 * 3600). `asOf` is when
+        the registry last received a usage snapshot for the period, or the response time if no
+        snapshot exists. Metering status distinguishes enabled meters that measured zero from
+        disabled meters. `unknown` means no usage producer has reported metering state for the
+        period. Durable and ephemeral storage both reflect the shared filesystem meter.
       parameters:
       - name: account_id
         schema:
@@ -657,6 +664,7 @@ paths:
         schema:
           type: string
         in: query
+        description: Billing period in YYYY-MM format. Defaults to the current UTC calendar month.
         required: false
         deprecated: false
         explode: true
@@ -666,7 +674,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/StorageUsage'
+                $ref: '#/components/schemas/AccountUsage'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -712,13 +720,16 @@ paths:
       security:
       - Cookie: []
       - Token: []
-      operationId: get_account_storage_usage
+      operationId: get_account_usage
   /v1/accounts/{account_id}/usage/history:
     get:
       tags:
       - RegistryService
       - Account
-      summary: Get storage usage for closed billing periods, newest first.
+      summary: Get sparse account usage for closed UTC calendar months, newest first.
+      description: |-
+        Each item uses the same metrics and metering-status contract as current usage. The response
+        does not include plan or limit metadata because historical limits are not snapshotted.
       parameters:
       - name: account_id
         schema:
@@ -744,7 +755,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/StorageUsageHistory'
+                  $ref: '#/components/schemas/AccountUsage'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -790,7 +801,7 @@ paths:
       security:
       - Cookie: []
       - Token: []
-      operationId: get_account_storage_usage_history
+      operationId: get_account_usage_history
   /v1/accounts/{account_id}/resource-overrides/max-storage-per-agent:
     get:
       tags:
@@ -9152,6 +9163,81 @@ components:
           format: uint64
         name:
           type: string
+    AccountUsage:
+      type: object
+      title: AccountUsage
+      required:
+      - accountId
+      - usage
+      properties:
+        accountId:
+          type: string
+          format: uuid
+        usage:
+          $ref: '#/components/schemas/AccountUsageMetrics'
+    AccountUsageMetering:
+      type: object
+      title: AccountUsageMetering
+      required:
+      - compute
+      - memory
+      - durableStorage
+      - ephemeralStorage
+      properties:
+        compute:
+          $ref: '#/components/schemas/MeteringStatus'
+        memory:
+          $ref: '#/components/schemas/MeteringStatus'
+        durableStorage:
+          $ref: '#/components/schemas/MeteringStatus'
+        ephemeralStorage:
+          $ref: '#/components/schemas/MeteringStatus'
+    AccountUsageMetrics:
+      type: object
+      title: AccountUsageMetrics
+      required:
+      - period
+      - asOf
+      - computeGcu
+      - memoryGbSeconds
+      - durableStorageGbMonth
+      - ephemeralStorageGbMonth
+      - metering
+      properties:
+        period:
+          $ref: '#/components/schemas/AccountUsagePeriod'
+        asOf:
+          type: string
+          format: date-time
+        computeGcu:
+          type: number
+          format: double
+        memoryGbSeconds:
+          type: integer
+          format: uint64
+        durableStorageGbMonth:
+          type: number
+          format: double
+        ephemeralStorageGbMonth:
+          type: number
+          format: double
+        metering:
+          $ref: '#/components/schemas/AccountUsageMetering'
+    AccountUsagePeriod:
+      type: object
+      title: AccountUsagePeriod
+      required:
+      - year
+      - month
+      properties:
+        year:
+          type: integer
+          format: int32
+        month:
+          type: integer
+          format: uint32
+          maximum: 12.0
+          minimum: 1.0
     AgentConfigDeclarationSchema:
       type: object
       required:
@@ -12263,6 +12349,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/Role'
           - nullable: true
+    MeteringStatus:
+      type: string
+      enum:
+      - enabled
+      - disabled
+      - unknown
     NamedField:
       type: object
       required:
@@ -15396,83 +15488,6 @@ components:
           format: uint64
         userConfigurable:
           type: boolean
-    StorageUsage:
-      type: object
-      title: StorageUsage
-      required:
-      - accountId
-      - planId
-      - planName
-      - usage
-      - maxStoragePerAgent
-      - maxMemoryPerAgent
-      - monthlyMemoryGbSeconds
-      properties:
-        accountId:
-          type: string
-          format: uuid
-        planId:
-          type: string
-          format: uuid
-        planName:
-          type: string
-        usage:
-          $ref: '#/components/schemas/StorageUsageMetrics'
-        maxStoragePerAgent:
-          $ref: '#/components/schemas/StorageLimit'
-        maxMemoryPerAgent:
-          $ref: '#/components/schemas/MemoryLimit'
-        monthlyMemoryGbSeconds:
-          $ref: '#/components/schemas/MemoryLimit'
-    StorageUsageHistory:
-      type: object
-      title: StorageUsageHistory
-      required:
-      - accountId
-      - usage
-      properties:
-        accountId:
-          type: string
-          format: uuid
-        usage:
-          $ref: '#/components/schemas/StorageUsageMetrics'
-    StorageUsageMetrics:
-      type: object
-      title: StorageUsageMetrics
-      required:
-      - period
-      - computeGcu
-      - memoryGbSeconds
-      - durableStorageGbMonth
-      - ephemeralStorageGbMonth
-      properties:
-        period:
-          $ref: '#/components/schemas/StorageUsagePeriod'
-        computeGcu:
-          type: number
-          format: double
-        memoryGbSeconds:
-          type: integer
-          format: uint64
-        durableStorageGbMonth:
-          type: number
-          format: double
-        ephemeralStorageGbMonth:
-          type: number
-          format: double
-    StorageUsagePeriod:
-      type: object
-      title: StorageUsagePeriod
-      required:
-      - year
-      - month
-      properties:
-        year:
-          type: integer
-          format: int32
-        month:
-          type: integer
-          format: uint32
     StoredCard:
       type: object
       oneOf:
@@ -16017,4 +16032,3 @@ components:
     Token:
       type: http
       scheme: bearer
-

--- a/openapi/golem-registry-service.yaml
+++ b/openapi/golem-registry-service.yaml
@@ -16032,3 +16032,4 @@ components:
     Token:
       type: http
       scheme: bearer
+

--- a/openapi/golem-service.yaml
+++ b/openapi/golem-service.yaml
@@ -2720,8 +2720,15 @@ paths:
       tags:
       - RegistryService
       - Account
-      summary: Get current durable and ephemeral storage usage and storage limit.
-      operationId: get_account_storage_usage
+      summary: Get account usage for a UTC calendar month.
+      description: |-
+        Compute is reported in GCU, memory in allocated linear-memory GB-seconds, and durable and
+        ephemeral storage in GB-month using byte-seconds / (1024^3 * 730 * 3600). `asOf` is when
+        the registry last received a usage snapshot for the period, or the response time if no
+        snapshot exists. Metering status distinguishes enabled meters that measured zero from
+        disabled meters. `unknown` means no usage producer has reported metering state for the
+        period. Durable and ephemeral storage both reflect the shared filesystem meter.
+      operationId: get_account_usage
       parameters:
       - in: path
         name: account_id
@@ -2734,6 +2741,7 @@ paths:
         style: simple
       - in: query
         name: period
+        description: Billing period in YYYY-MM format. Defaults to the current UTC calendar month.
         deprecated: false
         schema:
           type: string
@@ -2745,7 +2753,7 @@ paths:
           content:
             application/json; charset=utf-8:
               schema:
-                $ref: '#/components/schemas/StorageUsage'
+                $ref: '#/components/schemas/AccountUsage'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -2796,8 +2804,11 @@ paths:
       tags:
       - RegistryService
       - Account
-      summary: Get storage usage for closed billing periods, newest first.
-      operationId: get_account_storage_usage_history
+      summary: Get sparse account usage for closed UTC calendar months, newest first.
+      description: |-
+        Each item uses the same metrics and metering-status contract as current usage. The response
+        does not include plan or limit metadata because historical limits are not snapshotted.
+      operationId: get_account_usage_history
       parameters:
       - in: path
         name: account_id
@@ -2824,7 +2835,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/StorageUsageHistory'
+                  $ref: '#/components/schemas/AccountUsage'
         '400':
           description: Invalid request, returning with a list of issues detected in the request
           content:
@@ -17871,6 +17882,81 @@ components:
           type: string
       required:
       - currentRevision
+    AccountUsage:
+      title: AccountUsage
+      type: object
+      properties:
+        accountId:
+          type: string
+          format: uuid
+        usage:
+          $ref: '#/components/schemas/AccountUsageMetrics'
+      required:
+      - accountId
+      - usage
+    AccountUsageMetering:
+      title: AccountUsageMetering
+      type: object
+      properties:
+        compute:
+          $ref: '#/components/schemas/MeteringStatus'
+        memory:
+          $ref: '#/components/schemas/MeteringStatus'
+        durableStorage:
+          $ref: '#/components/schemas/MeteringStatus'
+        ephemeralStorage:
+          $ref: '#/components/schemas/MeteringStatus'
+      required:
+      - compute
+      - memory
+      - durableStorage
+      - ephemeralStorage
+    AccountUsageMetrics:
+      title: AccountUsageMetrics
+      type: object
+      properties:
+        period:
+          $ref: '#/components/schemas/AccountUsagePeriod'
+        asOf:
+          type: string
+          format: date-time
+        computeGcu:
+          type: number
+          format: double
+        memoryGbSeconds:
+          type: integer
+          format: uint64
+        durableStorageGbMonth:
+          type: number
+          format: double
+        ephemeralStorageGbMonth:
+          type: number
+          format: double
+        metering:
+          $ref: '#/components/schemas/AccountUsageMetering'
+      required:
+      - period
+      - asOf
+      - computeGcu
+      - memoryGbSeconds
+      - durableStorageGbMonth
+      - ephemeralStorageGbMonth
+      - metering
+    AccountUsagePeriod:
+      title: AccountUsagePeriod
+      type: object
+      properties:
+        year:
+          type: integer
+          format: int32
+        month:
+          type: integer
+          minimum: 1.0
+          maximum: 12.0
+          format: uint32
+      required:
+      - year
+      - month
     AgentConfigDeclarationSchema:
       type: object
       properties:
@@ -19929,6 +20015,12 @@ components:
       - planDefault
       - ceiling
       - userConfigurable
+    MeteringStatus:
+      type: string
+      enum:
+      - enabled
+      - disabled
+      - unknown
     NamedField:
       type: object
       properties:
@@ -21550,83 +21642,6 @@ components:
       - planDefault
       - ceiling
       - userConfigurable
-    StorageUsage:
-      title: StorageUsage
-      type: object
-      properties:
-        accountId:
-          type: string
-          format: uuid
-        planId:
-          type: string
-          format: uuid
-        planName:
-          type: string
-        usage:
-          $ref: '#/components/schemas/StorageUsageMetrics'
-        maxStoragePerAgent:
-          $ref: '#/components/schemas/StorageLimit'
-        maxMemoryPerAgent:
-          $ref: '#/components/schemas/MemoryLimit'
-        monthlyMemoryGbSeconds:
-          $ref: '#/components/schemas/MemoryLimit'
-      required:
-      - accountId
-      - planId
-      - planName
-      - usage
-      - maxStoragePerAgent
-      - maxMemoryPerAgent
-      - monthlyMemoryGbSeconds
-    StorageUsageHistory:
-      title: StorageUsageHistory
-      type: object
-      properties:
-        accountId:
-          type: string
-          format: uuid
-        usage:
-          $ref: '#/components/schemas/StorageUsageMetrics'
-      required:
-      - accountId
-      - usage
-    StorageUsageMetrics:
-      title: StorageUsageMetrics
-      type: object
-      properties:
-        period:
-          $ref: '#/components/schemas/StorageUsagePeriod'
-        computeGcu:
-          type: number
-          format: double
-        memoryGbSeconds:
-          type: integer
-          format: uint64
-        durableStorageGbMonth:
-          type: number
-          format: double
-        ephemeralStorageGbMonth:
-          type: number
-          format: double
-      required:
-      - period
-      - computeGcu
-      - memoryGbSeconds
-      - durableStorageGbMonth
-      - ephemeralStorageGbMonth
-    StorageUsagePeriod:
-      title: StorageUsagePeriod
-      type: object
-      properties:
-        year:
-          type: integer
-          format: int32
-        month:
-          type: integer
-          format: uint32
-      required:
-      - year
-      - month
     StreamSpec:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Resolves GOL-523

- Replace storage-specific account usage types and operation names with one current/history account usage contract.
- Report compute in GCU, allocated memory in GB-seconds, and durable and ephemeral storage in GB-month with UTC periods and `asOf` freshness.
- Persist compute, memory, and filesystem metering state so API and CLI output distinguish disabled collection from measured zero.
- Update the executor-to-registry payload, PostgreSQL and SQLite schemas, generated OpenAPI, REST docs, CLI output schema, and public-path tests.

## Breaking changes

- Rename storage-specific account usage types and generated client operations without compatibility aliases.
- Remove current plan and limit metadata from period usage responses because historical limits are not snapshotted.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p golem-common -p golem-registry-service --all-targets -- -D warnings`
- `cargo check -p golem-common -p golem-service-base -p golem-registry-service -p golem-worker-executor -p golem-cli --all-targets`
- `cargo make check-cli-output-schema`
- Account usage unit and repository tests on SQLite, PostgreSQL, and PostgreSQL TLS
- Current and history REST tests on SQLite and PostgreSQL
- Live CLI current/history, limits, and sparse allocated-memory tests
- 136 changed-line mutants: 39 caught, 92 unviable, 3 process-boundary mutants killed manually, and 2 behaviorally equivalent
- Fresh registry, worker, and merged OpenAPI generation matched the checked-in files byte-for-byte

`cargo make check-openapi` could not use the repository-root local database because it contains a stale migration checksum. Fresh-database generation and byte comparisons passed.

