### PR TITLE
Stop cloning the agent status record on the invocation path

### DIFF
--- a/golem-debugging-service/src/debug_context.rs
+++ b/golem-debugging-service/src/debug_context.rs
@@ -26,9 +26,9 @@ use golem_common::model::invocation_context::{
     self, AttributeValue, InvocationContextStack, SpanId,
 };
 use golem_common::model::oplog::{AgentError, TimestampedUpdateDescription};
+use golem_common::model::regions::DeletedRegions;
 use golem_common::model::{
-    AgentId, AgentInvocation, AgentInvocationOutput, AgentStatusRecord, IdempotencyKey,
-    OwnedAgentId, Timestamp,
+    AgentId, AgentInvocation, AgentInvocationOutput, IdempotencyKey, OwnedAgentId, Timestamp,
 };
 use golem_service_base::error::worker_executor::{InterruptKind, WorkerExecutorError};
 use golem_service_base::model::GetFileSystemNodeResult;
@@ -128,13 +128,13 @@ impl ExternalOperations<Self> for DebugContext {
         this: &This,
         agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        latest_worker_status: &AgentStatusRecord,
+        deleted_regions: &DeletedRegions,
     ) -> Option<LastError> {
         DurableWorkerCtx::<Self>::get_last_error_and_retry_count(
             this,
             agent_id,
             agent_mode,
-            latest_worker_status,
+            deleted_regions,
         )
         .await
     }

--- a/golem-worker-executor-test-utils/src/lib.rs
+++ b/golem-worker-executor-test-utils/src/lib.rs
@@ -50,12 +50,12 @@ use golem_common::model::oplog::{
     TimestampedUpdateDescription, types::ObjectMetadata,
 };
 use golem_common::model::plan::PlanId;
+use golem_common::model::regions::DeletedRegions;
 use golem_common::model::retry_policy::NamedRetryPolicy;
 use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto};
 use golem_common::model::{
-    AgentFilter, AgentId, AgentInvocation, AgentInvocationOutput, AgentStatusRecord,
-    IdempotencyKey, OplogIndex, OwnedAgentId, RdbmsPoolKey, RetryConfig, ShardAssignment, ShardId,
-    TransactionId,
+    AgentFilter, AgentId, AgentInvocation, AgentInvocationOutput, IdempotencyKey, OplogIndex,
+    OwnedAgentId, RdbmsPoolKey, RetryConfig, ShardAssignment, ShardId, TransactionId,
 };
 use golem_service_base::clients::registry::RegistryService;
 use golem_service_base::config::{BlobStorageConfig, LocalFileSystemBlobStorageConfig};
@@ -843,13 +843,13 @@ impl ExternalOperations<TestWorkerCtx> for TestWorkerCtx {
         this: &T,
         owned_agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        latest_worker_status: &AgentStatusRecord,
+        deleted_regions: &DeletedRegions,
     ) -> Option<LastError> {
         DurableWorkerCtx::<TestWorkerCtx>::get_last_error_and_retry_count(
             this,
             owned_agent_id,
             agent_mode,
-            latest_worker_status,
+            deleted_regions,
         )
         .await
     }

--- a/golem-worker-executor/src/durable_host/durability.rs
+++ b/golem-worker-executor/src/durable_host/durability.rs
@@ -759,12 +759,12 @@ impl<Ctx: WorkerCtx> InFunctionRetryHost for DurableWorkerCtx<Ctx> {
     }
 
     async fn current_retry_state_for(&self, retry_from: OplogIndex) -> Option<RetryPolicyState> {
-        let latest_status = self
-            .public_state
+        self.public_state
             .worker()
-            .get_non_detached_last_known_status()
-            .await;
-        latest_status.current_retry_state.get(&retry_from).cloned()
+            .with_non_detached_last_known_status(|status| {
+                status.current_retry_state.get(&retry_from).cloned()
+            })
+            .await
     }
 
     fn durable_execution_state(&self) -> DurableExecutionState {
@@ -907,16 +907,21 @@ impl<Ctx: WorkerCtx> DurabilityHost for DurableWorkerCtx<Ctx> {
         failure: Error,
         properties: RetryProperties,
     ) -> anyhow::Result<()> {
-        let latest_status = self
-            .public_state
-            .worker()
-            .get_non_detached_last_known_status()
-            .await;
         let current_retry_point = if let Some(region) = self.state.active_atomic_regions.last() {
             region.begin_index
         } else {
             self.state.current_retry_point
         };
+        let current_state = self
+            .public_state
+            .worker()
+            .with_non_detached_last_known_status(|status| {
+                status
+                    .current_retry_state
+                    .get(&current_retry_point)
+                    .cloned()
+            })
+            .await;
 
         // Resolve the matching named retry policy. The synthesized
         // default-from-config policy (with `Predicate::True`) is always
@@ -947,10 +952,6 @@ impl<Ctx: WorkerCtx> DurabilityHost for DurableWorkerCtx<Ctx> {
                 }
             };
 
-        let current_state = latest_status
-            .current_retry_state
-            .get(&current_retry_point)
-            .cloned();
         let total_attempts = current_state.as_ref().map(|s| s.retry_count()).unwrap_or(0);
 
         match evaluate_named_policy_step_resetting_on_invalid_state(

--- a/golem-worker-executor/src/durable_host/http/inline_retry.rs
+++ b/golem-worker-executor/src/durable_host/http/inline_retry.rs
@@ -711,11 +711,10 @@ pub(crate) fn spawn_http_status_retry_after_body_finish<Ctx: crate::workerctx::W
         );
 
         let current_retry_policy_state = worker
-            .get_non_detached_last_known_status()
-            .await
-            .current_retry_state
-            .get(&begin_index)
-            .cloned();
+            .with_non_detached_last_known_status(|status| {
+                status.current_retry_state.get(&begin_index).cloned()
+            })
+            .await;
         let mut task_ctx = crate::durable_host::durability::TaskRetryContext {
             retry_point: begin_index,
             environment_state_service,
@@ -959,11 +958,10 @@ pub fn spawn_http_request_with_retry<Ctx: crate::workerctx::WorkerCtx>(
                 Ok(Err(initial_error)) => {
                     let oplog = worker.oplog();
                     let current_retry_policy_state = worker
-                        .get_non_detached_last_known_status()
-                        .await
-                        .current_retry_state
-                        .get(&begin_index)
-                        .cloned();
+                        .with_non_detached_last_known_status(|status| {
+                            status.current_retry_state.get(&begin_index).cloned()
+                        })
+                        .await;
                     let mut task_ctx = crate::durable_host::durability::TaskRetryContext {
                         retry_point: begin_index,
                         environment_state_service,

--- a/golem-worker-executor/src/durable_host/mod.rs
+++ b/golem-worker-executor/src/durable_host/mod.rs
@@ -2522,14 +2522,16 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
 
         let in_atomic_region = !self.state.active_atomic_regions.is_empty();
 
-        let latest_status_before = self
+        // Only the retry state (one entry per active retry point) is needed here, so copy that
+        // rather than the whole record.
+        let current_retry_state_before = self
             .public_state
             .worker()
-            .get_non_detached_last_known_status()
+            .with_non_detached_last_known_status(|status| status.current_retry_state.clone())
             .await;
         let (decision, retry_policy_state) = self
             .get_recovery_decision_on_trap_with_semantic(
-                &latest_status_before.current_retry_state,
+                &current_retry_state_before,
                 trap_type,
                 in_atomic_region,
                 full_function_name,
@@ -2563,10 +2565,10 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
             self.public_state.worker().add_and_commit_oplog(entry).await;
         };
 
-        let latest_status = self
+        let latest_agent_status = self
             .public_state
             .worker()
-            .get_non_detached_last_known_status()
+            .with_non_detached_last_known_status(|status| status.status)
             .await;
 
         let giving_up = matches!(
@@ -2576,7 +2578,7 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
                 ..
             }
         ) || matches!(
-            latest_status.status,
+            latest_agent_status,
             AgentStatus::Interrupted | AgentStatus::Exited
         ) || decision == RetryDecision::None;
 
@@ -2598,7 +2600,7 @@ impl<Ctx: WorkerCtx> InvocationHooks for DurableWorkerCtx<Ctx> {
 
         debug!(
             "Recovery decision for {trap_type:?} with {:?} retries (in_atomic_region={in_atomic_region}): {:?}",
-            latest_status_before.current_retry_state, decision
+            current_retry_state_before, decision
         );
 
         decision
@@ -2973,9 +2975,9 @@ impl<Ctx: WorkerCtx> ExternalOperations<Ctx> for DurableWorkerCtx<Ctx> {
         this: &T,
         owned_agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        latest_worker_status: &AgentStatusRecord,
+        deleted_regions: &DeletedRegions,
     ) -> Option<LastError> {
-        last_error(this, owned_agent_id, agent_mode, latest_worker_status).await
+        last_error(this, owned_agent_id, agent_mode, deleted_regions).await
     }
 
     async fn resume_replay(
@@ -3683,7 +3685,7 @@ async fn last_error<T: HasOplogService + HasConfig>(
     this: &T,
     owned_agent_id: &OwnedAgentId,
     agent_mode: AgentMode,
-    latest_worker_status: &AgentStatusRecord,
+    deleted_regions: &DeletedRegions,
 ) -> Option<LastError> {
     let mut idx = this
         .oplog_service()
@@ -3696,10 +3698,7 @@ async fn last_error<T: HasOplogService + HasConfig>(
         let mut first_retry_from = OplogIndex::NONE;
         let mut last_error_index = idx;
         loop {
-            if latest_worker_status
-                .deleted_regions
-                .is_in_deleted_region(idx)
-            {
+            if deleted_regions.is_in_deleted_region(idx) {
                 if idx > OplogIndex::INITIAL {
                     idx = idx.previous();
                     continue;

--- a/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
+++ b/golem-worker-executor/src/durable_host/wasm_rpc/mod.rs
@@ -1266,11 +1266,13 @@ fn spawn_rpc_task_with_retry<Ctx: WorkerCtx>(
                 let execution_status = retry_params.execution_status;
                 let current_retry_policy_state = retry_params
                     .worker
-                    .get_non_detached_last_known_status()
-                    .await
-                    .current_retry_state
-                    .get(&retry_params.retry_point)
-                    .cloned();
+                    .with_non_detached_last_known_status(|status| {
+                        status
+                            .current_retry_state
+                            .get(&retry_params.retry_point)
+                            .cloned()
+                    })
+                    .await;
                 let task_ctx = crate::durable_host::durability::TaskRetryContext {
                     retry_point: retry_params.retry_point,
                     environment_state_service: retry_params.environment_state_service,

--- a/golem-worker-executor/src/grpc/mod.rs
+++ b/golem-worker-executor/src/grpc/mod.rs
@@ -59,6 +59,7 @@ use golem_common::model::invocation_context::InvocationContextStack;
 use golem_common::model::oplog::types::AgentMetadataForGuests;
 use golem_common::model::oplog::{OplogIndex, UpdateDescription};
 use golem_common::model::protobuf::to_protobuf_resource_description;
+use golem_common::model::regions::DeletedRegions;
 use golem_common::model::worker::{AgentConfigEntryDto, AgentMetadataDto, TypedAgentConfigEntry};
 use golem_common::model::{
     AgentEvent, AgentFilter, AgentFingerprint, AgentId, AgentInvocation, AgentInvocationOutput,
@@ -181,19 +182,23 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
         Ok(worker_executor)
     }
 
+    /// `agent_status` and `deleted_regions` come from the agent's latest status record. They are
+    /// taken as fields rather than the record so the invoke path can read them under the status
+    /// lock instead of copying the record, whose `invocation_results` grows with every invocation.
     async fn ensure_not_failed(
         &self,
         owned_agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        metadata: &AgentMetadata,
+        agent_status: AgentStatus,
+        deleted_regions: &DeletedRegions,
     ) -> Result<(), WorkerExecutorError> {
-        match &metadata.last_known_status.status {
+        match agent_status {
             AgentStatus::Failed => {
                 let error_and_retry_count = Ctx::get_last_error_and_retry_count(
                     self,
                     owned_agent_id,
                     agent_mode,
-                    &metadata.last_known_status,
+                    deleted_regions,
                 )
                 .await;
                 if let Some(last_error) = error_and_retry_count {
@@ -214,7 +219,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                     self,
                     owned_agent_id,
                     agent_mode,
-                    &metadata.last_known_status,
+                    deleted_regions,
                 )
                 .await;
                 debug!("Last error and retry count: {:?}", error_and_retry_count);
@@ -780,8 +785,13 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 owned_agent_id.agent_id(),
             ))?;
 
-        self.ensure_not_failed(&owned_agent_id, metadata.agent_mode, &metadata)
-            .await?;
+        self.ensure_not_failed(
+            &owned_agent_id,
+            metadata.agent_mode,
+            metadata.last_known_status.status,
+            &metadata.last_known_status.deleted_regions,
+        )
+        .await?;
 
         match &metadata.last_known_status.status {
             AgentStatus::Suspended | AgentStatus::Interrupted | AgentStatus::Idle => {
@@ -884,10 +894,36 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
             .await?;
         self.ensure_worker_belongs_to_this_executor(&agent_id)?;
 
-        let metadata = Worker::<Ctx>::get_latest_metadata(self, &owned_agent_id).await?;
+        // This runs on every invocation. For a resident worker, read the two fields the failure
+        // check needs under the status lock; only a worker that is not resident has its record
+        // materialised (from the cache and oplog), which is the same cold path as before.
+        let failure_check =
+            if let Some(worker) = self.active_workers().try_get(&owned_agent_id).await {
+                Some(
+                    worker
+                        .with_last_known_status(|status| {
+                            (
+                                worker.agent_mode(),
+                                status.status,
+                                status.deleted_regions.clone(),
+                            )
+                        })
+                        .await,
+                )
+            } else {
+                Worker::<Ctx>::get_latest_metadata(self, &owned_agent_id)
+                    .await?
+                    .map(|metadata| {
+                        (
+                            metadata.agent_mode,
+                            metadata.last_known_status.status,
+                            metadata.last_known_status.deleted_regions,
+                        )
+                    })
+            };
 
-        if let Some(metadata) = &metadata {
-            self.ensure_not_failed(&owned_agent_id, metadata.agent_mode, metadata)
+        if let Some((agent_mode, agent_status, deleted_regions)) = failure_check {
+            self.ensure_not_failed(&owned_agent_id, agent_mode, agent_status, &deleted_regions)
                 .await?;
         }
 
@@ -993,7 +1029,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
             self,
             &owned_agent_id,
             metadata.agent_mode,
-            &metadata.last_known_status,
+            &metadata.last_known_status.deleted_regions,
         )
         .await;
 
@@ -1072,7 +1108,7 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 self,
                 &worker_metadata.owned_agent_id(),
                 worker_metadata.agent_mode,
-                &worker_metadata.last_known_status,
+                &worker_metadata.last_known_status.deleted_regions,
             )
             .await;
             let metadata =
@@ -1317,8 +1353,13 @@ impl<Ctx: WorkerCtx, Svcs: HasAll<Ctx> + UsesAllDeps<Ctx = Ctx> + Send + Sync + 
                 owned_agent_id.agent_id(),
             ))?;
 
-        self.ensure_not_failed(&owned_agent_id, metadata.agent_mode, &metadata)
-            .await?;
+        self.ensure_not_failed(
+            &owned_agent_id,
+            metadata.agent_mode,
+            metadata.last_known_status.status,
+            &metadata.last_known_status.deleted_regions,
+        )
+        .await?;
 
         if metadata.last_known_status.status != AgentStatus::Interrupted {
             let event_service = Worker::get_or_create_suspended(

--- a/golem-worker-executor/src/services/oplog/plugin.rs
+++ b/golem-worker-executor/src/services/oplog/plugin.rs
@@ -40,7 +40,7 @@ use golem_common::model::oplog::{
 use golem_common::model::plugin_registration::PluginRegistrationId;
 use golem_common::model::{
     AgentId, AgentInvocation, AgentMetadata, AgentStatusRecord, IdempotencyKey, InvocationStatus,
-    OwnedAgentId, ScanCursor, ShardId,
+    OplogProcessorCheckpointState, OwnedAgentId, ScanCursor, ShardId,
 };
 use golem_common::read_only_lock;
 use golem_common::related_span;
@@ -999,14 +999,27 @@ impl ForwardingOplogState {
     /// Entries are always read from the persisted oplog (canonical source) to avoid
     /// buffer/index drift caused by checkpoint entries injected during flush.
     pub async fn try_flush(&mut self) {
-        let status = self.last_known_status.read().await.clone();
-        let flush_set = self.reconcile_plugin_state(&status);
+        // This runs every few commits on every agent, plugins or not, and the status record owns
+        // `invocation_results`, which grows with every invocation ever served. So decide from the
+        // two small fields the reconciliation needs, and copy the record only when a plugin is
+        // actually going to be sent to.
+        let status_lock = self.last_known_status.clone();
+        let status = status_lock.read().await;
+        let flush_set = self
+            .reconcile_plugin_state(&status.active_plugins, &status.oplog_processor_checkpoints);
 
         if flush_set.is_empty() {
+            drop(status);
             self.finish_empty_flush();
-        } else if let Some((metadata, component_metadata)) =
-            self.prepare_flush_context(&status).await
-        {
+            return;
+        }
+
+        let status = {
+            let snapshot = status.clone();
+            drop(status);
+            snapshot
+        };
+        if let Some((metadata, component_metadata)) = self.prepare_flush_context(&status).await {
             let committed_tail = self.last_committed_idx;
 
             for grant_id in flush_set {
@@ -1025,11 +1038,15 @@ impl ForwardingOplogState {
     /// Returns the flush set (active ∪ in-flight plugin grant IDs).
     fn reconcile_plugin_state(
         &mut self,
-        status: &AgentStatusRecord,
+        active_plugins: &HashSet<EnvironmentPluginGrantId>,
+        oplog_processor_checkpoints: &HashMap<
+            EnvironmentPluginGrantId,
+            OplogProcessorCheckpointState,
+        >,
     ) -> Vec<EnvironmentPluginGrantId> {
-        for grant_id in &status.active_plugins {
+        for grant_id in active_plugins {
             if let Entry::Vacant(e) = self.plugin_state.entry(*grant_id) {
-                let live = if let Some(cp) = status.oplog_processor_checkpoints.get(grant_id) {
+                let live = if let Some(cp) = oplog_processor_checkpoints.get(grant_id) {
                     LivePluginState {
                         target_agent_id: cp.target_agent_id.clone(),
                         confirmed_up_to: cp.confirmed_up_to,
@@ -1051,13 +1068,13 @@ impl ForwardingOplogState {
         }
 
         self.plugin_state.retain(|grant_id, state| {
-            status.active_plugins.contains(grant_id) || state.sending_up_to > state.confirmed_up_to
+            active_plugins.contains(grant_id) || state.sending_up_to > state.confirmed_up_to
         });
 
         self.plugin_state
             .iter()
             .filter(|(id, state)| {
-                status.active_plugins.contains(id) || state.sending_up_to > state.confirmed_up_to
+                active_plugins.contains(id) || state.sending_up_to > state.confirmed_up_to
             })
             .map(|(id, _)| *id)
             .collect()
@@ -1493,9 +1510,12 @@ impl ForwardingOplogState {
     /// delivery always goes to the recorded `target_agent_id` with deterministic
     /// idempotency keys.
     async fn try_locality_recovery(&mut self) {
-        let status = self.last_known_status.read().await.clone();
+        // Same shape as `try_flush`: reconcile from the two small fields, copy the record only
+        // once there is a plugin to recover.
+        let status_lock = self.last_known_status.clone();
+        let status = status_lock.read().await;
         // Ensure plugin_state is reconciled with current status
-        self.reconcile_plugin_state(&status);
+        self.reconcile_plugin_state(&status.active_plugins, &status.oplog_processor_checkpoints);
         let environment_id = self.initial_worker_metadata.environment_id;
 
         // Collect candidates: plugins with a target that might be non-local
@@ -1514,6 +1534,11 @@ impl ForwardingOplogState {
             return;
         }
 
+        let status = {
+            let snapshot = status.clone();
+            drop(status);
+            snapshot
+        };
         let component_metadata = match self.prepare_flush_context(&status).await {
             Some((_, cm)) => cm,
             None => return,

--- a/golem-worker-executor/src/services/scheduler.rs
+++ b/golem-worker-executor/src/services/scheduler.rs
@@ -1045,7 +1045,7 @@ mod tests {
         async fn set_assignment_tracking(
             &self,
             _owned_agent_id: &OwnedAgentId,
-            _status_value: &AgentStatusRecord,
+            _tracked: bool,
         ) -> Result<(), String> {
             Ok(())
         }

--- a/golem-worker-executor/src/services/worker.rs
+++ b/golem-worker-executor/src/services/worker.rs
@@ -333,10 +333,15 @@ pub trait WorkerService: Send + Sync {
     /// reshard will not resume, so it silently stops running with nothing recording that it should
     /// be. [`update_cached_status`](Self::update_cached_status) fails the operation it was part of,
     /// and the hot path (`AgentStatusFlusher::on_status_changed`) treats it as fatal.
+    ///
+    /// `tracked` is [`DefaultWorkerService::should_track_for_assignment_recovery`] of the status
+    /// being installed; the caller computes it so the status record itself need not be passed
+    /// around (or copied) for this one bit. Ephemeral workers are never tracked, and callers skip
+    /// them.
     async fn set_assignment_tracking(
         &self,
         owned_agent_id: &OwnedAgentId,
-        status_value: &AgentStatusRecord,
+        tracked: bool,
     ) -> Result<(), String>;
 
     /// Convenience cold-path helper that updates the recovery index *and* writes the blob in one
@@ -358,8 +363,14 @@ pub trait WorkerService: Send + Sync {
         previous_status: Option<&AgentStatusRecord>,
         status_value: AgentStatusRecord,
     ) -> Result<(), String> {
-        self.set_assignment_tracking(owned_agent_id, &status_value)
+        // Ephemeral workers are never tracked for recovery (mirrors `write_cached_status`).
+        if status_value.agent_mode != AgentMode::Ephemeral {
+            self.set_assignment_tracking(
+                owned_agent_id,
+                DefaultWorkerService::should_track_for_assignment_recovery(&status_value),
+            )
             .await?;
+        }
         self.write_cached_status(owned_agent_id, previous_status, status_value)
             .await
             .map(|_| ())
@@ -1087,14 +1098,9 @@ impl WorkerService for DefaultWorkerService {
     async fn set_assignment_tracking(
         &self,
         owned_agent_id: &OwnedAgentId,
-        status_value: &AgentStatusRecord,
+        tracked: bool,
     ) -> Result<(), String> {
         record_worker_call("set_assignment_tracking");
-
-        // Ephemeral workers are never tracked for recovery (mirrors `write_cached_status`).
-        if status_value.agent_mode == AgentMode::Ephemeral {
-            return Ok(());
-        }
 
         let shard_assignment = self
             .shard_service
@@ -1104,7 +1110,7 @@ impl WorkerService for DefaultWorkerService {
         let shard_id =
             ShardId::from_agent_id(&owned_agent_id.agent_id, shard_assignment.number_of_shards);
 
-        if Self::should_track_for_assignment_recovery(status_value) {
+        if tracked {
             debug!("Adding worker to the set of running workers in shard {shard_id}");
 
             self.key_value_storage

--- a/golem-worker-executor/src/worker/invocation_loop.rs
+++ b/golem-worker-executor/src/worker/invocation_loop.rs
@@ -39,7 +39,7 @@ use golem_common::model::{
     IdempotencyKey, OwnedAgentId, TimestampedAgentInvocation,
 };
 use golem_common::model::{
-    AgentStatusRecord, OplogIndex, Timestamp,
+    OplogIndex, Timestamp,
     invocation_context::{AttributeValue, InvocationContextStack},
 };
 use golem_common::retries::get_delay;
@@ -638,17 +638,28 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
     /// first pending_updates, then pending_invocations
     async fn drain_pending_from_status(&mut self) -> CommandOutcome {
         loop {
-            let status = self.parent.get_non_detached_last_known_status().await;
+            // Read the three things this needs under the status guard rather than copying the
+            // record, whose `invocation_results` grows with every invocation ever served.
+            let (has_pending_update, first_pending_invocation, last_automatic_snapshot_timestamp) =
+                self.parent
+                    .with_non_detached_last_known_status(|status| {
+                        (
+                            status.pending_updates.front().is_some(),
+                            status.pending_invocations.first().cloned(),
+                            status.last_automatic_snapshot_timestamp,
+                        )
+                    })
+                    .await;
 
             // First, try to process a pending update
-            if status.pending_updates.front().is_some() {
+            if has_pending_update {
                 // if the update made it to pending_updates (instead of pending invocations), it is ready
                 // to be processed on next restart. So just restart here and let the recovery logic take over
                 break CommandOutcome::BreakInnerLoop(RetryDecision::Immediate);
             }
 
             // Then, try to process a pending invocation
-            if let Some(pending_invocation) = status.pending_invocations.first() {
+            if let Some(pending_invocation) = &first_pending_invocation {
                 let idempotency_key = pending_invocation.idempotency_key();
                 let origin = match idempotency_key {
                     Some(idempotency_key) => self
@@ -728,8 +739,13 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                         // agents get a chance to run. The worker will self-wake
                         // and re-acquire its permit through the FIFO queue if
                         // more durable work remains.
-                        let status = self.parent.get_non_detached_last_known_status().await;
-                        if !status.pending_invocations.is_empty() {
+                        let more_pending = self
+                            .parent
+                            .with_non_detached_last_known_status(|status| {
+                                !status.pending_invocations.is_empty()
+                            })
+                            .await;
+                        if more_pending {
                             // More durable work remains — self-wake so we return
                             // to the outer loop, release the permit (entering
                             // idle), and re-enter through the scheduler queue.
@@ -741,7 +757,7 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                 }
             }
 
-            match self.periodic_snapshot_action(&status) {
+            match self.periodic_snapshot_action(last_automatic_snapshot_timestamp) {
                 PeriodicSnapshotAction::DueNow => {
                     self.inject_snapshot_as_next_action().await;
                     break CommandOutcome::Continue;
@@ -770,9 +786,14 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
                 }
             }
             SnapshotPolicy::Periodic { .. } => {
-                let status = self.parent.get_non_detached_last_known_status().await;
+                let last_automatic_snapshot_timestamp = self
+                    .parent
+                    .with_non_detached_last_known_status(|status| {
+                        status.last_automatic_snapshot_timestamp
+                    })
+                    .await;
                 if matches!(
-                    self.periodic_snapshot_action(&status),
+                    self.periodic_snapshot_action(last_automatic_snapshot_timestamp),
                     PeriodicSnapshotAction::DueNow
                 ) {
                     self.inject_snapshot_as_next_action().await;
@@ -785,14 +806,17 @@ impl<Ctx: WorkerCtx> InnerInvocationLoop<'_, Ctx> {
         }
     }
 
-    fn periodic_snapshot_action(&self, status: &AgentStatusRecord) -> PeriodicSnapshotAction {
+    fn periodic_snapshot_action(
+        &self,
+        last_automatic_snapshot_timestamp: Option<Timestamp>,
+    ) -> PeriodicSnapshotAction {
         let SnapshotPolicy::Periodic { period } = self.parent.snapshot_policy() else {
             return PeriodicSnapshotAction::NotNeeded;
         };
 
         let created_at = self.parent.get_initial_worker_metadata().created_at;
         let last_snapshot_timestamp =
-            snapshot_baseline_timestamp(status.last_automatic_snapshot_timestamp, created_at);
+            snapshot_baseline_timestamp(last_automatic_snapshot_timestamp, created_at);
 
         snapshot_action_at(last_snapshot_timestamp, *period, Timestamp::now_utc())
     }

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -1938,7 +1938,22 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     }
 
     pub async fn lookup_invocation_result(&self, key: &IdempotencyKey) -> LookupResult {
-        let status = self.last_known_status.read().await.clone();
+        // Snapshot the three fields used here instead of cloning the record.
+        // The record also owns `invocation_results`, which gains an entry per
+        // invocation and is never pruned, so cloning it to reach these made each
+        // lookup cost more than the last. Read under one guard at the point the
+        // clone was taken, so the values are the same consistent snapshot.
+        let status = {
+            let record = self.last_known_status.read().await;
+            InvocationLookupStatus {
+                agent_status: record.status,
+                current_idempotency_key: record.current_idempotency_key.clone(),
+                key_is_pending: record
+                    .pending_invocations
+                    .iter()
+                    .any(|entry| entry.has_idempotency_key(key)),
+            }
+        };
         let maybe_result = self.invocation_results.read().await.get(key).cloned();
         if let Some(mut result) = maybe_result {
             result
@@ -1946,12 +1961,8 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 .await;
             lookup_result_from_cached_result(&status, key, result)
         } else {
-            let is_pending = status
-                .pending_invocations
-                .iter()
-                .any(|entry| entry.has_idempotency_key(key));
             let is_current = status.current_idempotency_key.as_ref() == Some(key);
-            if is_pending || is_current {
+            if status.key_is_pending || is_current {
                 LookupResult::Pending
             } else {
                 LookupResult::New
@@ -2161,18 +2172,23 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
             }
         }
 
-        // Collect all idempotency keys to fail: pending invocations + currently running invocation
-        let status = self.last_known_status.read().await.clone();
-        let mut keys_to_fail: Vec<IdempotencyKey> = status
-            .pending_invocations
-            .iter()
-            .filter_map(|inv| inv.idempotency_key().cloned())
-            .collect();
-        if let Some(current_key) = &status.current_idempotency_key
-            && !keys_to_fail.contains(current_key)
-        {
-            keys_to_fail.push(current_key.clone());
-        }
+        // Collect all idempotency keys to fail: pending invocations + currently running invocation.
+        // Read under the guard rather than from a clone of the record, which
+        // would copy the unbounded `invocation_results` map along with them.
+        let keys_to_fail: Vec<IdempotencyKey> = {
+            let record = self.last_known_status.read().await;
+            let mut keys: Vec<IdempotencyKey> = record
+                .pending_invocations
+                .iter()
+                .filter_map(|inv| inv.idempotency_key().cloned())
+                .collect();
+            if let Some(current_key) = &record.current_idempotency_key
+                && !keys.contains(current_key)
+            {
+                keys.push(current_key.clone());
+            }
+            keys
+        };
 
         let mut invocation_results = self.invocation_results.write().await;
         for idempotency_key in &keys_to_fail {
@@ -3558,8 +3574,21 @@ impl InvocationResult {
     }
 }
 
+/// The fields of `AgentStatusRecord` an invocation lookup reads.
+///
+/// Owned rather than borrowed: `lookup_invocation_result` awaits between taking
+/// these and using them, and holding a status read guard across that await would
+/// block every writer.
+struct InvocationLookupStatus {
+    agent_status: AgentStatus,
+    current_idempotency_key: Option<IdempotencyKey>,
+    /// Whether `pending_invocations` held an entry for the key being looked up.
+    /// Resolved under the guard, since the answer is a bool and the list is not.
+    key_is_pending: bool,
+}
+
 fn lookup_result_from_cached_result(
-    status: &AgentStatusRecord,
+    status: &InvocationLookupStatus,
     key: &IdempotencyKey,
     result: InvocationResult,
 ) -> LookupResult {
@@ -3578,7 +3607,10 @@ fn lookup_result_from_cached_result(
                     ..
                 }),
         } if status.current_idempotency_key.as_ref() == Some(key)
-            && !matches!(status.status, AgentStatus::Failed | AgentStatus::Exited) =>
+            && !matches!(
+                status.agent_status,
+                AgentStatus::Failed | AgentStatus::Exited
+            ) =>
         {
             LookupResult::Pending
         }
@@ -3626,11 +3658,14 @@ mod tests {
     use golem_common::model::oplog::AgentError;
     use test_r::test;
 
-    fn status_with_current_key(status: AgentStatus, key: &IdempotencyKey) -> AgentStatusRecord {
-        AgentStatusRecord {
-            status,
+    fn status_with_current_key(
+        agent_status: AgentStatus,
+        key: &IdempotencyKey,
+    ) -> InvocationLookupStatus {
+        InvocationLookupStatus {
+            agent_status,
             current_idempotency_key: Some(key.clone()),
-            ..AgentStatusRecord::default()
+            key_is_pending: false,
         }
     }
 

--- a/golem-worker-executor/src/worker/mod.rs
+++ b/golem-worker-executor/src/worker/mod.rs
@@ -22,7 +22,7 @@ pub mod status_flusher;
 use self::agent_config::{
     ensure_required_agent_secrets_are_configured, parse_worker_creation_agent_config,
 };
-use self::status::update_status_with_new_entries;
+use self::status::fold_status_with_new_entries;
 use crate::durable_host::recover_stderr_logs;
 use crate::metrics::storage::record_filesystem_pool_released;
 use crate::metrics::workers::AdmissionPhase;
@@ -35,7 +35,7 @@ use crate::services::events::{Event, EventsSubscription};
 use crate::services::golem_config::SnapshotPolicy;
 use crate::services::oplog::plugin::ForwardingOplog;
 use crate::services::oplog::{CommitLevel, Oplog, OplogOps, downcast_oplog};
-use crate::services::worker::GetWorkerMetadataResult;
+use crate::services::worker::{DefaultWorkerService, GetWorkerMetadataResult};
 use crate::services::worker_event::{WorkerEventService, WorkerEventServiceDefault};
 use crate::services::{
     All, HasActiveWorkers, HasAgentTypesService, HasAgentWebhooksService, HasAll,
@@ -654,16 +654,31 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         self.last_known_status.read().await.clone()
     }
 
-    // Outside of reverts and updates, this will return the same status as get_latest_worker_metadata.
+    /// Reads from the last known status under its lock, for callers that need a field or two
+    /// and not a copy of the record (whose `invocation_results` grows with every invocation
+    /// served). Unlike `with_non_detached_last_known_status`, this makes no claim about the
+    /// status being fully folded up to the oplog tip.
+    pub async fn with_last_known_status<R>(&self, f: impl FnOnce(&AgentStatusRecord) -> R) -> R {
+        f(&*self.last_known_status.read().await)
+    }
+
+    // Outside of reverts and updates, this reads the same status as get_latest_worker_metadata.
     // This just has an additional assert built in for when decisions need to be sure that they are fully up to date on the oplog.
     // _NEVER_ call this from outside the invocation loop, as that is the only place that can reason about whether the status is detached or not.
-    pub async fn get_non_detached_last_known_status(&self) -> AgentStatusRecord {
+    //
+    // Takes a closure rather than returning the record: the record owns `invocation_results`,
+    // which gains an entry per invocation and is never pruned, so copying it out costs more on
+    // every call. Callers read the field or two they need under the guard instead.
+    pub async fn with_non_detached_last_known_status<R>(
+        &self,
+        f: impl FnOnce(&AgentStatusRecord) -> R,
+    ) -> R {
         // hold the update lock so we know that the atomic bool and state are consistent
         let update_state_lock_guard = self.update_state_lock.lock().await;
 
         let is_detached = self.last_known_status_detached.load(Ordering::Relaxed);
         assert!(!is_detached);
-        let result = self.last_known_status.read().await.clone();
+        let result = f(&*self.last_known_status.read().await);
 
         // ensure we hold mutex for the full duration
         drop(update_state_lock_guard);
@@ -2553,7 +2568,7 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
             // Install the recomputed status while still detached, so a concurrent background sweep
             // keeps skipping (the in-memory status is not authoritative until it is installed).
-            self.update_last_known_status(worker_status.clone()).await;
+            self.update_last_known_status(worker_status).await;
 
             // Now the in-memory status is authoritative again; clear the flag and force a flush.
             self.last_known_status_detached
@@ -2584,28 +2599,68 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
     ) -> bool {
         let new_entries = self.oplog.commit(commit_level).await;
 
-        if !self.last_known_status_detached.load(Ordering::Acquire) {
-            let old_status = self.last_known_status.read().await.clone();
+        if self.last_known_status_detached.load(Ordering::Acquire) {
+            return false;
+        }
+        if new_entries.is_empty() {
+            // Folding nothing onto the record is the identity, so there is nothing to install.
+            return false;
+        }
 
-            let updated_status = update_status_with_new_entries(
+        // Fold the new entries onto the record in place. The record owns `invocation_results`,
+        // which gains an entry per invocation and is never pruned, so every copy of it costs more
+        // than the last, and this runs on every oplog commit. So the record is taken out of the
+        // lock, folded, and put back, without a copy at any step. The fold is synchronous and
+        // proportional to the number of new entries, so the write lock is held only briefly.
+        let previous_metrics_status = self.metrics_status.status();
+        let (old_agent_status, old_tracked, folded) = {
+            let mut guard = self.last_known_status.write().await;
+            let old_status = std::mem::take(&mut *guard);
+            let old_agent_status = old_status.status;
+            let old_tracked =
+                DefaultWorkerService::should_track_for_assignment_recovery(&old_status);
+            match fold_status_with_new_entries(
                 self.agent_mode(),
-                old_status.clone(),
+                old_status,
                 new_entries,
                 &self.config().retry,
-            );
-
-            if let Some(updated_status) = updated_status {
-                if updated_status != old_status {
-                    self.update_last_known_status(updated_status.clone()).await;
-
-                    self.schedule_oplog_archive_if_needed(&old_status, &updated_status)
-                        .await;
-
-                    true
-                } else {
-                    false
+            ) {
+                Ok(updated_status) => {
+                    let new_agent_status = updated_status.status;
+                    let new_oplog_idx = updated_status.oplog_idx;
+                    *guard = updated_status;
+                    (
+                        old_agent_status,
+                        old_tracked,
+                        Some((new_agent_status, new_oplog_idx)),
+                    )
                 }
-            } else {
+                Err(old_status) => {
+                    *guard = old_status;
+                    (old_agent_status, old_tracked, None)
+                }
+            }
+        };
+
+        match folded {
+            Some((new_agent_status, new_oplog_idx)) => {
+                self.on_last_known_status_replaced(
+                    previous_metrics_status,
+                    old_tracked,
+                    new_agent_status,
+                )
+                .await;
+
+                self.schedule_oplog_archive_if_needed(
+                    old_agent_status,
+                    new_agent_status,
+                    new_oplog_idx,
+                )
+                .await;
+
+                true
+            }
+            None => {
                 // The status can no longer be incrementally computed by adding the new oplog entries, instead a full reload needs to be performed.
                 // This can happen during a revert or a snapshot update for example.
                 tracing::debug!("Detaching worker_status from oplog");
@@ -2617,29 +2672,28 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
                 self.status_flusher.invalidate_baseline().await;
                 true
             }
-        } else {
-            false
         }
     }
 
     async fn schedule_oplog_archive_if_needed(
         &self,
-        old_status: &AgentStatusRecord,
-        new_status: &AgentStatusRecord,
+        old_status: AgentStatus,
+        new_status: AgentStatus,
+        new_oplog_idx: OplogIndex,
     ) {
-        if old_status.status != new_status.status
+        if old_status != new_status
             && matches!(
-                new_status.status,
+                new_status,
                 AgentStatus::Idle | AgentStatus::Failed | AgentStatus::Exited
             )
         {
             let archive_interval = self.config().oplog.archive_interval;
-            let last_oplog_index = new_status.oplog_idx;
+            let last_oplog_index = new_oplog_idx;
             let account_id = self.initial_worker_metadata.created_by;
 
             debug!(
                 worker_id = %self.owned_agent_id,
-                new_status = ?new_status.status,
+                new_status = ?new_status,
                 "Scheduling ArchiveOplog after status transition"
             );
 
@@ -2710,9 +2764,8 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         if self.last_known_status_detached.load(Ordering::Acquire) {
             return;
         }
-        let status = self.last_known_status.read().await.clone();
         self.status_checkpointer
-            .maybe_checkpoint(&status, reason)
+            .maybe_checkpoint(&self.last_known_status, None, reason)
             .await;
     }
 
@@ -2733,15 +2786,10 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
         if self.last_known_status_detached.load(Ordering::Acquire) {
             return;
         }
-        let status = self.last_known_status.read().await.clone();
-        if let Some(marker) = min_exposed_marker
-            && status.oplog_idx > marker
-        {
-            return;
-        }
         self.status_checkpointer
             .maybe_checkpoint(
-                &status,
+                &self.last_known_status,
+                min_exposed_marker,
                 status_checkpointer::CheckpointReason::MidInvocation,
             )
             .await;
@@ -2764,19 +2812,39 @@ impl<Ctx: WorkerCtx> Worker<Ctx> {
 
     async fn update_last_known_status(&self, new_status: AgentStatusRecord) {
         let previous_metrics_status = self.metrics_status.status();
+        let new_agent_status = new_status.status;
         // The in-memory `last_known_status` is the authoritative live status; the flusher reads it
-        // when it persists the cached blob. We replace it here and hand the (previous, new) pair to
-        // the flusher, which updates the `RunningWorkers` recovery index synchronously and either
-        // marks the worker dirty for the background sweeper or writes the blob inline (when
-        // background flushing is disabled).
-        let previous_status = {
+        // when it persists the cached blob. We replace it here, keeping only what the follow-up
+        // needs from the old record, so neither record is copied.
+        let previous_tracked = {
             let mut guard = self.last_known_status.write().await;
-            std::mem::replace(&mut *guard, new_status.clone())
+            let previous_tracked =
+                DefaultWorkerService::should_track_for_assignment_recovery(&guard);
+            *guard = new_status;
+            previous_tracked
         };
+        self.on_last_known_status_replaced(
+            previous_metrics_status,
+            previous_tracked,
+            new_agent_status,
+        )
+        .await;
+    }
+
+    /// The follow-up to installing a new `last_known_status`: the status metric moves, and the
+    /// flusher updates the `RunningWorkers` recovery index synchronously and either marks the
+    /// worker dirty for the background sweeper or writes the blob inline (when background flushing
+    /// is disabled).
+    async fn on_last_known_status_replaced(
+        &self,
+        previous_metrics_status: AgentStatus,
+        previous_tracked: bool,
+        new_agent_status: AgentStatus,
+    ) {
         self.metrics_status
-            .update(previous_metrics_status, new_status.status);
+            .update(previous_metrics_status, new_agent_status);
         self.status_flusher
-            .on_status_changed(&previous_status, &new_status)
+            .on_status_changed(previous_tracked)
             .await;
     }
 }

--- a/golem-worker-executor/src/worker/status.rs
+++ b/golem-worker-executor/src/worker/status.rs
@@ -223,6 +223,21 @@ pub fn update_status_with_new_entries(
     // TODO: changing the retry policy will cause inconsistencies when reading existing oplogs.
     default_retry_policy: &RetryConfig,
 ) -> Option<AgentStatusRecord> {
+    fold_status_with_new_entries(agent_mode, last_known, new_entries, default_retry_policy).ok()
+}
+
+/// Folds `new_entries` onto `last_known`, consuming it.
+///
+/// `Err` hands `last_known` back untouched when the status cannot be computed from the new
+/// entries alone (a jump or revert covered its oplog index) and needs recalculating from the
+/// beginning. Returning the record rather than dropping it lets a caller that took it out of a
+/// lock put the same record back instead of a copy.
+pub fn fold_status_with_new_entries(
+    agent_mode: AgentMode,
+    last_known: AgentStatusRecord,
+    new_entries: BTreeMap<OplogIndex, OplogEntry>,
+    default_retry_policy: &RetryConfig,
+) -> Result<AgentStatusRecord, AgentStatusRecord> {
     let deleted_regions =
         calculate_deleted_regions(last_known.deleted_regions.clone(), &new_entries);
 
@@ -260,7 +275,7 @@ pub fn update_status_with_new_entries(
         // We might have already calculated the status with these skipped regions as an override during a snapshot update.
         // No need to recompute in this case, we are already up to date.
         if effective_skipped_regions_changed {
-            return None;
+            return Err(last_known);
         }
     }
 
@@ -364,7 +379,7 @@ pub fn update_status_with_new_entries(
         agent_mode,
     };
 
-    Some(result)
+    Ok(result)
 }
 
 fn calculate_latest_worker_status(

--- a/golem-worker-executor/src/worker/status_checkpointer.rs
+++ b/golem-worker-executor/src/worker/status_checkpointer.rs
@@ -33,10 +33,10 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tracing::debug;
 
-use golem_common::model::{AgentStatusRecord, OwnedAgentId};
+use golem_common::model::{AgentStatusRecord, OplogIndex, OwnedAgentId};
 
 use crate::services::worker::WorkerService;
 
@@ -143,7 +143,19 @@ impl StatusCheckpointer {
     ///
     /// Best-effort: a write failure is logged and metered, the baseline is left unchanged, and the
     /// worker continues. The oplog remains the source of truth.
-    pub async fn maybe_checkpoint(&self, status: &AgentStatusRecord, reason: CheckpointReason) {
+    ///
+    /// Reads the live status through its lock and copies it only once it has decided to write:
+    /// the record owns `invocation_results`, which grows by one entry per invocation and is never
+    /// pruned, and this is called after every durable function, where the throttle discards
+    /// nearly every call. `min_exposed_marker` is the per-invocation `get_oplog_index` watermark;
+    /// a committed tip beyond it is skipped, since a later `set_oplog_index` back to the marker
+    /// would delete what the checkpoint recorded.
+    pub async fn maybe_checkpoint(
+        &self,
+        status: &RwLock<AgentStatusRecord>,
+        min_exposed_marker: Option<OplogIndex>,
+        reason: CheckpointReason,
+    ) {
         if self.is_ephemeral || !self.enabled || self.delete_started.load(Ordering::Acquire) {
             return;
         }
@@ -153,6 +165,14 @@ impl StatusCheckpointer {
         // Re-check after taking the lock: `begin_delete` may have set the flag while we waited for
         // it (it takes this same lock as a barrier), so once we hold the lock the flag is final.
         if self.delete_started.load(Ordering::Acquire) {
+            return;
+        }
+
+        let status = status.read().await;
+
+        if let Some(marker) = min_exposed_marker
+            && status.oplog_idx > marker
+        {
             return;
         }
 
@@ -185,13 +205,13 @@ impl StatusCheckpointer {
             return;
         }
 
+        // Copy only what is about to be written, and release the status lock before the write.
+        let snapshot = status.clone();
+        drop(status);
+
         match self
             .worker_service
-            .write_status_checkpoint(
-                &self.owned_agent_id,
-                state.last_written.as_ref(),
-                status.clone(),
-            )
+            .write_status_checkpoint(&self.owned_agent_id, state.last_written.as_ref(), snapshot)
             .await
         {
             Ok(written) => {
@@ -304,7 +324,7 @@ mod tests {
         async fn set_assignment_tracking(
             &self,
             _owned_agent_id: &OwnedAgentId,
-            _status_value: &AgentStatusRecord,
+            _tracked: bool,
         ) -> Result<(), String> {
             Ok(())
         }
@@ -337,7 +357,7 @@ mod tests {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(10)), None, CheckpointReason::Idle)
             .await;
 
         assert_eq!(
@@ -351,11 +371,11 @@ mod tests {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(10)), None, CheckpointReason::Idle)
             .await; // first -> written (10)
-        cp.maybe_checkpoint(&status_at(50), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(50)), None, CheckpointReason::Idle)
             .await; // +40 < 100 -> skipped
-        cp.maybe_checkpoint(&status_at(110), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(110)), None, CheckpointReason::Idle)
             .await; // +100 >= 100 -> written (110)
 
         assert_eq!(
@@ -369,8 +389,12 @@ mod tests {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::MidInvocation)
-            .await;
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(10)),
+            None,
+            CheckpointReason::MidInvocation,
+        )
+        .await;
 
         assert_eq!(
             *service.writes.lock().unwrap(),
@@ -379,16 +403,56 @@ mod tests {
     }
 
     #[test]
+    async fn mid_invocation_skips_a_tip_beyond_the_exposed_marker() {
+        let service = Arc::new(RecordingWorkerService::default());
+        let cp = checkpointer(service.clone(), 100);
+
+        // The guest captured oplog index 40 through `get_oplog_index`; a checkpoint at 50 would
+        // be discarded by a later `set_oplog_index(40)`, so it is not written.
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(50)),
+            Some(OplogIndex::from_u64(40)),
+            CheckpointReason::MidInvocation,
+        )
+        .await;
+        assert!(service.writes.lock().unwrap().is_empty());
+
+        // A tip at or below the marker is safe to record.
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(40)),
+            Some(OplogIndex::from_u64(40)),
+            CheckpointReason::MidInvocation,
+        )
+        .await;
+        assert_eq!(
+            *service.writes.lock().unwrap(),
+            vec![OplogIndex::from_u64(40)]
+        );
+    }
+
+    #[test]
     async fn mid_invocation_throttles_like_idle() {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::MidInvocation)
-            .await; // first -> written (10)
-        cp.maybe_checkpoint(&status_at(50), CheckpointReason::MidInvocation)
-            .await; // +40 < 100 -> skipped
-        cp.maybe_checkpoint(&status_at(110), CheckpointReason::MidInvocation)
-            .await; // +100 >= 100 -> written (110)
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(10)),
+            None,
+            CheckpointReason::MidInvocation,
+        )
+        .await; // first -> written (10)
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(50)),
+            None,
+            CheckpointReason::MidInvocation,
+        )
+        .await; // +40 < 100 -> skipped
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(110)),
+            None,
+            CheckpointReason::MidInvocation,
+        )
+        .await; // +100 >= 100 -> written (110)
 
         assert_eq!(
             *service.writes.lock().unwrap(),
@@ -403,11 +467,15 @@ mod tests {
 
         // A mid-invocation checkpoint and a subsequent idle checkpoint use the same persisted
         // baseline, so the idle one is throttled relative to the mid-invocation write.
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::MidInvocation)
-            .await; // written (10)
-        cp.maybe_checkpoint(&status_at(40), CheckpointReason::Idle)
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(10)),
+            None,
+            CheckpointReason::MidInvocation,
+        )
+        .await; // written (10)
+        cp.maybe_checkpoint(&RwLock::new(status_at(40)), None, CheckpointReason::Idle)
             .await; // +30 < 100 -> skipped
-        cp.maybe_checkpoint(&status_at(150), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(150)), None, CheckpointReason::Idle)
             .await; // +140 >= 100 -> written (150)
 
         assert_eq!(
@@ -421,10 +489,14 @@ mod tests {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(10)), None, CheckpointReason::Idle)
             .await; // written (10)
-        cp.maybe_checkpoint(&status_at(20), CheckpointReason::Snapshot)
-            .await; // +10 but snapshot -> written (20)
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(20)),
+            None,
+            CheckpointReason::Snapshot,
+        )
+        .await; // +10 but snapshot -> written (20)
 
         assert_eq!(
             *service.writes.lock().unwrap(),
@@ -437,10 +509,10 @@ mod tests {
         let service = Arc::new(RecordingWorkerService::default());
         let cp = checkpointer(service.clone(), 100);
 
-        cp.maybe_checkpoint(&status_at(500), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(500)), None, CheckpointReason::Idle)
             .await; // written (500)
         // A revert truncated the oplog: the new tip is behind the stale checkpoint -> refresh.
-        cp.maybe_checkpoint(&status_at(200), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(200)), None, CheckpointReason::Idle)
             .await;
 
         assert_eq!(
@@ -455,7 +527,7 @@ mod tests {
         // High throttle so a small index delta alone would never trigger a refresh.
         let cp = checkpointer(service.clone(), 1000);
 
-        cp.maybe_checkpoint(&status_at(100), CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(status_at(100)), None, CheckpointReason::Idle)
             .await; // written (100)
 
         // A logical revert appends a `Revert` marker (tip advances to 121) and records a deleted
@@ -467,7 +539,7 @@ mod tests {
             start: OplogIndex::from_u64(80),
             end: OplogIndex::from_u64(120),
         });
-        cp.maybe_checkpoint(&after_revert, CheckpointReason::Idle)
+        cp.maybe_checkpoint(&RwLock::new(after_revert), None, CheckpointReason::Idle)
             .await;
 
         assert_eq!(
@@ -484,8 +556,12 @@ mod tests {
         cp.begin_delete().await;
         // Even a snapshot checkpoint (which otherwise bypasses every throttle) must not write after
         // deletion has started, so it cannot resurrect a deleted checkpoint.
-        cp.maybe_checkpoint(&status_at(10), CheckpointReason::Snapshot)
-            .await;
+        cp.maybe_checkpoint(
+            &RwLock::new(status_at(10)),
+            None,
+            CheckpointReason::Snapshot,
+        )
+        .await;
 
         assert!(service.writes.lock().unwrap().is_empty());
     }
@@ -496,12 +572,20 @@ mod tests {
 
         let disabled = StatusCheckpointer::new(owned_agent_id(), false, false, 0, service.clone());
         disabled
-            .maybe_checkpoint(&status_at(10), CheckpointReason::Snapshot)
+            .maybe_checkpoint(
+                &RwLock::new(status_at(10)),
+                None,
+                CheckpointReason::Snapshot,
+            )
             .await;
 
         let ephemeral = StatusCheckpointer::new(owned_agent_id(), true, true, 0, service.clone());
         ephemeral
-            .maybe_checkpoint(&status_at(10), CheckpointReason::Snapshot)
+            .maybe_checkpoint(
+                &RwLock::new(status_at(10)),
+                None,
+                CheckpointReason::Snapshot,
+            )
             .await;
 
         assert!(service.writes.lock().unwrap().is_empty());

--- a/golem-worker-executor/src/worker/status_flusher.rs
+++ b/golem-worker-executor/src/worker/status_flusher.rs
@@ -156,11 +156,10 @@ impl AgentStatusFlusher {
     /// synchronously (only when the tracking predicate transitions) and then either marks the
     /// worker dirty for the background sweeper or, when background flushing is disabled, flushes the
     /// blob synchronously.
-    pub async fn on_status_changed(
-        &self,
-        previous_status: &AgentStatusRecord,
-        new_status: &AgentStatusRecord,
-    ) {
+    /// `previous_tracked` is whether the status being replaced satisfied
+    /// [`DefaultWorkerService::should_track_for_assignment_recovery`]; the new status is read from
+    /// the shared `current_status`, which the caller has already updated.
+    pub async fn on_status_changed(&self, previous_tracked: bool) {
         if self.is_ephemeral {
             return;
         }
@@ -168,13 +167,14 @@ impl AgentStatusFlusher {
         // Recovery index: keep it synchronous (it must be timely for crash/reshard recovery), but
         // only touch the KV store when the predicate actually changes, to avoid a round-trip per
         // commit.
-        let track_now = DefaultWorkerService::should_track_for_assignment_recovery(new_status);
-        let track_before =
-            DefaultWorkerService::should_track_for_assignment_recovery(previous_status);
-        if track_now != track_before
+        let track_now = {
+            let status = self.current_status.read().await;
+            DefaultWorkerService::should_track_for_assignment_recovery(&status)
+        };
+        if track_now != previous_tracked
             && let Err(err) = self
                 .worker_service
-                .set_assignment_tracking(&self.owned_agent_id, new_status)
+                .set_assignment_tracking(&self.owned_agent_id, track_now)
                 .await
         {
             // Fatal, deliberately. This index is what a reshard or a crash consults to decide which
@@ -424,7 +424,7 @@ mod tests {
     #[derive(Default)]
     struct MockState {
         writes: Vec<RecordedWrite>,
-        tracking_calls: Vec<AgentStatus>,
+        tracking_calls: Vec<bool>,
         fail_writes: bool,
         fail_tracking: bool,
     }
@@ -532,10 +532,10 @@ mod tests {
         async fn set_assignment_tracking(
             &self,
             _owned_agent_id: &OwnedAgentId,
-            status_value: &AgentStatusRecord,
+            tracked: bool,
         ) -> Result<(), String> {
             let mut state = self.state.lock().unwrap();
-            state.tracking_calls.push(status_value.status);
+            state.tracking_calls.push(tracked);
             if state.fail_tracking {
                 return Err("injected tracking failure".to_string());
             }
@@ -772,14 +772,10 @@ mod tests {
     async fn ephemeral_is_noop() {
         let ws = MockWorkerService::arc();
         let queue = test_queue();
-        let (flusher, _current, _) = make_flusher(true, true, ws.clone(), queue.clone());
+        let (flusher, current, _) = make_flusher(true, true, ws.clone(), queue.clone());
 
-        flusher
-            .on_status_changed(
-                &status(AgentStatus::Idle, 0),
-                &status(AgentStatus::Running, 1),
-            )
-            .await;
+        *current.write().await = status(AgentStatus::Running, 1);
+        flusher.on_status_changed(false).await;
         flusher.mark_dirty();
         let _ = flusher.flush(FlushReason::Forced).await;
         queue.sweep().await;
@@ -793,31 +789,20 @@ mod tests {
     async fn assignment_tracking_fires_only_on_transition() {
         let ws = MockWorkerService::arc();
         let queue = test_queue();
-        let (flusher, _current, _) = make_flusher(false, true, ws.clone(), queue.clone());
+        let (flusher, current, _) = make_flusher(false, true, ws.clone(), queue.clone());
 
         // Idle -> Running: predicate transitions false -> true, fires.
-        flusher
-            .on_status_changed(
-                &status(AgentStatus::Idle, 0),
-                &status(AgentStatus::Running, 1),
-            )
-            .await;
+        *current.write().await = status(AgentStatus::Running, 1);
+        flusher.on_status_changed(false).await;
         // Running -> Running: no transition, does not fire.
-        flusher
-            .on_status_changed(
-                &status(AgentStatus::Running, 1),
-                &status(AgentStatus::Running, 2),
-            )
-            .await;
+        *current.write().await = status(AgentStatus::Running, 2);
+        flusher.on_status_changed(true).await;
         // Running -> Idle: transitions true -> false, fires.
-        flusher
-            .on_status_changed(
-                &status(AgentStatus::Running, 2),
-                &status(AgentStatus::Idle, 3),
-            )
-            .await;
+        *current.write().await = status(AgentStatus::Idle, 3);
+        flusher.on_status_changed(true).await;
 
         assert_eq!(ws.tracking_count(), 2);
+        assert_eq!(ws.state.lock().unwrap().tracking_calls, vec![true, false]);
     }
 
     #[test]
@@ -827,12 +812,7 @@ mod tests {
         let (flusher, current, _) = make_flusher(false, false, ws.clone(), queue.clone());
 
         *current.write().await = status(AgentStatus::Running, 1);
-        flusher
-            .on_status_changed(
-                &status(AgentStatus::Idle, 0),
-                &status(AgentStatus::Running, 1),
-            )
-            .await;
+        flusher.on_status_changed(false).await;
 
         // Blob written synchronously, nothing left in the queue.
         assert_eq!(ws.write_count(), 1);

--- a/golem-worker-executor/src/workerctx/default.rs
+++ b/golem-worker-executor/src/workerctx/default.rs
@@ -64,9 +64,9 @@ use golem_common::model::oplog::{
     AgentError, EphemeralCannotSuspendError, EphemeralFuelExhaustedError,
     TimestampedUpdateDescription,
 };
+use golem_common::model::regions::DeletedRegions;
 use golem_common::model::{
-    AgentId, AgentInvocation, AgentInvocationOutput, AgentStatusRecord, IdempotencyKey,
-    OwnedAgentId,
+    AgentId, AgentInvocation, AgentInvocationOutput, IdempotencyKey, OwnedAgentId,
 };
 use golem_service_base::error::worker_executor::{
     GolemSpecificWasmTrap, InterruptKind, WorkerExecutorError,
@@ -487,13 +487,13 @@ impl ExternalOperations<Context> for Context {
         this: &T,
         agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        worker_status_record: &AgentStatusRecord,
+        deleted_regions: &DeletedRegions,
     ) -> Option<LastError> {
         DurableWorkerCtx::<Context>::get_last_error_and_retry_count(
             this,
             agent_id,
             agent_mode,
-            worker_status_record,
+            deleted_regions,
         )
         .await
     }

--- a/golem-worker-executor/src/workerctx/mod.rs
+++ b/golem-worker-executor/src/workerctx/mod.rs
@@ -50,9 +50,9 @@ use golem_common::model::invocation_context::{
     AttributeValue, InvocationContextSpan, InvocationContextStack, SpanId,
 };
 use golem_common::model::oplog::{AgentError, TimestampedUpdateDescription};
+use golem_common::model::regions::DeletedRegions;
 use golem_common::model::{
-    AgentId, AgentInvocation, AgentInvocationOutput, AgentStatusRecord, IdempotencyKey, OplogIndex,
-    OwnedAgentId,
+    AgentId, AgentInvocation, AgentInvocationOutput, IdempotencyKey, OplogIndex, OwnedAgentId,
 };
 use golem_service_base::error::worker_executor::{InterruptKind, WorkerExecutorError};
 use golem_service_base::model::GetFileSystemNodeResult;
@@ -365,11 +365,15 @@ pub trait ExternalOperations<Ctx: WorkerCtx> {
 
     /// Gets how many times the worker has been retried to recover from an error, and what
     /// error was stored in the last entry.
+    ///
+    /// `deleted_regions` is the latest status record's `deleted_regions`: the only part of the
+    /// record the search needs, taken alone so the invoke path can pass it without copying the
+    /// record (whose `invocation_results` grows with every invocation served).
     async fn get_last_error_and_retry_count<T: HasAll<Ctx> + Send + Sync>(
         this: &T,
         owned_agent_id: &OwnedAgentId,
         agent_mode: AgentMode,
-        latest_worker_status: &AgentStatusRecord,
+        deleted_regions: &DeletedRegions,
     ) -> Option<LastError>;
 
     /// Resume the replay of a worker instance. Note that if the previous replay


### PR DESCRIPTION
`AgentStatusRecord` owns `invocation_results`, a map that gains an entry for
every invocation an agent has ever served and is never pruned. Anything that
clones the record therefore costs more on every invocation, and the executor was
cloning it roughly a dozen times per invocation:

* `commit_and_update_state_inner` runs on every oplog commit (two or three per
  invocation, more with durable host calls) and copied the record three times,
  then `update_last_known_status` copied it a fourth time and the `!=` check
  walked the whole map.
* `drain_pending_from_status` copied it two or three times per invocation to
  read `pending_updates.front()`, `pending_invocations.first()` and one
  timestamp.
* The gRPC invoke path copied it once per invocation through
  `get_latest_metadata`, to check the agent had not failed.
* The oplog-processor `ForwardingOplog`, which wraps every agent's oplog
  whether or not it has plugins, copied it every third commit
  (`plugin_max_commit_count`) in `try_flush`, and again on its timer.
* `checkpoint_status_mid_invocation` copied it after every durable function,
  before the throttle that discards nearly all of those calls.
* `lookup_invocation_result` copied it once per invocation (the first commit on
  this branch).

The cost of serving an invocation grew with the number already served: linear
per invocation, quadratic over the agent's life, while throughput stayed flat.
That is the creep.

## Measured

A throwaway in-process test (one durable `Counter` agent, `increment` invoked
20,000 times sequentially, debug build, Redis-backed) with `perf stat` counting
retired user-space instructions of the executor process per window of 1,000:

| history before window | unfixed, M instr/inv | fixed, M instr/inv |
| --: | --: | --: |
| 0 | 15.7 | 7.3 |
| 5,000 | 95.9 | 7.7 |
| 10,000 | 171.4 | 8.1 |
| 15,000 | 255.0 | 8.3 |
| 19,000 | 316.9 | 8.9 |
| fresh agent, same process, after the 20,000 | | 6.8 |

Retired instructions rather than CPU seconds because the machine is shared;
CPU per invocation tells the same story (6.4ms rising to 23.7ms unfixed, flat at
3.4 to 4.2ms fixed). Every intermediate step was measured the same way: the
first three sites above took the slope from 15.8M to 1.65M per 1,000 of
history, the forwarding oplog halved that, and the invoke path removed the rest.
The fresh-agent control is what showed the remainder was per-agent history and
not process state.

`perf record` on the unfixed build late in the run put about 70% of user CPU in
`malloc`, `free` and hashbrown's clone, iterate and drop of the
`(IdempotencyKey, OplogIndex)` map.

## What changed

* The commit path takes the record out of its lock, folds the new entries onto
  it and puts the result back, copying nothing. `update_status_with_new_entries`
  gained a `Result` twin, `fold_status_with_new_entries`, that hands the record
  back on the detach path so the lock never holds a placeholder. The `!=` check
  is replaced by "were there any new entries": the fold advances `oplog_idx` on
  any entry and is the identity on none, so the two are equivalent.
* `get_non_detached_last_known_status` is now
  `with_non_detached_last_known_status(|status| ...)`: callers read the field or
  two they need under the guard. Every caller was converted; none needed more
  than a scalar, a `PendingInvocationRef` or the (small) `current_retry_state`.
* `StatusCheckpointer::maybe_checkpoint` reads the live status through its lock
  and copies it only once it has decided to write, and the `get_oplog_index`
  marker guard moved in with it. Regression test added for the marker.
* `ForwardingOplogState` reconciles plugin state from `active_plugins` and
  `oplog_processor_checkpoints` alone, and copies the record only when there is
  a plugin to send to.
* `ensure_not_failed` takes the agent status and `deleted_regions`, which is
  all `last_error` reads, so `WorkerCtx::get_last_error_and_retry_count` takes
  `&DeletedRegions` instead of the record. The invoke path reads both under the
  resident worker's status lock; a non-resident worker still goes through
  `get_latest_metadata` as before.
* The flusher's `on_status_changed` takes the previous record's tracking bit
  rather than the record, and `WorkerService::set_assignment_tracking` takes
  that bit rather than a record. The ephemeral guard moved to the two callers.
  Recovery-index writes fire on exactly the same transitions as before; the
  flusher test now also asserts the direction of each write.

No ordering changes: the write lock is held only for the synchronous fold,
the recovery-index write and dirty-marking happen after the new record is
installed, as before.

## What this does not fix

* `AgentStatusRecord::invocation_results` and the in-memory
  `Worker::invocation_results` cache still retain one entry per invocation for
  the life of the agent, so RSS still grows with invocations served. Bounding
  them is a retention-policy change (#3820 on `main`).
* The background status flusher still copies the record once per second per
  dirty agent and walks the map to compute its delta. That is proportional to
  resident history rather than to invocation rate, and small at the history
  sizes the chaos runs reach; it stops being small for agents with hundreds of
  thousands of invocations. Same root cause as the retention point above.

## Testing

`cargo test -p golem-worker-executor --lib` 535 passed; `cargo clippy --workspace
--all-targets --no-deps -- -D warnings` and `cargo check --workspace --all-targets`
clean.
