### PR TITLE
Read the agent status through its Arc instead of cloning the record

### DIFF
--- a/golem-worker-executor/src/durable_host/call_coordinator.rs
+++ b/golem-worker-executor/src/durable_host/call_coordinator.rs
@@ -505,7 +505,7 @@ where
                 ctx.state.card_event_boundary_scan =
                     Some(crate::durable_host::CardEventBoundaryScan::new(
                         status.oplog_idx,
-                        status.pending_card_events,
+                        status.pending_card_events.clone(),
                     ));
             }
         }

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -1788,7 +1788,7 @@ impl<Ctx: WorkerCtx> DurableWorkerCtx<Ctx> {
             .get_non_detached_last_known_status()
             .await;
         let status_idx = status.oplog_idx;
-        let status_pending = status.pending_card_events;
+        let status_pending = status.pending_card_events.clone();
 
         let oplog = self.public_state.worker().oplog();
         let current_idx = oplog.current_oplog_index().await;

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -645,7 +645,8 @@ impl<Ctx: WorkerCtx> InvocationLoop<Ctx> {
                                             .parent
                                             .get_non_detached_last_known_status()
                                             .await
-                                            .current_idempotency_key;
+                                            .current_idempotency_key
+                                            .clone();
                                         match kind {
                                             InterruptKind::Suspend(_) => {
                                                 self.parent.add_and_commit_oplog(OplogEntry::suspend()).await;

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -1632,7 +1632,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     // Outside of reverts and updates, this will return the same status as get_latest_worker_metadata.
     // This just has an additional assert built in for when decisions need to be sure that they are fully up to date on the oplog.
     // _NEVER_ call this from outside the invocation loop, as that is the only place that can reason about whether the status is detached or not.
-    pub async fn get_non_detached_last_known_status(&self) -> AgentStatusRecord {
+    pub async fn get_non_detached_last_known_status(&self) -> Arc<AgentStatusRecord> {
         // Runs on the worker-state actor's status queue so the detached flag and the published
         // status are observed consistently with any in-flight commit/reattach transaction.
         self.state_actor.non_detached_status().await
@@ -2428,7 +2428,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     // should only be called from invocation loop
     pub async fn store_invocation_failure(&self, key: &IdempotencyKey, trap_type: &TrapType) {
-        let status = self.last_known_status.load_full().as_ref().clone();
+        let status = self.last_known_status.load_full();
         let keys_to_fail =
             invocation_keys_to_fail(&status, Some(key), !trap_type.is_invocation_rejection());
         let stderr = self.worker_event_service.get_last_invocation_errors();
@@ -5316,7 +5316,12 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     }
 
     pub async fn lookup_invocation_result(&self, key: &IdempotencyKey) -> LookupResult {
-        let status = self.last_known_status.load_full().as_ref().clone();
+        // Kept as an `Arc` rather than cloned out of. The record owns
+        // `invocation_results`, which gains an entry per invocation and is never
+        // pruned, so deep-copying it to read one key made each lookup cost more
+        // than the last. `load_full` already gives a consistent snapshot with the
+        // lifetime this needs.
+        let status = self.last_known_status.load_full();
         let maybe_result = self
             .invocation_results
             .read()
@@ -5709,7 +5714,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             }
         }
 
-        let status = self.last_known_status.load_full().as_ref().clone();
+        let status = self.last_known_status.load_full();
         let keys_to_fail = invocation_keys_to_fail(&status, None, true);
 
         let mut invocation_results = self.invocation_results.write().await;
@@ -6170,7 +6175,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         if self.last_known_status_detached.load(Ordering::Acquire) {
             return;
         }
-        let status = self.last_known_status.load_full().as_ref().clone();
+        let status = self.last_known_status.load_full();
         self.status_checkpointer
             .maybe_checkpoint(&status, reason)
             .await;
@@ -6193,7 +6198,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         if self.last_known_status_detached.load(Ordering::Acquire) {
             return;
         }
-        let status = self.last_known_status.load_full().as_ref().clone();
+        let status = self.last_known_status.load_full();
         if let Some(marker) = min_exposed_marker
             && status.oplog_idx > marker
         {

--- a/golem-worker-executor/src/worker/state_actor.rs
+++ b/golem-worker-executor/src/worker/state_actor.rs
@@ -129,7 +129,7 @@ enum StatusJob {
     /// but the caller decides how to react (it asserts): a job whose caller was cancelled must
     /// not be able to panic the actor.
     NonDetachedStatus {
-        done: oneshot::Sender<Option<AgentStatusRecord>>,
+        done: oneshot::Sender<Option<Arc<AgentStatusRecord>>>,
     },
     /// Commits, then — if the status became detached (a jump or revert made it non-foldable) —
     /// recomputes it from the oplog, republishes it, and forces a cache flush.
@@ -266,7 +266,7 @@ impl<Ctx: WorkerCtx> WorkerStateActor<Ctx> {
                         let status = if state.detached.load(Ordering::Acquire) {
                             None
                         } else {
-                            Some(state.last_known_status.load_full().as_ref().clone())
+                            Some(state.last_known_status.load_full())
                         };
                         let _ = done.send(status);
                     }
@@ -389,7 +389,7 @@ impl<Ctx: WorkerCtx> WorkerStateActor<Ctx> {
     /// Returns the published status, asserting it is attached to the oplog. Serialized behind
     /// any in-flight commit/reattach transactions. The assert lives here on the caller side, so
     /// a job left behind by a cancelled caller cannot panic the actor.
-    pub async fn non_detached_status(&self) -> AgentStatusRecord {
+    pub async fn non_detached_status(&self) -> Arc<AgentStatusRecord> {
         self.commit
             .run_status_job(|done| StatusJob::NonDetachedStatus { done })
             .await


### PR DESCRIPTION
Reading one field out of `AgentStatusRecord` currently deep-copies the whole
record, and the record owns `invocation_results`: a map that gains an entry for
every invocation a worker has accepted and is never pruned. The clone therefore
copies the worker's entire invocation history, and the hottest of the sites that
does it is `lookup_invocation_result`, which runs once per invocation. Cost per
invocation grows with the number of invocations already served, so the total is
quadratic in a long-lived worker's invocation count.

`last_known_status` is an `ArcSwap`, and `load_full()` already returns a
consistent snapshot with the lifetime every one of these callers needs. Each of
them only reads. So the fix is to keep the `Arc` instead of cloning out of it —
seven sites in `worker/mod.rs` plus the `NonDetachedStatus` job in
`state_actor.rs`, which now matches the `AttachedStatus` job sitting next to it
that already returned an `Arc`.

Three call sites moved a small field out of the returned value and now clone that
field instead: `pending_card_events` twice and `current_idempotency_key` once.
None of them is the growing map.

Nothing about what is read changes, so agent behaviour is unaffected. The
`Arc<AgentStatusRecord>` return type is also a small guard against the same
mistake coming back, since a future `.clone()` on it is visible at the call site.

## How it showed up

A chaos run driving 800 ops/s across ~200 agents for 12 minutes showed executor
CPU climbing steadily from start to finish and RSS growing over the run. A run of
the same shape at 100 ops/s — same agents, same duration, an eighth of the
invocations per agent — stayed flat, which is the signature of a per-invocation
cost that scales with invocation count rather than with agent count or wall time.

## What this does not fix

The CPU half only. Two things still grow without bound for the life of a worker,
and neither is addressed here:

- `AgentStatusRecord::invocation_results` keeps one `(IdempotencyKey,
  OplogIndex)` entry per invocation forever. Pruning it would change what a
  repeated idempotency key resolves to, so it needs its own design.
- The in-memory `Worker::invocation_results` cache stores each successful
  invocation's full `AgentInvocationOutput` and nothing evicts it. This is the
  larger of the two and is the likelier source of the observed RSS growth.
  Eviction looks safe in principle — a missing entry falls back to
  `InvocationResult::Lazy` and re-reads the result from the oplog — but that is a
  behaviour change and a separate piece of work.

So a build carrying this commit should show flat executor CPU across a long run
and still show memory growing.

## Testing

`cargo check --workspace --all-targets` clean; `cargo test -p
golem-worker-executor --lib` 1568 passed, 0 failed.

