### PR TITLE
Warm up restored SQLite connections and fall back to full replay when a snapshot's tail diverges

### DIFF
--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -798,6 +798,15 @@ impl TestWorkerExecutor {
             .await
     }
 
+    /// Arms a one-shot gate that leaves the next `Snapshot` oplog append for `agent_id` pending
+    /// forever, so dropping the executor simulates a crash between the invocation completing and
+    /// its automatic snapshot becoming durable.
+    pub async fn abort_next_snapshot_append(&self, agent_id: &AgentId) -> SnapshotAppendGateHandle {
+        self.additional_test_deps
+            .abort_next_snapshot_append(agent_id.clone())
+            .await
+    }
+
     /// Arms a one-shot gate immediately before the next discriminated p3 HTTP consume-body scope
     /// `End` is appended for `agent_id`. Must be armed before the invocation appends the scope's
     /// `Start` (the gate is consulted when tracking scope `Start` appends too).
@@ -3098,6 +3107,25 @@ impl TestOplog {
         gate.abort_append.load(Ordering::SeqCst)
     }
 
+    /// Returns `true` when an armed snapshot append gate intercepts this `Snapshot` append; the
+    /// caller must then leave the append pending forever.
+    async fn abort_snapshot_append(&self) -> bool {
+        let Some(gate) = self
+            .additional_test_deps
+            .snapshot_append_gate(&self.owned_agent_id.agent_id)
+            .await
+        else {
+            return false;
+        };
+        if !gate.armed.swap(false, Ordering::SeqCst) {
+            return false;
+        }
+        if let Some(reached_tx) = gate.reached_tx.lock().unwrap().take() {
+            let _ = reached_tx.send(());
+        }
+        true
+    }
+
     /// Recognizes the `End` of a tracked consume-body scope `Start`.
     fn is_consume_body_scope_end(&self, entry: &OplogEntry) -> bool {
         let OplogEntry::End { start_index, .. } = entry else {
@@ -3203,6 +3231,9 @@ impl Oplog for TestOplog {
         if self.is_consume_body_scope_end(&entry)
             && self.pause_before_consume_body_scope_end().await
         {
+            return std::future::pending().await;
+        }
+        if matches!(entry, OplogEntry::Snapshot { .. }) && self.abort_snapshot_append().await {
             return std::future::pending().await;
         }
         let track_scope_start = Self::is_consume_body_scope_start(&entry);
@@ -3618,6 +3649,10 @@ pub struct AdditionalTestDeps {
     consume_body_scope_start_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeStartGate>>>,
     consume_body_scope_end_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeEndGate>>>,
     consume_body_reply_defer_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyReplyDeferGate>>>,
+    /// One-shot gates leaving an agent's next `Snapshot` append pending forever inside the
+    /// [`TestOplog`] wrapper, so dropping the executor simulates a crash after the preceding
+    /// invocation completed but before its snapshot became durable.
+    snapshot_append_gates: Arc<scc::HashMap<AgentId, Arc<SnapshotAppendGate>>>,
     /// Captured once on first call to [`TestWorkerCtx::create`]. Used by the
     /// read-only test helpers (`worker_is_loaded`,
     /// `worker_eviction_class`, `worker_memory_requirement`) to observe
@@ -3646,6 +3681,7 @@ impl AdditionalTestDeps {
             consume_body_scope_start_gates: Arc::new(scc::HashMap::new()),
             consume_body_scope_end_gates: Arc::new(scc::HashMap::new()),
             consume_body_reply_defer_gates: Arc::new(scc::HashMap::new()),
+            snapshot_append_gates: Arc::new(scc::HashMap::new()),
             active_agents: Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -3736,6 +3772,28 @@ impl AdditionalTestDeps {
         agent_id: &AgentId,
     ) -> Option<Arc<ConsumeBodyScopeEndGate>> {
         self.consume_body_scope_end_gates
+            .read_async(agent_id, |_, gate| gate.clone())
+            .await
+    }
+
+    /// Arms a one-shot gate that leaves the given agent's next `Snapshot` append pending forever,
+    /// so the snapshot never becomes durable. Re-arming replaces a previously fired gate.
+    pub async fn abort_next_snapshot_append(&self, agent_id: AgentId) -> SnapshotAppendGateHandle {
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let gate = Arc::new(SnapshotAppendGate {
+            armed: AtomicBool::new(true),
+            reached_tx: std::sync::Mutex::new(Some(reached_tx)),
+        });
+        self.snapshot_append_gates
+            .entry_async(agent_id)
+            .await
+            .and_modify(|existing| *existing = gate.clone())
+            .or_insert_with(|| gate.clone());
+        SnapshotAppendGateHandle { reached_rx }
+    }
+
+    async fn snapshot_append_gate(&self, agent_id: &AgentId) -> Option<Arc<SnapshotAppendGate>> {
+        self.snapshot_append_gates
             .read_async(agent_id, |_, gate| gate.clone())
             .await
     }
@@ -4007,6 +4065,24 @@ impl ConsumeBodyScopeEndGateHandle {
 impl Drop for ConsumeBodyScopeEndGateHandle {
     fn drop(&mut self) {
         self.gate.release.add_permits(1);
+    }
+}
+
+struct SnapshotAppendGate {
+    armed: AtomicBool,
+    reached_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+pub struct SnapshotAppendGateHandle {
+    reached_rx: tokio::sync::oneshot::Receiver<()>,
+}
+
+impl SnapshotAppendGateHandle {
+    /// Resolves once the gated `Snapshot` append has been intercepted and left pending.
+    pub async fn reached(&mut self) {
+        (&mut self.reached_rx)
+            .await
+            .expect("the snapshot append gate was dropped without firing");
     }
 }
 

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -798,15 +798,6 @@ impl TestWorkerExecutor {
             .await
     }
 
-    /// Arms a one-shot gate that leaves the next `Snapshot` oplog append for `agent_id` pending
-    /// forever, so dropping the executor simulates a crash between the invocation completing and
-    /// its automatic snapshot becoming durable.
-    pub async fn abort_next_snapshot_append(&self, agent_id: &AgentId) -> SnapshotAppendGateHandle {
-        self.additional_test_deps
-            .abort_next_snapshot_append(agent_id.clone())
-            .await
-    }
-
     /// Arms a one-shot gate immediately before the next discriminated p3 HTTP consume-body scope
     /// `End` is appended for `agent_id`. Must be armed before the invocation appends the scope's
     /// `Start` (the gate is consulted when tracking scope `Start` appends too).
@@ -3107,25 +3098,6 @@ impl TestOplog {
         gate.abort_append.load(Ordering::SeqCst)
     }
 
-    /// Returns `true` when an armed snapshot append gate intercepts this `Snapshot` append; the
-    /// caller must then leave the append pending forever.
-    async fn abort_snapshot_append(&self) -> bool {
-        let Some(gate) = self
-            .additional_test_deps
-            .snapshot_append_gate(&self.owned_agent_id.agent_id)
-            .await
-        else {
-            return false;
-        };
-        if !gate.armed.swap(false, Ordering::SeqCst) {
-            return false;
-        }
-        if let Some(reached_tx) = gate.reached_tx.lock().unwrap().take() {
-            let _ = reached_tx.send(());
-        }
-        true
-    }
-
     /// Recognizes the `End` of a tracked consume-body scope `Start`.
     fn is_consume_body_scope_end(&self, entry: &OplogEntry) -> bool {
         let OplogEntry::End { start_index, .. } = entry else {
@@ -3231,9 +3203,6 @@ impl Oplog for TestOplog {
         if self.is_consume_body_scope_end(&entry)
             && self.pause_before_consume_body_scope_end().await
         {
-            return std::future::pending().await;
-        }
-        if matches!(entry, OplogEntry::Snapshot { .. }) && self.abort_snapshot_append().await {
             return std::future::pending().await;
         }
         let track_scope_start = Self::is_consume_body_scope_start(&entry);
@@ -3649,10 +3618,6 @@ pub struct AdditionalTestDeps {
     consume_body_scope_start_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeStartGate>>>,
     consume_body_scope_end_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyScopeEndGate>>>,
     consume_body_reply_defer_gates: Arc<scc::HashMap<AgentId, Arc<ConsumeBodyReplyDeferGate>>>,
-    /// One-shot gates leaving an agent's next `Snapshot` append pending forever inside the
-    /// [`TestOplog`] wrapper, so dropping the executor simulates a crash after the preceding
-    /// invocation completed but before its snapshot became durable.
-    snapshot_append_gates: Arc<scc::HashMap<AgentId, Arc<SnapshotAppendGate>>>,
     /// Captured once on first call to [`TestWorkerCtx::create`]. Used by the
     /// read-only test helpers (`worker_is_loaded`,
     /// `worker_eviction_class`, `worker_memory_requirement`) to observe
@@ -3681,7 +3646,6 @@ impl AdditionalTestDeps {
             consume_body_scope_start_gates: Arc::new(scc::HashMap::new()),
             consume_body_scope_end_gates: Arc::new(scc::HashMap::new()),
             consume_body_reply_defer_gates: Arc::new(scc::HashMap::new()),
-            snapshot_append_gates: Arc::new(scc::HashMap::new()),
             active_agents: Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -3772,28 +3736,6 @@ impl AdditionalTestDeps {
         agent_id: &AgentId,
     ) -> Option<Arc<ConsumeBodyScopeEndGate>> {
         self.consume_body_scope_end_gates
-            .read_async(agent_id, |_, gate| gate.clone())
-            .await
-    }
-
-    /// Arms a one-shot gate that leaves the given agent's next `Snapshot` append pending forever,
-    /// so the snapshot never becomes durable. Re-arming replaces a previously fired gate.
-    pub async fn abort_next_snapshot_append(&self, agent_id: AgentId) -> SnapshotAppendGateHandle {
-        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
-        let gate = Arc::new(SnapshotAppendGate {
-            armed: AtomicBool::new(true),
-            reached_tx: std::sync::Mutex::new(Some(reached_tx)),
-        });
-        self.snapshot_append_gates
-            .entry_async(agent_id)
-            .await
-            .and_modify(|existing| *existing = gate.clone())
-            .or_insert_with(|| gate.clone());
-        SnapshotAppendGateHandle { reached_rx }
-    }
-
-    async fn snapshot_append_gate(&self, agent_id: &AgentId) -> Option<Arc<SnapshotAppendGate>> {
-        self.snapshot_append_gates
             .read_async(agent_id, |_, gate| gate.clone())
             .await
     }
@@ -4065,24 +4007,6 @@ impl ConsumeBodyScopeEndGateHandle {
 impl Drop for ConsumeBodyScopeEndGateHandle {
     fn drop(&mut self) {
         self.gate.release.add_permits(1);
-    }
-}
-
-struct SnapshotAppendGate {
-    armed: AtomicBool,
-    reached_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
-}
-
-pub struct SnapshotAppendGateHandle {
-    reached_rx: tokio::sync::oneshot::Receiver<()>,
-}
-
-impl SnapshotAppendGateHandle {
-    /// Resolves once the gated `Snapshot` append has been intercepted and left pending.
-    pub async fn reached(&mut self) {
-        (&mut self.reached_rx)
-            .await
-            .expect("the snapshot append gate was dropped without firing");
     }
 }
 

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -3662,8 +3662,46 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
         } else {
             debug!("Snapshot loaded successfully from oplog index {snapshot_index}");
             Self::emit_snapshot_recovery_event(store, snapshot_index, true, None);
+            if snapshot_source == Some(SnapshotSource::Automatic) {
+                store
+                    .as_context_mut()
+                    .data_mut()
+                    .durable_ctx_mut()
+                    .state
+                    .replaying_automatic_snapshot_tail = true;
+            }
             SnapshotRecoveryResult::Success
         }
+    }
+
+    /// Abandons an automatic snapshot whose replayed tail diverged from the recorded oplog: the
+    /// worker is recreated with automatic snapshot recovery disabled so it replays the full oplog.
+    fn abandon_diverged_automatic_snapshot(
+        store: &mut (impl AsContextMut<Data = Ctx> + Send),
+        full_function_name: &str,
+        error: &AgentError,
+    ) -> RetryDecision {
+        let snapshot_index = store
+            .as_context()
+            .data()
+            .durable_ctx()
+            .state
+            .last_snapshot_index
+            .expect("an automatic snapshot tail is only replayed after loading a snapshot");
+        let error = format!(
+            "Replaying {full_function_name} after loading the snapshot diverged from the recorded oplog: {}; falling back to full replay",
+            error.message()
+        );
+        warn!("{error}");
+        Self::emit_snapshot_recovery_event(store, snapshot_index, false, Some(error));
+        store
+            .as_context()
+            .data()
+            .get_public_state()
+            .worker()
+            .snapshot_recovery_disabled
+            .store(true, Ordering::Release);
+        RetryDecision::Immediate
     }
 
     fn emit_snapshot_recovery_event(
@@ -5407,6 +5445,32 @@ impl<Ctx: WorkerCtx> ExternalOperations<Ctx> for DurableWorkerCtx<Ctx> {
                                     }
                                 };
                                 let decision = match trap_type {
+                                    // A recorded invocation that fails while its entries are still
+                                    // being replayed after an automatic snapshot load most likely
+                                    // diverged from the recorded execution because the guest state
+                                    // restored from the snapshot differs from the original one. The
+                                    // recorded oplog is authoritative, so instead of committing the
+                                    // failure the snapshot is abandoned and the worker replays from
+                                    // the beginning, which reproduces the recorded outcome.
+                                    Some(TrapType::Error { error, .. })
+                                        if store
+                                            .as_context()
+                                            .data()
+                                            .durable_ctx()
+                                            .state
+                                            .replaying_automatic_snapshot_tail
+                                            && !store
+                                                .as_context()
+                                                .data()
+                                                .durable_ctx()
+                                                .is_live() =>
+                                    {
+                                        Some(Self::abandon_diverged_automatic_snapshot(
+                                            store,
+                                            &full_function_name,
+                                            &error,
+                                        ))
+                                    }
                                     Some(trap_type) => {
                                         let decision = store
                                             .as_context_mut()
@@ -5465,6 +5529,15 @@ impl<Ctx: WorkerCtx> ExternalOperations<Ctx> for DurableWorkerCtx<Ctx> {
         };
 
         record_number_of_replayed_functions(number_of_replayed_functions);
+
+        if matches!(resume_result, Ok(None)) {
+            store
+                .as_context_mut()
+                .data_mut()
+                .durable_ctx_mut()
+                .state
+                .replaying_automatic_snapshot_tail = false;
+        }
 
         resume_result
     }
@@ -9174,6 +9247,12 @@ struct PrivateDurableWorkerState {
     current_phantom_id: Option<Uuid>,
     last_snapshot_index: Option<OplogIndex>,
     last_snapshot_source: Option<SnapshotSource>,
+    /// Set while the recorded invocations following a loaded automatic snapshot are being
+    /// replayed. The snapshot restores the agent's own state but not every implementation detail
+    /// of the guest (for example caches of an embedded database), so the replayed tail can issue a
+    /// host-call sequence different from the recorded one. Such a divergence is a snapshot recovery
+    /// failure: the snapshot is abandoned and the worker replays the full oplog instead.
+    replaying_automatic_snapshot_tail: bool,
 
     /// Number of outgoing HTTP calls made in the current invocation (live only, not replayed).
     /// Reset to 0 at the start of each exported function invocation.
@@ -9436,6 +9515,7 @@ impl PrivateDurableWorkerState {
             current_phantom_id: original_phantom_id,
             last_snapshot_index,
             last_snapshot_source,
+            replaying_automatic_snapshot_tail: false,
             resource_limit_entry,
         })
     }

--- a/golem-worker-executor/tests/durability.rs
+++ b/golem-worker-executor/tests/durability.rs
@@ -20,13 +20,13 @@ use golem_api_grpc::proto::golem::worker::LogEvent;
 use golem_common::model::oplog::{
     MultipartPartData, OplogIndex, PublicOplogEntry, PublicOplogEntryWithIndex, PublicSnapshotData,
 };
-use golem_common::model::{AgentEvent, AgentStatus, OwnedAgentId};
+use golem_common::model::{AgentEvent, AgentId, AgentStatus, OwnedAgentId};
 use golem_common::{agent_id, data_value};
 use golem_test_framework::dsl::TestDsl;
 use golem_worker_executor::services::golem_config::SnapshotPolicy;
 use golem_worker_executor_test_utils::{
-    LastUniqueId, PrecompiledComponent, TestContext, WorkerExecutorTestDependencies, start,
-    start_with_snapshot_policy,
+    LastUniqueId, PrecompiledComponent, TestContext, TestWorkerExecutor,
+    WorkerExecutorTestDependencies, start, start_with_snapshot_policy,
 };
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
@@ -110,6 +110,59 @@ pub(crate) async fn assert_snapshot_recovery_failed(
     })
     .await
     .expect("Timed out waiting for snapshot recovery event");
+}
+
+/// Expects a successful snapshot load followed by the snapshot being abandoned because the replayed
+/// tail diverged from the recorded oplog.
+pub(crate) async fn assert_snapshot_recovery_abandoned(
+    events: &mut UnboundedReceiver<LogEvent>,
+    expected_error: &str,
+) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let mut loaded_index = None;
+        while let Some(event) = events.recv().await {
+            match AgentEvent::try_from(event) {
+                Ok(AgentEvent::SnapshotRecoverySucceeded { snapshot_index, .. }) => {
+                    assert!(
+                        loaded_index.is_none(),
+                        "Snapshot recovery unexpectedly succeeded twice"
+                    );
+                    loaded_index = Some(snapshot_index);
+                }
+                Ok(AgentEvent::SnapshotRecoveryFailed {
+                    snapshot_index,
+                    error,
+                    ..
+                }) => {
+                    assert_eq!(
+                        loaded_index,
+                        Some(snapshot_index),
+                        "Snapshot recovery failed before the snapshot was loaded: {error}"
+                    );
+                    assert!(
+                        error.contains(expected_error),
+                        "Snapshot was abandoned with unexpected error: {error}"
+                    );
+                    return;
+                }
+                _ => {}
+            }
+        }
+        panic!("Worker event stream ended before the snapshot was abandoned");
+    })
+    .await
+    .expect("Timed out waiting for the snapshot to be abandoned");
+}
+
+async fn count_snapshots(
+    executor: &TestWorkerExecutor,
+    worker_id: &AgentId,
+) -> anyhow::Result<usize> {
+    let oplog = executor.get_oplog(worker_id, OplogIndex::INITIAL).await?;
+    Ok(oplog
+        .iter()
+        .filter(|entry| matches!(entry.entry, PublicOplogEntry::Snapshot(_)))
+        .count())
 }
 
 #[test]
@@ -1560,6 +1613,109 @@ async fn ts_sqlite_multipart_snapshot_recovery(
     );
 
     // Add more data after recovery to verify databases are functional
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("cherry"))
+        .await?;
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "addLog", data_value!("recovered"))
+        .await?;
+
+    let state_after_more = executor
+        .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
+        .await?;
+
+    let state_after_str = state_after_more.into_typed::<String>()?;
+    let state_after_json: serde_json::Value = serde_json::from_str(&state_after_str)?;
+    assert_eq!(state_after_json["label"], "after-init");
+    assert_eq!(
+        state_after_json["items"],
+        serde_json::json!(["apple", "banana", "cherry"])
+    );
+    assert_eq!(
+        state_after_json["logs"],
+        serde_json::json!(["started", "recovered"])
+    );
+
+    executor.check_oplog_is_queryable(&worker_id).await?;
+
+    drop(executor);
+    Ok(())
+}
+
+/// Simulates a crash between an invocation completing and its automatic snapshot becoming durable.
+/// The restarted worker loads the previous snapshot and replays the recorded invocation as a tail,
+/// but the SQLite state restored from the snapshot makes the guest issue a different host-call
+/// sequence than the recorded one. The executor must abandon the snapshot and fall back to a full
+/// replay instead of failing the worker.
+#[test]
+#[tracing::instrument]
+async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
+    last_unique_id: &LastUniqueId,
+    deps: &WorkerExecutorTestDependencies,
+    #[tagged_as("constructor_parameter_echo")] constructor_parameter_echo: &PrecompiledComponent,
+    _tracing: &Tracing,
+) -> anyhow::Result<()> {
+    let context = TestContext::new(last_unique_id);
+    let executor = start(deps, &context).await?;
+
+    let component = executor
+        .component_dep(&context.default_environment_id, constructor_parameter_echo)
+        .store()
+        .await?;
+    let agent_id = agent_id!("SqliteSnapshotAgent", "sqlite-tail-divergence");
+    let worker_id = executor
+        .start_agent(&component.id, agent_id.clone())
+        .await?;
+
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("apple"))
+        .await?;
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("banana"))
+        .await?;
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "addLog", data_value!("started"))
+        .await?;
+    executor
+        .invoke_and_await_agent(&component, &agent_id, "setLabel", data_value!("after-init"))
+        .await?;
+
+    let snapshots_before = count_snapshots(&executor, &worker_id).await?;
+    assert!(
+        snapshots_before > 0,
+        "Expected automatic snapshots before the gated invocation"
+    );
+
+    // The snapshot taken after this invocation never becomes durable, so recovery has to load the
+    // snapshot taken after `setLabel` and replay the recorded `getState` on top of it.
+    let mut snapshot_gate = executor.abort_next_snapshot_append(&worker_id).await;
+    let state_before = executor
+        .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
+        .await?;
+    tokio::time::timeout(Duration::from_secs(20), snapshot_gate.reached())
+        .await
+        .expect("Timed out waiting for the automatic snapshot append");
+
+    assert_eq!(
+        count_snapshots(&executor, &worker_id).await?,
+        snapshots_before,
+        "The snapshot of the gated invocation must not be durable"
+    );
+
+    drop(executor);
+    let executor = start(deps, &context).await?;
+    let mut events = executor.capture_output(&worker_id).await?;
+
+    let state_after = executor
+        .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
+        .await?;
+    assert_snapshot_recovery_abandoned(&mut events, "diverged from the recorded oplog").await;
+
+    assert_eq!(
+        state_before, state_after,
+        "Agent state should be preserved by the full replay fallback"
+    );
+
     executor
         .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("cherry"))
         .await?;

--- a/golem-worker-executor/tests/durability.rs
+++ b/golem-worker-executor/tests/durability.rs
@@ -20,13 +20,13 @@ use golem_api_grpc::proto::golem::worker::LogEvent;
 use golem_common::model::oplog::{
     MultipartPartData, OplogIndex, PublicOplogEntry, PublicOplogEntryWithIndex, PublicSnapshotData,
 };
-use golem_common::model::{AgentEvent, AgentId, AgentStatus, OwnedAgentId};
+use golem_common::model::{AgentEvent, AgentStatus, OwnedAgentId};
 use golem_common::{agent_id, data_value};
 use golem_test_framework::dsl::TestDsl;
 use golem_worker_executor::services::golem_config::SnapshotPolicy;
 use golem_worker_executor_test_utils::{
-    LastUniqueId, PrecompiledComponent, TestContext, TestWorkerExecutor,
-    WorkerExecutorTestDependencies, start, start_with_snapshot_policy,
+    LastUniqueId, PrecompiledComponent, TestContext, WorkerExecutorTestDependencies, start,
+    start_with_snapshot_policy,
 };
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
@@ -65,17 +65,29 @@ fn total_memory_growth(entries: &[PublicOplogEntryWithIndex]) -> u64 {
         .sum()
 }
 
+/// Expects the snapshot to be loaded and kept during recovery. Must be called after the first
+/// invocation on the recovered worker completed: the events are read up to that invocation's
+/// `InvocationFinished`, so a snapshot that was loaded but abandoned afterwards because its replayed
+/// tail diverged fails the assertion too.
 pub(crate) async fn assert_snapshot_recovery_loaded(events: &mut UnboundedReceiver<LogEvent>) {
     tokio::time::timeout(Duration::from_secs(10), async {
+        let mut loaded = false;
         while let Some(event) = events.recv().await {
             match AgentEvent::try_from(event) {
-                Ok(AgentEvent::SnapshotRecoverySucceeded { .. }) => return,
+                Ok(AgentEvent::SnapshotRecoverySucceeded { .. }) => loaded = true,
                 Ok(AgentEvent::SnapshotRecoveryFailed {
                     snapshot_index,
                     error,
                     ..
                 }) => {
                     panic!("Snapshot recovery from {snapshot_index} failed: {error}");
+                }
+                Ok(AgentEvent::InvocationFinished { .. }) => {
+                    assert!(
+                        loaded,
+                        "Invocation finished without a snapshot recovery event"
+                    );
+                    return;
                 }
                 _ => {}
             }
@@ -110,59 +122,6 @@ pub(crate) async fn assert_snapshot_recovery_failed(
     })
     .await
     .expect("Timed out waiting for snapshot recovery event");
-}
-
-/// Expects a successful snapshot load followed by the snapshot being abandoned because the replayed
-/// tail diverged from the recorded oplog.
-pub(crate) async fn assert_snapshot_recovery_abandoned(
-    events: &mut UnboundedReceiver<LogEvent>,
-    expected_error: &str,
-) {
-    tokio::time::timeout(Duration::from_secs(10), async {
-        let mut loaded_index = None;
-        while let Some(event) = events.recv().await {
-            match AgentEvent::try_from(event) {
-                Ok(AgentEvent::SnapshotRecoverySucceeded { snapshot_index, .. }) => {
-                    assert!(
-                        loaded_index.is_none(),
-                        "Snapshot recovery unexpectedly succeeded twice"
-                    );
-                    loaded_index = Some(snapshot_index);
-                }
-                Ok(AgentEvent::SnapshotRecoveryFailed {
-                    snapshot_index,
-                    error,
-                    ..
-                }) => {
-                    assert_eq!(
-                        loaded_index,
-                        Some(snapshot_index),
-                        "Snapshot recovery failed before the snapshot was loaded: {error}"
-                    );
-                    assert!(
-                        error.contains(expected_error),
-                        "Snapshot was abandoned with unexpected error: {error}"
-                    );
-                    return;
-                }
-                _ => {}
-            }
-        }
-        panic!("Worker event stream ended before the snapshot was abandoned");
-    })
-    .await
-    .expect("Timed out waiting for the snapshot to be abandoned");
-}
-
-async fn count_snapshots(
-    executor: &TestWorkerExecutor,
-    worker_id: &AgentId,
-) -> anyhow::Result<usize> {
-    let oplog = executor.get_oplog(worker_id, OplogIndex::INITIAL).await?;
-    Ok(oplog
-        .iter()
-        .filter(|entry| matches!(entry.entry, PublicOplogEntry::Snapshot(_)))
-        .count())
 }
 
 #[test]
@@ -1642,14 +1601,14 @@ async fn ts_sqlite_multipart_snapshot_recovery(
     Ok(())
 }
 
-/// Simulates a crash between an invocation completing and its automatic snapshot becoming durable.
-/// The restarted worker loads the previous snapshot and replays the recorded invocation as a tail,
-/// but the SQLite state restored from the snapshot makes the guest issue a different host-call
-/// sequence than the recorded one. The executor must abandon the snapshot and fall back to a full
-/// replay instead of failing the worker.
+/// `SqliteSnapshotAgent` snapshots every second invocation (the constructor counts as one), so the
+/// final `getState` below is recorded after the last snapshot and gets replayed on top of the
+/// restored SQLite databases after the restart. Reading the file-backed database from the restored
+/// connection must issue the same host calls as the live connection did, otherwise the replayed tail
+/// diverges from the oplog.
 #[test]
 #[tracing::instrument]
-async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
+async fn ts_sqlite_snapshot_recovery_replays_invocations_after_the_snapshot(
     last_unique_id: &LastUniqueId,
     deps: &WorkerExecutorTestDependencies,
     #[tagged_as("constructor_parameter_echo")] constructor_parameter_echo: &PrecompiledComponent,
@@ -1662,7 +1621,7 @@ async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
         .component_dep(&context.default_environment_id, constructor_parameter_echo)
         .store()
         .await?;
-    let agent_id = agent_id!("SqliteSnapshotAgent", "sqlite-tail-divergence");
+    let agent_id = agent_id!("SqliteSnapshotAgent", "sqlite-tail-replay");
     let worker_id = executor
         .start_agent(&component.id, agent_id.clone())
         .await?;
@@ -1671,35 +1630,25 @@ async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
         .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("apple"))
         .await?;
     executor
-        .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("banana"))
-        .await?;
-    executor
         .invoke_and_await_agent(&component, &agent_id, "addLog", data_value!("started"))
         .await?;
     executor
         .invoke_and_await_agent(&component, &agent_id, "setLabel", data_value!("after-init"))
         .await?;
-
-    let snapshots_before = count_snapshots(&executor, &worker_id).await?;
-    assert!(
-        snapshots_before > 0,
-        "Expected automatic snapshots before the gated invocation"
-    );
-
-    // The snapshot taken after this invocation never becomes durable, so recovery has to load the
-    // snapshot taken after `setLabel` and replay the recorded `getState` on top of it.
-    let mut snapshot_gate = executor.abort_next_snapshot_append(&worker_id).await;
     let state_before = executor
         .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
         .await?;
-    tokio::time::timeout(Duration::from_secs(20), snapshot_gate.reached())
-        .await
-        .expect("Timed out waiting for the automatic snapshot append");
 
-    assert_eq!(
-        count_snapshots(&executor, &worker_id).await?,
-        snapshots_before,
-        "The snapshot of the gated invocation must not be durable"
+    let oplog = executor.get_oplog(&worker_id, OplogIndex::INITIAL).await?;
+    let last_snapshot_position = oplog
+        .iter()
+        .rposition(|entry| matches!(entry.entry, PublicOplogEntry::Snapshot(_)))
+        .expect("Expected a snapshot before restart");
+    assert!(
+        oplog[last_snapshot_position..]
+            .iter()
+            .any(|entry| matches!(entry.entry, PublicOplogEntry::AgentInvocationStarted(_))),
+        "Expected an invocation recorded after the last snapshot"
     );
 
     drop(executor);
@@ -1709,20 +1658,16 @@ async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
     let state_after = executor
         .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
         .await?;
-    assert_snapshot_recovery_abandoned(&mut events, "diverged from the recorded oplog").await;
+    assert_snapshot_recovery_loaded(&mut events).await;
 
     assert_eq!(
         state_before, state_after,
-        "Agent state should be preserved by the full replay fallback"
+        "Agent state should be preserved by the snapshot and the replayed tail"
     );
 
     executor
-        .invoke_and_await_agent(&component, &agent_id, "addItem", data_value!("cherry"))
-        .await?;
-    executor
         .invoke_and_await_agent(&component, &agent_id, "addLog", data_value!("recovered"))
         .await?;
-
     let state_after_more = executor
         .invoke_and_await_agent(&component, &agent_id, "getState", data_value!())
         .await?;
@@ -1730,10 +1675,7 @@ async fn ts_sqlite_snapshot_tail_divergence_falls_back_to_full_replay(
     let state_after_str = state_after_more.into_typed::<String>()?;
     let state_after_json: serde_json::Value = serde_json::from_str(&state_after_str)?;
     assert_eq!(state_after_json["label"], "after-init");
-    assert_eq!(
-        state_after_json["items"],
-        serde_json::json!(["apple", "banana", "cherry"])
-    );
+    assert_eq!(state_after_json["items"], serde_json::json!(["apple"]));
     assert_eq!(
         state_after_json["logs"],
         serde_json::json!(["started", "recovered"])

--- a/sdks/ts/packages/golem-ts-sdk/src/runtime.ts
+++ b/sdks/ts/packages/golem-ts-sdk/src/runtime.ts
@@ -645,7 +645,7 @@ class ResolvedAgentImpl {
       for (const p of parts) {
         if (!p.name.startsWith('db:')) continue;
         const field = this.instance[p.name.slice(3)];
-        if (isDatabaseSync(field)) restoreDatabaseSync(field, p.body);
+        if (isDatabaseSync(field)) restoreDatabase(field, p.body);
       }
       return;
     }
@@ -660,6 +660,23 @@ class ResolvedAgentImpl {
  */
 function isDatabaseSync(val: unknown): val is DatabaseSync {
   return val instanceof DatabaseSync;
+}
+
+/**
+ * Restores `db` from snapshot bytes and leaves the connection warm.
+ *
+ * `restoreDatabaseSync` copies the pages into the open connection with SQLite's backup API, which
+ * bumps the schema cookie and discards the connection's cached schema. Left like that, the first
+ * statement run after the restore would reload the schema in a read transaction of its own before
+ * executing in a second one, while the same statement on the live (pre-snapshot) connection ran in
+ * a single read transaction. For a file-backed database each read transaction is a distinct
+ * sequence of filesystem host calls, and the invocations recorded after the snapshot are replayed
+ * against the recorded host calls, so the restored connection must behave like the live one did.
+ * Reading the schema here, while snapshot loading is not recorded, does exactly that.
+ */
+function restoreDatabase(db: DatabaseSync, bytes: Uint8Array): void {
+  restoreDatabaseSync(db, bytes);
+  db.prepare('SELECT count(*) FROM sqlite_master').get();
 }
 
 /** `val instanceof Ctor`, including builtins whose constructors are not public. */

--- a/test-components/agent-constructor-parameter-echo/package-lock.json
+++ b/test-components/agent-constructor-parameter-echo/package-lock.json
@@ -24,6 +24,9 @@
       "name": "@golemcloud/golem-ts-sdk",
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@rollup/plugin-commonjs": "^28.0.6",

--- a/test-components/agent-constructor-parameter-echo/src/main.ts
+++ b/test-components/agent-constructor-parameter-echo/src/main.ts
@@ -77,10 +77,11 @@ export const SnapshotCounterAgentImpl = SnapshotCounterAgent.implement({
     },
 });
 
+// The constructor counts as an invocation, so a snapshot is taken after every odd method call.
 export const SqliteSnapshotAgent = defineAgent({
     name: 'SqliteSnapshotAgent',
     id: { id: z.string() },
-    snapshotting: { everyNInvocations: 1 },
+    snapshotting: { everyNInvocations: 2 },
     methods: {
         addItem: method({ input: { value: z.string() }, returns: z.number() }),
         addLog: method({ input: { message: z.string() }, returns: z.number() }),


### PR DESCRIPTION
Fixes the flaky `ts_sqlite_multipart_snapshot_recovery` failure exposed by #3817 (https://github.com/golemcloud/golem/actions/runs/33642797522/job/100334536467).

## Root cause

The agent in that test snapshots after every invocation. #3817 correctly cancels invocation loops on executor shutdown, so the snapshot after the last `getState` sometimes never becomes durable (on `main` the leaked loop always finished it, hiding the issue). This is what a crash between "invocation completed" and "snapshot committed" looks like in production.

Recovery then loads the previous snapshot and replays the recorded `getState` as a tail. The TS SDK restores the SQLite databases with `restoreDatabaseSync`, which copies the snapshot pages into the open connection via SQLite's backup API. That bumps the schema cookie and discards the connection's cached schema, but nothing touches the connection afterwards. The first statement after the restore therefore runs a schema-reload read transaction *and then* its own read transaction — for the file-backed database that is two filesystem host-call cycles (`create_directory_at`, `metadata_hash_at`, `stat_at`, …) where the live connection did one. `stat_at` is durable, no matching `Start` exists in the oplog, `claim_start_matching_request` raises `UnexpectedOplogEntry`, an `Error` entry is committed and the worker becomes permanently `Failed`.

## Fix 1: warm up the restored connection (TS SDK)

`loadSnapshot` in `sdks/ts/packages/golem-ts-sdk/src/runtime.ts` now goes through `restoreDatabase`, which runs `SELECT count(*) FROM sqlite_master` right after `restoreDatabaseSync`. That forces the schema reload while the executor is still in snapshotting mode (host calls are neither recorded nor matched), so the first real invocation after the restore issues the same host calls as it did live and the tail replays cleanly. The Rust, MoonBit and Scala SDKs have no SQLite snapshot support, so nothing changes there.

## Fix 2: fall back to full replay when the tail diverges (executor)

The executor already falls back to full replay when snapshot *loading* fails, but not when the *tail replay* after a successful load diverges. `PrivateDurableWorkerState` now tracks `replaying_automatic_snapshot_tail` (set when an `Automatic` snapshot is loaded, cleared when replay finishes). In `resume_replay`, a `TrapType::Error` raised while that flag is set and the worker is still in replay mode abandons the snapshot: it emits `SnapshotRecoveryFailed` ("… diverged from the recorded oplog …; falling back to full replay"), sets `snapshot_recovery_disabled`, and returns `RetryDecision::Immediate` without committing an `Error` entry. The recreated worker replays the full oplog and reproduces the recorded outcome.

Only `Automatic` snapshots get this treatment; manual-update snapshots, `Interrupt`/`Exit` traps and live-mode errors are unchanged. Guest-side caches can never be fully captured by a snapshot, so this stays valuable as a general safety net.

## Tests

- `SqliteSnapshotAgent` (test component `agent-constructor-parameter-echo`) now snapshots every second invocation (the constructor counts as one). No test hooks are needed: after an odd number of invocations the last one is a recorded tail on top of the last snapshot.
- New `ts_sqlite_snapshot_recovery_replays_invocations_after_the_snapshot` in `durability.rs`: `addItem`, `addLog`, `setLabel`, `getState` → snapshot after `setLabel`, `getState` is the tail → restart → asserts the snapshot was loaded and kept, state equality, and that the agent keeps working.
- `assert_snapshot_recovery_loaded` now reads events up to the recovered invocation's `InvocationFinished`, so a snapshot that was loaded and then abandoned by the fallback fails the assertion (previously it returned on the first `SnapshotRecoverySucceeded` and a later `SnapshotRecoveryFailed` went unnoticed). All existing callers invoke first and then assert, so they are unaffected.

## Verification

- New test with the component built **without** the SDK warm-up: `Snapshot recovery from 136 failed: Replaying getState after loading the snapshot diverged from the recorded oplog: Unexpected oplog entry during replay: expected Start { filesystem::types::descriptor::stat_at, ReadLocal … }` (the fallback fires, the test catches it). With the warm-up: 3/3 pass, `Snapshot loaded successfully`, no divergence.
- Executor fallback without the fix (earlier commit): the exact CI error; with the fix the worker recovers via full replay.
- `ts_sqlite_multipart_snapshot_recovery`: 5/5 on top of #3817, 2/2 on this branch with the rebuilt component.
- All `snapshot`-filtered worker-executor integration tests (durability, hot_update, scope_cards): 24 passed.
- `cargo fmt --check`, `cargo clippy -p golem-worker-executor --tests -D warnings` clean; SDK prettier + eslint clean, `golem-ts-sdk` vitest 697 passed.
