### PR TITLE
Fix the build on main: launch test's RunDetails is missing leadership

### DIFF
--- a/cli/golem/src/launch.rs
+++ b/cli/golem/src/launch.rs
@@ -563,6 +563,7 @@ mod tests {
         let shard_manager = golem_shard_manager::RunDetails {
             http_port: 0,
             grpc_port: 0,
+            leadership: None,
         };
         let registry = golem_registry_service::SingleExecutableRunDetails {
             grpc_port: 0,


### PR DESCRIPTION
`main` does not compile with `--all-targets`, so `check-clippy-and-format` and
`build-and-store` fail on every PR branched off it:

```
error[E0063]: missing field `leadership` in initializer of `golem_shard_manager::RunDetails`
   --> cli/golem/src/launch.rs:563:29
```

#3840 added `local_server_system_memory_override_reaches_executor_config` to
`launch.rs`. #3824 then added `RunDetails.leadership` and updated the call site
in the same file, but not that test's literal — its CI had been running against
a base that predated #3840, and the build workflow does not run on push to
`main`, so nothing re-checked the combination.

`None` is the value the test's scenario produces: it stands in for the
single-binary local server, and `Deployment::Embedded` bails out of the
leadership path rather than acquiring a handle.

## Testing

`cargo clippy -p golem --all-targets --no-deps -- -D warnings` passes; it fails
on `main` without this.