### PR TITLE
Speed up CI: single-pass build, more it-cli shards, parallel SDK tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,5 @@ archive.include = [
     { path = "dev-ci/golem-registry-service", relative-to = "target" },
     { path = "dev-ci/golem-shard-manager", relative-to = "target" },
     { path = "dev-ci/golem-worker-service", relative-to = "target" },
-    { path = "dev-ci/rib-repl", relative-to = "target" },
     { path = "dev-ci/worker-executor", relative-to = "target" },
 ]

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -20,7 +20,10 @@ runs:
         summary: true
         summary-report: true
         failed-report: true
-        slowest-report: true
+        # `slowest-report` (like the previous-results/flaky-rate/fail-rate/insights reports) makes
+        # the reporter crawl previous runs of this workflow, which took ~35 s per test job. Per-test
+        # durations remain available in the uploaded CTRF artifact.
+        slowest-report: false
         github-report: true
         flaky-report: true
         collapse-large-reports: true

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -56,7 +56,9 @@ runs:
         save-if: ${{ inputs.cache-save-if }}
     - name: Install cargo-make
       if: inputs.install-cargo-make == 'true'
-      uses: davidB/rust-cargo-make@v1
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-make
     - name: Install cargo-binstall
       if: inputs.install-cargo-binstall == 'true'
       uses: cargo-bins/cargo-binstall@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,8 +295,10 @@ jobs:
             description: "IT #4"
           - name: integration-tests-group5
             description: "IT #5"
-          - name: integration-tests-group6
-            description: "IT #6"
+          - name: integration-tests-group6-coordinated
+            description: "IT #6a"
+          - name: integration-tests-group6-rest
+            description: "IT #6b"
           - name: integration-tests-group7
             description: "IT #7"
           - name: integration-tests-group8
@@ -363,7 +365,11 @@ jobs:
       matrix:
         group:
           - { name: cli-integration-tests-agents, shard: agents }
+          - { name: cli-integration-tests-agents-guest-bridge, shard: agents_guest_bridge }
+          - { name: cli-integration-tests-agents-streaming, shard: agents_streaming }
           - { name: cli-integration-tests-bridge, shard: bridge_gen }
+          - { name: cli-integration-tests-bridge-rust, shard: bridge_gen_rust }
+          - { name: cli-integration-tests-deploy, shard: deploy }
           - { name: cli-integration-tests-core, shard: core }
     steps:
       - uses: actions/checkout@v5
@@ -697,8 +703,25 @@ jobs:
         run: moon test cmd lib
         working-directory: sdks/moonbit/golem_sdk_tools
 
+  # The Rust SDK test suite is dominated by three integration test targets that each shell out to
+  # cargo (tool: one `cargo check` per test, tool_middleware_component: a full wasm component
+  # build, ui: trybuild). They run as separate matrix entries; the `check` entry runs lint and every
+  # other test target and fails if a test target is added without being assigned to an entry.
   build-golem-rust:
-    runs-on: blacksmith
+    name: build-golem-rust (${{ matrix.part.name }})
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+      matrix:
+        part:
+          - name: check
+            test-args: --lib --bins --test agent --test tool_canonical --test schema_reexport
+          - name: tool
+            test-args: --test tool
+          - name: tool-middleware-component
+            test-args: --test tool_middleware_component
+          - name: ui
+            test-args: --test ui
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
@@ -710,13 +733,36 @@ jobs:
       - name: Install wasm-tools
         run: cargo binstall --force --locked wasm-tools@1.248.0
       - name: Check formatting
+        if: matrix.part.name == 'check'
         run: cargo fmt -- --check
         working-directory: sdks/rust
       - name: Clippy
+        if: matrix.part.name == 'check'
         run: cargo clippy -- -Dwarnings
         working-directory: sdks/rust
+      - name: Check that every test target is covered by the matrix
+        if: matrix.part.name == 'check'
+        working-directory: sdks/rust
+        run: |
+          expected='agent
+          schema_reexport
+          tool
+          tool_canonical
+          tool_middleware_component
+          ui'
+          actual=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[].targets[] | select(.kind | index("test")) | .name' | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "Test targets of sdks/rust changed; update the build-golem-rust matrix in ci.yaml:"
+            diff <(echo "$expected") <(echo "$actual") || true
+            exit 1
+          fi
       - name: Tests
-        run: cargo test --all-features
+        run: cargo test --all-features ${{ matrix.part.test-args }}
+        working-directory: sdks/rust
+      - name: Doc tests
+        if: matrix.part.name == 'check'
+        run: cargo test --all-features --doc
         working-directory: sdks/rust
 
   build-golem-ts:
@@ -811,8 +857,11 @@ jobs:
 
   build-test-components:
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    # Test components only need a `golem-cli` binary, so they are built from the optimized CLI
+    # produced by build-cli-test-bins rather than waiting for the full build-and-store job. This
+    # lets the component builds finish while build-and-store is still compiling test binaries.
     needs:
-      - build-and-store
+      - build-cli-test-bins
       - build-golem-ts
       - list-test-component-groups
     strategy:
@@ -827,13 +876,15 @@ jobs:
         with:
           use-cache: 'false'
           rust-targets: 'wasm32-wasip1 wasm32-wasip2'
-          install-cargo-binstall: 'true'
           install-cargo-make: 'false'
-      - uses: ./.github/actions/restore-binaries
+      - name: Restore CLI test binaries
+        uses: actions/cache/restore@v5
         with:
-          run-id: ${{ github.run_id }}
-          copy-to-target: 'true'
-          fail-on-cache-miss: 'true'
+          path: tmp/golem-cli-test-binaries
+          key: golem-cli-test-binaries-${{ github.run_id }}
+          fail-on-cache-miss: true
+      - name: Install golem-cli
+        run: chmod +x tmp/golem-cli-test-binaries/golem-cli
 
       - name: Restore built TS SDK
         if: matrix.chunk.needs-node
@@ -868,6 +919,7 @@ jobs:
         working-directory: test-components
         env:
           GOLEM_TS_PRESET: quick
+          GOLEM_CLI: ${{ github.workspace }}/tmp/golem-cli-test-binaries/golem-cli
         run: ./build-components.sh ${{ matrix.chunk.name }}
 
       - name: Collect built WASMs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -877,6 +877,7 @@ jobs:
           use-cache: 'false'
           rust-targets: 'wasm32-wasip1 wasm32-wasip2'
           install-cargo-make: 'false'
+          install-cargo-binstall: 'true'
       - name: Restore CLI test binaries
         uses: actions/cache/restore@v5
         with:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -161,13 +161,11 @@ args = ["build", "--workspace", "--all-targets"]
 [tasks.build-all-bins-including-tests]
 dependencies = ["wit"]
 description = "Builds all executables in debug mode, including the single-executable golem and all tests"
-
-script_runner = "@duckscript"
-script = '''
-exec --fail-on-error cargo build --profile %{PROFILE}
-exec --fail-on-error cargo test --no-run --profile %{PROFILE}
-'''
-
+# A single cargo invocation is used on purpose: `cargo build` followed by `cargo test --no-run`
+# resolves features twice (dev-dependencies enable e.g. `golem-common/proptest` only in the second
+# pass), which recompiles every workspace crate. Building bins and tests together resolves once.
+command = "cargo"
+args = ["build", "--workspace", "--bins", "--tests", "--profile", "${PROFILE}"]
 
 [tasks.build-bins]
 dependencies = ["wit"]
@@ -692,6 +690,24 @@ script = '''
 cargo-test-r run --package integration-tests --test sharding -- --nocapture --report-time $JUNIT_OPTS
 '''
 
+# CI runs the sequential sharding suite as two jobs (see the `it` matrix in ci.yaml): the
+# coordinated scenarios and everything else. Together they cover exactly `integration-tests-group6`.
+[tasks.integration-tests-group6-coordinated]
+description = "Runs integration tests (group 6/11 - sharding, coordinated scenarios only)"
+dependencies = ["build-bins-non-ci"]
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_ATTEMPTS" = "20", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_DELAY" = "1s" }
+script = '''
+cargo-test-r run --package integration-tests --test sharding coordinated_scenario -- --nocapture --report-time $JUNIT_OPTS
+'''
+
+[tasks.integration-tests-group6-rest]
+description = "Runs integration tests (group 6/11 - sharding, everything except the coordinated scenarios)"
+dependencies = ["build-bins-non-ci"]
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_ATTEMPTS" = "20", "GOLEM__WORKER_EXECUTOR_RETRIES__MAX_DELAY" = "1s" }
+script = '''
+cargo-test-r run --package integration-tests --test sharding -- --skip coordinated_scenario --nocapture --report-time $JUNIT_OPTS
+'''
+
 [tasks.integration-tests-group7]
 description = "Runs integration tests (group 7/11 - otlp_plugin, plugins)"
 dependencies = ["build-bins-non-ci"]
@@ -763,28 +779,66 @@ description = "Runs all CLI integration tests with dev-release golem and golem-c
 env = { "GOLEM_CLI_TEST_BIN_PROFILE" = "dev-release" }
 run_task = "cli-integration-tests"
 
-# it-cli CI shards, split by module-level test-r tag (see the it-cli matrix in ci.yaml).
+# it-cli CI shards, split by test-r tags (see the it-cli matrix in ci.yaml and the `tag_suite!`
+# and `#[tag]` declarations under cli/golem-cli/tests). Shards that are a subset of a module-level
+# tag use `--skip` on the more specific tag so every test is in exactly one shard.
 [tasks.cli-integration-tests-agents]
 dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
-description = "Runs the it-cli 'agents' shard (app::agents)"
+description = "Runs the it-cli 'agents' shard (app::agents without the guest-bridge and streaming tests)"
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:agents" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:agents" -- --skip ":tag:agents_guest_bridge|agents_streaming" --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+'''
+
+[tasks.cli-integration-tests-agents-guest-bridge]
+dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
+description = "Runs the it-cli 'agents_guest_bridge' shard (app::agents::*_guest_bridge_e2e)"
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:agents_guest_bridge" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+'''
+
+[tasks.cli-integration-tests-agents-streaming]
+dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
+description = "Runs the it-cli 'agents_streaming' shard (app::agents streaming end-to-end tests)"
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:agents_streaming" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
 '''
 
 [tasks.cli-integration-tests-bridge]
 dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
-description = "Runs the it-cli 'bridge' shard (bridge_gen)"
+description = "Runs the it-cli 'bridge_gen' shard (bridge_gen without bridge_gen::rust)"
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script_runner = "@duckscript"
 script = '''
-exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:bridge_gen" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:bridge_gen" -- --skip ":tag:bridge_gen_rust" --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+'''
+
+[tasks.cli-integration-tests-bridge-rust]
+dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
+description = "Runs the it-cli 'bridge_gen_rust' shard (bridge_gen::rust)"
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:bridge_gen_rust" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
+'''
+
+[tasks.cli-integration-tests-deploy]
+dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
+description = "Runs the it-cli 'deploy' shard (app modules other than agents and app)"
+env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error cargo-test-r run --package golem-cli --test integration ":tag:deploy" -- --nocapture --test-threads=%{CLI_TEST_THREADS} --report-time %{JUNIT_OPTS}
 '''
 
 [tasks.cli-integration-tests-core]
 dependencies = ["build-cli-test-bins-non-ci", "build-sdk-ts"]
-description = "Runs the it-cli 'core' shard (everything not tagged agents/bridge_gen)"
+description = "Runs the it-cli 'core' shard (untagged tests, i.e. app::app)"
 env = { "RUST_LOG" = "info", "RUST_BACKTRACE" = "1", "QUIET" = "true" }
 script_runner = "@duckscript"
 script = '''

--- a/cli/golem-cli/tests/app/agents.rs
+++ b/cli/golem-cli/tests/app/agents.rs
@@ -16,7 +16,7 @@ use indoc::{formatdoc, indoc};
 use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
-use test_r::{inherit_test_dep, test, timeout};
+use test_r::{inherit_test_dep, tag, test, timeout};
 use uuid::Uuid;
 
 inherit_test_dep!(Tracing);
@@ -226,6 +226,7 @@ fn assert_generated_driver(output: std::process::Output, language: &str, marker:
 }
 
 #[test]
+#[tag(agents_streaming)]
 #[timeout("15 minutes")]
 async fn test_streaming_invocation_cli_end_to_end() {
     let ctx = streaming_invocation_context().await;
@@ -1011,6 +1012,7 @@ async fn test_streaming_invocation_cli_end_to_end() {
 }
 
 #[test]
+#[tag(agents_streaming)]
 #[timeout("30 minutes")]
 async fn test_generated_streaming_bridges_end_to_end() {
     let ctx = streaming_invocation_context().await;
@@ -1505,6 +1507,7 @@ async fn test_rust_counter() {
 /// direct guest ABI and native same-component agent RPC. This does not depend
 /// on generated cross-component bridges or public streaming bridge clients.
 #[test]
+#[tag(agents_streaming)]
 #[timeout("15 minutes")]
 async fn test_scala_streaming_rpc_e2e() {
     let mut ctx = TestContext::new();
@@ -2273,6 +2276,7 @@ async fn test_rust_code_first_with_rpc_and_all_types() {
 /// assertions accordingly — only then does this test validate the generated
 /// command path and input encoding against the provider.
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_rust_tool_guest_bridge_e2e() {
     let mut ctx = TestContext::new();
@@ -2591,6 +2595,7 @@ async fn test_mixed_agent_and_tool_component_deployment_e2e() {
 /// linking against the generated crate. The deployment and invocation also prove
 /// the generated guest client reaches the worker executor's Wasm RPC path.
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_rust_agent_guest_bridge_e2e() {
     let mut ctx = TestContext::new();
@@ -2756,6 +2761,7 @@ fn add_ts_guest_bridge_source(ctx: &TestContext, package_name: &str, generated_s
 }
 
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_ts_agent_guest_bridge_e2e() {
     let mut ctx = TestContext::new();
@@ -2873,6 +2879,7 @@ async fn test_ts_agent_guest_bridge_e2e() {
 }
 
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_ts_tool_guest_bridge_e2e() {
     let mut ctx = TestContext::new();
@@ -3038,6 +3045,7 @@ async fn test_ts_tool_guest_bridge_e2e() {
 }
 
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_moonbit_agent_guest_bridge_e2e() {
     let mut ctx = TestContext::new();
@@ -3174,6 +3182,7 @@ async fn test_moonbit_agent_guest_bridge_e2e() {
 }
 
 #[test]
+#[tag(agents_guest_bridge)]
 #[timeout("15 minutes")]
 async fn test_moonbit_tool_guest_bridge_e2e() {
     let mut ctx = TestContext::new();

--- a/cli/golem-cli/tests/app/mod.rs
+++ b/cli/golem-cli/tests/app/mod.rs
@@ -28,9 +28,22 @@ mod tool_middleware;
 
 inherit_test_dep!(Tracing);
 
-// Tag for the it-cli `agents` CI shard. Must live in the `app` module so the tag's module-path
-// prefix resolves to `app::agents`.
+// Tags for the it-cli CI shards. They must live in the `app` module so the tag's module-path
+// prefix resolves to `app::<module>`.
+//
+// The `agents` module is split further by per-test `#[tag(agents_guest_bridge)]` and
+// `#[tag(agents_streaming)]` attributes; the `agents` CI shard skips those two tags.
 tag_suite!(agents, agents);
+// Everything except `app::agents` and `app::app` runs in the `deploy` shard; the untagged
+// remainder (`:tag:`) is the `core` shard, which is only `app::app`.
+tag_suite!(account, deploy);
+tag_suite!(build_and_deploy_all, deploy);
+tag_suite!(cards, deploy);
+tag_suite!(directory_source_ifs, deploy);
+tag_suite!(moonbit_tool_middleware, deploy);
+tag_suite!(plugins, deploy);
+tag_suite!(scala_tool_middleware, deploy);
+tag_suite!(tool_middleware, deploy);
 
 use crate::{Tracing, crate_path, workspace_path};
 use anyhow::Context;

--- a/cli/golem-cli/tests/bridge_gen/mod.rs
+++ b/cli/golem-cli/tests/bridge_gen/mod.rs
@@ -16,6 +16,9 @@ pub mod fixtures;
 pub mod moonbit;
 pub mod parameter_naming;
 pub mod rust;
+// The Rust compile checks are the bulk of the bridge_gen suite; the it-cli `bridge_gen_rust`
+// CI shard runs only them and the `bridge_gen` shard skips them.
+test_r::tag_suite!(rust, bridge_gen_rust);
 pub mod scala;
 // Scala compile checks reference the in-tree SDK and share its sbt target directories.
 test_r::sequential_suite!(scala);

--- a/cli/golem-cli/tests/lib.rs
+++ b/cli/golem-cli/tests/lib.rs
@@ -23,7 +23,8 @@ test_r::enable!();
 mod app;
 mod bridge_gen;
 
-// Tag for the it-cli `bridge_gen` CI shard (see the it-cli matrix in ci.yaml).
+// Tag for the it-cli `bridge_gen` and `bridge_gen_rust` CI shards (see the it-cli matrix in
+// ci.yaml); `bridge_gen::rust` is additionally tagged `bridge_gen_rust` in bridge_gen/mod.rs.
 tag_suite!(bridge_gen, bridge_gen);
 
 #[derive(Debug)]

--- a/golem-client/build.rs
+++ b/golem-client/build.rs
@@ -10,18 +10,21 @@ fn main() {
     let root_yaml_path = PathBuf::from("../openapi/golem-service.yaml");
     let local_yaml_path = PathBuf::from("openapi/golem-service.yaml");
 
-    println!("cargo::rerun-if-changed={}", root_yaml_path.display());
-    println!("cargo::rerun-if-changed={}", local_yaml_path.display());
-
     println!("Starting code generation for Golem OpenAPI client.");
 
     println!("Output directory: {out_dir:?}");
     println!("Workspace OpenAPI file: {root_yaml_path:?}");
 
+    // Only the file this build actually reads from is tracked. The local copy is written by this
+    // script, so tracking it while it is (re)created would make the script stale on the very next
+    // cargo invocation and recompile golem-client and all of its dependents.
     if root_yaml_path.exists() {
+        println!("cargo::rerun-if-changed={}", root_yaml_path.display());
         // Copying the file to the crate so it gets packaged
         std::fs::create_dir_all(local_yaml_path.parent().unwrap()).unwrap();
         copy_if_different(root_yaml_path.clone(), local_yaml_path.clone()).unwrap();
+    } else {
+        println!("cargo::rerun-if-changed={}", local_yaml_path.display());
     };
     generate(local_yaml_path.clone(), out_dir)
 }


### PR DESCRIPTION
Analysis of the last successful full `main` run (26 min wall) showed the critical path was `build-and-store` (12 min; compile was a two-pass `cargo build` + `cargo test --no-run` that rebuilt `golem-common`/`golem-schema` and downstream because dev-deps enable `proptest`) followed by `it-cli (agents)` (13.4 min, dominated by a handful of 2–5 minute guest-bridge/streaming e2e tests). `build-golem-rust` took 22 min standalone on a 2 vCPU runner (36 min in the previous run, where it was the critical path). Every test job also spent ~35 s in the CTRF reporter crawling 400 previous workflow runs.

Changes (no tests removed; every test still runs in exactly one job):

- `build-all-bins-including-tests`: single `cargo build --workspace --bins --tests --profile ${PROFILE}`.
- `build-test-components` depends on `build-cli-test-bins` and uses its `golem-cli` (`GOLEM_CLI`) instead of waiting for `build-and-store`.
- it-cli: 3 → 7 shards via test-r tags: `agents` (minus the two tags below), `agents_guest_bridge` (six `*_guest_bridge_e2e`), `agents_streaming` (three streaming e2e), `bridge_gen` (minus rust), `bridge_gen_rust`, `deploy` (all `app::*` modules except `agents`/`app`), `core` (`app::app`). Parent shards use `--skip ":tag:…"`. `cargo make cli-integration-tests` is unchanged for local runs.
- `build-golem-rust`: 4-way matrix (`tool`, `tool-middleware-component`, `ui`, `check` = fmt/clippy/lib+doc tests/remaining targets) on 16 vCPU runners. The `check` entry fails if a `[[test]]` target is added without a matrix entry.
- IT #6 (sharding suite) split into `coordinated_scenario` tests and the rest.
- `publish-test-report`: `slowest-report: false` (it triggers the previous-runs crawl). CTRF artifacts with per-test durations are still uploaded on success.
- Removed the stale `dev-ci/rib-repl` nextest profile entry.

Verification: `cargo check/clippy/fmt -p golem-cli --tests` clean; built the `integration` test binary and confirmed the 298 listed tests partition into the 7 shards with no leftovers (agents 13 / guest_bridge 6 / streaming 3 / deploy 15 / core 93 / bridge_gen 132 / bridge_gen_rust 36, matching the CTRF counts of the analysed run). `sdks/rust` `check` invocation produces all expected executables; the target-coverage guard passes locally.

Expected: critical path ≈ 26 → ~18 min, `build-golem-rust` ≈ 22 → ~6 min. This PR's own CI run is the real measurement.
