### PR TITLE
Separate active and resolved flaky tests

### DIFF
--- a/.github/tools/flaky-tests/src/lib.rs
+++ b/.github/tools/flaky-tests/src/lib.rs
@@ -6,6 +6,7 @@ use std::io::{Cursor, Read};
 
 pub const ISSUE_TITLE: &str = "Known flaky tests";
 pub const ISSUE_MARKER: &str = "<!-- known-flaky-tests:v1 -->";
+pub const CLEAN_RUNS_TO_RESOLVE: usize = 10;
 
 #[derive(Clone, Debug)]
 pub struct Observation {
@@ -44,7 +45,8 @@ pub struct TestStats {
     pub main_failures: u64,
     pub main_failure_runs: HashSet<u64>,
     pub durations: Vec<f64>,
-    pub last_seen: String,
+    pub last_flaky: String,
+    pub clean_runs_since_flaky: usize,
     pub links: Vec<String>,
     pub flips: u64,
 }
@@ -62,6 +64,61 @@ impl TestStats {
         self.flips * 5
             + self.retried_runs.len() as u64 * 3
             + self.main_failure_runs.len() as u64 * 2
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.clean_runs_since_flaky < CLEAN_RUNS_TO_RESOLVE
+    }
+}
+
+#[derive(Default)]
+struct RunEvidence {
+    seen_at: String,
+    statuses: HashMap<u32, HashSet<String>>,
+    retries: u64,
+    main_failure: bool,
+}
+
+impl RunEvidence {
+    fn is_flip(&self) -> bool {
+        let failed = self
+            .statuses
+            .iter()
+            .filter(|(_, statuses)| statuses.contains("failed"))
+            .map(|(attempt, _)| *attempt);
+        let passed = self
+            .statuses
+            .iter()
+            .filter(|(_, statuses)| statuses.contains("passed"))
+            .map(|(attempt, _)| *attempt)
+            .collect::<Vec<_>>();
+        failed.into_iter().any(|failed_attempt| {
+            passed
+                .iter()
+                .any(|passed_attempt| failed_attempt < *passed_attempt)
+        })
+    }
+
+    fn is_flaky_signal(&self) -> bool {
+        self.retries > 0 || self.main_failure || self.is_flip()
+    }
+
+    fn is_clean(&self) -> bool {
+        self.retries == 0
+            && self
+                .statuses
+                .values()
+                .any(|statuses| statuses.contains("passed"))
+            && !self
+                .statuses
+                .values()
+                .any(|statuses| statuses.contains("failed"))
+    }
+
+    fn was_executed(&self) -> bool {
+        self.statuses
+            .values()
+            .any(|statuses| statuses.contains("passed") || statuses.contains("failed"))
     }
 }
 
@@ -139,9 +196,22 @@ pub fn observations_from_archive(
 pub fn aggregate(mut observations: Vec<Observation>) -> Vec<TestStats> {
     observations.sort_by(|left, right| left.seen_at.cmp(&right.seen_at));
     let mut stats = HashMap::<String, TestStats>::new();
-    let mut statuses = HashMap::<(String, u64, u32), HashSet<String>>::new();
+    let mut evidence = HashMap::<(String, u64), RunEvidence>::new();
 
     for observation in observations {
+        let run = evidence
+            .entry((observation.name.clone(), observation.run_id))
+            .or_default();
+        if observation.seen_at > run.seen_at {
+            run.seen_at = observation.seen_at.clone();
+        }
+        run.statuses
+            .entry(observation.attempt)
+            .or_default()
+            .insert(observation.status.clone());
+        run.retries += observation.retries;
+        run.main_failure |= observation.status == "failed" && observation.branch == "main";
+
         let test = stats
             .entry(observation.name.clone())
             .or_insert_with(|| TestStats {
@@ -155,24 +225,14 @@ pub fn aggregate(mut observations: Vec<Observation>) -> Vec<TestStats> {
                 main_failures: 0,
                 main_failure_runs: HashSet::new(),
                 durations: Vec::new(),
-                last_seen: String::new(),
+                last_flaky: String::new(),
+                clean_runs_since_flaky: 0,
                 links: Vec::new(),
                 flips: 0,
             });
         test.observations += 1;
         test.runs.insert(observation.run_id);
         test.durations.push(observation.duration);
-        if observation.seen_at > test.last_seen {
-            test.last_seen = observation.seen_at.clone();
-        }
-        statuses
-            .entry((
-                observation.name.clone(),
-                observation.run_id,
-                observation.attempt,
-            ))
-            .or_default()
-            .insert(observation.status.clone());
 
         if observation.retries > 0 {
             test.retries += observation.retries;
@@ -192,29 +252,31 @@ pub fn aggregate(mut observations: Vec<Observation>) -> Vec<TestStats> {
         }
     }
 
-    let mut attempts = HashMap::<(String, u64), HashMap<u32, HashSet<String>>>::new();
-    for ((name, run_id, attempt), values) in statuses {
-        attempts
-            .entry((name, run_id))
-            .or_default()
-            .insert(attempt, values);
+    for ((name, _), run) in &evidence {
+        let test = stats.get_mut(name).expect("test stats must exist");
+        if run.is_flip() {
+            test.flips += 1;
+        }
+        if run.is_flaky_signal() && run.seen_at > test.last_flaky {
+            test.last_flaky = run.seen_at.clone();
+        }
     }
-    for ((name, _), run_attempts) in attempts {
-        let failed = run_attempts
+
+    for test in stats.values_mut() {
+        let mut later_runs = evidence
             .iter()
-            .filter(|(_, values)| values.contains("failed"))
-            .map(|(attempt, _)| *attempt);
-        let passed = run_attempts
-            .iter()
-            .filter(|(_, values)| values.contains("passed"))
-            .map(|(attempt, _)| *attempt)
+            .filter(|((name, _), run)| {
+                name == &test.name && run.seen_at > test.last_flaky && run.was_executed()
+            })
+            .map(|(_, run)| run)
             .collect::<Vec<_>>();
-        if failed.into_iter().any(|failed_attempt| {
-            passed
-                .iter()
-                .any(|passed_attempt| failed_attempt < *passed_attempt)
-        }) {
-            stats.get_mut(&name).expect("test stats must exist").flips += 1;
+        later_runs.sort_by(|left, right| left.seen_at.cmp(&right.seen_at));
+        for run in later_runs {
+            if run.is_clean() {
+                test.clean_runs_since_flaky += 1;
+            } else {
+                test.clean_runs_since_flaky = 0;
+            }
         }
     }
 
@@ -224,15 +286,16 @@ pub fn aggregate(mut observations: Vec<Observation>) -> Vec<TestStats> {
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| {
         right
-            .score()
-            .cmp(&left.score())
+            .is_active()
+            .cmp(&left.is_active())
+            .then_with(|| right.score().cmp(&left.score()))
             .then_with(|| {
                 right
                     .fail_rate()
                     .partial_cmp(&left.fail_rate())
                     .unwrap_or(Ordering::Equal)
             })
-            .then_with(|| right.last_seen.cmp(&left.last_seen))
+            .then_with(|| right.last_flaky.cmp(&left.last_flaky))
             .then_with(|| right.name.cmp(&left.name))
     });
     candidates
@@ -334,37 +397,17 @@ fn checked_tests(body: &str) -> HashSet<String> {
         .collect()
 }
 
-pub fn render_report(
-    candidates: &[TestStats],
-    run_count: usize,
-    artifact_count: usize,
-    days: u64,
-    generated: &str,
-    existing_body: &str,
-    limit: usize,
-) -> String {
-    let shown = candidates.iter().take(limit).collect::<Vec<_>>();
-    let claimed = checked_tests(existing_body);
-    let mut lines = vec![
-        ISSUE_MARKER.to_string(),
-        format!("# {ISSUE_TITLE}"),
-        String::new(),
-        format!(
-            "Generated {generated} from **{run_count}** CI runs and **{artifact_count}** test-report artifacts in the last **{days} days**."
-        ),
-        String::new(),
-        "Score = 5 × cross-attempt flips + 3 × runs with in-run retries + 2 × runs failing on `main`. Failures seen only on a feature branch are not treated as flaky unless they later pass in another attempt of the same run.".to_string(),
-        String::new(),
-        "| Test | Score | Runs | Failures | Flips | Retries | Main failures | Fail rate | p50 | p95 | Last seen | Failing jobs |".to_string(),
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |".to_string(),
-    ];
-    if shown.is_empty() {
-        lines.push(
-            "| No known flaky tests in this window | 0 | 0 | 0 | 0 | 0 | 0 | 0% | — | — | — | — |"
-                .to_string(),
-        );
+fn append_table(lines: &mut Vec<String>, tests: &[&TestStats], empty_message: &str) {
+    lines.extend([
+        "| Test | Score | Runs | Failures | Flips | Retries | Main failures | Fail rate | Clean runs | Last flaky | p50 | p95 | Failing jobs |".to_string(),
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |".to_string(),
+    ]);
+    if tests.is_empty() {
+        lines.push(format!(
+            "| {empty_message} | 0 | 0 | 0 | 0 | 0 | 0 | 0% | 0 | — | — | — | — |"
+        ));
     }
-    for test in &shown {
+    for test in tests {
         let links = if test.links.is_empty() {
             "—".to_string()
         } else {
@@ -379,7 +422,7 @@ pub fn render_report(
                 .join(" ")
         };
         lines.push(format!(
-            "| <code>{}</code> | {} | {} | {} | {} | {} | {} | {:.1}% | {:.0} ms | {:.0} ms | {} | {} |",
+            "| <code>{}</code> | {} | {} | {} | {} | {} | {} | {:.1}% | {} | {} | {:.0} ms | {:.0} ms | {} |",
             html_escape(&test.name),
             test.score(),
             test.runs.len(),
@@ -388,17 +431,63 @@ pub fn render_report(
             test.retries,
             test.main_failures,
             test.fail_rate() * 100.0,
+            test.clean_runs_since_flaky,
+            test.last_flaky.get(..10).unwrap_or(&test.last_flaky),
             percentile(&test.durations, 0.50),
             percentile(&test.durations, 0.95),
-            test.last_seen.get(..10).unwrap_or(&test.last_seen),
             links
         ));
     }
-    lines.extend([String::new(), "## Claim a test".to_string(), String::new()]);
-    if shown.is_empty() {
+}
+
+pub fn render_report(
+    candidates: &[TestStats],
+    run_count: usize,
+    artifact_count: usize,
+    days: u64,
+    generated: &str,
+    existing_body: &str,
+    limit: usize,
+) -> String {
+    let shown = candidates.iter().take(limit).collect::<Vec<_>>();
+    let active = shown
+        .iter()
+        .copied()
+        .filter(|test| test.is_active())
+        .collect::<Vec<_>>();
+    let resolved = shown
+        .iter()
+        .copied()
+        .filter(|test| !test.is_active())
+        .collect::<Vec<_>>();
+    let claimed = checked_tests(existing_body);
+    let mut lines = vec![
+        ISSUE_MARKER.to_string(),
+        format!("# {ISSUE_TITLE}"),
+        String::new(),
+        format!(
+            "Generated {generated} from **{run_count}** CI runs and **{artifact_count}** test-report artifacts in the last **{days} days**."
+        ),
+        String::new(),
+        "Score = 5 × cross-attempt flips + 3 × runs with in-run retries + 2 × runs failing on `main`. Failures seen only on a feature branch are not treated as flaky unless they later pass in another attempt of the same run.".to_string(),
+        String::new(),
+        format!(
+            "A test moves to recently resolved after **{CLEAN_RUNS_TO_RESOLVE} consecutive clean runs** following its last flaky signal. It remains visible there until that signal leaves the rolling window."
+        ),
+        String::new(),
+        "## Active flaky tests".to_string(),
+        String::new(),
+    ];
+    append_table(&mut lines, &active, "No active flaky tests in this window");
+    lines.extend([
+        String::new(),
+        "## Claim an active test".to_string(),
+        String::new(),
+    ]);
+    if active.is_empty() {
         lines.push("No tests to claim.".to_string());
     }
-    for test in &shown {
+    for test in &active {
         let mark = if claimed.contains(&test.name) {
             "x"
         } else {
@@ -410,11 +499,21 @@ pub fn render_report(
             encode_test_name(&test.name)
         ));
     }
-    if candidates.len() > limit {
+    lines.extend([
+        String::new(),
+        "## Recently resolved".to_string(),
+        String::new(),
+    ]);
+    append_table(
+        &mut lines,
+        &resolved,
+        "No recently resolved flaky tests in this window",
+    );
+    if candidates.len() > shown.len() {
         lines.extend([
             String::new(),
             format!(
-                "Showing the top {} of {} known flaky tests.",
+                "Showing the top {} of {} known flaky tests across both sections.",
                 shown.len(),
                 candidates.len()
             ),
@@ -525,6 +624,106 @@ mod tests {
         assert_eq!(result[0].score(), 5);
         assert_eq!(result[1].score(), 3);
         assert_eq!(result[2].score(), 2);
+    }
+
+    #[test]
+    fn resolves_only_after_ten_consecutive_clean_runs() {
+        let mut nine_clean = vec![observation(
+            "suite::flaky",
+            "passed",
+            1,
+            1,
+            "feature",
+            1,
+            10.0,
+        )];
+        nine_clean.extend(
+            (2..=10).map(|run| observation("suite::flaky", "passed", run, 1, "main", 0, 10.0)),
+        );
+
+        let active = aggregate(nine_clean.clone());
+        assert!(active[0].is_active());
+        assert_eq!(active[0].clean_runs_since_flaky, 9);
+
+        nine_clean.push(observation(
+            "suite::flaky",
+            "passed",
+            11,
+            1,
+            "main",
+            0,
+            10.0,
+        ));
+        let resolved = aggregate(nine_clean);
+        assert!(!resolved[0].is_active());
+        assert_eq!(resolved[0].clean_runs_since_flaky, 10);
+        assert_eq!(resolved[0].last_flaky, "2026-09-03T10:01:01Z");
+
+        let report = render_report(&resolved, 11, 11, 30, "2026-09-03 12:00 UTC", "", 100);
+        assert!(report.contains("## Recently resolved"));
+        assert!(report.contains("No active flaky tests in this window"));
+        assert!(!report.contains("- [ ] <code>suite::flaky</code>"));
+    }
+
+    #[test]
+    fn later_non_clean_run_resets_the_clean_streak() {
+        let mut observations = vec![observation(
+            "suite::flaky",
+            "passed",
+            1,
+            1,
+            "feature",
+            1,
+            10.0,
+        )];
+        observations.extend(
+            (2..=11).map(|run| observation("suite::flaky", "passed", run, 1, "main", 0, 10.0)),
+        );
+        observations.push(observation(
+            "suite::flaky",
+            "failed",
+            12,
+            1,
+            "feature",
+            0,
+            10.0,
+        ));
+
+        let result = aggregate(observations);
+
+        assert!(result[0].is_active());
+        assert_eq!(result[0].clean_runs_since_flaky, 0);
+    }
+
+    #[test]
+    fn report_limit_caps_total_tests_across_sections() {
+        let mut observations = vec![observation(
+            "suite::active",
+            "passed",
+            1,
+            1,
+            "feature",
+            1,
+            10.0,
+        )];
+        observations.push(observation(
+            "suite::resolved",
+            "passed",
+            20,
+            1,
+            "feature",
+            1,
+            10.0,
+        ));
+        observations.extend(
+            (21..=30).map(|run| observation("suite::resolved", "passed", run, 1, "main", 0, 10.0)),
+        );
+        let tests = aggregate(observations);
+
+        let report = render_report(&tests, 30, 30, 30, "2026-09-03 12:00 UTC", "", 1);
+
+        assert!(report.contains("<code>suite::active</code>"));
+        assert!(!report.contains("<code>suite::resolved</code>"));
     }
 
     #[test]

--- a/.github/tools/flaky-tests/src/main.rs
+++ b/.github/tools/flaky-tests/src/main.rs
@@ -219,6 +219,12 @@ fn command_output(args: &[String], input: Option<&[u8]>, retries: u32) -> Result
         }
         last_error = String::from_utf8_lossy(&output.stderr).trim().to_string();
         if attempt < retries {
+            eprintln!(
+                "GitHub request failed; retrying (attempt={}/{}, error={})",
+                attempt + 1,
+                retries + 1,
+                last_error
+            );
             thread::sleep(Duration::from_secs(1 << attempt));
         }
     }
@@ -339,7 +345,7 @@ fn collect_attempts(github: &GitHub, run: &WorkflowRun) -> Result<BTreeMap<u32, 
 
 fn collect_artifacts(github: &GitHub, runs: &[WorkflowRun]) -> Result<Vec<ArtifactWork>> {
     let mut work = Vec::new();
-    for run in runs {
+    for (index, run) in runs.iter().enumerate() {
         let attempts = Arc::new(collect_attempts(github, run)?);
         let endpoint = format!("/repos/{}/actions/runs/{}/artifacts", github.repo, run.id);
         let artifacts = github.paginated(&endpoint, |value| {
@@ -355,6 +361,14 @@ fn collect_artifacts(github: &GitHub, runs: &[WorkflowRun]) -> Result<Vec<Artifa
                     attempts: attempts.clone(),
                 }),
         );
+        if (index + 1) % 25 == 0 || index + 1 == runs.len() {
+            eprintln!(
+                "Scanned CI runs for artifacts (completed={}/{}, reports={})",
+                index + 1,
+                runs.len(),
+                work.len()
+            );
+        }
     }
     Ok(work)
 }
@@ -377,9 +391,10 @@ fn infer_attempt(artifact: &Artifact, attempts: &BTreeMap<u32, WorkflowRun>) -> 
 }
 
 fn download_reports(github: &GitHub, work: Vec<ArtifactWork>) -> Result<Vec<Observation>> {
+    let total = work.len();
     let queue = Arc::new(Mutex::new(VecDeque::from(work)));
     let (sender, receiver) = mpsc::channel();
-    thread::scope(|scope| {
+    thread::scope(|scope| -> Result<Vec<Observation>> {
         for _ in 0..8 {
             let queue = queue.clone();
             let sender = sender.clone();
@@ -409,13 +424,21 @@ fn download_reports(github: &GitHub, work: Vec<ArtifactWork>) -> Result<Vec<Obse
             });
         }
         drop(sender);
-    });
 
-    let mut observations = Vec::new();
-    for result in receiver {
-        observations.extend(result?);
-    }
-    Ok(observations)
+        let mut observations = Vec::new();
+        for (index, result) in receiver.into_iter().enumerate() {
+            observations.extend(result?);
+            if (index + 1) % 25 == 0 || index + 1 == total {
+                eprintln!(
+                    "Downloaded test reports (completed={}/{}, observations={})",
+                    index + 1,
+                    total,
+                    observations.len()
+                );
+            }
+        }
+        Ok(observations)
+    })
 }
 
 fn add_job_links(github: &GitHub, observations: &mut [Observation]) -> Result<()> {
@@ -585,13 +608,31 @@ fn main() -> Result<()> {
         repo: args.repo.clone(),
     };
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    eprintln!(
+        "Discovering CI runs (repository={}, workflow={}, window_days={})",
+        args.repo, args.workflow, args.days
+    );
     let runs = collect_runs(&github, &args, now)?;
+    eprintln!("Discovered CI runs (runs={})", runs.len());
+    eprintln!("Discovering test-report artifacts");
     let work = collect_artifacts(&github, &runs)?;
     let artifact_count = work.len();
+    eprintln!("Discovered test-report artifacts (reports={artifact_count})");
+    eprintln!("Downloading and parsing test reports (workers=8)");
     let mut observations = download_reports(&github, work)?;
+    eprintln!("Parsed test reports (observations={})", observations.len());
+    eprintln!("Resolving failing job links");
     add_job_links(&github, &mut observations)?;
+    eprintln!("Aggregating flaky-test signals");
     let candidates = aggregate(observations);
+    let active_count = candidates.iter().filter(|test| test.is_active()).count();
+    eprintln!(
+        "Aggregated flaky-test signals (active={}, recently_resolved={})",
+        active_count,
+        candidates.len() - active_count
+    );
     let existing = if args.update_issue {
+        eprintln!("Looking up the known-flaky-tests issue");
         find_issue(&github)?
     } else {
         None
@@ -618,8 +659,10 @@ fn main() -> Result<()> {
         fs::write(summary, &body)?;
     }
     if args.update_issue {
+        eprintln!("Updating and pinning the known-flaky-tests issue");
         eprintln!("Updated {}", upsert_issue(&github, existing, &body)?);
     }
+    eprintln!("Flaky-test report completed");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- track each test's last flaky signal instead of its latest ordinary execution
- classify a test as recently resolved after 10 consecutive executed CI runs pass without failures or retries
- reset the clean streak when a later run fails or retries
- split the issue and job summary into active and recently resolved tables, with clean-run and last-flaky columns
- keep claim checkboxes only for active tests; resolved history remains visible until it ages out of the rolling window

## Verification

- `cargo fmt --manifest-path .github/tools/flaky-tests/Cargo.toml -- --check`
- `cargo check --locked --manifest-path .github/tools/flaky-tests/Cargo.toml --all-targets`
- `cargo clippy --locked --manifest-path .github/tools/flaky-tests/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path .github/tools/flaky-tests/Cargo.toml` (11 tests)
- end-to-end one-day aggregation: 40 CI runs and 618 artifacts; five active and four recently resolved tests, including clean streaks of 12–22 runs

The existing top-100 limit remains global across both sections.