### PR TITLE
Replay resumed output streams in tree order (fix flaky concurrent_nested_sibling_output_replays_after_executor_restart)

### DIFF
--- a/golem-worker-executor/src/durable_host/durable_session.rs
+++ b/golem-worker-executor/src/durable_host/durable_session.rs
@@ -3011,23 +3011,41 @@ impl DurableSessionStreams {
         responses: &mpsc::Sender<InvocationResponse>,
     ) -> Result<(), String> {
         self.recover_session_mappings().await?;
-        let output_mapping_ids = self.session_root_output_mapping_ids().await?;
-        self.pump_output_streams_from_recovered(&HashMap::new(), &output_mapping_ids, responses)
-            .await
+        let root_output_mapping_ids = self.session_root_output_mapping_ids().await?;
+        self.pump_output_streams_from_recovered(
+            &HashMap::new(),
+            &root_output_mapping_ids,
+            &[],
+            responses,
+        )
+        .await
     }
 
+    /// Replays output streams for a resumed attachment.
+    ///
+    /// The root output streams are pumped first, and nested streams are pumped only after the
+    /// enclosing item that announces their transport mapping has been emitted, so the client
+    /// observes the same tree order as during the original invocation. Output streams that were
+    /// already mapped but are not reached by that traversal, because a cursor skipped the parent
+    /// item that introduced them, are pumped afterwards.
     pub(crate) async fn pump_output_streams_from(
         &self,
         cursors: &HashMap<
             golem_common::model::durable_stream::StreamId,
             Option<golem_common::model::durable_stream::StreamOffsetV1>,
         >,
-        output_mapping_ids: &[u64],
+        root_output_mapping_ids: &[u64],
+        known_output_mapping_ids: &[u64],
         responses: &mpsc::Sender<InvocationResponse>,
     ) -> Result<(), String> {
         self.recover_session_mappings().await?;
-        self.pump_output_streams_from_recovered(cursors, output_mapping_ids, responses)
-            .await
+        self.pump_output_streams_from_recovered(
+            cursors,
+            root_output_mapping_ids,
+            known_output_mapping_ids,
+            responses,
+        )
+        .await
     }
 
     async fn pump_output_streams_from_recovered(
@@ -3036,12 +3054,36 @@ impl DurableSessionStreams {
             golem_common::model::durable_stream::StreamId,
             Option<golem_common::model::durable_stream::StreamOffsetV1>,
         >,
+        root_output_mapping_ids: &[u64],
+        known_output_mapping_ids: &[u64],
+        responses: &mpsc::Sender<InvocationResponse>,
+    ) -> Result<(), String> {
+        let mut seen = HashSet::new();
+        self.pump_output_stream_trees(cursors, root_output_mapping_ids, &mut seen, responses)
+            .await?;
+        let detached = known_output_mapping_ids
+            .iter()
+            .copied()
+            .filter(|transport_stream_id| !seen.contains(transport_stream_id))
+            .collect::<Vec<_>>();
+        self.pump_output_stream_trees(cursors, &detached, &mut seen, responses)
+            .await
+    }
+
+    async fn pump_output_stream_trees(
+        &self,
+        cursors: &HashMap<
+            golem_common::model::durable_stream::StreamId,
+            Option<golem_common::model::durable_stream::StreamOffsetV1>,
+        >,
         output_mapping_ids: &[u64],
+        seen: &mut HashSet<u64>,
         responses: &mpsc::Sender<InvocationResponse>,
     ) -> Result<(), String> {
         let mut pending = output_mapping_ids
             .iter()
             .copied()
+            .filter(|transport_stream_id| seen.insert(*transport_stream_id))
             .map(|transport_stream_id| {
                 let mapping = self.mapping(transport_stream_id).ok_or_else(|| {
                     format!("unknown durable output stream {transport_stream_id}")
@@ -3049,10 +3091,6 @@ impl DurableSessionStreams {
                 Ok((transport_stream_id, mapping.handle))
             })
             .collect::<Result<Vec<_>, String>>()?;
-        let mut seen = pending
-            .iter()
-            .map(|(transport_stream_id, _)| *transport_stream_id)
-            .collect::<HashSet<_>>();
         while !pending.is_empty() {
             let nested = try_join_all(pending.into_iter().map(|(transport_stream_id, handle)| {
                 let after = cursors.get(&handle.stream_id).copied().flatten();
@@ -6321,7 +6359,7 @@ mod tests {
         ]);
         let (responses, mut receiver) = mpsc::channel(8);
         restarted
-            .pump_output_streams_from(&cursors, &[7, nested_transport_stream_id], &responses)
+            .pump_output_streams_from(&cursors, &[7], &[7, nested_transport_stream_id], &responses)
             .await
             .unwrap();
         drop(responses);

--- a/golem-worker-executor/src/grpc/invocation_session.rs
+++ b/golem-worker-executor/src/grpc/invocation_session.rs
@@ -1420,7 +1420,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
             }
         });
         let streams = acceptance.streams;
-        let output_mapping_ids = acceptance
+        let known_output_mapping_ids = acceptance
             .mappings
             .iter()
             .filter(|mapping| mapping.role == SessionStreamRoleV1::Output)
@@ -1556,8 +1556,16 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 }
             }
         };
-        if let Some((result, new_stream_mappings)) = persisted_result
-            && responses
+        let mut root_output_mapping_ids = Vec::new();
+        if let Some((result, new_stream_mappings)) = persisted_result {
+            root_output_mapping_ids = new_stream_mappings
+                .iter()
+                .filter(|mapping| {
+                    mapping.role() == golem_api_grpc::proto::golem::worker::StreamMappingRole::Output
+                })
+                .map(|mapping| mapping.transport_stream_id)
+                .collect();
+            if responses
                 .send(InvocationResponse {
                     response: Some(invocation_response::Response::Result(
                         InvocationSessionResult {
@@ -1585,6 +1593,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
             {
                 return;
             }
+        }
 
         {
             let mut output_pump = tokio::task::JoinSet::new();
@@ -1594,7 +1603,8 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 output_streams
                     .pump_output_streams_from(
                         &cursor_map,
-                        &output_mapping_ids,
+                        &root_output_mapping_ids,
+                        &known_output_mapping_ids,
                         &output_responses,
                     )
                     .await


### PR DESCRIPTION
Fixes the flaky worker-executor test `concurrent_nested_sibling_output_replays_after_executor_restart` (example failure: https://github.com/golemcloud/golem/runs/100201637440, `worker-tests-group3`).

## Root cause

The failure message was `item arrived for unknown nested sibling stream 2`, raised during the **ResumeAttach** phase of the test (second executor), not the first pass.

On resume, `run_resumed_agent_session` (`golem-worker-executor/src/grpc/invocation_session.rs`) handed *every* persisted Output mapping from the acceptance record to `pump_output_streams_from`. For this test that is roots `0,1` and nested streams `2,3`. `pump_output_streams_from_recovered` (`durable_session.rs`) then pumped all of them concurrently with `try_join_all`, so a nested stream's items could be sent to the client before the parent root `OutputItem` whose `new_stream_mappings` announces that nested stream.

The protocol validator (`InvocationSessionState`) tolerates items on streams already known from `Accepted` before they are re-announced, so the server output was protocol-legal, but it violated the tree order that the live path always produces: `pump_output_streams` starts from `session_root_output_mapping_ids()` and discovers nested streams level by level, so nested items are only emitted after their announcing parent item. The test's shared reader (`read_nested_sibling_output`) relies on that order for both the Start and Resume passes. Whether the resume replay happened to be in order depended on task scheduling, hence the flakiness.

## Fix

`pump_output_streams_from` now takes both the root output mapping IDs and the full set of known output mapping IDs:

1. **Tree order first** — the roots are pumped with the existing level-by-level traversal, so a nested stream is only pumped after the item that introduced its mapping has been emitted (same order as the original invocation).
2. **Detached streams afterwards** — any known output stream not reached by that traversal (because a client cursor skipped the parent item that introduced it) is pumped afterwards. This preserves the existing requirement covered by the unit test `output_catch_up_persists_a_missing_nested_transport_mapping_before_emitting`.

In `run_resumed_agent_session`, the root IDs are derived from the persisted `Result`'s `new_stream_mappings` filtered to `StreamMappingRole::Output`; the acceptance mappings remain the "known" set. The live path passes an empty known set and behaves exactly as before.

## Verification

- Original binary: 2/25 local runs failed with exactly the CI error `item arrived for unknown nested sibling stream 2`.
- Fixed binary: 25/25, then 60/60 under background CPU load, plus a final `cargo test -p golem-worker-executor --test integration -- concurrent_nested_sibling_output_replays_after_executor_restart` → passed.
- Unit test `output_catch_up_persists_a_missing_nested_transport_mapping_before_emitting` passes.
- Related `rpc.rs` streaming tests pass (`generated_rust_client_streaming_rpc_e2e`, `durable_agent_live_await_streaming_is_allowed`, `durable_streaming_input_recovers_after_executor_restart`, `caller_recovery_restarts_input_drain_after_rpc_result_commit`, `stream_local_output_failure_does_not_fail_sibling_or_invocation`, `malformed_request_after_streaming_result_terminalizes_open_streams`).
- `cargo fmt -p golem-worker-executor -- --check` and `cargo clippy -p golem-worker-executor --tests` are clean.

