### PR TITLE
Add global known-flaky-tests report

### DIFF
--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         report-path: "**/target/ctrf-*.json"
         upload-artifact: 'true'
-        artifact-name: ${{ inputs.artifact-name }}
+        artifact-name: ${{ inputs.artifact-name }}-attempt${{ github.run_attempt }}
         summary: true
         summary-report: true
         failed-report: true

--- a/.github/scripts/flaky_tests.py
+++ b/.github/scripts/flaky_tests.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import concurrent.futures
+import datetime as dt
+import html
+import io
+import json
+import math
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ISSUE_TITLE = "Known flaky tests"
+ISSUE_MARKER = "<!-- known-flaky-tests:v1 -->"
+REPORT_NAME = re.compile(r"-report(?:-attempt(?P<attempt>[1-9][0-9]*))?$")
+
+
+def utc_now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def parse_time(value):
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def format_time(value):
+    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
+
+
+def percentile(values, percentile_value):
+    if not values:
+        return 0
+    ordered = sorted(values)
+    rank = max(1, math.ceil(percentile_value * len(ordered)))
+    return ordered[rank - 1]
+
+
+def markdown_code(value):
+    return "<code>{}</code>".format(
+        html.escape(str(value)).replace("|", "&#124;").replace("\n", " ")
+    )
+
+
+def report_job_name(artifact_name):
+    base = re.sub(r"-attempt[1-9][0-9]*$", "", artifact_name)
+    base = re.sub(r"-report$", "", base)
+    if base == "unit-tests":
+        return "unit-tests-and-checks"
+    if base.startswith("worker-executor-tests-"):
+        return base.replace("worker-executor-tests-", "worker-tests-", 1)
+    if base.startswith("integration-tests-group"):
+        return base
+    if base.startswith("cli-integration-tests-"):
+        shard = base.removeprefix("cli-integration-tests-")
+        if shard == "bridge":
+            shard = "bridge_gen"
+        return f"it-cli ({shard})"
+    return base
+
+
+def select_job_url(jobs, artifact_name, fallback):
+    expected = report_job_name(artifact_name)
+    for job in jobs:
+        name = job.get("name", "")
+        integration_match = expected.startswith("integration-tests-group") and name.startswith(
+            f"it ({expected},"
+        )
+        if name == expected or integration_match:
+            return job.get("html_url", fallback)
+    return fallback
+
+
+class GitHubApi:
+    def __init__(self, repo, token):
+        self.repo = repo
+        self.token = token
+        self.base_url = "https://api.github.com"
+
+    def request(self, path, method="GET", data=None, absolute=False):
+        url = path if absolute else f"{self.base_url}{path}"
+        body = None if data is None else json.dumps(data).encode()
+        request = urllib.request.Request(url, data=body, method=method)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_unredirected_header("Authorization", f"Bearer {self.token}")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if body is not None:
+            request.add_header("Content-Type", "application/json")
+
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(request, timeout=90) as response:
+                    return response.read()
+            except urllib.error.HTTPError as error:
+                if error.code not in (429, 500, 502, 503, 504) or attempt == 3:
+                    raise
+                delay = int(error.headers.get("Retry-After", 2**attempt))
+            except urllib.error.URLError:
+                if attempt == 3:
+                    raise
+                delay = 2**attempt
+            time.sleep(delay)
+        raise RuntimeError("unreachable")
+
+    def json(self, path, method="GET", data=None):
+        return json.loads(self.request(path, method, data))
+
+    def paginated(self, path, key):
+        separator = "&" if "?" in path else "?"
+        page = 1
+        while True:
+            response = self.json(f"{path}{separator}per_page=100&page={page}")
+            values = response[key]
+            yield from values
+            if len(values) < 100:
+                return
+            page += 1
+
+
+@dataclass
+class Observation:
+    name: str
+    status: str
+    duration: float
+    retries: int
+    run_id: int
+    attempt: int
+    branch: str
+    seen_at: dt.datetime
+    artifact_name: str
+    run_url: str
+    job_url: str = ""
+
+
+@dataclass
+class TestStats:
+    name: str
+    observations: int = 0
+    runs: set = field(default_factory=set)
+    failure_runs: set = field(default_factory=set)
+    failures: int = 0
+    retries: int = 0
+    retried_runs: set = field(default_factory=set)
+    main_failures: int = 0
+    main_failure_runs: set = field(default_factory=set)
+    durations: list = field(default_factory=list)
+    last_seen: dt.datetime | None = None
+    links: list = field(default_factory=list)
+    flips: int = 0
+
+    @property
+    def fail_rate(self):
+        return len(self.failure_runs) / len(self.runs) if self.runs else 0
+
+    @property
+    def score(self):
+        return self.flips * 5 + len(self.retried_runs) * 3 + len(self.main_failure_runs) * 2
+
+
+def aggregate(observations):
+    stats = {}
+    statuses = defaultdict(lambda: defaultdict(lambda: defaultdict(set)))
+
+    for observation in sorted(observations, key=lambda item: item.seen_at):
+        test = stats.setdefault(observation.name, TestStats(observation.name))
+        test.observations += 1
+        test.runs.add(observation.run_id)
+        test.durations.append(observation.duration)
+        test.last_seen = max(test.last_seen or observation.seen_at, observation.seen_at)
+        statuses[observation.name][observation.run_id][observation.attempt].add(observation.status)
+
+        if observation.retries > 0:
+            test.retries += observation.retries
+            test.retried_runs.add(observation.run_id)
+        if observation.status == "failed":
+            test.failures += 1
+            test.failure_runs.add(observation.run_id)
+            if observation.branch == "main":
+                test.main_failures += 1
+                test.main_failure_runs.add(observation.run_id)
+            link = observation.job_url or observation.run_url
+            if link and link not in test.links:
+                test.links.append(link)
+
+    for name, runs in statuses.items():
+        for attempts in runs.values():
+            failed_attempts = [number for number, values in attempts.items() if "failed" in values]
+            passed_attempts = [number for number, values in attempts.items() if "passed" in values]
+            if any(failed < passed for failed in failed_attempts for passed in passed_attempts):
+                stats[name].flips += 1
+
+    candidates = [
+        test
+        for test in stats.values()
+        if test.flips or test.retries or test.main_failures
+    ]
+    return sorted(
+        candidates,
+        key=lambda test: (test.score, test.fail_rate, test.last_seen, test.name),
+        reverse=True,
+    )
+
+
+def checked_tests(issue_body):
+    checked = set()
+    pattern = re.compile(r"^- \[[xX]\].*<!-- flaky-test:([A-Za-z0-9_-]+) -->$", re.MULTILINE)
+    for encoded in pattern.findall(issue_body or ""):
+        padding = "=" * (-len(encoded) % 4)
+        try:
+            checked.add(base64.urlsafe_b64decode(encoded + padding).decode())
+        except (ValueError, UnicodeDecodeError):
+            continue
+    return checked
+
+
+def render_report(candidates, run_count, artifact_count, days, existing_body="", limit=100):
+    shown = candidates[:limit]
+    claimed = checked_tests(existing_body)
+    generated = utc_now().strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        ISSUE_MARKER,
+        f"# {ISSUE_TITLE}",
+        "",
+        f"Generated {generated} from **{run_count}** CI runs and **{artifact_count}** test-report artifacts in the last **{days} days**.",
+        "",
+        "Score = 5 × cross-attempt flips + 3 × runs with in-run retries + 2 × runs failing on `main`. "
+        "Failures seen only on a feature branch are not treated as flaky unless they later pass in another attempt of the same run.",
+        "",
+        "| Test | Score | Runs | Failures | Flips | Retries | Main failures | Fail rate | p50 | p95 | Last seen | Failing jobs |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+    ]
+
+    if not shown:
+        lines.append("| No known flaky tests in this window | 0 | 0 | 0 | 0 | 0 | 0 | 0% | — | — | — | — |")
+    for test in shown:
+        links = " ".join(
+            f"[log {number}]({url})" for number, url in enumerate(test.links[-3:], start=1)
+        ) or "—"
+        lines.append(
+            "| {name} | {score} | {runs} | {failures} | {flips} | {retries} | {main} | {rate:.1%} | {p50:.0f} ms | {p95:.0f} ms | {seen} | {links} |".format(
+                name=markdown_code(test.name),
+                score=test.score,
+                runs=len(test.runs),
+                failures=test.failures,
+                flips=test.flips,
+                retries=test.retries,
+                main=test.main_failures,
+                rate=test.fail_rate,
+                p50=percentile(test.durations, 0.50),
+                p95=percentile(test.durations, 0.95),
+                seen=format_time(test.last_seen),
+                links=links,
+            )
+        )
+
+    lines.extend(["", "## Claim a test", ""])
+    if not shown:
+        lines.append("No tests to claim.")
+    for test in shown:
+        encoded = base64.urlsafe_b64encode(test.name.encode()).decode().rstrip("=")
+        mark = "x" if test.name in claimed else " "
+        lines.append(f"- [{mark}] <code>{html.escape(test.name)}</code> <!-- flaky-test:{encoded} -->")
+
+    if len(candidates) > len(shown):
+        lines.extend(["", f"Showing the top {len(shown)} of {len(candidates)} known flaky tests."])
+    return "\n".join(lines) + "\n"
+
+
+class Collector:
+    def __init__(self, api, workflow, days, run_ids=None):
+        self.api = api
+        self.workflow = workflow
+        self.days = days
+        self.run_ids = run_ids or []
+        self.jobs = {}
+
+    def runs(self):
+        if self.run_ids:
+            return [self.api.json(f"/repos/{self.api.repo}/actions/runs/{run_id}") for run_id in self.run_ids]
+
+        now = utc_now()
+        since = now - dt.timedelta(days=self.days)
+        runs = {}
+        day = since.replace(hour=0, minute=0, second=0, microsecond=0)
+        while day <= now:
+            end = min(day + dt.timedelta(days=1) - dt.timedelta(seconds=1), now)
+            created = urllib.parse.quote(f"{day.isoformat()}..{end.isoformat()}")
+            path = f"/repos/{self.api.repo}/actions/workflows/{self.workflow}/runs?created={created}"
+            for run in self.api.paginated(path, "workflow_runs"):
+                if parse_time(run["created_at"]) >= since:
+                    runs[run["id"]] = run
+            day += dt.timedelta(days=1)
+        return list(runs.values())
+
+    def attempts(self, run):
+        count = int(run.get("run_attempt", 1))
+        if count == 1:
+            return {1: run}
+        return {
+            number: self.api.json(
+                f"/repos/{self.api.repo}/actions/runs/{run['id']}/attempts/{number}"
+            )
+            for number in range(1, count + 1)
+        }
+
+    def artifacts(self, runs):
+        result = []
+        for run in runs:
+            path = f"/repos/{self.api.repo}/actions/runs/{run['id']}/artifacts"
+            for artifact in self.api.paginated(path, "artifacts"):
+                if REPORT_NAME.search(artifact["name"]) and not artifact.get("expired", False):
+                    result.append((run, artifact))
+        return result
+
+    def infer_attempt(self, artifact, attempts):
+        match = REPORT_NAME.search(artifact["name"])
+        if match and match.group("attempt"):
+            return int(match.group("attempt"))
+        created = parse_time(artifact["created_at"])
+        started = [
+            (number, parse_time(attempt["run_started_at"]))
+            for number, attempt in attempts.items()
+            if attempt.get("run_started_at")
+        ]
+        eligible = [item for item in started if item[1] <= created]
+        return max(eligible, key=lambda item: item[1])[0] if eligible else 1
+
+    def download_report(self, run, artifact, attempts):
+        archive = self.api.request(artifact["archive_download_url"], absolute=True)
+        reports = []
+        with zipfile.ZipFile(io.BytesIO(archive)) as zipped:
+            for name in zipped.namelist():
+                if name.endswith(".json"):
+                    report = json.loads(zipped.read(name))
+                    if isinstance(report.get("results", {}).get("tests"), list):
+                        reports.append(report)
+        if not reports:
+            raise ValueError(f"artifact {artifact['id']} contains no CTRF report")
+
+        attempt = self.infer_attempt(artifact, attempts)
+        seen_at = parse_time(artifact["created_at"])
+        observations = []
+        for report in reports:
+            for test in report["results"]["tests"]:
+                retries = test.get("retries", 0)
+                if not isinstance(retries, int) or retries < 0:
+                    retries = 0
+                if retries == 0 and test.get("flaky") is True:
+                    retries = 1
+                duration = test.get("duration", 0)
+                if not isinstance(duration, (int, float)) or duration < 0:
+                    duration = 0
+                observations.append(
+                    Observation(
+                        name=str(test.get("name", "<unnamed test>")),
+                        status=str(test.get("status", "unknown")).lower(),
+                        duration=duration,
+                        retries=retries,
+                        run_id=run["id"],
+                        attempt=attempt,
+                        branch=run.get("head_branch") or "",
+                        seen_at=seen_at,
+                        artifact_name=artifact["name"],
+                        run_url=run["html_url"],
+                    )
+                )
+        return observations
+
+    def job_url(self, observation):
+        key = (observation.run_id, observation.attempt)
+        if key not in self.jobs:
+            path = f"/repos/{self.api.repo}/actions/runs/{observation.run_id}/attempts/{observation.attempt}/jobs"
+            self.jobs[key] = list(self.api.paginated(path, "jobs"))
+        fallback = f"{observation.run_url}/attempts/{observation.attempt}"
+        return select_job_url(self.jobs[key], observation.artifact_name, fallback)
+
+    def collect(self):
+        runs = self.runs()
+        attempts_by_run = {run["id"]: self.attempts(run) for run in runs}
+        artifacts = self.artifacts(runs)
+        observations = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [
+                executor.submit(self.download_report, run, artifact, attempts_by_run[run["id"]])
+                for run, artifact in artifacts
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                observations.extend(future.result())
+
+        for observation in observations:
+            if observation.status == "failed":
+                observation.job_url = self.job_url(observation)
+        return observations, len(runs), len(artifacts)
+
+
+def find_issue(api):
+    query = urllib.parse.quote(f'repo:{api.repo} is:issue in:title "{ISSUE_TITLE}"')
+    exact_match = None
+    for issue in api.json(f"/search/issues?q={query}&per_page=100")["items"]:
+        if issue["title"] != ISSUE_TITLE:
+            continue
+        if ISSUE_MARKER in (issue.get("body") or ""):
+            return issue
+        exact_match = exact_match or issue
+    return exact_match
+
+
+def ensure_label(api):
+    path = f"/repos/{api.repo}/labels/flaky-test"
+    try:
+        api.json(path)
+    except urllib.error.HTTPError as error:
+        if error.code != 404:
+            raise
+        api.json(
+            f"/repos/{api.repo}/labels",
+            "POST",
+            {"name": "flaky-test", "color": "d73a4a", "description": "Tests with evidence of intermittent failure"},
+        )
+
+
+def pin_issue(api, issue):
+    query = "query($id:ID!){node(id:$id){... on Issue{isPinned}}}"
+    result = api.json("/graphql", "POST", {"query": query, "variables": {"id": issue["node_id"]}})
+    if result.get("errors"):
+        raise RuntimeError(f"could not query issue pin: {result['errors']}")
+    if result.get("data", {}).get("node", {}).get("isPinned"):
+        return
+    mutation = "mutation($id:ID!){pinIssue(input:{issueId:$id}){issue{id}}}"
+    result = api.json("/graphql", "POST", {"query": mutation, "variables": {"id": issue["node_id"]}})
+    if result.get("errors"):
+        raise RuntimeError(f"could not pin issue: {result['errors']}")
+
+
+def upsert_issue(api, body):
+    ensure_label(api)
+    issue = find_issue(api)
+    if issue:
+        labels = {label["name"] for label in issue.get("labels", [])}
+        labels.add("flaky-test")
+        data = {"title": ISSUE_TITLE, "body": body, "labels": sorted(labels), "state": "open"}
+        issue = api.json(f"/repos/{api.repo}/issues/{issue['number']}", "PATCH", data)
+    else:
+        data = {"title": ISSUE_TITLE, "body": body, "labels": ["flaky-test"]}
+        issue = api.json(f"/repos/{api.repo}/issues", "POST", data)
+    pin_issue(api, issue)
+    return issue["html_url"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Aggregate CTRF artifacts into a known-flaky-tests report")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--workflow", default="ci.yaml")
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--run-id", type=int, action="append", default=[])
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--output")
+    parser.add_argument("--summary")
+    parser.add_argument("--update-issue", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not args.repo:
+        raise SystemExit("--repo or GITHUB_REPOSITORY is required")
+    if not token:
+        raise SystemExit("GH_TOKEN or GITHUB_TOKEN is required")
+    if args.days < 1:
+        raise SystemExit("--days must be at least 1")
+
+    api = GitHubApi(args.repo, token)
+    collector = Collector(api, args.workflow, args.days, args.run_id)
+    observations, run_count, artifact_count = collector.collect()
+    candidates = aggregate(observations)
+
+    issue = find_issue(api) if args.update_issue else None
+    body = render_report(
+        candidates,
+        run_count,
+        artifact_count,
+        args.days,
+        existing_body=(issue or {}).get("body", ""),
+        limit=args.limit,
+    )
+    if args.output:
+        Path(args.output).write_text(body)
+    else:
+        print(body, end="")
+    if args.summary:
+        Path(args.summary).write_text(body)
+    if args.update_issue:
+        print(f"Updated {upsert_issue(api, body)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_flaky_tests.py
+++ b/.github/scripts/test_flaky_tests.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+import datetime as dt
+import io
+import json
+import unittest
+import zipfile
+
+from flaky_tests import Collector, Observation, aggregate, checked_tests, render_report, select_job_url
+
+
+NOW = dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc)
+
+
+def observation(name, status, run_id, attempt, branch="feature", retries=0, duration=10):
+    return Observation(
+        name=name,
+        status=status,
+        duration=duration,
+        retries=retries,
+        run_id=run_id,
+        attempt=attempt,
+        branch=branch,
+        seen_at=NOW + dt.timedelta(minutes=run_id + attempt),
+        artifact_name="unit-tests-report-attempt1",
+        run_url=f"https://example.test/runs/{run_id}",
+        job_url=f"https://example.test/jobs/{run_id}-{attempt}" if status == "failed" else "",
+    )
+
+
+def report_archive(tests):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr("ctrf-report.json", json.dumps({"results": {"tests": tests}}))
+    return output.getvalue()
+
+
+class FakeApi:
+    repo = "golemcloud/golem"
+
+    def __init__(self, archives):
+        self.archives = archives
+
+    def request(self, url, absolute=False):
+        return self.archives[url]
+
+
+class AggregateTests(unittest.TestCase):
+    def test_aggregates_synthetic_ctrf_reports_across_attempts(self):
+        first = report_archive(
+            [
+                {"name": "suite::flip", "status": "failed", "duration": 10},
+                {"name": "suite::retry", "status": "passed", "duration": 20, "retries": 2},
+            ]
+        )
+        second = report_archive(
+            [
+                {"name": "suite::flip", "status": "passed", "duration": 30},
+                {"name": "suite::retry", "status": "passed", "duration": 40},
+            ]
+        )
+        run = {"id": 123, "head_branch": "feature", "html_url": "https://example.test/runs/123"}
+        attempts = {
+            1: {"run_started_at": "2026-09-03T10:00:00Z"},
+            2: {"run_started_at": "2026-09-03T11:00:00Z"},
+        }
+        artifacts = [
+            {
+                "id": 1,
+                "name": "unit-tests-report-attempt1",
+                "created_at": "2026-09-03T10:30:00Z",
+                "archive_download_url": "first",
+            },
+            {
+                "id": 2,
+                "name": "unit-tests-report-attempt2",
+                "created_at": "2026-09-03T11:30:00Z",
+                "archive_download_url": "second",
+            },
+        ]
+        collector = Collector(FakeApi({"first": first, "second": second}), "ci.yaml", 30)
+        observations = [
+            item
+            for artifact in artifacts
+            for item in collector.download_report(run, artifact, attempts)
+        ]
+
+        result = {test.name: test for test in aggregate(observations)}
+
+        self.assertEqual(result["suite::flip"].flips, 1)
+        self.assertEqual(result["suite::retry"].retries, 2)
+
+    def test_aggregates_flip_retries_main_failures_and_durations(self):
+        observations = [
+            observation("flip", "failed", 1, 1, duration=10),
+            observation("flip", "passed", 1, 2, duration=20),
+            observation("flip", "passed", 2, 1, duration=30),
+            observation("retry", "passed", 3, 1, retries=2, duration=100),
+            observation("main failure", "failed", 4, 1, branch="main", duration=200),
+            observation("ordinary failure", "failed", 5, 1),
+        ]
+
+        result = {test.name: test for test in aggregate(observations)}
+
+        self.assertEqual(set(result), {"flip", "retry", "main failure"})
+        self.assertEqual(result["flip"].flips, 1)
+        self.assertEqual(len(result["flip"].runs), 2)
+        self.assertEqual(result["flip"].fail_rate, 0.5)
+        self.assertEqual(result["flip"].score, 5)
+        self.assertEqual(result["retry"].retries, 2)
+        self.assertEqual(result["retry"].score, 3)
+        self.assertEqual(result["main failure"].main_failures, 1)
+        self.assertEqual(result["main failure"].score, 2)
+
+    def test_report_preserves_claimed_checkboxes(self):
+        test = aggregate([observation("suite::flaky", "passed", 1, 1, retries=1)])[0]
+        first = render_report([test], 1, 1, 30)
+        claimed = first.replace("- [ ] <code>suite::flaky</code>", "- [x] <code>suite::flaky</code>")
+
+        second = render_report([test], 2, 2, 30, existing_body=claimed)
+
+        self.assertEqual(checked_tests(second), {"suite::flaky"})
+        self.assertIn("- [x] <code>suite::flaky</code>", second)
+
+    def test_selects_the_job_that_produced_each_report(self):
+        jobs = [
+            {"name": "worker-tests-group2", "html_url": "worker-url"},
+            {"name": "it (integration-tests-group4, IT #4)", "html_url": "it-url"},
+            {"name": "it-cli (bridge_gen)", "html_url": "cli-url"},
+        ]
+
+        self.assertEqual(
+            select_job_url(jobs, "worker-executor-tests-group2-report-attempt2", "fallback"),
+            "worker-url",
+        )
+        self.assertEqual(
+            select_job_url(jobs, "integration-tests-group4-report-attempt1", "fallback"),
+            "it-url",
+        )
+        self.assertEqual(
+            select_job_url(jobs, "cli-integration-tests-bridge-report-attempt1", "fallback"),
+            "cli-url",
+        )
+
+    def test_selects_exact_integration_group_when_group_name_is_prefix_of_another(self):
+        jobs = [
+            {"name": "it (integration-tests-group10, IT #10)", "html_url": "group10-url"},
+            {"name": "it (integration-tests-group1, IT #1)", "html_url": "group1-url"},
+        ]
+
+        self.assertEqual(
+            select_job_url(jobs, "integration-tests-group1-report-attempt1", "fallback"),
+            "group1-url",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -1,0 +1,42 @@
+name: Known flaky tests
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: Number of days of CI history to inspect
+        required: false
+        default: 30
+        type: number
+
+concurrency:
+  group: known-flaky-tests
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  report:
+    name: Update known flaky tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DAYS: ${{ inputs.days || '30' }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Test aggregator
+        run: python3 .github/scripts/test_flaky_tests.py
+      - name: Aggregate CI test reports
+        run: >-
+          python3 .github/scripts/flaky_tests.py
+          --repo "${GITHUB_REPOSITORY}"
+          --days "${DAYS}"
+          --summary "${GITHUB_STEP_SUMMARY}"
+          --output flaky-tests.md
+          --update-issue


### PR DESCRIPTION
## Summary

- retain CTRF artifacts from each CI run attempt by suffixing artifact names with `github.run_attempt`
- add a weekly and manually dispatchable workflow that aggregates CI reports across branches and attempts
- publish the ranked report to the job summary and a pinned `Known flaky tests` issue labelled `flaky-test`, preserving claimed checkboxes
- rank cross-attempt flips, in-run retries, and failures on `main`, with run/failure counts, fail rate, duration percentiles, and failing job links

## Verification

- `python3 .github/scripts/test_flaky_tests.py`
- `python3 -m py_compile .github/scripts/flaky_tests.py .github/scripts/test_flaky_tests.py`
- `npx --yes js-yaml .github/workflows/flaky-tests.yaml`
- `npx --yes js-yaml .github/actions/publish-test-report/action.yml`
- end-to-end aggregation against CI runs 33738071199, 33637628766, 33734791995, and 33743294206 (green, red-on-main, and retried runs; 91 report artifacts)

`actionlint` was not available in the development environment.