### PR TITLE
Add worker executor durable execution guidance (AGENTS.md files and skill)

### DIFF
--- a/.agents/skills/understanding-durable-execution/SKILL.md
+++ b/.agents/skills/understanding-durable-execution/SKILL.md
@@ -1,0 +1,499 @@
+---
+name: understanding-durable-execution
+description: "Explains how the Golem worker executor implements durable execution: oplog recording and deterministic replay, durable host calls and guest completion delivery, the replay-to-live transition, the invocation queue and results, durable RPC exactly-once, streaming invocations and durable streams, tool invocations and entity bodies, snapshots and updates, and interruption, suspension, and reconstruction. Use when changing, reviewing, or debugging golem-worker-executor code or tests that involve replay, oplog entries, crash recovery, idempotency keys, or worker lifecycle."
+---
+
+# Understanding Durable Execution
+
+The worker executor runs WASM agents whose progress survives the loss of the process running
+them. Everything below is verified against `golem-worker-executor/src/` and `tests/`; when code
+and guide disagree, the code wins and the guide needs a fix. The scoped `AGENTS.md` files under
+`golem-worker-executor/` state the mandatory rules; this skill explains the mechanisms.
+
+Deeper material lives in `reference/`: `timelines.md` (worked oplog timelines), `crash-matrix.md`
+(what recovery does for each crash window), `testing-patterns.md` (tests that fail under a wrong
+model), `streams.md` (durable streams and streaming invocations), `tools.md` (tool invocations
+and entity bodies) and `retries.md` (in-function versus trap-based retries).
+
+## Three axioms
+
+1. **Replay is deterministic by construction.** The guest is a deterministic function of its
+   guest-observable host inputs. The executor records every nondeterministic host interaction in
+   the oplog and feeds the recorded result back during replay. If a replaying guest asks for a
+   different host call than the one recorded next, the executor has a bug (missing recording,
+   wrong reconstruction, wrong completion association). It is never "normal nondeterminism".
+   The *host* side is not deterministic — completions are tokio futures and finish in varying
+   order — but replay reproduces the guest-visible completion order from the recorded
+   `CompletionDelivered` markers, so the guest sees the same inputs in the same order.
+   Owner: `durable_host/replay_state/claims.rs` (a missing `Start` match while replay is active
+   is a strict divergence error, except for entries deleted by a `Jump`). The axiom is about
+   replaying the *same* execution contract; replaying old history against a changed component
+   during an `Automatic` update may legitimately diverge, and that is reported as `FailedUpdate`,
+   not tolerated.
+
+2. **The resident runtime is disposable.** The Wasmtime `Store`, the worker task, the executor
+   process, sockets, channels and subscriptions can vanish while work is pending. Suspension,
+   eviction, resharding, restart and crash must all be recoverable the same way: throw the
+   instance away, build a new `Store`, replay the oplog, continue. Lifecycle hints (`Suspend`,
+   `Interrupted`, `Restart`) change status and scheduling policy, not the recovery mechanism.
+   Owner: `worker/invocation_loop.rs::run` (outer loop: create instance → recover → run →
+   suspend/retry) and `durable_host/mod.rs::prepare_instance`.
+
+3. **Durable agent RPC is exactly-once at the logical callee-invocation level.** The caller may
+   attempt a dispatch many times (replay, transport retry, atomic-region rollback), but every
+   attempt carries the same durable idempotency key, the target persists one invocation, and one
+   durable result exists. Attempts are not executions. Owner: `durable_host/wasm_rpc/mod.rs`
+   (`derive_idempotency_key(begin_index)`), `worker/mod.rs::enqueue_worker_invocation_with_effect`
+   (`lookup_invocation_result` dedupe before appending `PendingAgentInvocation`).
+
+```diagram
+┌──────────────┐ host call ┌──────────────────┐ append ┌──────────────┐
+│  live guest  │──────────▶│ durable_host fn  │───────▶│    oplog     │
+│  (Store #1)  │◀──────────│ Start…End…Deliver│        │ (persistent) │
+└──────────────┘  result   └──────────────────┘        └──────┬───────┘
+        ✕ Store #1 disappears (suspend / evict / crash / restart)  │
+┌──────────────┐ host call ┌──────────────────┐  read   │
+│ replay guest │──────────▶│ claim Start,     │◀────────┘
+│  (Store #2)  │◀──────────│ resolve End,     │
+└──────────────┘ recorded  │ deliver at marker│
+                           └────────┬─────────┘
+                    cursor exhausted│ + reconstruction validated
+                                    ▼
+                           publish Live → new work appends again
+```
+
+## Durable versus resident state
+
+| Durable (authoritative) | Resident (disposable, derived) |
+|---|---|
+| Oplog entries and their payloads (`golem-common/src/base_model/oplog/mod.rs`) | Wasmtime `Store`, instance, linear memory |
+| `PendingAgentInvocation` / `AgentInvocationStarted` / `AgentInvocationFinished` | `Worker.queue: VecDeque<QueuedWorkerInvocation>`, event subscriptions |
+| Idempotency keys and recorded invocation results | `hydrated_invocation_results` cache, read-only cache |
+| Durable-call `Start`/`End`/`Cancelled` and `CompletionDelivered`/`CompletionDiscarded` markers | `DurableCallSession`, `ReplayableOneshot`, spawned store tasks |
+| `PendingUpdate` / `SuccessfulUpdate` / `FailedUpdate`, `Snapshot` hints, snapshot blobs | In-flight update decision, loaded snapshot bytes |
+| `BeginAtomicRegion`/`EndAtomicRegion`/`Jump` entries (they mark skipped history; existing entries keep their indices) | Atomic-region logical idempotency counter (rebuilt from those entries during replay) |
+| Agent status **folded from the oplog** (`worker/status.rs`) | Status cache / checkpoints (baselines only) |
+| Persisted promises and scheduler actions (`WakeupScheduler`), `RunningWorkers` recovery index | Tokio timers, in-memory wake channels |
+
+Anything in the right column may be rebuilt from the left column at any time; a design that needs
+something from the right column to survive a restart is wrong. Sockets and other OS resources are
+recreated, not preserved (`durable_host/sockets`, `durable_host/http`); the application protocol
+must tolerate reconnect. Durable liveness also needs *rediscovery*: a timed wait schedules its
+wakeup as a persisted scheduler action first (`durable_host/suspendable_wait.rs`,
+`WakeupScheduler::sleep_until`), and the shard-keyed `RunningWorkers` index is updated
+synchronously so a crash/reshard can enumerate workers with pending work
+(`worker/status_flusher.rs`). The status blob cache is an asynchronously flushed baseline only.
+
+Two persistence steps matter for every crash window: **append** puts an entry in the oplog
+buffer; **commit** makes it recoverable (`commit_oplog_and_update_state(CommitLevel)`). The
+buffer is a performance trade-off (no storage round trip per append); where an entry must be
+recoverable before the executor proceeds — accepting remote work, `AgentInvocationFinished`
+before notifying waiters — the code commits explicitly. `CommitLevel` (`services/oplog/mod.rs`)
+says how strict that commit is: `Always` waits for durable storage; `DurableOnly` does so only
+for durable agents (`PrimaryOplog::commit` flushes everything; `EphemeralOplog` honours the
+level). Guarantees such as "accepted only after commit" refer to the commit, not the append.
+
+## Component map
+
+| Area | Files | Responsibility |
+|---|---|---|
+| Oplog model | `golem-common/src/base_model/oplog/{mod.rs,oplog_macro.rs}` | Entry kinds, `is_hint()`, Start/End pairing rules |
+| Replay cursor | `durable_host/replay_state/{mod.rs,cursor.rs,claims.rs}` | Single cursor lock, speculative read vs commit, identity claims, Replaying→Settling→Live |
+| Durable calls | `durable_host/concurrent/{mod.rs,call.rs,delivery.rs,replay.rs}` | `DurableCallSession` state machine, drop policies, completion delivery tokens |
+| Durability guard | `durable_host/durability.rs` | `begin_durable_function`/`end_durable_function`, `DurableFunctionType`, in-function retry |
+| Host context | `durable_host/mod.rs` | `prepare_instance`, `resume_replay`, `switch_to_live`, `PendingReplayToLive`, idempotency-key derivation, snapshot boundary checks |
+| Tail work | `durable_host/tail_work.rs` | Keeps store tasks running until no durable work is active before `AgentInvocationFinished` |
+| RPC | `durable_host/wasm_rpc/mod.rs` | Key derivation, first dispatch vs `MayExist`, replay claims, ephemeral phantom identity |
+| Worker | `worker/{mod.rs,invocation_loop.rs,lifecycle.rs,instance.rs,status.rs}` | Queue persistence, dedupe, interrupt/resume/update decisions, eviction, retry decisions |
+| Cut points | `worker/cut_point.rs` | Rejects revert/fork cuts that split a paired durable construct |
+| Durable streams | `durable_host/{durable_stream.rs,durable_session.rs,stream_session.rs,stream_bus.rs,stream_transport.rs,schema_value_stream.rs}` | Producer-oplog stream records, consumer session journal, exactly-once item delivery, protocol terminals |
+| Tool invocations | `durable_host/tool/{mod.rs,operation.rs,attachment.rs}`, `durable_host/entity.rs`, `worker/{entity_slot.rs,owner_lane.rs,entity_invocation.rs,instance.rs}` | Discovery/authorization, owner-oplog boundary for entity bodies, shared replay cursor, lane serialization, attachment memory admission |
+
+## Worker lifecycle and reconstruction
+
+`Worker` (`worker/mod.rs`) receives invocations, persists them, and processes them in order. The
+run loop (`worker/invocation_loop.rs::run`) is:
+
+```diagram
+┌─────────────────────────────────────────────────────────────────────┐
+│ outer loop (one iteration = one resident instance)                  │
+│  create Store + instance ──▶ prepare_instance                       │
+│    durable agent:  handle PendingUpdate ▸ try snapshot ▸ resume_replay│
+│    ephemeral:      replay first invocation only, append Restart     │
+│  ──▶ inner loop: pop durable queue, run invocation, persist Finished │
+│  ──▶ instance ends (idle / interrupt / trap / suspend)               │
+│  ──▶ RetryDecision: Immediate | Delayed | ReacquirePermits | None | TryStop │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+`resume_replay` (`durable_host/mod.rs`) loops `get_oplog_entry_agent_invocation_started`, replays
+each recorded invocation in `InvocationMode::Replay`, and when there is no further
+`AgentInvocationStarted` it switches to live. Replay starts from the chosen snapshot baseline
+(see Snapshots and updates), not necessarily from `OplogIndex::INITIAL`. Interruption kinds
+(`Worker::set_interrupting`): `Interrupt` stays interrupted, `Restart` is a simulated crash with
+automatic recovery, `Suspend` unloads and resumes on demand; all three end in the same
+reconstruction path. Eviction (`EvictionClass::{LoadedIdle, WarmRunnable}`) never unloads a
+worker that is executing or holds non-durable in-memory work. Ephemeral agents are fail-stop:
+`reconstructed_ephemeral` rebuilds only for observation and result lookup, "but the instance must
+never be started again" (`worker/mod.rs`, `INACTIVE_EPHEMERAL_AGENT_ERROR`).
+
+## Oplog model
+
+Entries are positional or hints (`OplogEntry::is_hint()`). Replay consumes positional entries in
+order and skips hints. Key kinds:
+
+- `Start { parent_start_index, observational_owner, request }` paired with
+  `End { start_index, response }` or `Cancelled { start_index, partial }`. A call is identified by
+  its `Start` index; `End`/`Cancelled` is its *terminal*. A terminal is *visible* when it lies
+  below the replay target and outside a `Jump`/`Revert`-skipped region
+  (`has_visible_terminal` / `visible_terminal_record`, `replay_state/cursor.rs`). Request-less Start/End pairs are *scopes* (batched writes, transactions),
+  named `<scope:batched-write>` or, when the caller supplies a discriminator,
+  `<scope:batched-write:DISCRIMINATOR>`; a discriminated claim matches only its exact name and
+  never falls back to a plain sibling scope (`execute_access_scope_start`, `concurrent/call.rs`).
+- `AgentInvocationStarted` / `AgentInvocationFinished` bracket one invocation;
+  `PendingAgentInvocation` (hint) is the durable queue entry.
+- `CompletionDelivered` / `CompletionDiscarded` (hints, always after their `End`) record the
+  guest-observation boundary of an accessor completion.
+- `HostStreamFrame` (hint): a frame of a host-owned stream (e.g. a p3 HTTP request body) attached
+  to its owning call by `parent_start_index`; consumers find frames by scanning, interrupted
+  recordings need no closing entry.
+- `BeginAtomicRegion` / `EndAtomicRegion`, `Jump`, `Revert`, `NoOp`.
+- `PendingUpdate`, `SuccessfulUpdate`, `FailedUpdate`, `Snapshot` (hint).
+- Lifecycle hints: `Suspend`, `Error`, `Interrupted`, `Exited`, `Restart`.
+
+Hints are skipped by `skip_forward` (the physical cursor moves past them, but
+`last_replayed_non_hint_index` does not), take part in no `Start`/terminal pairing, and never
+satisfy a claim. `Jump`/`Revert` do not relocate entries: they mark a region as skipped or deleted,
+and the atomic-region logical counter is rebuilt from them (see RPC section).
+
+## Durable host call lifecycle
+
+Every nondeterministic host function goes through `begin_durable_function` /
+`end_durable_function` (`durability.rs`). Concurrent (p3 accessor) calls run inside a
+`DurableCallSession` (`concurrent/call.rs`); the serialized p2 path uses
+`persist_durable_function_invocation` / `read_persisted_durable_function_invocation` with the same
+`Start`/`End` shape.
+
+Live (accessor path): append `Start` eagerly → run the live action → append `End` (or
+`Cancelled`) → hand the result to the guest → append `CompletionDelivered` (or
+`CompletionDiscarded` if the guest dropped the completion unread). The serialized direct path
+has no markers: its result is delivered when the host function returns. A trap while a call is
+in flight leaves `Start` incomplete (`abandon_for_trap`); a trap never writes `Cancelled`.
+
+Replay: claim the matching `Start` (`StartClaim`, identity + optional request payload match),
+resolve its terminal through `ConcurrentReplayResolver`, then classify with
+`classify_replay_resolution` (`concurrent/call.rs`), which is total and shared by every path:
+
+| Recorded | `ReplayedResolution` | Guest handoff |
+|---|---|---|
+| `End` + `CompletionDelivered` | `Delivered`, `AtMarker` | released exactly at the recorded marker boundary (`ReplayDeliveryBarrier` holds the cursor gate) |
+| `End`, no marker (accessor) | `Delivered`, `AtReplayTail` | crash after host completion, before observation: withheld until the cursor drains (`await_natural_tail_end`, `replay_state/resolution.rs`), then delivered live-armed; the effect is **not** re-run |
+| `Cancelled { partial: Some }` | `Delivered`, `Immediate` | guest-initiated, deterministic drop point; no gating |
+| `Cancelled { partial: None }` or `End` + `CompletionDiscarded` | `Undelivered` | the guest never saw a value; the future is parked for the guest's deterministic drop |
+| `Start` without terminal | `Incomplete` | see below |
+
+**Custom durable invocations** (`golem:durability/durability.begin-custom-durable-invocation`,
+`durability.rs::begin_custom_durable_invocation`) wrap a whole guest block as one logical durable
+operation. Completed: the recorded root result is returned and the body does not run (nested
+entries are consumed as a replay-inert subtree). Incomplete: the block goes live under its
+original root `Start` and the **whole body re-runs**, re-recording nested calls as new physical
+`Start`s. This is the one ordinary durable path where a completed nested effect legitimately
+repeats; the block author owns its idempotency (`reference/timelines.md` §15,
+`tests/durability.rs::custom_durability_crash_mid_live_invocation_reexecutes_whole_body`).
+
+`Incomplete` (`prepare_incomplete_live_repair`): the handle switches to live completion of the
+*existing* `Start` — no second `Start` is appended — if `can_reexecute_on_incomplete_replay`
+(`durability.rs`): `ReadLocal`, `ReadRemote`, `WriteLocal` always; `WriteRemote` only while the
+guest's idempotence mode is on (`assume_idempotence`, default `true`);
+`WriteRemoteBatched`/`WriteRemoteTransaction` never. Otherwise the session
+hard-errors and the enclosing durable scope's `ScopeReplayRecovery` decides whether recovery is
+possible; a hard error by itself is not a recovery.
+
+Host completion time and guest observation time are different facts. Only the second is a guest
+input, and only the second must recur exactly; the first may vary between runs.
+
+## Replay cursor, claims and strictness
+
+`ReplayCursor` (`replay_state/cursor.rs`) is the single chokepoint: `try_get_oplog_entry` reads
+speculatively, `commit_consumed_entry` commits, `move_replay_idx` advances and emits
+`ReplayFinished` exactly once. Concurrent accessor host calls may append `Start` entries in
+scheduling order that replay does not reproduce, so `claim_start_matching` claims the *first
+unclaimed matching* `Start` between cursor and target. That is the only justified use of
+scan-ahead: it routes concurrent completions to the right awaiter. It does not license the guest
+to make different calls; when no matching `Start` exists, replay fails with a divergence error.
+
+Tolerance machinery (poll-ID stabilisation, response reordering, synthesized readiness, "skip
+unmatched entries") hides the first real bug and must not be added.
+
+## Replay-to-live
+
+Three different facts are involved, each with its own owner:
+
+1. **Cursor exhaustion** — the recorded history has been consumed. An observation only.
+2. **Shared primary publication** — `transition_phase` moves Replaying → Settling → Live
+   (`replay_state/cursor.rs`). `ReplayState::switch_to_live` with `ReplayToLiveRole::PrimaryAgent`
+   runs `begin_primary_settling`, then `finish_settling_to_live` loops until every
+   `HistoricalReconstruction` fence has validated and `CursorTx::finish_primary_settling`
+   publishes Live (or reports `ReplayResumed` when new history appeared).
+3. **Entity-local liveness** — `store_is_live(mode, local_live_tail, shared_live_published)`
+   (`durable_host/mod.rs`): the primary Store is live iff (2) has published; a
+   `ReplayingCompleted` entity Store is never live; a `ReplayingIncomplete`/`Live` entity Store is
+   live iff its own `local_live_tail` is set by `PendingReplayToLive::finish` (`#[must_use]`).
+   For `ReplayToLiveRole::NonPrimary`, `switch_to_live` skips (2): the entity Store goes live for
+   its own invocation scope (after attachment admission) without waiting for the primary.
+
+Tests: `entity_store_liveness_is_scoped_to_its_invocation_mode`,
+`pending_replay_to_live_is_fail_closed_until_finished`,
+`replay_state/tests.rs::switch_to_live_wakes_parked_awaiter_as_incomplete`,
+`tests/tool_streaming.rs::completed_reconstruction_claim_blocks_concurrent_replay_to_live`.
+
+Consequences: a host function must not perform a live effect because "the cursor is at the end";
+it must observe `is_live` from the durable context. A markerless `End` is delivered once the
+cursor drains (`await_natural_tail_end`) with a live-armed delivery token
+(`CompletionDelivery::prepare_delivery`), which makes "crash after End, before delivery" safe
+without re-executing.
+
+## Invocation queue and results
+
+`enqueue_worker_invocation_with_effect` (`worker/mod.rs`): dedupe via `lookup_invocation_result`
+(anything other than `LookupResult::New` returns without appending), then append
+`PendingAgentInvocation` and commit before the caller learns the invocation was accepted. The
+invocation loop appends `AgentInvocationStarted`, runs the guest, and
+`on_agent_invocation_success` (`durable_host/mod.rs`) appends `AgentInvocationFinished` with the
+result and commits with `CommitLevel::Always` *before* waiters are notified; failures go through
+`on_invocation_failure`. During replay the recorded result is compared with the recomputed one
+(`replay_equivalent`); a mismatch is an `unexpected_oplog_entry` determinism error. Tail work
+(`durable_host/tail_work.rs`) keeps the store loop running until no spawned task is still
+*active*, so a task's positional `Start`/`End` never lands after `AgentInvocationFinished`
+(tasks parked at guest-driven safe park points may span invocations). Hints can follow
+`Finished`: `invocation_loop.rs::agent_invocation_finished` completes the streaming session
+(protocol terminals, `StreamSession { Finished }`) after `on_agent_invocation_success`.
+
+Test: `tests/api.rs::invoking_with_same_idempotency_key_is_idempotent_after_restart` — after an
+executor restart, an old key returns the recorded result without re-running the guest.
+
+## Durable RPC exactly-once
+
+1. The caller opens a durable call; its `Start` index `begin_index` is the call identity.
+2. `derive_idempotency_key(begin_index)` (`durable_host/mod.rs`) yields
+   `IdempotencyKey::derived(current_key, current_idempotency_key_oplog_index(begin_index))`. Inside
+   an atomic region the index is the outermost region's *logical* counter
+   (`next_idempotency_key_oplog_index`), not the physical index, because a rollback re-executes
+   the region at new physical positions and must not mint a new key. The streaming RPC path
+   (`prepared.is_streaming()` in `wasm_rpc/mod.rs`) instead derives
+   `IdempotencyKey::derived(&parent_key, handle.start_index())` from the physical index — a
+   discrepancy with the non-streaming path worth investigating before relying on streaming RPC
+   keys inside atomic regions.
+3. Caller state that the target may depend on is committed before the first dispatch.
+4. The target persists `PendingAgentInvocation` (durable acceptance) and later
+   `AgentInvocationFinished`; same-key arrivals attach to that one invocation/result.
+5. Replay of a completed call returns the recorded `End`; replay of an incomplete call (`Start`
+   without `End`) re-dispatches with the **same** key (`InvocationFreshnessDisposition::MayExist`,
+   the default). RPC is a `WriteRemote` call, so this repair is allowed by the idempotence mode
+   (`assume_idempotence`, default `true`; `golem:api/host.set-idempotence-mode(false)` turns it
+   off, after which an incomplete remote write fails instead of being re-dispatched).
+6. `KnownFresh` is allowed only when `is_live && is_ephemeral && !assume_idempotence`
+   (`wasm_rpc/mod.rs`) and forces a `DurableOnly` commit before dispatch. Ephemeral phantom
+   identity is `ephemeral_invocation_phantom_id` = UUIDv5 of the idempotency key — deterministic,
+   never random.
+
+Exactly-once describes the *target's logical execution and effect*. It does not describe caller
+attempts, packets, or replay spans. Tests: `tests/rpc.rs::counter_resource_test_2_with_restart`
+(counter continues 1 → 2 across a caller restart, so the recorded call is not re-executed),
+`failed_ephemeral_invocation_retry_does_not_reexecute`,
+`ephemeral_rpc_invocations_get_distinct_final_identities`,
+`reacquire_permits_restart_preserves_accepted_queued_live_invocation`, and
+`tests/api.rs::lost_card_transfer_response_converges_after_source_and_target_restart` (a wrapped
+worker proxy drops the response; after both sides restart the proxy has seen *two* identical
+attempts while the target oplog holds exactly one `CardTransferred` — attempts ≠ executions).
+
+Ephemeral targets are deliberately fail-stop: a same-key retry does not re-execute accepted
+incomplete work, but eventual completion is not guaranteed because the target has no durability
+to resume from. An agent calling itself is rejected ("RPC calls to the same agent are not
+supported"); an entity body's synchronous call into its owner must pass
+`OwnerLane::ensure_synchronous_owner_call` (`WouldDeadlock` otherwise).
+
+## Snapshots and updates
+
+Snapshot save/load runs guest code in a third mode: it neither appends nor consumes durable-call
+oplog entries (`DurableCallSession` created with `persisted: false`; `durability_is_suppressed`
+is exactly `snapshotting_mode`).
+
+Which history the new instance replays is decided in `Worker` construction (`worker/mod.rs`,
+`component_version_for_replay`): the last manual-update snapshot is the baseline; a
+revision-matching automatic snapshot overrides it and skips `INITIAL+1..=snapshot_idx`, but only
+while no update is pending and `snapshot_recovery_disabled` is unset. `prepare_instance`
+(`durable_host/mod.rs`) then branches on `PendingUpdate`:
+
+- `SnapshotBased` — the save hook already ran and the payload is already recorded; the store must
+  already be live, and `finalize_pending_snapshot_update` loads it into the new revision.
+- `Automatic` — `try_load_snapshot` loads the baseline, then `resume_replay` replays the remaining
+  old history against the new component; success is recorded during that replay. If replay fails
+  while the update is still pending, `on_worker_update_failed` appends `FailedUpdate` and returns
+  `RetryDecision::Immediate` so the worker rebuilds on the old revision.
+- No pending update — `try_load_snapshot`; on `Failed`, set the resident `Worker`'s
+  `snapshot_recovery_disabled` flag and retry immediately with full replay.
+
+`SnapshotBoundaryConditions` lists what blocks taking a snapshot: replaying, open atomic region,
+open durable scope, snapshotting already, in-flight live host call. Automatic snapshots are
+revision-scoped and ignored once the revision changes.
+
+Resetting a cursor is not recreating an instance: component metadata, revision and plugin context
+come from instance creation. When history or provenance changes, go through the outer loop.
+
+## Concurrency and guest completion delivery
+
+p3 `Accessor` host calls run concurrently inside one `Store`; p2 `&mut self` calls are serialized
+(`concurrent/mod.rs`). Concurrent completions may finish in any host order, but the guest observes
+them in exactly one order per run, and that order is recorded by the `CompletionDelivered` markers.
+`ReplayDeliveryBarrier` transfers the cursor gate so replay releases each completion at its
+recorded boundary. `supersede_prior_completion_delivery` hard-errors if an observer is still armed:
+delivery must be the tail operation of a host function. Tests: `tests/concurrent_delivery_order.rs`
+(bare Wasmtime: guest initiation order is stable across re-execution while host completion order
+is not — the properties replay relies on), `replay_state` unit tests
+`switch_to_live_wakes_parked_awaiter_as_incomplete`, `await_natural_tail_end_returns_once_tail_drains`.
+
+Spawned store tasks that outlive an invocation are safe only while parked at a guest-driven wait
+(`tail_work.rs` "safe park points"); pending durable work must finish before `AgentInvocationFinished`.
+
+## Streaming invocations
+
+A streaming RPC is an ordinary durable RPC whose method carries input or output streams
+(`remote_method_uses_streams`, `wasm_rpc/mod.rs`). Three facts prevent most mistakes:
+
+- **Two journals are authoritative, nothing else.** The producer's oplog holds
+  `StreamRegistered`/`StreamItems`/`StreamEnd`/`StreamCancel` (`durable_stream.rs`), committed
+  *before* publication to `DurableLiveStreamBus` (a bounded live-tail optimization). The
+  consumer's `StreamSession` journal (`durable_session.rs`) holds attempts, offset mappings,
+  terminals and `Finished`. All are hints. Buses, readers, sockets and attachments are recreated.
+- **Delivery is by offset, identity is by fingerprint.** A restarted consumer replays its journal
+  by `consumer_read_ordinal`, then reads producer segments after the last `source_offset`. The
+  producer is pinned by `AgentFingerprint`; a recreated agent with the same `AgentId` is rejected
+  (`validate_forwarded_mapping`, `CorruptHistory`).
+- **RPC result and stream draining are separate.** The caller's durable call completes with the
+  result *stripped of streams*, so the RPC `End` may be recorded while items still flow.
+  Streaming keys derive from the physical `Start` index (see RPC section). Terminals are
+  finalized exactly once; a protocol terminal fences later guest terminals.
+
+Tests: `tests/rpc.rs::durable_streaming_{output,input}_recovers_after_executor_restart`; full
+mechanics and crash windows: `reference/streams.md`.
+
+## Tool invocations and entity bodies
+
+`durable_host/tool/mod.rs` implements `golem:tool/host@0.1.0`. Tool bodies (sidecars, middleware)
+are *entity bodies*: guest code in its own Wasmtime `Store` with **no oplog or cursor of its own**
+(`durable_host/entity.rs`). They record into the owner's oplog and share its `ReplayState`
+cursor (`OwnerExecution`, `worker/instance.rs`).
+
+- `dispatch_tool_call` claims (replay) or creates (live) an `EntityInvocationDurability`, a
+  `DurableCallSession<GolemEntityInvoke, LeaveIncompleteOnDrop>` in the owner's oplog. Its
+  `Start` index is the entity invocation id; body host calls carry `parent_start_index`.
+- `InvocationExecutionMode` comes from `has_visible_terminal(start_index)`.
+  `ReplayingCompleted` **re-executes the body's guest export** (`invoke_tool_sidecar`) with its
+  durable host calls replayed from the owner oplog, then validates the claim
+  (`StartClaim::owned_tool_invocation`) and releases the recorded terminal: no repeated external
+  effect, but a second guest call. The body is re-executed rather than replaced by its recorded
+  result because the entity Store shares the agent's filesystem (attached to the owner's
+  `AgentFilesystem` generation via `OwnerRuntimeResources`): files the body wrote are agent
+  state and must be reapplied for the agent's own replay to see them; `OwnerLane` therefore
+  serializes filesystem-capable bodies. Exception: a terminal recorded with
+  `body_execution: Skipped` is returned without invoking the export.
+- `HistoricalReconstruction` fences keep the primary's `PendingReplayToLive` fail-closed until
+  every completed body has validated (`completed_reconstruction_claim_blocks_concurrent_replay_to_live`).
+- A body trap fails the owner invocation without inventing entity terminals.
+
+Tests: `tests/tool_streaming.rs::deterministic_stream_crash_checkpoint_matrix` and the list in
+`reference/tools.md` (which also covers scheduling and memory admission).
+
+## External-effect boundaries
+
+| Peer | Guarantee | Who enforces it |
+|---|---|---|
+| Durable Golem agent (RPC) | Exactly-once logical invocation and result | Target's durable queue + shared key |
+| Ephemeral Golem agent (RPC) | At-most-once per accepted invocation; no resumption after target loss | Fail-stop target, deterministic phantom id |
+| Oplog-processor plugin | Exactly-once delivery of each oplog batch | `services/oplog/plugin.rs`: deterministic batch key (`oplog_processor_idempotency_key`: source agent, grant id, first/last index → UUIDv5) and per-plugin `confirmed_up_to`/`sending_up_to` checkpoints persisted in `AgentStatusRecord.oplog_processor_checkpoints` |
+| External HTTP/TCP/DB/etc. | Exactly-once only if the peer honours an idempotency key; otherwise retries in the ambiguous crash window are visible | Golem attaches an `idempotency-key` header to outgoing HTTP from `derive_idempotency_key(begin_index)` (`http/policy.rs`, unless the guest set one) and offers `golem:api/host.generate-idempotency-key`; the peer must deduplicate; atomic regions group calls |
+
+Four exactly-once contracts coexist and must not be conflated: RPC exactly-once (one logical
+target invocation per key), oplog-processor delivery (batch key + checkpoints), stream-item
+exactly-once (each `StreamOffsetV1` consumed once per consumer session, owned by
+`durable_stream.rs`/`durable_session.rs`), and exactly-once finalization (one terminal per
+stream, protocol terminal fencing guest terminals). A change that
+satisfies one does not imply the others.
+
+## Wrong model → right model
+
+| Wrong | Right | Fails under wrong model |
+|---|---|---|
+| "HashMap iteration / poll order makes the guest nondeterministic, so replay must tolerate different calls." | Guest inputs are recorded; same inputs ⇒ same calls. Different calls = executor bug. | `no matching Start` / `unexpected_oplog_entry` errors in replay tests |
+| "Cursor reached the end, so I can do the live effect now." | Liveness is `store_is_live(...)`: the primary needs `switch_to_live` to publish after reconstruction fences; an entity Store needs its own `local_live_tail`. Cursor exhaustion is neither. | `pending_replay_to_live_is_fail_closed_until_finished`, `entity_store_liveness_is_scoped_to_its_invocation_mode` |
+| "Suspension needs a feature-specific safety gate proving the guest is parked." | Arbitrary unload is the baseline; every obligation must be durable or reconstructible. | Simulated-crash tests at arbitrary points (`simulated_crash`, `interrupt`) |
+| "Restart differs from suspend." | Both discard the `Store` and reconstruct. | `counter_resource_test_2_with_restart` (state continues across an executor restart), `reacquire_permits_restart_preserves_accepted_queued_live_invocation` |
+| "A retried RPC attempt executed the target again." | Same key ⇒ same target invocation; count target mutations, not attempts. | Provider-side counter tests in `tests/rpc.rs` |
+| "Atomic rollback should generate a fresh RPC key." | Logical counter is owned by the outermost atomic region; keys survive `Jump`. | `tests/transactions.rs`, `tests/revert.rs` |
+| "Equal return values prove deduplication." | Deterministic echoes are equal even with duplicate execution; count side effects. | Counter-based RPC tests |
+| "A snapshot load is just a fast-forwarded replay, so its host calls are recorded/consumed like any other." | Snapshotting mode (`durability_is_suppressed`) neither appends nor consumes; the loaded state replaces skipped history from a revision-scoped baseline. | `tests/hot_update.rs::{auto_update_invalidates_snapshot_from_previous_revision, automatic_snapshot_invalid_entry_fallback_recreates_replay_context}` |
+| "Spawned continuations can live in Store memory after the invocation finished." | Store memory is disposable; only oplog-backed work survives. | Restart tests after `AgentInvocationFinished` |
+| "Rewinding the cursor recreates the worker." | Only the outer loop recreates metadata/revision context. | `tests/hot_update.rs::snapshot_after_auto_update_recovers_with_updated_component_context` |
+| "The stream bus / socket is where stream items live; losing a reader loses items." | Producer oplog is authoritative; the bus is a live-tail optimization over committed records; consumers resume by offset. | `durable_streaming_output_recovers_after_executor_restart`, `callee_recovery_continues_output_after_committed_item` |
+| "A stream reference stays valid as long as the target agent id exists." | Liveness is bound to the durable `AgentFingerprint`; a recreated agent is a different producer. | Fingerprint-mismatch unit tests in `durable_session.rs` / `durable_stream.rs` |
+| "A completed tool replay either skips the body entirely, or must redo its external effects." | The body's guest export is re-executed; its durable host calls replay from the owner oplog; the recorded terminal is validated and released. No repeated external effect. | `completed_tool_replay_bypasses_current_attachment_memory_pressure`, `deterministic_stream_crash_checkpoint_matrix` |
+| "An entity body has its own oplog and cursor." | Bodies record into the owner oplog under `parent_start_index` and share the owner's cursor. | `concurrent_tool_attempt_identity_survives_reordered_admission_and_replay` |
+| "`AttemptId::fresh()` in a replay-sensitive path breaks determinism." | Randomness is fine when appended and committed before observation and read back on replay. | Consumer-journal replay in `durable_session.rs` |
+
+## Retries: in-function versus trap-based
+
+A failed durable call has two recovery paths (`durable_host/durability.rs`):
+
+- **In-function retry** re-runs the effect inside the same host call under the same `Start`.
+  `InFunctionRetryState::decide_retry_with_properties` allows it only when the function type is
+  `is_eligible_for_internal_retry` (`ReadLocal`/`ReadRemote`/`WriteLocal`; `WriteRemote` only
+  with `assume_idempotence`; batched/transaction writes never — the same set as
+  `can_reexecute_on_incomplete_replay`), the call is not inside an atomic region, the resolved
+  `NamedRetryPolicy` still permits an attempt, and the delay is ≤ `max_in_function_retry_delay`.
+  Each attempt appends and commits an `OplogEntry::Error { retry_from, .. }` hint.
+- **Trap-based retry** is the fallback (`FallBackToTrap`/`Exhausted` →
+  `try_trigger_host_trap_retry`): the invocation traps, `on_invocation_failure` produces a
+  `RetryDecision`, and the whole worker is reconstructed and replayed to `retry_from`.
+
+In-function retry is the large optimisation over trap-based reconstruction; a new or changed
+durable function must pick its `DurableFunctionType` with that eligibility in mind. Decision
+table and tests: `reference/retries.md`.
+
+## Review checklist for executor changes
+
+1. Does every new nondeterministic host interaction go through `begin_durable_function` and a
+   `DurableCallSession`, with a `DurableFunctionType` chosen for both its incomplete-replay
+   re-execution and its in-function retry eligibility (the same predicate)?
+2. Does the replay path claim by identity and fail on missing `Start` rather than skipping?
+3. Is guest observation recorded (`CompletionDelivered`/`Discarded`) as the tail op of the host
+   function, and is the replay boundary preserved?
+4. Is any live effect gated on published liveness, not cursor position?
+5. After an arbitrary `Store` loss at any point, is every obligation either in the oplog or
+   deterministically recomputable from it? List the crash windows explicitly.
+6. Is every identity that replay must reproduce derived from oplog indices, keys or *recorded*
+   values? Randomness is fine only when appended and committed before the guest can observe it
+   and read back on replay; unrecorded guest-observable randomness is a bug.
+7. Does acceptance of remote work return only after `PendingAgentInvocation` is committed?
+8. Does the change alter oplog shape? Audit every consumer — `is_hint()`, the WIT `oplog-entry`
+   types, cut-point validation (`worker/cut_point.rs`, which also refuses to cut between an `End`
+   and its delivery marker), status folding (`worker/status.rs`), public oplog rendering.
+
+## Debugging workflow
+
+1. Get the oplog: test DSL `get_oplog` / `search_oplog`
+   (`golem-test-framework/src/dsl/mod.rs`), or `golem-cli agent oplog`. Locate the last
+   `AgentInvocationStarted`, then walk `Start`/`End`/marker pairs.
+2. Classify the failure:
+   - `unexpected_oplog_entry` / no matching `Start` → determinism break. Find which host input
+     differed (missing recording, wrong request-identity match, delivery at wrong boundary).
+   - Hang in replay → an awaiter waiting for a terminal that is not in history or a delivery
+     gate never released; check `ReplayDeliveryBarrier` and `switch_to_live_wakes_parked_awaiter`.
+   - Live effect during replay → liveness read from the wrong place; check `store_is_live`.
+   - Duplicate side effect → key derivation or acceptance ordering; compare keys across attempts.
+3. Reproduce with a real reconstruction (`simulated_crash`, or executor drop + restart via
+   `start_with_overrides`), injecting the failure at the exact window with
+   `TestExecutorOverrides` — see `reference/testing-patterns.md`. Never a cursor reset.
+4. Fix the recording/reconstruction bug. Do not add tolerance to replay.
+
+Use the `testing` skill to run tests and `debugging-hanging-tests` for stuck runs.

--- a/.agents/skills/understanding-durable-execution/reference/crash-matrix.md
+++ b/.agents/skills/understanding-durable-execution/reference/crash-matrix.md
@@ -1,0 +1,107 @@
+# Crash-window matrix
+
+"Crash" here means any loss of the resident runtime: process death, `Restart` (simulated crash),
+`Suspend`, eviction, resharding (`on_shard_assignment_changed`), or an executor drop in a test.
+Reconstruction is identical in every case: new `Store`, `prepare_instance`, `resume_replay`,
+publish Live. The matrix says what the next incarnation does for a crash inside each window and
+which durable fact makes that safe.
+
+## Durable host call (`concurrent/call.rs`, `concurrent/delivery.rs`)
+
+| Crash window | Oplog shape left behind | Reconstruction behaviour | Durable fact relied on |
+|---|---|---|---|
+| Before `Start` is appended | nothing | Guest replays to this point and issues the call live for the first time | Guest determinism reaches the same call |
+| After `Start`, before the live effect | `Start` only | `Incomplete`: re-executable types (`ReadLocal`/`ReadRemote`/`WriteLocal`, `WriteRemote` while idempotence mode is on) run the action under the existing `Start`; non-idempotent / batched / transactional writes hard-error into durable-scope recovery (`ScopeReplayRecovery`) | `DurableFunctionType` chosen at the call site |
+| After the effect, before `End` | `Start` only | Same as above. For external peers this is the ambiguous window: the effect may have happened; the peer must be idempotent | Peer-side idempotency, not Golem |
+| After `End`, before guest observation | `Start`, `End` | `Delivered`/`AtReplayTail`: result withheld until the cursor drains, then delivered live-armed; no re-execution | `End` payload |
+| After `CompletionDelivered` | `Start`, `End`, marker | `Delivered`: result released at the recorded boundary | Marker position |
+| Guest dropped the future before completion | `Start`, `Cancelled { partial }` | `partial: Some` → `Delivered`/`Immediate`; `partial: None` → `Undelivered` (parked for the guest's deterministic drop) | `Cancelled` entry |
+| Guest dropped the completion after `End` without reading it | `Start`, `End`, `CompletionDiscarded` | `Undelivered`: parked, the guest drops at the same point | Marker |
+| Guest trapped mid-call | `Start` only | Same as "after Start" — trap is never `Cancelled` | `abandon_for_trap` |
+
+## Invocation (`worker/mod.rs`, `durable_host/mod.rs::on_agent_invocation_success`)
+
+| Crash window | Oplog shape | Reconstruction behaviour | Durable fact |
+|---|---|---|---|
+| Before `PendingAgentInvocation` commits | nothing | Caller was never told "accepted"; retrying with the same key enqueues once | Acceptance returns only after commit |
+| After `PendingAgentInvocation`, before `AgentInvocationStarted` | pending hint | Status fold sees the pending invocation; the invocation loop runs it | Status is folded from the oplog (`worker/status.rs`) |
+| Mid-invocation | `Started` + prefix of calls | Prefix replays, guest continues live from the tail | Every host input in the prefix is recorded |
+| After `AgentInvocationFinished` commits, before waiters are notified | `Finished` | `lookup_invocation_result(key)` returns the recorded result; the guest does not run | `CommitLevel::Always` before notification |
+| Spawned store task still active at finish | must not happen | `tail_work.rs` blocks `Finished` until no task is active (bounded by tail-drain timeout) | `AgentInvocationFinished` is the last *positional* entry of the invocation; hints (stream session completion) may follow |
+
+## Durable RPC (`durable_host/wasm_rpc/mod.rs`)
+
+| Crash window (caller) | Caller oplog | Reconstruction behaviour | Durable fact |
+|---|---|---|---|
+| Before caller `Start` | nothing | First dispatch happens on replay-to-live; one key, one target invocation | Key derived from `Start` index |
+| After caller `Start`, before target accepted | `Start` | Re-dispatch with same key (`MayExist`); target sees it as new and executes once | Same key |
+| After target accepted, before caller `End` | `Start` | Re-dispatch with same key; target's `lookup_invocation_result` attaches to the existing invocation/result | Target `PendingAgentInvocation` |
+| After caller `End` | `Start`, `End` | Recorded response returned; no dispatch | `End` payload |
+| Atomic-region rollback around the call | `Jump` + re-executed `Start` | Same logical counter → same key → target dedupes (non-streaming path; the streaming path keys from the physical index, see SKILL RPC section) | `next_idempotency_key_oplog_index` |
+
+| Crash window (target) | Target behaviour | Durable fact |
+|---|---|---|
+| Durable target before `PendingAgentInvocation` commits | Caller retry re-enqueues once | Acceptance after commit |
+| Durable target mid-invocation | Target replays its own prefix and finishes; caller retry attaches | Target oplog |
+| Ephemeral target lost after acceptance | Fail-stop: no resumption, same-key retry does not re-execute; caller receives an error, not a duplicate | `reconstructed_ephemeral`, deterministic phantom id |
+
+## Snapshots and updates (`durable_host/mod.rs::prepare_instance`, `worker/lifecycle.rs`)
+
+| Crash window | Reconstruction behaviour | Durable fact |
+|---|---|---|
+| After `PendingUpdate`, before the update runs | `prepare_instance` sees the pending update and starts it | `PendingUpdate` hint |
+| Snapshot load fails for an automatic update | `FailedUpdate` appended, `RetryDecision::Immediate`, old revision reconstructed | Old oplog is untouched by snapshotting mode |
+| Snapshot load fails with no pending update | Resident `Worker.snapshot_recovery_disabled` set, `RetryDecision::Immediate`, full replay from the manual baseline | Baseline chosen at instance creation |
+| Replay under the new component diverges | `FailedUpdate` appended, `RetryDecision::Immediate`, old revision reconstructed | `FailedUpdate` |
+| After `SuccessfulUpdate` | New revision loaded on every later reconstruction; automatic snapshots from the old revision fail the revision filter and are ignored | `SuccessfulUpdate`, revision-scoped snapshots |
+| `SnapshotBased` update pending across a crash | Save hook already ran and payload is recorded; the new instance must be live at `prepare_instance`, then `finalize_pending_snapshot_update` loads it | Recorded snapshot payload |
+| Snapshot requested at an unsafe boundary | Rejected with the blocking `SnapshotBoundaryConditions` reason; never partially taken | Boundary predicate |
+
+## Replay-to-live (`replay_state/mod.rs`, `durable_host/mod.rs::PendingReplayToLive`)
+
+| Situation | Behaviour | Durable fact |
+|---|---|---|
+| Cursor exhausted, reconstruction validation pending | Phase `Settling`; `finish_settling_to_live` loops until every `HistoricalReconstruction` fence validates; live effects still refused | Only `CursorTx::finish_primary_settling` publishes the shared flag |
+| Non-primary entity store reaches its own tail | Does not wait for the primary: `PendingReplayToLive::finish` (`NonPrimary`) sets its `local_live_tail` after attachment admission; `store_is_live` is per-Store | `ReplayToLiveRole`, `local_live_tail` |
+| Awaiter parked on a terminal that never comes | `switch_to_live` wakes it as `Incomplete` (re-execute if allowed) | Replay target index |
+| Recorded delivery cannot be reproduced | `delivery_failure` poisons replay; reconstruction fails loudly instead of diverging | Marker semantics |
+
+## Durable streams (`durable_host/durable_stream.rs`, `durable_session.rs`, `stream_bus.rs`)
+
+| Crash window | Oplog shape | Reconstruction behaviour | Durable fact |
+|---|---|---|---|
+| Producer after committing `StreamItems`, before bus publication | producer: `StreamItems` | Items are already durable; consumers catch up by offset from producer segments | Commit precedes `publish_committed` |
+| Producer between guest write and `StreamItems` commit | producer: previous items only | Producer replays and the guest re-drives the write; sequence continues from the last committed `first_sequence` | Guest determinism + committed sequence |
+| Consumer after `ConsumerItemValue`, before the guest observed it | consumer: journal record | Journal replays by `consumer_read_ordinal`; the item is delivered once from the journal, not refetched | `consumer_read_ordinal` / `source_offset` |
+| Consumer bus reader closed (socket, executor loss) | consumer journal up to last offset | Resubscribe samples high-water under the publication lock; overlap discarded by offset; gap filled from producer segments | Offsets, not connection state |
+| Producer deleted and recreated with same `AgentId` | new producer has a new `AgentFingerprint` | Fingerprint checks (`validate_forwarded_mapping`, producer-side `CorruptHistory`) reject the session; the consumer never sees a spliced stream | Fingerprint pinned at registration |
+| Caller RPC `End` recorded, stream still draining | caller: `Start`, `End`; journals partial | Recorded RPC result returned; stream resumes by offset from the journals | Result completed stripped of streams |
+| Producing invocation ends with streams open | `AgentInvocationFinished` then protocol terminals | Open inputs protocol-cancelled, open outputs protocol-ended with error context, then `Finished`; a later guest terminal is fenced | `authored_by: Protocol` terminal ordering |
+| Caller before `CallerAttempt` commit | nothing | `caller_attempt_id` mints once and commits before use | Recorded-before-observed randomness |
+
+## Tool invocations / entity bodies (`durable_host/entity.rs`, `durable_host/tool/`)
+
+| Crash window | Owner oplog shape | Reconstruction behaviour | Durable fact |
+|---|---|---|---|
+| After discovery/authorization, before entity `Start` | discovery/authorization `Start`/`End` pairs only | Owner replays to the call; those reads replay; `dispatch_tool_call` appends the entity `Start` live (there is no outer `call-tool` `Start`) | Guest determinism reaches the same call |
+| After entity `Start`, before body terminal | entity `Start` (+ body's own `Start`/`End` pairs with `parent_start_index`) | `ReplayingIncomplete`: body Store recreated sharing the owner cursor; body's completed calls replay, then the body goes live after `activate_live_attachment_memory_accounting` admits it; terminal appended under the original `Start` | `LeaveIncompleteOnDrop` leaves no fake terminal |
+| After body terminal, before the owner observed it | entity `Start` … `End`/`Cancelled` | `ReplayingCompleted`: the body's guest export runs again with its host calls replayed from the owner oplog; recorded terminal released by `drive_access` after reconstruction validates the claim; no repeated external effect | `StartClaim::owned_tool_invocation` |
+| Live attachment memory exhausted during incomplete replay | rejection persisted | The rejection is durable; later replays do not retry admission | `incomplete_tool_replay_persists_attachment_upgrade_rejection` |
+| Body traps | no entity terminal | Owner invocation fails; owner group drains; siblings blocked on the lane are fenced | `guest_trap_fences_a_blocked_sibling_and_drains_the_owner_group` |
+| Owner reaches replay tail while a body is still reconstructing | — | `HistoricalReconstruction` fences keep `PendingReplayToLive` closed until every active body validates | `completed_reconstruction_claim_blocks_concurrent_replay_to_live` |
+
+## Oplog-processor plugins (`services/oplog/plugin.rs`)
+
+| Crash window | Recovery |
+|---|---|
+| Batch sent, plugin not confirmed | `sending_up_to` is not persisted as confirmed; the batch is re-sent with the same deterministic key (`oplog_processor_idempotency_key`: source agent, grant id, first/last index → UUIDv5), so the processor deduplicates |
+| Plugin confirmed, checkpoint not persisted | Same re-send with the same key; `confirmed_up_to` is seeded from `AgentStatusRecord.oplog_processor_checkpoints` on reload |
+
+## External effects (not covered by Golem guarantees)
+
+| Effect | Ambiguous window | What Golem provides | What the application must provide |
+|---|---|---|---|
+| HTTP request | Between send and `End` | Re-execution policy via `DurableFunctionType`; atomic regions to group calls; an `idempotency-key` header derived from the call's durable position (`http/policy.rs`, on unless the guest set one) or minted via `golem:api/host.generate-idempotency-key` | A peer that deduplicates on the key; otherwise a safe-to-retry design |
+| TCP / WebSocket connection | Any crash | Recreated socket; recorded bytes replay to the guest | Reconnect / resume protocol |
+| Filesystem, stdio | Any crash | Recorded stream chunks replay; live tail continues | Nothing for replay; effects outside the worker filesystem are the app's problem |
+| Key-value / blob store | Between write and `End` | Same as HTTP; writes are re-executable when idempotent by construction | Value-level idempotency for non-idempotent writes |

--- a/.agents/skills/understanding-durable-execution/reference/retries.md
+++ b/.agents/skills/understanding-durable-execution/reference/retries.md
@@ -1,0 +1,72 @@
+# Retries: in-function versus trap-based
+
+Owner: `golem-worker-executor/src/durable_host/durability.rs` (decision and inline loop),
+`durable_host/mod.rs::on_invocation_failure` (post-trap recovery decision),
+`worker/status.rs` (folds `OplogEntry::Error` into `current_retry_state`, keyed by `retry_from`).
+
+## Two paths, one budget
+
+A durable host call that fails with a retryable error can recover in two ways:
+
+| | In-function (inline) retry | Trap-based retry |
+|---|---|---|
+| Where | Inside the same host function, under the **same** `Start` | The invocation traps; the worker is torn down and reconstructed |
+| Oplog | Appends and commits one `OplogEntry::Error { retry_from, inside_atomic_region, retry_policy_state }` hint per attempt (`InFunctionRetryHost::append_retry_error_entry`) | Appends `OplogEntry::Error` in `on_invocation_failure`, then the outer loop replays to `retry_from` |
+| Cost | A sleep and a second live action | Full `Store` teardown, instance creation, replay of all history since the last baseline |
+| Decided by | `InFunctionRetryState::decide_retry_with_properties` → `AsyncRetryDecision::{Retry, FallBackToTrap, Exhausted}` | `try_trigger_host_trap_retry` attaches a `SemanticTrapRetryOverride`; `on_invocation_failure` turns it into a `RetryDecision` (`Immediate`, `Delayed`, `None`, …) |
+
+The two paths share one retry budget: `retry_count` (in-memory attempts of this host call) plus
+the number of recorded `Error` entries with the same `retry_from`
+(`count_oplog_errors_for`, `current_retry_state_for`). After a trap and replay the in-memory
+count resets but the oplog count does not, so a policy exhausted inline stays exhausted.
+
+## When inline retry is allowed
+
+`decide_retry_with_properties` returns `Retry(delay)` only when all of these hold:
+
+1. The function type is eligible (`is_eligible_for_internal_retry`):
+   - `ReadLocal`, `ReadRemote`, `WriteLocal` — always;
+   - `WriteRemote` — only while the guest's idempotence mode is on (`assume_idempotence`);
+   - `WriteRemoteBatched` / `WriteRemoteTransaction` — never (the enclosing scope owns recovery).
+   This is deliberately the same predicate as `can_reexecute_on_incomplete_replay`: a call that
+   may be re-run when its `End` is missing after a crash may also be re-run inline.
+2. The call is not inside an atomic region (`in_atomic_region()` → `FallBackToTrap`, because the
+   region's rollback semantics must own the re-execution).
+3. A `NamedRetryPolicy` resolves for the call's `RetryProperties` and its step verdict is
+   `Retry(delay)` rather than `GiveUp` (→ `Exhausted`).
+4. `delay <= max_in_function_retry_delay` (config); a longer wait falls back to the trap path so
+   the worker can be unloaded instead of holding a resident `Store` idle.
+
+Otherwise `FallBackToTrap` calls `try_trigger_host_trap_retry`; if that finds no applicable
+policy, the failure is persisted as the call's result (`InternalRetryResult::Persist`).
+
+Spawned store tasks use the same decision but `FallBackToTrap` there means "stop inline retries
+and let the invocation loop's trap path take over" (`durability.rs`, spawned-task section).
+
+## What this means for a new durable function
+
+- Pick the `DurableFunctionType` for its **re-execution safety**, not for what the peer is. A
+  non-idempotent remote write must be `WriteRemote` with idempotence off (or batched /
+  transactional) so it is neither retried inline nor re-executed on incomplete replay.
+- If the function has a natural idempotency handle (HTTP `idempotency-key`, keyed writes), make
+  it `WriteRemote` so the cheap inline path applies while `assume_idempotence` is on.
+- Attach `RetryProperties` so named policies can distinguish, e.g., HTTP status classes.
+- Add a test for both transitions: an inline retry that succeeds (oplog has `Error` hints under
+  the same `retry_from`, one `Start`/`End`), and a fallback to trap (no extra inline hints, the
+  worker was reconstructed).
+
+## Tests
+
+- `tests/in_function_retry/host_services.rs::{keyvalue_set_retries_inline_when_idempotent,
+  in_function_retry_transitions_from_inline_to_trap_based}` — the second documents the shared
+  budget arithmetic in its comments.
+- `tests/in_function_retry/http_request.rs::{http_zone1_falls_back_to_trap_when_delay_exceeds_threshold,
+  http_post_fails_permanently_when_idempotence_disabled,
+  http_get_retried_inline_even_when_idempotence_disabled}` (and the p3 mirrors in
+  `tests/in_function_retry/p3.rs`).
+- `tests/in_function_retry/{http_servers.rs,http_streams.rs}` — streaming bodies and server
+  failure modes.
+- `tests/retry_lifecycle.rs::{interrupt_worker_during_delayed_recovery_retry,
+  delete_worker_during_delayed_recovery_retry}` — trap-based `Delayed` retries interact with
+  interruption and deletion.
+- `tests/retry_policies.rs` — named policies are persisted to the oplog and survive restart.

--- a/.agents/skills/understanding-durable-execution/reference/streams.md
+++ b/.agents/skills/understanding-durable-execution/reference/streams.md
@@ -1,0 +1,94 @@
+# Streaming invocations and durable streams
+
+Detailed mechanics behind the "Streaming invocations" section of `SKILL.md`. Paths are relative to
+`golem-worker-executor/src/` unless stated.
+
+
+A streaming RPC is an ordinary durable RPC whose method signature carries input or output streams
+(`remote_method_uses_streams` in `durable_host/wasm_rpc/mod.rs`). Live streams require
+invoke-and-await; a fire-and-forget streaming call is rejected with `RpcError::ProtocolError`.
+
+### Identity
+
+The caller's durable call `Start` is the identity. On the streaming path
+(`prepared.is_streaming()`) every stream handle derives its key as
+`IdempotencyKey::derived(&parent_key, handle.start_index())` from the *physical* `Start` index.
+The non-streaming path goes through `derive_idempotency_key`, which substitutes the outermost
+atomic region's logical counter; the streaming path does not. Treat that as a discrepancy to
+investigate before relying on streaming RPC keys inside atomic regions, not as a guarantee.
+
+The target is pinned by `streaming_target_fingerprint`: `AgentFingerprint`
+(`golem-common/src/base_model/worker.rs`) is minted once at agent creation and stable across
+restarts, so a deleted-and-recreated agent with the same `AgentId` is a different producer.
+
+### Two durable journals
+
+Only these are authoritative:
+
+- The **producer's own oplog** holds `StreamRegistered`, `StreamItems`, `StreamEnd` and
+  `StreamCancel` (`DurableStreamProducer::{register, write_items, end, cancel_open}` in
+  `durable_host/durable_stream.rs`). Each `StreamItemsRecordV1` carries `first_sequence`, per-item
+  `StreamOffsetV1 { oplog index, sub_index }` and `producer_fingerprint`. Records are committed
+  first and only then published to `DurableLiveStreamBus` (`durable_host/stream_bus.rs`), which is
+  documented as a "bounded live-tail optimization for events that have already committed to the
+  producer oplog": losing the bus, a reader or a socket loses nothing.
+- The **consumer's `StreamSession` journal** (`StreamSessionRecordV1` in
+  `golem-common/src/base_model/durable_stream.rs`) records caller attempts, attach/detach,
+  mappings, topology, `ConsumerItemValue { source_offset, consumer_read_ordinal }`, cancel intent,
+  terminals, the invocation result and `Finished`.
+
+All of these entries are hints (`is_hint()`): they take part in no `Start`/terminal pairing and
+never satisfy a claim, so a stream-only change cannot desynchronize `Start`/`End` pairing.
+
+### RPC result versus stream draining
+
+On the synchronous streaming path the caller calls `handle.complete(...)` with the result
+*stripped of streams* (`strip_streams`) and only then returns the stream-bearing value to the
+guest (`wasm_rpc/mod.rs`). The caller's RPC `End` can therefore already be recorded while items
+are still being produced and consumed. Three crash windows follow:
+
+1. Stream setup done, RPC result not yet recorded — replay finds an incomplete `Start` and
+   re-dispatches with the same key; the target attaches to the same invocation.
+2. RPC result recorded, streams partially consumed — replay returns the recorded result; the
+   consumer session resumes by offset (below).
+3. Invocation finished, session cleanup pending — `invocation_loop.rs::agent_invocation_finished`
+   runs `complete_durable_streaming_session` after `on_agent_invocation_success`, appending
+   protocol terminals and `StreamSession { Finished }` as hints after `AgentInvocationFinished`.
+
+### Exactly-once item delivery
+
+Delivery works by offsets, not by connection state. A restarted consumer first replays its own
+journal in `consumer_read_ordinal` order, then reads producer oplog segments after the last
+`source_offset` (`read_segment` / `RoutedAttachedStreamSegmentSource` in
+`durable_host/durable_session.rs`); a live subscription samples the bus high-water under the
+publication lock and discards overlap by offset. A restarted producer replays its items from its
+oplog and resumes writing after the last committed sequence.
+
+Producer identity is checked wherever a durable stream identity crosses a boundary:
+`validate_forwarded_mapping` (`durable_session.rs`) requires the attachment's session key,
+consumer and expected producer fingerprint to match the durable session, and producer-side record
+application (`durable_stream.rs`) rejects records naming another producer incarnation as
+`CorruptHistory`. A recreated agent fails these checks and is never reattached to.
+
+Randomness is allowed where it is recorded before it is observed: `caller_attempt_id` calls
+`AttemptId::fresh()` only when no `CallerAttempt` record exists, appends and commits it, and every
+later run reads the persisted value.
+
+### Terminals
+
+Terminals are either guest-authored (`StreamEnd` with the guest's result, `StreamCancel` with
+`GuestDrop`/`Cancelled`) or protocol-authored. When the producing invocation completes or fails
+with streams still open, the protocol cancels open inputs and ends open outputs with an error
+context, then appends `Finished`; a protocol terminal fences any later guest terminal. A stream
+failing locally does not fail sibling streams or the invocation
+(`tests/rpc.rs::stream_local_output_failure_does_not_fail_sibling_or_invocation`).
+
+### Tests
+
+`tests/rpc.rs::{durable_streaming_output_recovers_after_executor_restart,
+durable_streaming_input_recovers_after_executor_restart,
+caller_recovery_restarts_input_drain_after_rpc_result_commit,
+callee_recovery_continues_output_after_committed_item,
+malformed_request_after_streaming_result_terminalizes_open_streams}`. These mostly assert the
+recovered *values*; offset- and terminal-shape assertions are proposed additions (see
+`testing-patterns.md`), not existing coverage.

--- a/.agents/skills/understanding-durable-execution/reference/testing-patterns.md
+++ b/.agents/skills/understanding-durable-execution/reference/testing-patterns.md
@@ -1,0 +1,200 @@
+# Testing patterns for durable execution
+
+A durable-execution test earns its place when a plausible wrong implementation fails it. The
+wrong implementations that recur are: duplicate execution hidden behind equal return values,
+tolerance machinery in replay, liveness inferred from cursor position, and resident state treated
+as authoritative. Each pattern below names the mistake it catches and an existing test to copy.
+
+Run tests with the `testing` skill (`cargo make worker-executor-tests-groupN` or a `cargo test -p
+golem-worker-executor --test <file> -- <filter>`); build the required WASM fixtures with
+`modifying-test-components`.
+
+## Tooling
+
+- `golem-worker-executor-test-utils/src/lib.rs`
+  - `start_with_overrides(deps, &context, TestExecutorOverrides { .. })` — start an executor with
+    wrapped services. Dropping the returned executor and starting another with the same context
+    tears down and recreates the whole executor in-process (new `Store`s, new caches, new
+    invocation queues) over the same oplog storage; that is a complete reconstruction even
+    though no OS process dies.
+  - `TestExecutorOverrides::wrap_rpc` — intercept RPC dispatch to drop, delay or duplicate
+    attempts.
+  - `TestExecutorOverrides::wrap_key_value_storage` — inject storage faults above the retry
+    decorator (`FaultInjectingKeyValueStorage` from `src/storage/keyvalue/fault_injecting.rs`,
+    used in `tests/api.rs`).
+  - `TestExecutorOverrides::wrap_shard_service` — fake ownership changes.
+  - `executor.oplog_service_call_count(&worker_id, "read_exact")` — prove a path did not scan
+    the oplog.
+- `golem-test-framework/src/dsl/mod.rs`
+  - `simulated_crash(&agent_id)` — `InterruptKind::Restart`; the worker reconstructs immediately.
+  - `interrupt(&agent_id)` / `resume(&agent_id, force)` — stop and later reconstruct.
+  - `get_oplog(&agent_id, from)` / `search_oplog(&agent_id, query)` — assert oplog shape.
+  - `wait_for_status(..)`, `check_oplog_is_queryable(..)`.
+- Test components under `test-components/` provide counters (`agent_counters`) and host-API
+  drivers (`host_api_tests`); a counter is the canonical provider-side effect meter.
+
+## Pattern 1: count the effect, not the echo
+
+Mistake caught: duplicate execution that returns equal values.
+
+Do: increment a durable counter in the target (or an external stub), crash or retry the caller,
+then read the counter. Assert the *count* and, separately, that the *next* fresh invocation
+continues from that count.
+
+Copy: `tests/api.rs::invoking_with_same_idempotency_key_is_idempotent_after_restart` — 32
+increments, executor drop + restart, re-sending the oldest key returns `1` (the recorded result),
+and the next fresh key returns `33`: the dedupe oracle is the fresh key, which proves the repeated
+key did not increment. `tests/rpc.rs::failed_ephemeral_invocation_retry_does_not_reexecute` — two
+failed attempts of `increment_remote_then_fail`, then a plain `increment` on the target returns
+`2` (one from the single execution of the failing body, one from the observation call); a
+re-executed body would make it `3`.
+
+## Pattern 2: assert identity and execution count separately
+
+Mistake caught: "same result, so probably deduped" and "new key on retry".
+
+Do: capture the idempotency key the target observes on each attempt (e.g. via `wrap_rpc`),
+assert the keys are equal, and assert one `AgentInvocationStarted` for that key in the target
+oplog. After an ordinary crash-retry the caller keeps a single `Start` (the incomplete call is
+repaired under the existing entry). A second physical `Start` for the same logical call appears
+under atomic-region rollback (`Jump`, both attempts carry the same key) and inside a custom
+durable invocation recovered incomplete (the nested calls are re-recorded with
+`observational_owner`, and the block author owns their idempotency).
+
+Copy: `tests/api.rs::lost_card_transfer_response_converges_after_source_and_target_restart` —
+a wrapped `RecordingWorkerProxy` drops the RPC response; after both source and target restart,
+the proxy has seen two identical attempts and the target oplog holds exactly one
+`CardTransferred`. `tests/rpc.rs::counter_resource_test_2_with_restart` (counter reads `1`
+before and `2` after the restart: reconstruction neither lost nor repeated the increment).
+`tests/rpc.rs::ephemeral_rpc_invocations_get_distinct_final_identities` (distinct *logical*
+invocations must get distinct phantom identities; the same one must not).
+
+## Pattern 3: gate a crash at a named window
+
+Mistake caught: designs that are only correct for the crash windows the author imagined.
+
+Do: pick the windows from `crash-matrix.md` — before `Start`, after effect before `End`, after
+`End` before delivery, after `AgentInvocationFinished`, during snapshot load, mid-update — and
+force the crash there. Use `wrap_rpc`/`wrap_key_value_storage` to fail the exact operation, or
+a guest method that performs the effect and then traps (`increment_remote_then_fail`), or
+`simulated_crash` while a guest is parked on a known await.
+
+Copy: `tests/rpc.rs::caller_recovery_restarts_input_drain_after_rpc_result_commit`
+(crash after the RPC result was committed, before the caller drained the stream),
+`callee_recovery_continues_output_after_committed_item`,
+`tests/durability.rs::custom_durability_crash_mid_live_invocation_reexecutes_whole_body`.
+
+## Pattern 4: real reconstruction, both state and oplog
+
+Mistake caught: "cursor rewind is recreation" and fixes that only work while caches are warm.
+
+Do: drop the executor (or `simulated_crash`) and start again; then assert (a) guest-visible state
+via a fresh invocation and (b) oplog shape via `get_oplog`/`search_oplog`: exactly one
+`AgentInvocationFinished` per key, every `Start` in successfully settled history has one
+terminal, no positional `Start`/`End` after the last `AgentInvocationFinished` (hint entries such
+as stream-session completion may follow), expected `CompletionDelivered` markers present. When
+component
+revision, plugins or metadata matter, the restart must go through instance creation
+(`recovering_an_old_worker_after_updating_a_component`).
+
+Copy: `tests/api.rs::p3_promise_suspend_survives_executor_restart`,
+`tests/rpc.rs::ts_cancel_survives_executor_restart`,
+`tests/durability.rs::snapshot_based_recovery_preserves_state_across_multiple_restarts`.
+
+## Pattern 5: completed replay performs no new effect
+
+Mistake caught: re-executing a recorded call during replay.
+
+Do: stop or count the external dependency before restarting. With a wrapped RPC or storage
+service, assert its call count is unchanged after a restart that replays a completed call. With
+an HTTP test server, stop it before restart; replay must still succeed.
+
+Copy: `tests/api.rs::invoking_with_same_idempotency_key_is_idempotent_after_restart` — the
+`read_exact` count is unchanged across the repeated-key lookup, proving the recorded result came
+from the physical index rather than an oplog scan; the effect assertion is the `33` on the fresh
+key. `tests/rpc.rs::durable_streaming_output_recovers_after_executor_restart` — after the restart
+the consumer receives exactly `66 - observed` remaining items and each output stream ends once,
+so no already-observed item is re-emitted.
+
+## Pattern 6: asymmetric concurrent orderings
+
+Mistake caught: delivery-order logic that only works when completion order equals initiation
+order.
+
+Do: run several concurrent host calls whose completion order is a non-identity permutation of
+their initiation order, record the delivery order, restart, and assert the guest observes the
+same delivery order on replay. Use permutations, not a single reversed case.
+
+Copy: `tests/concurrent_delivery_order.rs::delivery_order_matches_completion_order_for_permutations`,
+`concurrent_host_call_initiation_order_is_stable_across_reexecution`.
+
+## Pattern 7: replay strictness is a passing condition
+
+Mistake caught: treating replay errors as flakes.
+
+Do: when a test produces `unexpected_oplog_entry`, "no matching Start", an unexpected extra
+entry, or a changed set of pending completions, the test has found a determinism bug. Do not
+retry the test, loosen the assertion or add a scan-ahead/tolerance path. Reproduce with
+`get_oplog` before and after the restart and diff the guest-visible inputs.
+
+Unit-level copies: `src/durable_host/replay_state/tests.rs` (cursor, claims, barrier semantics,
+`switch_to_live_wakes_parked_awaiter_as_incomplete`), `src/durable_host/mod.rs` tests
+`pending_replay_to_live_is_fail_closed_until_finished` and
+`entity_store_liveness_is_scoped_to_its_invocation_mode`.
+
+## Pattern 8: snapshot and update modes
+
+Mistake caught: snapshot hooks that append or consume oplog entries; updates that keep stale
+snapshots.
+
+Do: take a snapshot, invoke, restart, and assert the oplog after the snapshot has no durable-call
+entries from the save/load hooks; update the revision and assert the pre-update snapshot is not
+loaded.
+
+Copy: `tests/durability.rs::{automatic_snapshot_every_2nd_invocation, snapshot_based_recovery}`,
+`tests/hot_update.rs::auto_update_invalidates_snapshot_from_previous_revision`.
+
+## Pattern 9: unload during arbitrary progress
+
+Mistake caught: feature-specific "safe to suspend" gates.
+
+Do: interrupt or crash while the guest is inside the feature under test (mid-RPC, mid-stream,
+mid-transaction, holding a spawned task), then resume and assert progress completes with the
+recorded effects exactly once. If the feature needs the runtime to stay resident to finish, the
+feature is not durable yet.
+
+Copy: `tests/rpc.rs::reacquire_permits_restart_preserves_accepted_queued_live_invocation`,
+`tests/api.rs::pending_self_card_transfer_recovery_does_not_deadlock`,
+`lost_card_transfer_response_converges_after_source_and_target_restart`.
+
+## Pattern 10: streams and tool bodies at named crash checkpoints
+
+Mistake caught: stream liveness inferred from the bus/socket; tool bodies repeating their
+external effect on completed replay; body state kept only in the transient entity Store;
+admission skipped for incomplete bodies.
+
+Do: for streams, crash the producer after a committed `StreamItems` and the consumer after a
+journaled `ConsumerItemValue`, restart, and assert every item is observed exactly once by offset
+and that exactly one terminal is recorded. For tools, drive the body to a named checkpoint with an
+in-process crash-checkpoint server (`tests/tool_streaming.rs::start_crash_checkpoint_server`, a
+tokio task — not an external process), crash, restart, and assert (a) the completed path
+(`ReplayingCompleted`) runs the body's guest export again with its host calls replayed from the
+owner oplog and releases the recorded terminal without a repeated external effect (checkpoint
+server hit count unchanged), (b) the incomplete path completes under the original entity `Start`
+index, and (c) the owner oplog has one entity terminal per `Start`.
+
+Copy: `tests/rpc.rs::{durable_streaming_output_recovers_after_executor_restart,
+callee_recovery_continues_output_after_committed_item,
+caller_recovery_restarts_input_drain_after_rpc_result_commit}`,
+`tests/tool_streaming.rs::{deterministic_stream_crash_checkpoint_matrix,
+active_stream_crash_replays_pinned_activation_with_fresh_attachments,
+concurrent_tool_attempt_identity_survives_reordered_admission_and_replay,
+completed_reconstruction_claim_blocks_concurrent_replay_to_live}`.
+
+## Anti-patterns
+
+- A "restart" that only calls `resume` on a still-resident worker, or resets a cursor.
+- Asserting only the caller's return value for an RPC or external effect.
+- Sleeping until "probably replayed" instead of `wait_for_status` / awaiting the invocation.
+- Loosening replay to make a flaky test green.
+- Random inputs that mostly exercise argument validation.

--- a/.agents/skills/understanding-durable-execution/reference/timelines.md
+++ b/.agents/skills/understanding-durable-execution/reference/timelines.md
@@ -1,0 +1,354 @@
+# Worked oplog timelines
+
+Each timeline lists the oplog as the previous incarnation left it, then what the reconstructing
+incarnation does with it. Indices are illustrative and the `Start`/`End` shapes are simplified
+(real entries carry function names, payload references and timestamps). `(h)` marks hint entries
+that replay skips positionally. Owners are the functions that implement the behaviour.
+
+## 1. Durable host call, happy path
+
+Guest calls a nondeterministic host function (say a key-value `get`), receives the result, and
+continues.
+
+```
+#10 AgentInvocationStarted
+#11 Start { fn: keyvalue/get, request: k }        begin_durable_function → DurableCallSession
+#12 End   { start_index: 11, response: Some(v) }  live action finished
+#13 CompletionDelivered { start_index: 11 } (h)   guest observed v (tail op of the host fn)
+#14 ... guest continues ...
+```
+
+Replay: claim `Start#11` by identity (`StartClaim`), resolve `End#12` through
+`ConcurrentReplayResolver`, classify as `Delivered`, release `v` to the guest at the boundary
+recorded by `#13` (`CompletionDelivery::AtMarker`). No live action runs.
+Owners: `concurrent/call.rs::run`, `concurrent/delivery.rs`, `replay_state/cursor.rs`.
+
+## 2. Crash after `End`, before guest observation
+
+```
+#11 Start { fn: http/send, request: req }
+#12 End   { start_index: 11, response: resp }
+     ✕ crash: guest never observed resp, no marker written
+```
+
+Replay: `Start#11` matches, `End#12` resolves, and `classify_replay_resolution` yields
+`Delivered` with `CompletionDelivery::AtReplayTail` because no `CompletionDelivered`/`Discarded`
+follows. The response is withheld until the cursor drains to its natural tail
+(`await_natural_tail_end`, which waits for exhaustion, not for Live publication); the delivery
+token is then live-armed and the guest receives `resp` as its first post-replay observation,
+writing `CompletionDelivered` for the next incarnation. The HTTP request is **not** re-sent.
+Owners: `concurrent/call.rs::classify_replay_resolution`,
+`replay_state/resolution.rs::await_natural_tail_end`, `concurrent/delivery.rs`.
+
+Wrong models: "re-execute because it was not delivered" (duplicates the effect) and "deliver
+immediately during replay" (moves the guest-observation boundary into replay, so a later live call
+may be issued while history is still being consumed).
+
+## 3. Crash after `Start`, before `End`
+
+```
+#11 Start { fn: keyvalue/get, request: k }
+     ✕ crash
+```
+
+Replay: `Start#11` matches but has no terminal — `CallReplayOutcome::Incomplete`. For re-executable
+`DurableFunctionType`s the live action runs again under the *same* `Start` (no new `Start` is
+appended; `End` is appended when it finishes). For non-idempotent, batched or transactional
+writes the session hard-errors and recovery falls to the enclosing durable scope handled in
+`begin_durable_function`. Owner: `concurrent/call.rs::run`, `durability.rs`.
+
+Trap variant: if the guest trapped while the call was in flight, `abandon_for_trap` leaves the
+`Start` incomplete in exactly the same shape. A trap is never recorded as `Cancelled`.
+
+## 4. Guest drops a pending completion
+
+```
+#11 Start { fn: http/send, request: req }
+#12 End   { start_index: 11, response: resp }
+#13 CompletionDiscarded { start_index: 11 } (h)   guest dropped the future without reading it
+```
+
+Replay: classification `Undelivered`; the future is parked and the guest's deterministic drop
+happens at the same point, nothing is delivered. If the drop happened before host completion the
+entry is `Cancelled { start_index: 11, partial }` instead — guest-initiated and markerless:
+`partial: Some` classifies as `Delivered`/`Immediate` (the guest saw the partial value),
+`partial: None` as `Undelivered`.
+
+## 5. One invocation, end to end
+
+```
+#20 PendingAgentInvocation { key: K, payload } (h)   enqueue_worker_invocation_with_effect,
+                                                     committed before the caller sees "accepted"
+#21 AgentInvocationStarted { key: K, ... }          invocation loop picked it up
+#22..#40 durable calls of the invocation
+#41 AgentInvocationFinished { result: R }           on_agent_invocation_success, CommitLevel::Always,
+                                                     then waiters are notified
+```
+
+Crash before `#20` commits: the caller was never told "accepted"; it retries with the same key.
+Crash after `#20`, before `#21`: reconstruction folds status from the oplog, sees the pending
+invocation, and runs it. Crash between `#21` and `#41`: `resume_replay` replays the recorded prefix
+of this invocation, then the guest continues live from the tail. Crash after `#41`: a repeated
+call with key `K` hits `lookup_invocation_result` and returns `R` without touching the guest.
+Test: `tests/api.rs::invoking_with_same_idempotency_key_is_idempotent_after_restart`.
+
+During replay `on_agent_invocation_success` compares the recomputed result with `#41` via
+`replay_equivalent`; a mismatch is an `unexpected_oplog_entry` error, i.e. a determinism failure.
+Failures take `on_invocation_failure`; whether a failed invocation is terminalized in the oplog
+depends on the retry decision, so do not model a trap as `AgentInvocationFinished { Err }`.
+
+## 6. Durable RPC exactly-once with a caller crash
+
+Caller C invokes target T's `increment` through durable RPC.
+
+```
+Caller C                                             Target T
+#30 Start { fn: rpc/invoke-and-await, request }      
+    key = derive_idempotency_key(#30)                
+    dispatch(key) ─────────────────────────────────▶ #5 PendingAgentInvocation { key } (h)
+                                                     #6 AgentInvocationStarted { key }
+                                                     ... counter 0 → 1 ...
+                                                     #9 AgentInvocationFinished { result: 1 }
+     ✕ caller crashes before End
+```
+
+Caller reconstruction: `Start#30` is incomplete. RPC is a `WriteRemote` durable call; with the
+default idempotence mode (`assume_idempotence == true`) it is re-executable, so the path
+re-dispatches under the existing `Start` with the *same* key
+(`InvocationFreshnessDisposition::MayExist`). (With `set-idempotence-mode(false)` the incomplete
+remote write would fail instead of re-dispatching.) T's
+`lookup_invocation_result(key)` is not `New`, so it attaches to invocation `#6..#9` and returns
+`1`. C appends `End { start_index: 30, response: 1 }`. Two caller attempts, one target
+execution, counter 1.
+
+What a test must assert: T's counter (a provider-side effect) equals 1, the key observed by T is
+identical across both attempts, and C's oplog shows one `Start` with one `End`. Asserting only
+that C got `1` proves nothing, because a duplicated increment would also return a value.
+Tests: `tests/api.rs::lost_card_transfer_response_converges_after_source_and_target_restart`
+(wrapped proxy drops the response, both sides restart, two proxy attempts, one target admission);
+`tests/rpc.rs::counter_resource_test_2_with_restart` covers the weaker "completed call is not
+re-executed across restart" property (1 then 2).
+
+## 7. Atomic region rollback keeps the RPC key
+
+```
+#50 BeginAtomicRegion
+#51 Start { rpc/invoke, request }   key = derived(logical counter n)
+#52 End   { start_index: 51 }
+#53 Start { keyvalue/set }          ✕ trap inside the region
+     → retry: a Jump covering #51..#54 is appended; those entries stay where they are but are
+       skipped by replay. The region ends at the Jump's own index
+       (`end: pending.replay_target().next()`, `golem/v1x.rs`) so the Jump skips itself too
+       and `BeginAtomicRegion` at #50 is kept
+#54 Jump { region: 51..=54 }
+#55 Start { rpc/invoke, request }   key = derived(logical counter n)   ← same key, new position
+```
+
+`current_idempotency_key_oplog_index` uses the outermost atomic region's logical counter
+(`next_idempotency_key_oplog_index`) rather than the physical index, so the re-executed RPC
+carries the same key and the target deduplicates. The physical position of the re-executed call
+changed (#51 → #55); identity did not. The counter is resident state rebuilt during replay from
+the region's entries. Tests: `tests/transactions.rs::{golem_rust_atomic_region,
+golem_rust_idempotence_on, golem_rust_idempotence_off}`, `tests/revert.rs`.
+
+## 8. Concurrent completions, one recorded delivery order
+
+Two accessor calls A and B run concurrently; the host finishes B first in this run.
+
+```
+#60 Start A
+#61 Start B
+#62 End B
+#63 End A
+#64 CompletionDelivered A (h)    guest happened to observe A first
+#65 CompletionDelivered B (h)
+```
+
+Replay: both `Start`s are claimed by identity (scheduling order of `Start`s is not reproduced,
+only the per-task initiation order is), both `End`s are prefetched, but A is released to the
+guest first and B second because the markers say so. Host completion order (#62 before #63) is
+not a guest input; delivery order (#64 before #65) is. Owner: `ReplayDeliveryBarrier`,
+`CompletionDelivery::AtMarker`. `tests/concurrent_delivery_order.rs` establishes the runtime
+property this relies on (bare Wasmtime, no oplog); the marker mechanics are covered by
+`replay_state/tests.rs` and `concurrent/tests.rs`.
+
+## 9. Automatic update with snapshot
+
+```
+#70 PendingUpdate { target revision r2, Automatic } (h)
+    worker unloaded and reconstructed by the outer loop
+```
+
+Instance creation (`worker/mod.rs`, `component_version_for_replay`): because an update is
+pending, automatic snapshots are ignored and the baseline is the last manual-update snapshot (or
+`INITIAL`); the new instance is created for revision `r2`. `prepare_instance` then, for
+`Automatic`: `try_load_snapshot` loads that baseline (the load hook runs in snapshotting mode:
+no oplog append or consume), and `resume_replay` replays the remaining old history against the
+`r2` component; success appends `SuccessfulUpdate` during that replay. If replay fails while the
+update is still pending, `on_worker_update_failed` appends `FailedUpdate` and returns
+`RetryDecision::Immediate`, so the outer loop rebuilds on the old revision with its automatic
+snapshot eligible again. Old-revision automatic snapshots are never used for `r2`
+(`tests/hot_update.rs::auto_update_invalidates_snapshot_from_previous_revision`).
+
+`SnapshotBased` differs: the save hook ran and the payload was recorded *before* unload;
+`prepare_instance` requires the store to be live already and `finalize_pending_snapshot_update`
+loads the payload into `r2`.
+
+A cursor rewind cannot do this: the component revision and metadata come from instance
+creation in the outer loop, not from the cursor.
+
+## 10. Suspend, evict, restart: one path
+
+```
+... live invocation running ...
+#80 Suspend (h)         or   #80 Interrupted (h)   or   #80 Restart (h) / nothing at all (crash)
+```
+
+In every case the `Store` is discarded. The next incarnation runs `prepare_instance` →
+`resume_replay` from the snapshot baseline to the tail and publishes Live. The hints annotate
+*why* the previous incarnation stopped and drive status/scheduling (`Interrupted` stays
+interrupted until resumed; `Suspend` resumes on demand; `Restart` recovers automatically), but the
+reconstruction mechanism is identical.
+Owners: `Worker::set_interrupting` (`Interrupt` / `Restart` / `Suspend`),
+`worker/invocation_loop.rs::run`, `RetryDecision`.
+
+## 11. Streaming RPC: producer restart mid-stream
+
+Caller C invokes `P.generate()` whose result is an output stream. Two oplogs are involved.
+
+```
+Caller C oplog                                   Producer P oplog
+#20 Start { fn: rpc/invoke-and-await, P.generate } #40 PendingAgentInvocation { key: derived(C#20) } (h)
+#21 StreamSession { CallerAttempt { attempt_id } } (h)
+#22 StreamSession { Prepared / Attached }         (h)  #41 AgentInvocationStarted
+                                                  #42 StreamRegistered { stream, fingerprint(P) } (h)
+                                                  #43 StreamItems { first_sequence: 0, items a,b } (h)
+#23 StreamSession { ConsumerItemValue a, ordinal 0, source_offset (43,0) } (h)
+#24 StreamSession { ConsumerItemValue b, ordinal 1, source_offset (43,1) } (h)
+                                                  #44 StreamItems { first_sequence: 2, items c } (h)
+                                                       ✕ P's executor dies; C's bus reader closes
+```
+
+P reconstructs: replays #40–#44 (all stream records are hints; the guest's writes are re-driven
+from recorded inputs and the producer resumes writing at sequence 3), then continues live and
+eventually appends `StreamEnd`. On C's side the RPC `End` for `#20` may or may not be recorded
+yet: the synchronous streaming path completes the durable call with the result stripped of
+streams before handing the stream to the guest. Either way C never re-executes P: an incomplete
+`Start#20` re-dispatches with the same key and attaches to P's `#40`; a completed one returns the
+recorded result. C's consumer resubscribes; the live
+subscription samples the bus high-water, and `read_segment` fetches P's committed segments after
+C's last `source_offset` `(43,1)`, so `c` at `(44,0)` is delivered exactly once and `a`, `b` are
+never re-delivered.
+Owners: `DurableStreamProducer::write_items`, `DurableLiveStreamBus::{subscribe,
+publish_committed}`, `durable_session.rs::read_segment`, `wasm_rpc/mod.rs::spawn_streaming_invoke_and_await_task`.
+Test: `tests/rpc.rs::callee_recovery_continues_output_after_committed_item`.
+
+## 12. Streaming RPC: consumer restart after partial read
+
+```
+Caller C oplog (as left behind)
+#20 Start { rpc P.generate }                #23 StreamSession { ConsumerItemValue a, ordinal 0 } (h)
+#21 StreamSession { CallerAttempt }   (h)   #24 StreamSession { ConsumerItemValue b, ordinal 1 } (h)
+#22 StreamSession { Attached }        (h)        ✕ C's executor dies before observing c
+```
+
+C reconstructs: `Start#20` is claimed (completed or incomplete, see timeline 11) and the guest
+reaches the stream read again; `caller_attempt_id` returns the persisted `attempt_id` instead of
+minting a new one; the consumer journal replays `a`, `b` by `consumer_read_ordinal`, then the
+session reattaches to P by fingerprint and reads from offset `(43,1)` onward. If P had been
+deleted and recreated in the meantime, the fingerprint checks (`validate_forwarded_mapping`,
+producer-side `CorruptHistory`) reject the mismatch rather than splicing a different producer's
+items into the session. Three windows matter: setup done but result not recorded; result recorded
+with partial consumption; invocation finished with session cleanup (protocol terminals,
+`Finished`) still pending — the last is completed by
+`invocation_loop.rs::agent_invocation_finished` after `AgentInvocationFinished`.
+Test: `tests/rpc.rs::caller_recovery_restarts_input_drain_after_rpc_result_commit`,
+`durable_streaming_input_recovers_after_executor_restart`.
+
+## 13. Streaming RPC: invocation ends with streams open
+
+```
+Producer P oplog
+#42 StreamRegistered { out }                            (h)
+#43 StreamItems { ... }                                 (h)
+#45 AgentInvocationFinished { result }     the guest returned without ending `out`
+                                           (a failed invocation goes through on_invocation_failure
+                                            instead and is terminalized per the retry decision)
+#46 StreamEnd { out, result: ErrorContext, authored_by: Protocol }   (h)
+#47 StreamSession { Finished }                          (h)
+```
+
+On completion (or terminal failure) of the producing invocation,
+`invocation_loop.rs::agent_invocation_finished` runs `complete_durable_streaming_session`: open
+inputs get `StreamCancel { reason: InvocationFailed | Protocol, authored_by: Protocol }`, open
+outputs get a protocol `StreamEnd`, then `Finished` is appended. These hints legitimately follow
+`AgentInvocationFinished`. A later guest terminal for the same stream is fenced by the protocol
+one; consumers observe one terminal.
+Test: `tests/rpc.rs::malformed_request_after_streaming_result_terminalizes_open_streams`.
+
+## 14. Tool invocation through an entity body
+
+The owner agent O calls a tool; the body runs in a transient entity `Store` but records into O's
+oplog.
+
+```
+Owner O oplog
+#60 ... tool discovery / authorization reads (durable reads, ordinary Start/End pairs) ...
+#61 Start { fn: golem-entity-invoke, entity: sidecar }              entity invocation id = 61
+                                                                    (dispatch_tool_call; no outer
+                                                                     call-tool Start wraps it)
+#62 Start { fn: http/send, parent_start_index: 61 }                 body's own host call
+#63 End   { start_index: 62, response }
+#64 CompletionDelivered { start_index: 62 } (h)
+#65 End   { start_index: 61, response: tool result }                body finished → terminal
+```
+
+Completed replay (`InvocationExecutionMode::ReplayingCompleted`): `StartClaim::owned_tool_invocation`
+claims #61; a fresh body `Store` is created, sharing O's cursor; `invoke_tool_sidecar` calls the
+sidecar's guest export again (the body **is** re-executed) and its `http/send` at #62 is resolved
+as `Delivered` from #63/#64 — no live HTTP; once the body has reconstructed, `drive_access`
+validates and releases the recorded #65. The observable contract is "no repeated external
+effect", not "the sidecar export is skipped". Memory for attachments is charged from the
+historical record, not current pressure.
+
+Incomplete replay (crash between #61 and #65): `ReplayingIncomplete` switches the body to live,
+`activate_live_attachment_memory_accounting` must return `Admitted` (or a rejection is persisted),
+`PendingReplayToLive::finish` with `ReplayToLiveRole::NonPrimary` sets the entity Store's
+`local_live_tail`, and the terminal is appended under the original index 61.
+
+Trap inside the body: no entity terminal is invented; the owner invocation fails and the owner
+group drains (`guest_trap_fences_a_blocked_sibling_and_drains_the_owner_group`).
+Owners: `durable_host/entity.rs::{EntityInvocationDurability, drive_access}`,
+`durable_host/tool/{mod.rs,operation.rs}`, `worker/instance.rs::{OwnerExecution,
+HostedInstance::invoke_scoped}`, `worker/owner_lane.rs`.
+Tests: `tests/tool_streaming.rs::{completed_tool_replay_bypasses_current_attachment_memory_pressure,
+incomplete_tool_replay_persists_attachment_upgrade_rejection, deterministic_stream_crash_checkpoint_matrix}`.
+
+## 15. Custom durable invocation, crash mid-body
+
+A guest library wraps a block as one logical durable operation with
+`golem:durability/durability.begin-custom-durable-invocation`
+(`durability.rs::begin_custom_durable_invocation`). Nested host calls inside the block point at the
+root via `observational_owner` / `parent_start_index`.
+
+```
+#70 Start { fn: custom:my-op }                          root
+#71 Start { fn: probe,    observational_owner: 70 }     nested, completed
+#72 End   { start_index: 71 }
+#73 Start { fn: callback, observational_owner: 70 }     nested, completed
+#74 End   { start_index: 73 }
+      ✕ crash before the root End
+```
+
+Completed root (`End { start_index: 70 }` present): replay returns the recorded root result and the
+body does **not** run; every nested entry is consumed as a replay-inert subtree (`cursor.rs`
+`custom_subtrees`).
+
+Incomplete root (as above): the block goes live under the *original* root `Start` #70 and the
+**whole body runs again**. The nested calls that had already completed are re-recorded as new
+physical `Start`s (#75 probe, #77 callback, `observational_owner = 70`), then the root `End` is
+appended. One logical `Start`, one terminal, possibly repeated nested effects — this is the one
+ordinary durable path where a completed nested effect legitimately repeats, and the block author
+owns its idempotency.
+Test: `tests/durability.rs::custom_durability_crash_mid_live_invocation_reexecutes_whole_body`
+expects the effect sequence `probe, callback, probe, callback`.

--- a/.agents/skills/understanding-durable-execution/reference/tools.md
+++ b/.agents/skills/understanding-durable-execution/reference/tools.md
@@ -1,0 +1,97 @@
+# Tool invocations and entity bodies
+
+Detailed mechanics behind the "Tool invocations and entity bodies" section of `SKILL.md`. Paths
+are relative to `golem-worker-executor/src/` unless stated.
+
+`durable_host/tool/mod.rs` implements `golem:tool/host@0.1.0`. Tool discovery is a durable read
+of environment state; authorization is enforced before any backend runs.
+
+### Dispatch and ownership
+
+`dispatch_tool_call` claims (replay, `EntityInvocationDurability::replay_tool_access`) or creates
+(live) the entity invocation directly — there is no outer `Start { call-tool }` wrapping it. An
+accepted call becomes an `OwnerToolOperation` (`prepare_tool_call`) and is executed by
+`execute_accepted_tool_call` as a `ToolSidecarInvocation` driven by a `ToolExecutionTask`.
+
+Entity bodies (tool sidecars, middleware chains) run in their own Wasmtime `Store` but have **no
+oplog of their own**. `durable_host/entity.rs` is the "durable owner-oplog boundary for transient
+entity bodies": `EntityInvocationDurability` wraps a `DurableCallSession<GolemEntityInvoke,
+LeaveIncompleteOnDrop>` in the owner's oplog, and its `Start` index *is* the entity invocation ID.
+Its terminal is an ordinary `End` (success) or `Cancelled` (cancellation); a trap leaves the
+`Start` incomplete. Every host call the body makes records its own `Start` in the owner oplog
+with `parent_start_index` pointing at its enclosing scope — normally that entity `Start`
+(`durable_host/concurrent/call.rs`).
+
+`OwnerExecution` (`worker/instance.rs`) is "the durable execution stream shared by every Store
+belonging to one owner": entity Stores clone the primary's `ReplayState`, which shares the cursor
+rather than opening a second cursor over the same oplog, and `HostedInstance::invoke_scoped` runs
+one entity export and then destroys the body `Store`.
+
+### Why completed bodies re-execute
+
+A tool body is not a plain host call whose result can be replayed from its `End`. The entity
+`Store` attaches to the **owner's** `AgentFilesystem` generation
+(`OwnerRuntimeResources::filesystem_generation_handle`, `worker/instance.rs`), so every file the
+body reads or writes is the agent's own state. Replaying the agent must therefore rebuild those
+filesystem effects, which only re-running the body does; the recorded terminal is then used to
+*validate* the reconstruction and to hand the recorded result to the owner. External effects made
+through durable host calls inside the body are not repeated: they replay from the owner oplog.
+This is also why `OwnerLane` serializes filesystem-capable bodies (see Scheduling).
+
+### Execution modes
+
+Replay chooses one of three `InvocationExecutionMode`s (`golem-common/src/model/entity.rs`) from
+`replay.has_visible_terminal(start_index)`:
+
+- `ReplayingCompleted` — `invoke_tool_sidecar` (`tool/mod.rs`) still calls the sidecar's guest
+  export (`guest.call_invoke`) so the body re-executes from recorded inputs; its durable host
+  calls are replayed from the owner oplog, so no completed external effect is performed again.
+  `drive_access` (`entity.rs`) releases the recorded terminal only after that reconstruction
+  validates against the claim (`StartClaim::owned_tool_invocation` in
+  `durable_host/replay_state/claims.rs` matches the accepted `GolemEntityInvoke` or a recorded
+  `GolemToolInvocationRejected` by `parent_start_index` and `ToolInvocationClaimIdentity`). The
+  test oracle is "no repeated external effect", not "no second guest call". One exception:
+  `execute_accepted_tool_call_inner` first checks `recorded_terminal_access`; a terminal whose
+  `body_execution` is `Skipped` (admission was rejected before the body ran, e.g. an attachment
+  upgrade hitting `ResourceExhausted`) is returned by `execute_recorded_skipped_tool_call` with no
+  guest call at all (`tests/tool_streaming.rs::incomplete_tool_replay_persists_attachment_upgrade_rejection`).
+- `ReplayingIncomplete` — a `Start` without terminal switches the body to live and completes it
+  under the *original* `Start` index; `enter_incomplete_live_repair_before_body_access` avoids
+  deadlocking the primary's own transition.
+- `Live` — ordinary recording.
+
+### Fences and admission
+
+Completed reconstructions are fenced: `HistoricalReconstruction` / `ReconstructionClaimState`
+(`durable_host/concurrent/replay.rs`) keep `PendingReplayToLive` fail-closed until every active
+body has validated
+(`tests/tool_streaming.rs::completed_reconstruction_claim_blocks_concurrent_replay_to_live`).
+An incomplete tool entity must additionally be admitted by
+`OwnerToolOperation::activate_live_attachment_memory_accounting` (`tool/operation.rs`), which
+returns `Admitted` or `ResourceExhausted`, before `ReplayToLiveRole::NonPrimary` sets the entity
+Store's `local_live_tail`; completed replays reuse historical memory charges and bypass current
+pressure (`completed_tool_replay_bypasses_current_attachment_memory_pressure`,
+`incomplete_tool_replay_persists_attachment_upgrade_rejection`). Attachments
+(`tool/attachment.rs`) are in-memory stdin/stdout endpoints and are recreated, never preserved.
+
+### Scheduling
+
+`EntitySlot` (`worker/entity_slot.rs`) only registers active invocations and "never grants
+execution"; `OwnerLane` (`worker/owner_lane.rs`) "serializes filesystem-capable guest bodies at
+causal invocation boundaries" while filesystem-incapable invocations get an immediate off-lane
+permit. A synchronous call from a body back into its blocked owner must pass
+`OwnerLane::ensure_synchronous_owner_call` and is otherwise rejected with `WouldDeadlock` instead
+of hanging; asynchronous owner calls are allowed. A body trap fails the owner invocation and
+drains the owner group without inventing entity terminals
+(`guest_trap_fences_a_blocked_sibling_and_drains_the_owner_group`,
+`detached_and_fire_and_forget_traps_fail_the_owner_without_entity_terminals`).
+
+### Tests
+
+`tests/tool_streaming.rs::{concurrent_tool_attempt_identity_survives_reordered_admission_and_replay,
+active_stream_crash_replays_pinned_activation_with_fresh_attachments,
+deterministic_stream_crash_checkpoint_matrix,
+capable_terminal_lane_return_and_delayed_publication_survive_crash}` and
+`tests/tool_discovery.rs`. These use an in-process tokio crash-checkpoint server
+(`start_crash_checkpoint_server`), so they stay within the no-external-process rule.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Load these skills for guided workflows on complex tasks:
 | `adding-dependencies` | Adding or updating crate dependencies (covers workspace dependency management, versioning, features) |
 | `testing` | Running and debugging tests (covers test filtering, debugging failures, test components, timeouts) |
 | `debugging-hanging-tests` | Diagnosing worker executor or integration tests that hang indefinitely |
+| `understanding-durable-execution` | Changing, reviewing, or debugging worker executor replay, oplog, durable host calls, RPC exactly-once, streaming invocations, tool/entity invocations, snapshots, or worker lifecycle |
 | `modifying-test-components` | Building or modifying test WASM components, or rebuilding after SDK changes |
 | `modifying-wit-interfaces` | Adding or modifying WIT interfaces and synchronizing across sub-projects |
 | `modifying-cli-manifest-schema` | Adding or changing application manifest JSON schema versions and aligning CLI schema references |

--- a/golem-worker-executor/AGENTS.md
+++ b/golem-worker-executor/AGENTS.md
@@ -1,0 +1,55 @@
+# Worker Executor
+
+Load the `understanding-durable-execution` skill before changing replay, oplog, host-call,
+RPC, durable-stream, tool/entity, snapshot, or worker-lifecycle code. This file states the rules; the skill explains the
+mechanisms, timelines and tests behind them.
+
+## Axioms
+
+1. **Replay is deterministic.** The guest is a deterministic function of its guest-observable
+   host inputs, and every such input is recorded in the oplog. A replaying guest that asks for a
+   host call different from the one recorded next has exposed an executor bug (missing recording,
+   wrong reconstruction, wrong completion association). Fix the recording or reconstruction; never
+   add tolerance (skipping, reordering, synthesized results, "stable IDs") to replay.
+2. **The resident runtime is disposable.** `Store`, worker task, process, sockets, channels and
+   subscriptions may vanish at any instruction boundary. Suspend, evict, reshard, restart and
+   crash all reconstruct the instance from the oplog through the same path
+   (`src/worker/invocation_loop.rs::run` → `src/durable_host/mod.rs::prepare_instance` →
+   `resume_replay`). Do not design feature-specific "safe to unload" gates; make every pending
+   obligation durable or deterministically recomputable instead.
+3. **Durable agent RPC is exactly-once per logical target invocation.** Caller attempts (replay,
+   transport retry, atomic-region rollback) share one idempotency key derived from the caller's
+   invocation key and the durable call's position (`derive_idempotency_key`: the `Start` index,
+   or the outermost atomic region's logical counter); the target persists one invocation and one
+   result. Attempts are not executions.
+
+## Durable versus resident state
+
+Authoritative: oplog entries and payloads, `PendingAgentInvocation` / `AgentInvocationStarted` /
+`AgentInvocationFinished`, idempotency keys and recorded results, `Start`/`End`/`Cancelled` and
+`CompletionDelivered`/`CompletionDiscarded` markers, update and snapshot entries, and status folded
+from the oplog. Derived and disposable: `Store` memory, in-memory queues, caches, event
+subscriptions, spawned store tasks, sockets. Never let correctness after a restart depend on
+anything in the second list.
+
+## External effects
+
+Golem itself enforces exactly-once for durable agent RPC and for oplog-processor plugin delivery
+(`services/oplog/plugin.rs`: batch keys from `oplog_processor_idempotency_key`, checkpoints in
+`AgentStatusRecord.oplog_processor_checkpoints`). Ephemeral targets are fail-stop (accepted work is
+not re-executed, but completion is not guaranteed). For external peers the crash window between
+the effect and its `End` entry is ambiguous, so exactly-once depends on the peer honouring an
+idempotency key: outgoing HTTP requests carry an `idempotency-key` header derived from the call's
+durable position (`http/policy.rs`, on by default unless the guest set its own), and guests can
+mint keys with `golem:api/host.generate-idempotency-key`. Peers without such support get
+at-least-once in that window. Choose the `DurableFunctionType` of a host call by whether
+re-executing it after a crash is safe.
+
+## Changing oplog shape
+
+A new or changed `OplogEntry` requires updating, in the same change: `is_hint()` classification,
+the WIT `oplog-entry` / `public-oplog-entry` variants in `wit/deps/golem-1.x/golem-oplog.wit`
+(the `oplog_macro` binds `wit_raw_type` / `wit_public_type`; load `modifying-wit-interfaces`),
+replay claims (`src/durable_host/replay_state/claims.rs`), cut-point validation
+(`src/worker/cut_point.rs`), status folding (`src/worker/status.rs`), public oplog rendering, and
+a test that restarts a worker across the new entry.

--- a/golem-worker-executor/src/durable_host/AGENTS.md
+++ b/golem-worker-executor/src/durable_host/AGENTS.md
@@ -1,0 +1,126 @@
+# Durable host functions
+
+Rules for code under `durable_host/`. Mechanisms, timelines and crash matrices are in the
+`understanding-durable-execution` skill.
+
+## Execute, append, claim, observe are four different steps
+
+Vocabulary: a durable call is a `Start` entry plus its *terminal* (`End` or `Cancelled`), both
+identified by the `Start` index. A *claim* is the replay step that matches the host call the
+guest is making now against the next recorded `Start` (`ReplayState::claim_start`,
+`replay_state/cursor.rs`; the identity is a `StartClaim` from `replay_state/claims.rs`: function
+name, owner, optional request payload). *Observe* is the guest reading the result.
+
+- **Execute** a live effect only when the durable context reports live
+  (`store_is_live` / `is_live()` on the `DurableWorkerCtx`), never because the replay cursor is
+  exhausted. Cursor exhaustion is an observation. The primary Store is live only after
+  `ReplayState::switch_to_live` has settled every `HistoricalReconstruction` fence and published
+  the shared flag; an entity Store is live only after its own `PendingReplayToLive::finish` set
+  `local_live_tail` (a `ReplayingCompleted` entity Store is never live).
+- **Append** `Start` eagerly when a durable call begins and `End`/`Cancelled` when it terminates,
+  through `begin_durable_function` / `end_durable_function` (`durability.rs`) and a
+  `DurableCallSession` (`concurrent/call.rs`). A trap leaves `Start` incomplete
+  (`abandon_for_trap`); never write `Cancelled` for a trap.
+- **Claim** during replay by identity (`StartClaim`, optional request-payload match). Scan-ahead
+  claiming exists only to route concurrent completions to the right awaiter; a `Start` that does
+  not exist in history is a divergence error, not something to skip past. Scopes are named
+  `<scope:batched-write>` or `<scope:batched-write:DISCRIMINATOR>`; a discriminated claim never
+  falls back to a plain-named sibling.
+- **Observe**: the guest's consumption of a completion is recorded by `CompletionDelivered` /
+  `CompletionDiscarded` as the tail operation of the host function
+  (`supersede_prior_completion_delivery` hard-errors otherwise). This applies to accessor
+  (concurrent) calls: replay releases each completion at its recorded boundary
+  (`CompletionDelivery::AtMarker`); an accessor `End` without a marker is a
+  crash-after-completion and is withheld until the natural replay tail (`AtReplayTail`), never
+  re-executed and never delivered early. The serialized direct path records no markers
+  (`DurableCallSession::replay` rejects `CompletionDelivered` for a non-accessor call) and
+  delivers at the host return.
+
+## Identity on the replay path
+
+Any value replay must reproduce (idempotency keys, phantom ids, scope discriminators, span ids
+that reach the guest) derives from oplog indices or recorded data — `derive_idempotency_key`,
+`ephemeral_invocation_phantom_id` (UUIDv5 of the key). Fresh randomness or clock reads are
+allowed only when appended and committed before the guest can observe them and read back on
+replay (as `caller_attempt_id` does); unrecorded guest-observable randomness is a bug. Inside
+atomic regions use the outermost region's logical counter (`current_idempotency_key_oplog_index`),
+not the physical index: a rollback re-executes the region at new physical positions.
+
+## Retry eligibility is part of the function type
+
+`DurableFunctionType` decides two things with one predicate (`is_eligible_for_internal_retry`
+== `can_reexecute_on_incomplete_replay`, `durability.rs`): whether a failed call may be retried
+in-function under the same `Start` instead of trapping and reconstructing the worker, and whether
+an incomplete `Start` may be re-executed on replay. `ReadLocal`/`ReadRemote`/`WriteLocal` always;
+`WriteRemote` only under `assume_idempotence`; batched/transaction writes never. Choose the type
+for re-execution safety, and test both the inline path and the fall-back-to-trap path
+(`tests/in_function_retry/`).
+
+## RPC
+
+The key is derived from the durable call's `Start` index and reused by every attempt.
+`InvocationFreshnessDisposition::MayExist` is the default; `KnownFresh` is allowed only for live,
+ephemeral, non-`assume_idempotence` dispatch and must commit `DurableOnly` first
+(`wasm_rpc/mod.rs`). Same-key retry attaches to the existing target invocation; it is never new
+work. Ephemeral targets are fail-stop; do not build resumption for them.
+
+## Durable streams
+
+- The producer's oplog (`StreamRegistered`/`StreamItems`/`StreamEnd`/`StreamCancel`) and the
+  consumer's `StreamSession` journal are the only authoritative stream state. Commit before
+  `DurableLiveStreamBus::publish_committed`; the bus, readers, sockets and transports are
+  resumable optimizations and must never be the only holder of an item or terminal.
+- Consumers resume by `StreamOffsetV1` / `consumer_read_ordinal`, never by connection state.
+- Stream liveness is bound to the durable `AgentFingerprint` of the producer; every place a stream
+  identity crosses a boundary checks it (`validate_forwarded_mapping`, producer-side
+  `CorruptHistory` checks). Reject mismatches rather than reattaching to a recreated agent.
+- Every stream is finalized exactly once. Protocol terminals appended on invocation completion or
+  failure fence later guest terminals; do not add a second finalization path.
+- Stream entries are hints and must stay hints: they take part in no `Start`/terminal pairing and
+  never satisfy a claim.
+- The RPC result is completed (stripped of streams) before the stream-bearing value reaches the
+  guest; do not assume an open stream implies an incomplete RPC `Start`.
+
+## Entity bodies and tool invocations
+
+An *entity* is a transient guest body that runs inside an agent's durable context but is not the
+agent: a tool sidecar or a tool middleware (`AgentEntity::{Tool, ToolMiddleware}`,
+`golem-common/src/model/entity.rs`). It gets its own Wasmtime `Store` and attaches to the
+owner's `AgentFilesystem` generation (`OwnerRuntimeResources`, `worker/instance.rs`), so its
+filesystem effects are the agent's; that is why completed bodies are re-executed on replay
+rather than replaced by a recorded result.
+
+- Entity bodies (`entity.rs`, `tool/`) record into the **owner's** oplog with
+  `parent_start_index`; they have no oplog or cursor of their own. Entity Stores clone the owner's
+  `ReplayState` and share its cursor.
+- The entity `Start` index is the entity invocation id and its terminal is a plain `End` or
+  `Cancelled`. Dropping before terminal selection leaves the `Start` incomplete
+  (`LeaveIncompleteOnDrop`); a trap appends no terminal. There is no outer `call-tool` durable
+  call around the entity invocation.
+- Completed replay (`InvocationExecutionMode::ReplayingCompleted`) re-executes the body's guest
+  export with its durable host calls replayed from the owner oplog, validates the claim, then
+  releases the recorded terminal. Completed external effects are never performed again; the guest
+  export itself does run again — unless the recorded terminal carries
+  `body_execution: Skipped` (admission rejected before the body ran), in which case
+  `execute_recorded_skipped_tool_call` returns it without a body. Incomplete replay completes
+  under the original `Start` index.
+- An entity Store's liveness is its own (`store_is_live`): `ReplayingCompleted` is never live;
+  `ReplayingIncomplete`/`Live` become live when `PendingReplayToLive::finish` sets
+  `local_live_tail`, which for incomplete tool entities first requires
+  `activate_live_attachment_memory_accounting` to admit them. Completed replays use historical
+  memory charges, not current pressure.
+
+## Snapshotting
+
+Snapshot save/load runs in snapshotting mode (`durability_is_suppressed` ==
+`snapshotting_mode`): durable calls neither append nor consume entries (`DurableCallSession` with
+`persisted: false`). Snapshot admission is governed by `SnapshotBoundaryConditions`; do not add
+parallel boundary predicates.
+Automatic snapshots are revision-scoped baselines chosen at instance creation; a failed load sets
+the resident `Worker`'s `snapshot_recovery_disabled` flag and the next instance replays fully.
+
+## Spawned store tasks
+
+Tasks spawned on the store (`tail_work.rs`) must be parked only at guest-driven waits when an
+invocation finishes; any durable `Start`/`End` they can still produce must land before
+`AgentInvocationFinished`. Work that must survive a restart belongs in the oplog, not in a task.

--- a/golem-worker-executor/src/worker/AGENTS.md
+++ b/golem-worker-executor/src/worker/AGENTS.md
@@ -1,0 +1,56 @@
+# Worker lifecycle
+
+Rules for code under `worker/`. The `understanding-durable-execution` skill explains the
+reconstruction path, invocation timelines and crash windows these rules protect.
+
+## One reconstruction path
+
+Suspend, interrupt, `Restart` (simulated crash), eviction, resharding and process loss all end
+in the same place: the outer loop of `invocation_loop.rs::run` creates a new `Store`, runs
+`prepare_instance`, replays, and publishes Live. Do not add a second recovery mechanism or a
+lifecycle branch that assumes the previous `Store` still exists. Component revision, plugins and
+metadata are fixed at instance creation; changing them means going through the outer loop, not
+rewinding a cursor.
+
+## Invocation acceptance and results
+
+- An invocation is accepted only after its `PendingAgentInvocation` entry is committed
+  (`enqueue_worker_invocation_with_effect`). Never report acceptance to a caller — local or
+  remote — before that commit.
+- Dedupe by idempotency key before appending (`lookup_invocation_result` ≠ `LookupResult::New`
+  returns the existing invocation). Same key = same invocation, never new work.
+- `AgentInvocationFinished` is committed with `CommitLevel::Always` before waiters are notified
+  (`on_agent_invocation_success`; failures go through `on_invocation_failure`); keep that
+  ordering. No positional durable-call `Start`/`End` may be appended for an invocation after its
+  `Finished` entry (`tail_work.rs` enforces this); hint entries such as streaming-session
+  completion legitimately follow it.
+- Status (`status.rs`) is folded from the oplog; caches and checkpoints are baselines, never a
+  source of truth. Checkpoint only at clean boundaries.
+
+## Eviction and retry
+
+`EvictionClass` must never unload an actively executing worker or one holding non-durable
+in-memory work. `RetryDecision` decides *when* to reconstruct, not *whether* state survives — a
+scheduling-triggered unload must not become a guest-visible timeout, cancellation, failed
+invocation, retry-budget charge or new idempotency key.
+
+## Ephemeral agents
+
+Ephemeral agents are fail-stop. `reconstructed_ephemeral` exists for observation and invocation
+result lookup; the instance must never be started again (`INACTIVE_EPHEMERAL_AGENT_ERROR`).
+
+## Entity scheduling
+
+`OwnerExecution` (`instance.rs`) is the single durable execution stream for an owner and all of
+its entity Stores; `HostedInstance::invoke_scoped` runs one entity export and destroys its Store.
+`EntitySlot` (`entity_slot.rs`) only registers active invocations and never grants execution;
+`OwnerLane` (`owner_lane.rs`) alone serializes filesystem-capable bodies and returns
+`WouldDeadlock` for a synchronous call back into a blocked owner. Do not add a second scheduler
+or move admission into the slot.
+
+## Cut points
+
+Revert and fork split the oplog at a cut point. `cut_point.rs` rejects cuts that separate a
+`Start` from its terminal, an `End` from its `CompletionDelivered`/`CompletionDiscarded` marker,
+or split an atomic region or remote transaction. Any new paired durable construct must be added
+to that validation.

--- a/golem-worker-executor/tests/AGENTS.md
+++ b/golem-worker-executor/tests/AGENTS.md
@@ -1,0 +1,37 @@
+# Worker executor tests
+
+Test-running mechanics are in the `testing` skill; test patterns, tooling and exemplar tests for
+durable execution are in `understanding-durable-execution` (`reference/testing-patterns.md`).
+Tests here must never spawn external processes (see the repository `AGENTS.md`).
+
+## Rules for durability, replay and RPC tests
+
+- **Count effects, not echoes.** Equal deterministic return values do not prove deduplication.
+  Assert a provider-side counter (target agent counter, wrapped service call count, external
+  stub) and, separately, that the next fresh invocation continues from that count.
+- **Assert identity and execution count separately.** Capture the idempotency key each attempt
+  carries (`TestExecutorOverrides::wrap_rpc`), assert equality, and assert one
+  `AgentInvocationStarted` for it in the target oplog.
+- **Crash at named windows.** Gate the crash before `Start`, after the effect but before `End`,
+  after `End` before delivery, after `AgentInvocationFinished`, during snapshot load, and during
+  an update, using `simulated_crash`, wrapped services, or a guest method that effects-then-traps.
+- **Restart for real.** Drop the executor and `start_with_overrides` again (in-process executor
+  teardown and recreation over the same storage — a genuine reconstruction, not OS process
+  death), or `simulated_crash`; a cursor reset or `resume` on a resident worker is not a restart.
+  Then check both guest-visible state and oplog shape (`get_oplog`, `search_oplog`): one
+  `Finished` per key; every `Start` in successfully settled history has a terminal (an
+  incomplete `Start` is expected only where the crash was injected); no positional `Start`/`End`
+  after the last `Finished`.
+- **Prove no repeated effect on completed replay.** Stop or count the dependency before the
+  restart; replay of a completed call must not touch it.
+- **Use asymmetric concurrent orderings.** Completion order must differ from initiation order in
+  at least one permutation.
+- **Streams and tool bodies: crash at checkpoints, assert by offset and by `Start`.** Crash the
+  producer after a committed `StreamItems` and the consumer after a journaled item; assert each
+  item is observed once and one terminal is recorded. Drive tool bodies to named checkpoints with
+  the in-process crash-checkpoint server in `tool_streaming.rs` (never an external process) and
+  assert one entity terminal per `Start` and no repeated external effect on completed replay
+  (the body's guest export does run again; count what it calls, not whether it ran).
+- **Replay errors are findings.** `unexpected_oplog_entry`, "no matching Start", extra entries or
+  a changed pending-completion set mean a determinism bug. Never retry, loosen, or add tolerance
+  to make such a test green.

--- a/golem-worker-executor/worker-executor-walkthrough.html
+++ b/golem-worker-executor/worker-executor-walkthrough.html
@@ -1,0 +1,2287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Golem Worker Executor — An Interactive Walkthrough</title>
+<meta name="description" content="A standalone, interactive walkthrough of the Golem worker executor: architecture, oplog, deterministic replay, durable host calls, exactly-once RPC, streams, tools, snapshots, lifecycle and recovery.">
+<style>
+:root {
+  --bg: #f7f7f5;
+  --bg-elev: #ffffff;
+  --bg-sunken: #eeeeea;
+  --fg: #1c1c1a;
+  --fg-muted: #5b5b56;
+  --border: #d9d9d3;
+  --accent: #0b6e99;
+  --accent-soft: #d9ecf5;
+  --ok: #2b7a3b;
+  --ok-soft: #dcf0df;
+  --warn: #9a6400;
+  --warn-soft: #fbeccc;
+  --bad: #b3261e;
+  --bad-soft: #f8d9d6;
+  --hint: #6a4fbf;
+  --hint-soft: #e6dff7;
+  --code-bg: #ecece8;
+  --shadow: 0 1px 2px rgba(0,0,0,.06), 0 4px 16px rgba(0,0,0,.05);
+  --radius: 10px;
+  --sidebar-w: 280px;
+  --content-max: 900px;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #14161a; --bg-elev: #1c1f25; --bg-sunken: #0f1114;
+    --fg: #e6e6e2; --fg-muted: #a3a39c; --border: #2f333b;
+    --accent: #5bb4dd; --accent-soft: #143140;
+    --ok: #6fcf7d; --ok-soft: #173321;
+    --warn: #e6b04e; --warn-soft: #3a2c10;
+    --bad: #ef6f66; --bad-soft: #3d1b19;
+    --hint: #b19cf0; --hint-soft: #2a2247;
+    --code-bg: #23262d;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 4px 16px rgba(0,0,0,.35);
+  }
+}
+:root[data-theme="dark"] {
+  --bg: #14161a; --bg-elev: #1c1f25; --bg-sunken: #0f1114;
+  --fg: #e6e6e2; --fg-muted: #a3a39c; --border: #2f333b;
+  --accent: #5bb4dd; --accent-soft: #143140;
+  --ok: #6fcf7d; --ok-soft: #173321;
+  --warn: #e6b04e; --warn-soft: #3a2c10;
+  --bad: #ef6f66; --bad-soft: #3d1b19;
+  --hint: #b19cf0; --hint-soft: #2a2247;
+  --code-bg: #23262d;
+  --shadow: 0 1px 2px rgba(0,0,0,.4), 0 4px 16px rgba(0,0,0,.35);
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 4.5rem; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { transition: none !important; animation: none !important; } }
+body { margin: 0; font: 16px/1.6 var(--font); color: var(--fg); background: var(--bg); }
+a { color: var(--accent); }
+a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, summary:focus-visible, [tabindex]:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
+code, pre, kbd { font-family: var(--mono); font-size: .92em; }
+code { background: var(--code-bg); padding: .1em .35em; border-radius: 4px; }
+pre { background: var(--code-bg); padding: .9rem 1rem; border-radius: var(--radius); overflow-x: auto; line-height: 1.45; border: 1px solid var(--border); }
+pre code { background: none; padding: 0; }
+h1, h2, h3, h4 { line-height: 1.25; scroll-margin-top: 4.5rem; }
+h1 { font-size: 2rem; margin: .2rem 0 .5rem; }
+h2 { font-size: 1.55rem; margin: 3rem 0 1rem; padding-top: 1.25rem; border-top: 1px solid var(--border); }
+h2 .num { color: var(--fg-muted); font-weight: 500; margin-right: .5rem; }
+h3 { font-size: 1.2rem; margin: 2rem 0 .6rem; }
+h4 { font-size: 1.02rem; margin: 1.4rem 0 .4rem; }
+p, ul, ol { margin: .6rem 0; }
+li { margin: .25rem 0; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .94rem; }
+th, td { overflow-wrap: break-word; }
+@media (max-width: 700px) { .table-wrap table { min-width: 640px; } }
+code { overflow-wrap: anywhere; }
+main { min-width: 0; }
+th, td { text-align: left; vertical-align: top; padding: .5rem .6rem; border-bottom: 1px solid var(--border); }
+th { background: var(--bg-sunken); font-weight: 600; }
+.table-wrap { overflow-x: auto; }
+.skip-link { position: absolute; left: -999px; top: 0; background: var(--accent); color: #fff; padding: .5rem 1rem; z-index: 100; }
+.skip-link:focus { left: .5rem; top: .5rem; }
+
+/* Layout */
+.topbar { position: sticky; top: 0; z-index: 50; display: flex; align-items: center; gap: 1rem; padding: .55rem 1rem; background: var(--bg-elev); border-bottom: 1px solid var(--border); }
+.topbar .brand { font-weight: 700; text-decoration: none; color: var(--fg); display: flex; align-items: center; gap: .5rem; }
+.topbar .brand .logo { width: 22px; height: 22px; border-radius: 6px; background: linear-gradient(135deg, var(--accent), var(--hint)); display: inline-block; }
+.topbar .spacer { flex: 1; }
+.topbar .progress { position: absolute; left: 0; bottom: -1px; height: 2px; background: var(--accent); width: 0; }
+.topbar .btn { white-space: nowrap; }
+@media (max-width: 480px) { .topbar { gap: .5rem; padding: .5rem .75rem; } .topbar .brand { font-size: .92rem; } .topbar .btn.small { font-size: .78rem; padding: .25rem .5rem; } }
+.btn { font: inherit; font-size: .9rem; padding: .35rem .75rem; border-radius: 8px; border: 1px solid var(--border); background: var(--bg-elev); color: var(--fg); cursor: pointer; }
+.btn:hover { border-color: var(--accent); }
+.btn.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn.small { font-size: .8rem; padding: .2rem .55rem; }
+.btn[aria-pressed="true"] { background: var(--accent-soft); border-color: var(--accent); }
+.layout { display: grid; grid-template-columns: var(--sidebar-w) minmax(0, 1fr); gap: 0; max-width: 1400px; margin: 0 auto; }
+.sidebar { position: sticky; top: 3.4rem; align-self: start; height: calc(100vh - 3.4rem); overflow-y: auto; padding: 1rem .75rem 2rem 1rem; border-right: 1px solid var(--border); font-size: .9rem; }
+.sidebar nav ol { list-style: none; padding: 0; margin: 0; }
+.sidebar nav li { margin: 0; }
+.sidebar nav a { display: block; padding: .28rem .6rem; border-radius: 6px; color: var(--fg-muted); text-decoration: none; border-left: 2px solid transparent; }
+.sidebar nav a:hover { color: var(--fg); background: var(--bg-sunken); }
+.sidebar nav a.active { color: var(--accent); border-left-color: var(--accent); background: var(--accent-soft); }
+.sidebar nav .part { margin: .9rem 0 .25rem; font-size: .72rem; letter-spacing: .06em; text-transform: uppercase; color: var(--fg-muted); padding-left: .6rem; }
+.sidebar-toggle { display: none; }
+main { padding: 1.5rem 2rem 6rem; max-width: calc(var(--content-max) + 4rem); }
+@media (max-width: 980px) {
+  .layout { grid-template-columns: minmax(0, 1fr); }
+  .sidebar { position: static; height: auto; border-right: 0; border-bottom: 1px solid var(--border); padding: .5rem 1rem; }
+  .sidebar > details > summary { cursor: pointer; font-weight: 600; padding: .4rem 0; }
+  main { padding: 1rem 1rem 5rem; }
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.35rem; }
+}
+@media (min-width: 981px) { .sidebar > details > summary { display: none; } .sidebar > details { display: contents; } }
+
+/* Callouts and cards */
+.callout { border-left: 4px solid var(--accent); background: var(--accent-soft); padding: .7rem 1rem; border-radius: 0 var(--radius) var(--radius) 0; margin: 1rem 0; }
+.callout.warn { border-color: var(--warn); background: var(--warn-soft); }
+.callout.bad { border-color: var(--bad); background: var(--bad-soft); }
+.callout.ok { border-color: var(--ok); background: var(--ok-soft); }
+.callout.hint { border-color: var(--hint); background: var(--hint-soft); }
+.callout > :first-child { margin-top: 0; } .callout > :last-child { margin-bottom: 0; }
+.callout .label { font-size: .75rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 700; display: block; margin-bottom: .2rem; }
+.card { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.1rem; box-shadow: var(--shadow); margin: 1rem 0; }
+.card > :first-child { margin-top: 0; } .card > :last-child { margin-bottom: 0; }
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+.grid-wide { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 1rem; }
+@media (max-width: 700px) { .grid-wide { grid-template-columns: 1fr; } }
+.grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: .8rem; }
+details.disclosure { border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-elev); margin: .8rem 0; }
+details.disclosure > summary { cursor: pointer; padding: .7rem 1rem; font-weight: 600; list-style: none; display: flex; align-items: center; gap: .5rem; }
+details.disclosure > summary::-webkit-details-marker { display: none; }
+details.disclosure > summary::before { content: "▸"; color: var(--fg-muted); transition: transform .15s; }
+details.disclosure[open] > summary::before { transform: rotate(90deg); }
+details.disclosure > .body { padding: 0 1rem 1rem; }
+details.disclosure > .body > :first-child { margin-top: 0; }
+.pill { display: inline-block; font-size: .74rem; padding: .05rem .5rem; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-sunken); color: var(--fg-muted); vertical-align: middle; font-weight: 600; letter-spacing: .02em; }
+.pill.pos { background: var(--accent-soft); color: var(--accent); border-color: transparent; }
+.pill.hint { background: var(--hint-soft); color: var(--hint); border-color: transparent; }
+.pill.ok { background: var(--ok-soft); color: var(--ok); border-color: transparent; }
+.pill.bad { background: var(--bad-soft); color: var(--bad); border-color: transparent; }
+.pill.warn { background: var(--warn-soft); color: var(--warn); border-color: transparent; }
+.src { font-size: .8rem; color: var(--fg-muted); overflow-wrap: anywhere; }
+.src code { font-size: .95em; }
+.muted { color: var(--fg-muted); }
+.legend { display: flex; flex-wrap: wrap; gap: .5rem 1rem; font-size: .85rem; margin: .5rem 0; }
+.legend span::before { content: ""; display: inline-block; width: .8em; height: .8em; border-radius: 3px; margin-right: .35em; vertical-align: -1px; }
+.legend .l-pos::before { background: var(--accent); }
+.legend .l-hint::before { background: var(--hint); }
+.legend .l-lost::before { background: var(--bad); }
+.legend .l-live::before { background: var(--ok); }
+
+/* Diagrams */
+.diagram { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem; margin: 1rem 0; overflow-x: auto; }
+.diagram pre { background: none; border: 0; padding: 0; margin: 0; font-size: .82rem; line-height: 1.35; }
+.diagram figcaption, figure figcaption { font-size: .85rem; color: var(--fg-muted); margin-top: .6rem; }
+figure { margin: 1rem 0; }
+svg.dg { width: 100%; height: auto; display: block; font-family: var(--font); }
+@media (max-width: 700px) {
+  figure { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  figure svg.dg, .svg-scroll svg.dg { min-width: 640px; }
+  .svg-scroll { overflow-x: auto; }
+  figure figcaption { position: sticky; left: 0; }
+  figure figcaption::after { content: " (scroll the diagram sideways on small screens)"; color: var(--fg-muted); }
+}
+svg.dg text { fill: var(--fg); font-size: 13px; }
+svg.dg .box { fill: var(--bg-elev); stroke: var(--border); stroke-width: 1.2; rx: 8; }
+svg.dg .box.accent { fill: var(--accent-soft); stroke: var(--accent); }
+svg.dg .box.ok { fill: var(--ok-soft); stroke: var(--ok); }
+svg.dg .box.hint { fill: var(--hint-soft); stroke: var(--hint); }
+svg.dg .box.warn { fill: var(--warn-soft); stroke: var(--warn); }
+svg.dg .box.bad { fill: var(--bad-soft); stroke: var(--bad); }
+svg.dg .box.sunken { fill: var(--bg-sunken); }
+svg.dg .arrow { stroke: var(--fg-muted); stroke-width: 1.4; fill: none; marker-end: url(#arr); }
+svg.dg .arrow.strong { stroke: var(--accent); stroke-width: 2; }
+svg.dg .arrow.dashed { stroke-dasharray: 5 4; }
+svg.dg .lbl { font-size: 11.5px; fill: var(--fg-muted); }
+svg.dg .title { font-weight: 700; }
+svg.dg .mono { font-family: var(--mono); font-size: 11px; }
+svg.dg .lbl.muted { opacity: .75; font-style: italic; }
+svg.dg .clickable { cursor: pointer; }
+svg.dg .clickable:hover .box, svg.dg .clickable:focus .box { stroke: var(--accent); stroke-width: 2; }
+svg.dg .clickable.selected .box { stroke: var(--accent); stroke-width: 2.5; }
+svg.dg .clickable:focus { outline: none; }
+
+/* Oplog tape */
+.tape { display: flex; flex-wrap: wrap; gap: .4rem; margin: .8rem 0; padding: .6rem; background: var(--bg-sunken); border-radius: var(--radius); border: 1px solid var(--border); }
+.entry { display: inline-flex; flex-direction: column; min-width: 96px; padding: .35rem .55rem; border-radius: 8px; border: 1px solid var(--border); background: var(--bg-elev); font-family: var(--mono); font-size: .76rem; line-height: 1.3; position: relative; }
+.entry .idx { color: var(--fg-muted); font-size: .7rem; }
+.entry .kind { font-weight: 700; }
+.entry .meta { color: var(--fg-muted); white-space: nowrap; }
+.entry.pos { border-left: 4px solid var(--accent); }
+.entry.hint { border-left: 4px solid var(--hint); border-style: dashed; border-left-style: solid; }
+.entry.lost { opacity: .35; text-decoration: line-through; }
+.entry.live { border-color: var(--ok); box-shadow: 0 0 0 2px var(--ok-soft); }
+.entry.new { border-color: var(--ok); background: var(--ok-soft); }
+.entry.skipped { background: repeating-linear-gradient(45deg, transparent 0 6px, var(--bg-sunken) 6px 12px); }
+.entry.crash-marker { border: 2px dashed var(--bad); color: var(--bad); background: var(--bad-soft); justify-content: center; font-weight: 700; min-width: 60px; }
+.lane { margin: .6rem 0; }
+.lane .lane-title { font-size: .8rem; font-weight: 700; color: var(--fg-muted); text-transform: uppercase; letter-spacing: .05em; margin-bottom: .2rem; }
+
+/* Interactive widgets */
+.widget { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.1rem; margin: 1.2rem 0; box-shadow: var(--shadow); }
+.widget h4 { margin-top: 0; display: flex; align-items: center; gap: .5rem; }
+.widget h4 .pill { font-weight: 600; }
+.controls { display: flex; flex-wrap: wrap; gap: .6rem 1rem; align-items: center; margin: .6rem 0; }
+.controls label { display: inline-flex; flex-direction: column; gap: .15rem; font-size: .85rem; color: var(--fg-muted); max-width: 100%; }
+.controls select { max-width: 100%; }
+.controls select, .controls input[type=range] { font: inherit; font-size: .9rem; padding: .25rem .4rem; border-radius: 6px; border: 1px solid var(--border); background: var(--bg-elev); color: var(--fg); min-width: 160px; }
+.controls input[type=range] { padding: 0; accent-color: var(--accent); }
+.controls .grow { flex: 1 1 280px; }
+.foot { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); font-size: .9rem; }
+.controls .check { flex-direction: row; align-items: center; gap: .4rem; color: var(--fg); }
+.result { margin-top: .8rem; padding: .8rem 1rem; border-radius: var(--radius); background: var(--bg-sunken); border: 1px solid var(--border); }
+.result .verdict { font-weight: 700; margin-bottom: .3rem; }
+.result.ok { border-color: var(--ok); background: var(--ok-soft); }
+.result.bad { border-color: var(--bad); background: var(--bad-soft); }
+.result.warn { border-color: var(--warn); background: var(--warn-soft); }
+.result.hint { border-color: var(--hint); background: var(--hint-soft); }
+.result > :last-child { margin-bottom: 0; }
+.steps { counter-reset: step; list-style: none; padding: 0; }
+.steps li { counter-increment: step; position: relative; padding-left: 2.2rem; margin: .5rem 0; }
+.steps li::before { content: counter(step); position: absolute; left: 0; top: .1rem; width: 1.6rem; height: 1.6rem; border-radius: 50%; background: var(--accent); color: #fff; font-weight: 700; font-size: .8rem; display: flex; align-items: center; justify-content: center; }
+.crash-list { list-style: none; padding: 0; margin: 0; }
+.crash-list li { padding: .5rem .7rem; border-radius: 8px; border: 1px solid var(--border); margin: .35rem 0; background: var(--bg-elev); }
+.crash-list li .t { font-weight: 700; }
+.state-chip { display: inline-block; padding: .1rem .5rem; border-radius: 6px; font-family: var(--mono); font-size: .8rem; background: var(--bg-sunken); border: 1px solid var(--border); }
+.flip { display: grid; grid-template-columns: 1fr; gap: .5rem; }
+.flip .wrong, .flip .right { padding: .6rem .8rem; border-radius: 8px; }
+.flip .wrong { background: var(--bad-soft); border-left: 4px solid var(--bad); }
+.flip .right { background: var(--ok-soft); border-left: 4px solid var(--ok); }
+.flip .tag { font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 700; display: block; }
+.kv { display: grid; grid-template-columns: max-content 1fr; gap: .3rem 1rem; font-size: .92rem; }
+.kv dt { font-weight: 600; } .kv dd { margin: 0; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+@media (max-width: 700px) { .two-col { grid-template-columns: 1fr; } }
+.state-col { border: 1px solid var(--border); border-radius: var(--radius); padding: .8rem 1rem; background: var(--bg-elev); transition: opacity .3s; }
+.state-col h4 { margin-top: 0; }
+.state-col ul { padding-left: 1.1rem; }
+.state-col.gone { opacity: .35; }
+.state-col.gone h4::after { content: " — gone"; color: var(--bad); }
+.fold-grid { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(260px, 1fr); gap: 1rem; align-items: start; }
+@media (max-width: 900px) { .fold-grid { grid-template-columns: 1fr; } }
+.fold-tape { font-size: .88rem; margin: 0; }
+.fold-tape td, .fold-tape th { padding: .35rem .5rem; }
+.fold-tape td:nth-child(2) code { overflow-wrap: normal; }
+.fold-tape tr.skip td { color: var(--fg-muted); }
+.fold-tape tr.skip td:nth-child(2) { text-decoration: line-through; text-decoration-color: var(--warn); }
+.js .fold-tape tr.todo td { opacity: .45; }
+.js .fold-tape tr.cur td { background: var(--accent-soft); opacity: 1; }
+.js .fold-tape tr.cur td:first-child { box-shadow: inset 4px 0 0 var(--accent); }
+.fold-record { border: 1px solid var(--border); border-radius: var(--radius); padding: .8rem 1rem; background: var(--bg-elev); position: sticky; top: 3.4rem; }
+.fold-record h4 { margin-top: 0; }
+.fold-record .kv { grid-template-columns: max-content minmax(0, 1fr); }
+.fold-record dd.changed { animation: flash 1s ease-out; }
+@keyframes flash { from { background: var(--accent-soft); } to { background: transparent; } }
+@media (max-width: 900px) { .fold-record { position: static; } }
+@media (max-width: 700px) {
+  .table-wrap .fold-tape { min-width: 0; font-size: .82rem; }
+  .fold-tape td, .fold-tape th { padding: .3rem .35rem; vertical-align: top; }
+  .fold-tape td:nth-child(2) code { font-size: .78rem; }
+  .fold-tape td:nth-child(2) .muted { display: block; }
+  #fold-pos { flex-basis: 100%; }
+}
+.toc-inline { columns: 2; column-gap: 2rem; font-size: .92rem; }
+@media (max-width: 700px) { .toc-inline { columns: 1; } }
+.back-top { position: fixed; right: 1rem; bottom: 1rem; z-index: 40; opacity: 0; pointer-events: none; transition: opacity .2s; }
+.back-top.show { opacity: 1; pointer-events: auto; }
+@media (max-width: 700px) { .back-top { display: none; } }
+.js-only { display: none; }
+.js .js-only { display: revert; }
+.js .controls.js-only { display: flex; }
+.js .pill.js-only { display: inline-block; }
+.js .no-js-only { display: none; }
+[data-tl-tape]:empty, [data-tl-result]:empty { display: none; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+mark { background: var(--warn-soft); color: inherit; padding: 0 .15em; border-radius: 3px; }
+.hero { background: linear-gradient(135deg, var(--accent-soft), var(--hint-soft)); border-radius: 14px; padding: 1.4rem 1.5rem; margin-bottom: 1.5rem; border: 1px solid var(--border); }
+.hero p { margin: .4rem 0; }
+.hero .meta { font-size: .85rem; color: var(--fg-muted); }
+.axioms { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: .8rem; margin: 1rem 0; }
+.axiom { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: .9rem 1rem; }
+.axiom .n { font-size: 1.6rem; font-weight: 800; color: var(--accent); line-height: 1; }
+.axiom h4 { margin: .3rem 0 .3rem; }
+.axiom p { margin: 0; font-size: .92rem; }
+.phase-track { display: flex; align-items: stretch; gap: .5rem; margin: .8rem 0; flex-wrap: wrap; }
+.phase { flex: 1 1 150px; padding: .6rem .8rem; border-radius: 8px; border: 2px solid var(--border); background: var(--bg-elev); text-align: center; font-weight: 600; }
+.phase.on { border-color: var(--accent); background: var(--accent-soft); }
+.phase.done { border-color: var(--ok); }
+.phase small { display: block; font-weight: 400; color: var(--fg-muted); font-size: .8rem; }
+.print-only { display: none; }
+@media print {
+  .topbar, .sidebar, .back-top, .btn { display: none !important; }
+  .layout { display: block; }
+  main { max-width: none; padding: 0; }
+  details { open: true; }
+  details > .body { display: block !important; }
+  .print-only { display: block; }
+}
+</style>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="topbar">
+  <a class="brand" href="#top"><span class="logo" aria-hidden="true"></span>Golem Worker Executor</a>
+  <span class="spacer"></span>
+  <button class="btn small js-only" id="expand-all" type="button" title="Open every collapsible section">Expand all</button>
+  <button class="btn small js-only" id="theme-toggle" type="button" aria-pressed="false" title="Toggle dark / light theme">Theme</button>
+  <div class="progress" id="progress" aria-hidden="true"></div>
+</header>
+<div class="layout">
+<aside class="sidebar" aria-label="Table of contents">
+  <details open>
+    <summary>Contents</summary>
+    <nav id="toc">
+      <ol>
+        <li class="part">Part I — Foundations</li>
+        <li><a href="#s-overview">1. What the executor is</a></li>
+        <li><a href="#s-architecture">2. Architecture &amp; component map</a></li>
+        <li><a href="#s-actors">3. Who is who: agents, entities, streams, peers</a></li>
+        <li><a href="#s-state">4. Durable vs. resident state</a></li>
+        <li><a href="#s-oplog">5. The oplog</a></li>
+        <li class="part">Part II — Running work</li>
+        <li><a href="#s-lifecycle">6. Worker lifecycle</a></li>
+        <li><a href="#s-invocations">7. Invocation queue &amp; results</a></li>
+        <li><a href="#s-hostcalls">8. Durable host calls &amp; replay</a></li>
+        <li><a href="#s-cursor">9. Cursor, claims &amp; replay-to-live</a></li>
+        <li><a href="#s-concurrency">10. Concurrency &amp; completion delivery</a></li>
+        <li><a href="#s-retries">11. Retries</a></li>
+        <li class="part">Part III — Talking to others</li>
+        <li><a href="#s-rpc">12. Exactly-once RPC &amp; atomic regions</a></li>
+        <li><a href="#s-streams">13. Streaming invocations</a></li>
+        <li><a href="#s-tools">14. Tools &amp; entity bodies</a></li>
+        <li><a href="#s-external">15. External effects: the guarantee boundary</a></li>
+        <li><a href="#s-processors">16. Oplog processor delivery</a></li>
+        <li class="part">Part IV — Change and recovery</li>
+        <li><a href="#s-snapshots">17. Snapshots &amp; updates</a></li>
+        <li><a href="#s-recovery">18. Interrupt, suspend, restart, evict, recover</a></li>
+        <li><a href="#s-glossary">19. Glossary</a></li>
+      </ol>
+    </nav>
+  </details>
+</aside>
+<main id="main">
+<div id="top"></div>
+<div class="hero">
+  <h1>The Golem Worker Executor, explained</h1>
+  <p>An interactive walkthrough of how Golem runs WASM agents so that their progress survives the loss of the process running them: the architecture, the oplog, deterministic replay, durable host calls, exactly-once RPC, streams, tools, snapshots, lifecycle and recovery.</p>
+  <p class="meta">Describes the executor in <code>golem-worker-executor/src</code> as of September 2026. Collapsible sections open with a click or <kbd>Enter</kbd>; the interactive widgets need JavaScript, but every fact they show is also written out in plain text.</p>
+</div>
+
+<div class="callout hint">
+  <span class="label">How to read this</span>
+  Part I gives the mental model (read it in order). Parts II–IV can be read independently once you know the vocabulary from sections 3–5. Words in <em>italics</em> at first use are defined in the <a href="#s-glossary">glossary</a>.
+</div>
+
+<!-- ===================== 1. OVERVIEW ===================== -->
+<h2 id="s-overview"><span class="num">1</span>What the executor is</h2>
+<p>The <strong>worker executor</strong> (<code>golem-worker-executor/</code>) is the process that actually runs agents. An <em>agent</em> is a WebAssembly component instance with a durable identity (<code>AgentId</code>) and an append-only history called the <em>oplog</em>. For a durable agent the oplog is what the agent is rebuilt from; an ephemeral agent also writes one, but only so that its status and results can be observed afterwards — it is never resumed from it. The worker service routes invocations to the executor that owns the agent's shard; the executor loads the component into a Wasmtime <code>Store</code>, feeds it invocations, records every nondeterministic interaction the guest has with the host, and — whenever the running instance is lost — rebuilds it by replaying that record.</p>
+
+<p>Three guarantees come up in almost every later section, so they are worth stating once up front. The code is structured around them, and many non-obvious pieces of the executor exist to protect one of them.</p>
+
+<div class="axioms">
+  <div class="axiom">
+    <div class="n">1</div>
+    <h4>Replay is deterministic by construction</h4>
+    <p>The guest is a deterministic function of its guest-observable host inputs. The executor records every such input in the oplog and feeds it back on replay. If a replaying guest asks for a host call different from the one recorded next, the <em>executor</em> has a bug. It is never "normal nondeterminism".</p>
+  </div>
+  <div class="axiom">
+    <div class="n">2</div>
+    <h4>The resident runtime is disposable</h4>
+    <p>The Wasmtime <code>Store</code>, the worker task, sockets, channels, caches and the executor process itself may vanish at any instruction boundary. Suspend, evict, reshard, restart and crash are all recovered the same way: throw the instance away, build a new <code>Store</code>, replay the oplog, continue.</p>
+  </div>
+  <div class="axiom">
+    <div class="n">3</div>
+    <h4>Durable RPC is exactly-once per logical callee invocation</h4>
+    <p>A caller may attempt a dispatch many times (replay, transport retry, atomic-region rollback). Every attempt carries the same durable idempotency key, the target persists one invocation, and one durable result exists. <strong>Attempts are not executions.</strong></p>
+  </div>
+</div>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 330" role="img" aria-labelledby="fig1-title fig1-desc">
+  <title id="fig1-title">Live execution, loss of the Store, replay, and return to live</title>
+  <desc id="fig1-desc">A live guest in Store 1 makes host calls through durable host functions, which append Start, End and delivery entries to the persistent oplog and return results. Store 1 disappears. A replay guest in Store 2 makes the same host calls; the host claims the recorded Start, resolves the recorded End and delivers the result at the recorded marker, reading from the oplog. When the cursor is exhausted the Store is published as live and new work appends to the oplog again.</desc>
+  <defs><marker id="arr1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <rect class="box accent" x="20" y="30" width="190" height="80"/>
+  <text x="115" y="62" text-anchor="middle" class="title">Live guest</text>
+  <text x="115" y="84" text-anchor="middle" class="lbl">Wasmtime Store #1</text>
+  <rect class="box" x="300" y="30" width="250" height="80"/>
+  <text x="425" y="56" text-anchor="middle" class="title">Durable host function</text>
+  <text x="425" y="76" text-anchor="middle" class="lbl">append Start → run effect → append End</text>
+  <text x="425" y="94" text-anchor="middle" class="lbl">→ deliver result, append marker</text>
+  <rect class="box ok" x="660" y="30" width="220" height="270"/>
+  <text x="770" y="56" text-anchor="middle" class="title">Oplog (persistent)</text>
+  <text x="680" y="84" class="lbl">#41 AgentInvocationStarted</text>
+  <text x="680" y="104" class="lbl">#42 Start keyvalue/get</text>
+  <text x="680" y="124" class="lbl">#43 End → "42"</text>
+  <text x="680" y="144" class="lbl">#44 CompletionDelivered</text>
+  <text x="680" y="164" class="lbl">#45 Start http/send</text>
+  <text x="680" y="184" class="lbl">#46 End → 200 OK</text>
+  <text x="680" y="204" class="lbl">#47 CompletionDelivered</text>
+  <text x="680" y="224" class="lbl">#48 AgentInvocationFinished</text>
+  <text x="680" y="254" class="lbl muted">… survives any process loss</text>
+  <path class="arrow" style="marker-end:url(#arr1)" d="M210 58 H298"/><text x="254" y="50" text-anchor="middle" class="lbl">host call</text>
+  <path class="arrow" style="marker-end:url(#arr1)" d="M298 90 H212"/><text x="254" y="104" text-anchor="middle" class="lbl">result</text>
+  <path class="arrow strong" style="marker-end:url(#arr1)" d="M550 70 H658"/><text x="604" y="62" text-anchor="middle" class="lbl">append + commit</text>
+  <line x1="20" y1="140" x2="640" y2="140" stroke="var(--bad)" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="330" y="132" text-anchor="middle" class="lbl" fill="var(--bad)" style="fill:var(--bad)">✕ Store #1 is lost: suspend, evict, reshard, restart or crash</text>
+  <rect class="box accent" x="20" y="165" width="190" height="80"/>
+  <text x="115" y="197" text-anchor="middle" class="title">Replay guest</text>
+  <text x="115" y="219" text-anchor="middle" class="lbl">Wasmtime Store #2 (fresh)</text>
+  <rect class="box" x="300" y="165" width="250" height="80"/>
+  <text x="425" y="191" text-anchor="middle" class="title">Same host function, replaying</text>
+  <text x="425" y="211" text-anchor="middle" class="lbl">claim the recorded Start, resolve End,</text>
+  <text x="425" y="229" text-anchor="middle" class="lbl">release the result at the recorded marker</text>
+  <path class="arrow" style="marker-end:url(#arr1)" d="M210 193 H298"/><text x="254" y="185" text-anchor="middle" class="lbl">same host call</text>
+  <path class="arrow" style="marker-end:url(#arr1)" d="M298 225 H212"/><text x="254" y="239" text-anchor="middle" class="lbl">recorded result</text>
+  <path class="arrow dashed" style="marker-end:url(#arr1)" d="M658 205 H552"/><text x="604" y="197" text-anchor="middle" class="lbl">read, no effect</text>
+  <path class="arrow" style="marker-end:url(#arr1)" d="M425 245 V285"/>
+  <rect class="box sunken" x="300" y="285" width="250" height="34"/>
+  <text x="425" y="307" text-anchor="middle" class="lbl">cursor exhausted → published Live → appends again</text>
+</svg>
+<figcaption id="fig1-cap">The whole story in one picture: live execution appends to the oplog; a lost Store is replaced by a fresh one that replays from the oplog and then goes live.</figcaption>
+</figure>
+
+<h3>What "durable execution" buys an application developer</h3>
+<ul>
+  <li>Agent code is written as ordinary sequential code — awaiting an HTTP response, sleeping for a week, waiting for another agent — and the platform guarantees the code continues after any infrastructure failure from exactly the point it reached.</li>
+  <li>State lives in the agent's linear memory and filesystem, not in an external database, because memory is reconstructed from the oplog.</li>
+  <li>Calls between durable agents are exactly-once; a failed executor cannot cause a duplicated transfer.</li>
+  <li>Agents can be updated to a new component revision while keeping their history, snapshotted, reverted to an earlier point, or forked.</li>
+</ul>
+
+<h3>What it does <em>not</em> promise</h3>
+<ul>
+  <li>Exactly-once effects on <em>arbitrary external services</em>. Between performing an external effect and durably recording its result there is an ambiguous crash window; Golem attaches idempotency keys and offers atomic regions, but the peer has to honour them (<a href="#s-external">§15</a>).</li>
+  <li>Resumption of <em>ephemeral</em> agents. They are deliberately fail-stop (<a href="#s-actors">§3</a>).</li>
+</ul>
+
+<div class="callout hint">
+  <span class="label">Why the guest is deterministic</span>
+  The guest is a sandboxed WebAssembly component. It has no clock, no randomness, no network, no filesystem and no shared memory of its own; every interaction with the outside world is a call into one of the executor's host functions, and every host function that can return a different answer on a different day records what it returned. Given the same sequence of recorded answers, the guest computes the same sequence of requests. Determinism is therefore not a property the application developer has to maintain — it follows from the component model, and the executor's job is to make sure that the recorded answers are fed back at exactly the same points.
+</div>
+
+<!-- ===================== 2. ARCHITECTURE ===================== -->
+<h2 id="s-architecture"><span class="num">2</span>Architecture &amp; component map</h2>
+
+<p>Golem is a set of services. The worker executor is where guest code runs; the others route to it, store metadata for it, and split agents across executors.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 450" role="img" aria-labelledby="arch-title arch-desc">
+  <title id="arch-title">Golem services around the worker executor</title>
+  <desc id="arch-desc">Clients call the worker service over HTTP or gRPC. The worker service asks the shard manager which executor owns an agent's shard and forwards the invocation to that executor over gRPC. Inside the executor, a Worker object per agent owns an invocation queue, a Wasmtime Store and a durable host context; the durable host context appends to and replays from the oplog service, which is backed by indexed storage (Redis or SQLite) with archive layers in blob storage. Executors also talk to the registry service for components and metadata, and to each other for RPC.</desc>
+  <defs><marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <rect class="box" x="20" y="30" width="180" height="50"/><text x="110" y="52" text-anchor="middle" class="title">Clients</text><text x="110" y="69" text-anchor="middle" class="lbl">CLI, HTTP API, SDKs</text>
+  <rect class="box" x="240" y="30" width="170" height="50"/><text x="325" y="52" text-anchor="middle" class="title">Worker service</text><text x="325" y="69" text-anchor="middle" class="lbl">routing, API gateway</text>
+  <rect class="box" x="470" y="30" width="180" height="50"/><text x="560" y="52" text-anchor="middle" class="title">Shard manager</text><text x="560" y="69" text-anchor="middle" class="lbl">shard → executor assignment</text>
+  <rect class="box" x="690" y="30" width="190" height="50"/><text x="785" y="52" text-anchor="middle" class="title">Registry service</text><text x="785" y="69" text-anchor="middle" class="lbl">components, metadata, plugins</text>
+  <path class="arrow" d="M200 55 H238"/>
+  <path class="arrow dashed" d="M410 55 H468"/>
+  <!-- executor big box -->
+  <rect class="box accent" x="20" y="120" width="860" height="310"/>
+  <text x="40" y="145" class="title">Worker executor (one of many; each owns a set of shards)</text>
+  <path class="arrow strong" d="M325 80 V118"/><text x="335" y="105" class="lbl">gRPC: invoke, interrupt, resume, update, oplog…</text>
+  <path class="arrow dashed" d="M785 80 V118"/>
+  <path class="arrow dashed" d="M560 80 V118"/>
+  <rect class="box" x="40" y="165" width="200" height="60"/><text x="140" y="188" text-anchor="middle" class="title">gRPC server</text><text x="140" y="206" text-anchor="middle" class="lbl">src/grpc, src/server.rs</text>
+  <rect class="box" x="270" y="165" width="220" height="60"/><text x="380" y="188" text-anchor="middle" class="title">Worker (per agent)</text><text x="380" y="206" text-anchor="middle" class="lbl">queue, status, invocation loop</text>
+  <rect class="box" x="520" y="165" width="160" height="60"/><text x="600" y="188" text-anchor="middle" class="title">Wasmtime Store</text><text x="600" y="206" text-anchor="middle" class="lbl">guest instance, memory</text>
+  <rect class="box" x="710" y="165" width="150" height="60"/><text x="785" y="188" text-anchor="middle" class="title">Shard service</text><text x="785" y="206" text-anchor="middle" class="lbl">check_worker, reshard</text>
+  <path class="arrow" d="M240 195 H268"/><path class="arrow" d="M490 195 H518"/>
+  <rect class="box hint" x="270" y="250" width="410" height="76"/><text x="475" y="273" text-anchor="middle" class="title">Durable host context (DurableWorkerCtx)</text><text x="475" y="292" text-anchor="middle" class="lbl">durability guard · durable call sessions · replay cursor</text><text x="475" y="309" text-anchor="middle" class="lbl">host APIs: http, key-value, rpc, tools, streams…</text>
+  <path class="arrow" d="M600 225 V248"/>
+  <rect class="box" x="40" y="250" width="200" height="76"/><text x="140" y="273" text-anchor="middle" class="title">Services</text><text x="140" y="292" text-anchor="middle" class="lbl">scheduler, promises, rpc,</text><text x="140" y="309" text-anchor="middle" class="lbl">events, plugins</text>
+  <rect class="box ok" x="270" y="352" width="410" height="66"/><text x="475" y="374" text-anchor="middle" class="title">Oplog service (multi-layer)</text><text x="475" y="392" text-anchor="middle" class="lbl">primary: indexed storage (Redis or SQLite)</text><text x="475" y="408" text-anchor="middle" class="lbl">archive layers: compressed, then blob storage</text>
+  <path class="arrow strong" d="M475 326 V350"/>
+  <rect class="box sunken" x="710" y="250" width="150" height="168"/><text x="785" y="273" text-anchor="middle" class="title">Other executors</text><text x="785" y="295" text-anchor="middle" class="lbl">durable RPC</text><text x="785" y="312" text-anchor="middle" class="lbl">stream transport</text><text x="785" y="329" text-anchor="middle" class="lbl">worker proxy</text>
+  <path class="arrow dashed" d="M680 280 H708"/>
+</svg>
+<figcaption>The services around the executor. Solid arrows are the main invocation path; dashed arrows are lookups and peer traffic.</figcaption>
+</figure>
+
+<h3>Inside the executor: a component map</h3>
+<p>Click a box (or use the table below it) to see what each part owns. Paths are relative to <code>golem-worker-executor/src/</code>.</p>
+
+<div class="widget" id="compmap-widget">
+  <div class="svg-scroll">
+  <svg class="dg" viewBox="0 0 900 470" role="group" aria-label="Interactive component map of the worker executor; select a component to read its responsibility">
+    <defs><marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+    <g class="clickable" tabindex="0" role="button" data-comp="worker"><rect class="box" x="20" y="20" width="270" height="70"/><text x="155" y="48" text-anchor="middle" class="title">Worker &amp; invocation loop</text><text x="155" y="68" text-anchor="middle" class="lbl">worker/{mod,invocation_loop,…}.rs</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="ctx"><rect class="box hint" x="315" y="20" width="270" height="70"/><text x="450" y="48" text-anchor="middle" class="title">Durable host context</text><text x="450" y="68" text-anchor="middle" class="lbl">durable_host/mod.rs</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="oplogmodel"><rect class="box" x="610" y="20" width="270" height="70"/><text x="745" y="48" text-anchor="middle" class="title">Oplog model</text><text x="745" y="68" text-anchor="middle" class="lbl">golem-common/…/oplog/mod.rs</text></g>
+
+    <g class="clickable" tabindex="0" role="button" data-comp="durability"><rect class="box" x="20" y="130" width="200" height="70"/><text x="120" y="158" text-anchor="middle" class="title">Durability guard</text><text x="120" y="178" text-anchor="middle" class="lbl">durable_host/durability.rs</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="concurrent"><rect class="box" x="240" y="130" width="200" height="70"/><text x="340" y="158" text-anchor="middle" class="title">Durable call sessions</text><text x="340" y="178" text-anchor="middle" class="lbl">durable_host/concurrent/*</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="replay"><rect class="box" x="460" y="130" width="200" height="70"/><text x="560" y="158" text-anchor="middle" class="title">Replay cursor &amp; claims</text><text x="560" y="178" text-anchor="middle" class="lbl">durable_host/replay_state/*</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="tail"><rect class="box" x="680" y="130" width="200" height="70"/><text x="780" y="158" text-anchor="middle" class="title">Tail work</text><text x="780" y="178" text-anchor="middle" class="lbl">durable_host/tail_work.rs</text></g>
+
+    <g class="clickable" tabindex="0" role="button" data-comp="rpc"><rect class="box" x="20" y="240" width="200" height="70"/><text x="120" y="268" text-anchor="middle" class="title">Durable RPC</text><text x="120" y="288" text-anchor="middle" class="lbl">durable_host/wasm_rpc/</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="streams"><rect class="box" x="240" y="240" width="200" height="70"/><text x="340" y="268" text-anchor="middle" class="title">Durable streams</text><text x="340" y="288" text-anchor="middle" class="lbl">durable_host/durable_stream*</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="tools"><rect class="box" x="460" y="240" width="200" height="70"/><text x="560" y="268" text-anchor="middle" class="title">Tools &amp; entity bodies</text><text x="560" y="288" text-anchor="middle" class="lbl">durable_host/{tool,entity}</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="hostapis"><rect class="box" x="680" y="240" width="200" height="70"/><text x="780" y="268" text-anchor="middle" class="title">Host API impls</text><text x="780" y="288" text-anchor="middle" class="lbl">durable_host/{http,keyvalue,…}</text></g>
+
+    <g class="clickable" tabindex="0" role="button" data-comp="oplogsvc"><rect class="box ok" x="20" y="350" width="270" height="70"/><text x="155" y="378" text-anchor="middle" class="title">Oplog service</text><text x="155" y="398" text-anchor="middle" class="lbl">services/oplog/*</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="sched"><rect class="box" x="315" y="350" width="270" height="70"/><text x="450" y="378" text-anchor="middle" class="title">Scheduler, promises, status flusher</text><text x="450" y="398" text-anchor="middle" class="lbl">services/{scheduler,promise}.rs</text></g>
+    <g class="clickable" tabindex="0" role="button" data-comp="cut"><rect class="box" x="610" y="350" width="270" height="70"/><text x="745" y="378" text-anchor="middle" class="title">Cut points, eviction, shard service</text><text x="745" y="398" text-anchor="middle" class="lbl">worker/cut_point.rs, services/shard.rs</text></g>
+    <path class="arrow" style="marker-end:url(#arr2)" d="M155 90 V128"/>
+    <path class="arrow" style="marker-end:url(#arr2)" d="M450 90 V128"/>
+    <path class="arrow" style="marker-end:url(#arr2)" d="M340 200 V238"/>
+    <path class="arrow" style="marker-end:url(#arr2)" d="M155 310 V348"/>
+    <path class="arrow" style="marker-end:url(#arr2)" d="M560 200 V238"/>
+    <text x="450" y="455" text-anchor="middle" class="lbl">Arrows show the main "uses" direction; every host API goes through the durability guard and a call session before it touches the oplog.</text>
+  </svg>
+  </div>
+  <div class="result" id="compmap-detail" aria-live="polite">
+    <div class="verdict">Select a component</div>
+    <p class="muted">The detail for the selected component appears here.</p>
+  </div>
+</div>
+
+<details class="disclosure">
+  <summary>Component responsibilities as a table</summary>
+  <div class="body table-wrap">
+  <table id="compmap-table">
+    <thead><tr><th scope="col">Area</th><th scope="col">Files</th><th scope="col">Responsibility</th></tr></thead>
+    <tbody>
+      <tr data-comp="worker"><td>Worker &amp; invocation loop</td><td><code>worker/{mod,invocation_loop,lifecycle,instance,status}.rs</code></td><td>One <code>Worker</code> per resident agent. Accepts and persists invocations, dedupes by idempotency key, runs the outer loop (create instance → prepare/replay → run → decide retry), folds status from the oplog, decides interrupt/resume/update, eviction and retry.</td></tr>
+      <tr data-comp="ctx"><td>Durable host context</td><td><code>durable_host/mod.rs</code></td><td><code>DurableWorkerCtx</code>: the per-Store host state. <code>prepare_instance</code>, <code>resume_replay</code>, <code>switch_to_live</code>, <code>PendingReplayToLive</code>, idempotency-key derivation, snapshot boundary checks, invocation success/failure hooks.</td></tr>
+      <tr data-comp="oplogmodel"><td>Oplog model</td><td><code>golem-common/src/base_model/oplog/{mod,oplog_macro}.rs</code></td><td>The <code>OplogEntry</code> enum generated by the <code>oplog_entry!</code> macro: each kind's fields, whether it is a hint, its public rendering and WIT type binding.</td></tr>
+      <tr data-comp="durability"><td>Durability guard</td><td><code>durable_host/durability.rs</code></td><td><code>begin_durable_function</code> / <code>end_durable_function</code>, <code>DurableFunctionType</code>, the shared re-execution / in-function-retry eligibility predicate, custom durable invocations, retry error entries.</td></tr>
+      <tr data-comp="concurrent"><td>Durable call sessions</td><td><code>durable_host/concurrent/{mod,call,delivery,replay}.rs</code></td><td><code>DurableCallSession</code> state machine for one durable call: append <code>Start</code>, run or replay, append terminal, deliver to the guest with a <code>CompletionDelivered</code>/<code>Discarded</code> marker; drop policies; <code>classify_replay_resolution</code>.</td></tr>
+      <tr data-comp="replay"><td>Replay cursor &amp; claims</td><td><code>durable_host/replay_state/{mod,cursor,claims,resolution}.rs</code></td><td>The single <code>ReplayCursor</code>: speculative read vs. commit, identity claims for <code>Start</code> entries, the Replaying → Settling → Live phase machine, reconstruction fences.</td></tr>
+      <tr data-comp="tail"><td>Tail work</td><td><code>durable_host/tail_work.rs</code></td><td>Keeps the Store's event loop running until no spawned durable work is still active, so a task's <code>Start</code>/<code>End</code> never lands after <code>AgentInvocationFinished</code>.</td></tr>
+      <tr data-comp="rpc"><td>Durable RPC</td><td><code>durable_host/wasm_rpc/mod.rs</code></td><td>Agent-to-agent calls: key derivation from the <code>Start</code> index, first dispatch vs. <code>MayExist</code> re-dispatch, replay claims, ephemeral phantom identity, streaming RPC setup.</td></tr>
+      <tr data-comp="streams"><td>Durable streams</td><td><code>durable_host/{durable_stream,durable_session,stream_session,stream_bus,stream_transport,schema_value_stream}.rs</code></td><td>Producer-side stream records in the producer's oplog, consumer-side session journal, live-tail bus, exactly-once item delivery by offset, protocol terminals.</td></tr>
+      <tr data-comp="tools"><td>Tools &amp; entity bodies</td><td><code>durable_host/tool/{mod,operation,attachment}.rs</code>, <code>durable_host/entity.rs</code>, <code>worker/{entity_slot,owner_lane,entity_invocation,instance}.rs</code></td><td>Tool discovery and authorization, the owner-oplog boundary for transient entity bodies, shared replay cursor, lane serialization, attachment memory admission.</td></tr>
+      <tr data-comp="hostapis"><td>Host API implementations</td><td><code>durable_host/{http,keyvalue,blobstore,rdbms,sockets,clocks,random,golem,cli,config,secrets,websocket,…}</code></td><td>Each WASI / Golem host interface, implemented as durable functions: pick a <code>DurableFunctionType</code>, run the effect through a call session, return the recorded value on replay.</td></tr>
+      <tr data-comp="oplogsvc"><td>Oplog service</td><td><code>services/oplog/{mod,primary,multilayer,compressed,blob,ephemeral,plugin}.rs</code></td><td>Append buffer and commit levels, primary indexed storage plus archive layers, ephemeral-agent oplogs writing straight to archive layers, oplog-processor plugin delivery with checkpoints.</td></tr>
+      <tr data-comp="sched"><td>Scheduler, promises, status flusher</td><td><code>services/{scheduler,promise}.rs</code>, <code>durable_host/suspendable_wait.rs</code>, <code>worker/status_flusher.rs</code></td><td>Persisted wake-ups (<code>ScheduledAction::{CompletePromise, Invoke, Resume, ArchiveOplog}</code>), durable promises, the shard-keyed <code>RunningWorkers</code> index and asynchronous status baselines.</td></tr>
+      <tr data-comp="cut"><td>Cut points, eviction, shard service</td><td><code>worker/cut_point.rs</code>, <code>worker/mod.rs</code> (<code>EvictionClass</code>), <code>services/shard.rs</code></td><td>Validation of revert/fork cut points; which resident workers may be unloaded under memory pressure; shard ownership checks and reassignment.</td></tr>
+    </tbody>
+  </table>
+  </div>
+</details>
+
+<h3>The rest of the crate: what surrounds the durable core</h3>
+<p>The component map above is the part of the executor that makes progress durable. It is embedded in a larger process that has to be placed in a cluster, admit work without running out of memory, load code, expose host interfaces and talk to storage. The cards below group the remaining modules under <code>golem-worker-executor/src</code>; each later section refers back to them when needed.</p>
+
+<div class="grid-wide">
+  <div class="card">
+    <h4>gRPC API surface <span class="src">src/grpc/mod.rs</span></h4>
+    <p>The only way in. The worker service calls it; workers never call it themselves. Worker control: <code>create</code>, <code>delete</code>, <code>interrupt</code>, <code>resume</code>, <code>update</code>, <code>revert</code>, <code>fork</code>, <code>resolve_revert_last_invocations</code>. Work: <code>invoke_and_await_worker</code>, <code>invoke_worker</code>, <code>invoke_agent_session</code>, <code>cancel_invocation</code>, <code>complete_promise</code>. Observation: <code>connect_worker</code> (live log/event stream), <code>get_oplog</code>, <code>search_oplog</code>, <code>get_workers_metadata</code>, <code>get_running_workers_metadata</code>, <code>get_agent_metadata</code>, <code>get_agent_wallet</code>, <code>get_file_contents</code>, <code>get_file_system_node</code>. Streams: <code>read_durable_stream_segment</code>, <code>control_durable_stream_attachment</code>. Cluster: <code>assign_shards</code>, <code>revoke_shards</code>, <code>set_shard_assignment</code>, <code>process_oplog_entries</code>, <code>deliver_card_transfer</code>, <code>activate_plugin</code> / <code>deactivate_plugin</code>.</p>
+  </div>
+  <div class="card">
+    <h4>Placement &amp; scaling <span class="src">services/{shard,shard_manager,worker_proxy,worker_enumeration,worker_activator}.rs</span></h4>
+    <p>Every agent id hashes to a <em>shard</em>; the shard manager assigns shards to executors and each executor's <code>ShardService</code> accepts or refuses work by shard (<code>check_worker</code>). The single-binary <code>golem</code> uses <code>ShardManagerServiceSingleShard</code>. When an agent needs another agent that lives elsewhere, <code>RemoteWorkerProxy</code> forwards the call to the owning executor over gRPC. <code>worker_enumeration</code> lists agents by scanning oplogs (durable agents only, unless the filter asks for ephemeral modes). <code>worker_activator</code> wakes agents in the background (for example after a shard is assigned, to resume interrupted work).</p>
+  </div>
+  <div class="card">
+    <h4>Admission, memory, fuel &amp; quota <span class="src">services/active_agents/*, linear_memory.rs, resource_limits.rs, quota.rs, workerctx/default.rs</span></h4>
+    <p>Before a worker becomes resident it must be <em>admitted</em>. The <code>AdmissionController</code> compares the larger of <em>measured RSS</em> (cgroup <code>memory.current</code>) and the <em>total linear memory granted</em> to live workers against a usable ceiling; when short it evicts resident <em>idle</em>, then <em>warm</em> workers, and if that is not enough it rejects rather than over-commits. The <code>MemoryGrant</code> guard returns the reservation exactly once when dropped. A per-account <code>ConcurrentAgentsScheduler</code> hands out execution permits fairly (FIFO per account). CPU is metered with Wasmtime <em>fuel</em>: each Store borrows fuel batches from a shared per-account pool and only re-borrows when the batch is spent; ephemeral invocations get a bounded local overdraft (<code>EphemeralFuelExhausted</code> when it runs out). <code>QuotaService</code> leases resource limits from the shard manager with a credit model (<code>credit_rate</code>, <code>max_credit</code>) so hot paths do not call out per use. <code>compilation_limiter</code> bounds how many local Wasmtime compilations can run when both the component cache and the compiled artifact store miss.</p>
+  </div>
+  <div class="card">
+    <h4>Code &amp; files <span class="src">services/{component,file_loader,agent_types,environment_state,registry_event_subscriber}.rs, services/agent_filesystem/*, sandbox_filesystem/*</span></h4>
+    <p><code>component</code> downloads component bytes and precompiled artifacts from the registry and caches them; engines are built through the shared <code>golem_common::wasmtime_config</code> so precompiled artifacts stay loadable. <code>file_loader</code> fetches content-addressed initial files. Each worker gets a sandboxed filesystem (<code>sandbox_filesystem</code>, with pressure monitoring in <code>filesystem_pressure.rs</code>) exposed through WASI filesystem p2 and p3. <code>environment_state</code> caches per-environment facts the executor needs at call time — deployments, secrets, retry policies, which tools an agent may reach — and <code>registry_event_subscriber</code> invalidates those caches when the registry changes.</p>
+  </div>
+  <div class="card">
+    <h4>Cross-agent plumbing <span class="src">services/{rpc,promise,scheduler,worker_event,events,stream_session_index,card,card_interest,direct_invocation_auth,agent_webhooks}.rs</span></h4>
+    <p><code>rpc</code> implements the agent-to-agent invocation path (local worker or remote proxy). <code>promise</code> creates, polls and completes durable promises that external parties can fulfil; <code>scheduler</code> persists timed actions (wake a sleeping agent, complete a promise, invoke, archive an oplog) so a timer set before a crash still fires after it. <code>worker_event</code> is the per-worker log/event stream behind <code>connect_worker</code>. <code>card</code> / <code>card_interest</code> implement permission cards (check, derive, revoke, ancestors) and <code>direct_invocation_auth</code> authorizes local RPC by principal. <code>agent_webhooks</code> delivers agent-defined webhooks.</p>
+  </div>
+  <div class="card">
+    <h4>Storage backends <span class="src">src/storage/{indexed,keyvalue,scheduler}/*</span></h4>
+    <p>The oplog service, key-value service, scheduler and status flusher are written against three small storage traits. Implementations: in-memory (tests), SQLite and multi-SQLite (single binary, local runs), PostgreSQL and Redis (clusters). Decorators exist for retrying, namespace routing and fault injection (used by the tests that simulate storage failure). Blob storage for oplog archive layers and snapshots is provided by <code>golem-service-base</code>.</p>
+  </div>
+</div>
+
+<details class="disclosure">
+  <summary>Host interfaces the guest can call (what <code>create_linker</code> wires up)</summary>
+  <div class="body">
+  <p>A guest agent talks to the world only through imported WIT interfaces. The executor links every one of them to a method on <code>DurableWorkerCtx</code>, which is what lets it record and replay them. The full list, from <code>wasi_host/mod.rs::create_linker</code> and <code>lib.rs</code>:</p>
+  <div class="table-wrap"><table>
+    <thead><tr><th scope="col">Group</th><th scope="col">Interfaces</th><th scope="col">Implementation</th></tr></thead>
+    <tbody>
+      <tr><td>WASI 0.2 (p2)</td><td><code>cli</code> (environment, exit, stdin/stdout/stderr, terminals), <code>clocks</code> (wall, monotonic incl. the 0.2.6 variant), <code>io</code> (error, poll, streams), <code>random</code>, <code>sockets</code> (tcp, udp, ip-name-lookup, network), <code>http</code> (outgoing-handler, types), <code>filesystem</code></td><td><code>durable_host/{cli,clocks,io,random,sockets,http}</code>, <code>wasi_filesystem/p2</code></td></tr>
+      <tr><td>WASI 0.3 (p3)</td><td>Same families as p3 async interfaces: <code>cli</code>, <code>clocks</code>, <code>filesystem</code>, <code>random</code>, <code>sockets</code>, <code>http</code></td><td><code>durable_host/p3/*</code>, <code>wasi_filesystem/p3</code></td></tr>
+      <tr><td>WASI proposals</td><td><code>wasi:blobstore</code>, <code>wasi:keyvalue</code> (cache, eventual, eventual-batch, types), <code>wasi:logging</code>, <code>wasi:config/store</code></td><td><code>durable_host/{blobstore,keyvalue,logging,config}</code>, backed by <code>services/{blob_store,key_value}.rs</code></td></tr>
+      <tr><td>Golem host API</td><td><code>golem:api/host</code> (promises, oplog index and commit, atomic regions, idempotency mode, agent metadata, fork, update), <code>golem:api/retry</code>, <code>golem:api/oplog</code> (reading the oplog), <code>golem:api/context</code> (invocation context / tracing), <code>golem:durability/durability</code> (custom durable functions)</td><td><code>durable_host/golem/{v1x,retry_api,invocation_context_api}.rs</code>, <code>durable_host/durability.rs</code></td></tr>
+      <tr><td>Agents, tools, RPC</td><td><code>golem:agent/host</code>, <code>golem:tool/host</code> plus the tool wire schema, <code>golem:rpc</code> (agent handles, invoke, invoke-and-await, streaming), schema wire encoding</td><td><code>durable_host/golem/agent.rs</code>, <code>durable_host/tool/*</code>, <code>durable_host/wasm_rpc/mod.rs</code></td></tr>
+      <tr><td>Permissions</td><td><code>golem:permissions/{types,inspect,derive,revoke,wallet,kernel-introspection}</code></td><td><code>durable_host/permissions/*</code>, <code>services/card.rs</code></td></tr>
+      <tr><td>Data &amp; secrets</td><td><code>golem:rdbms/{postgres,mysql,ignite2}</code>, <code>golem:websocket/client</code>, <code>golem:quota/types</code>, <code>golem:secrets/{types,reveal}</code></td><td><code>durable_host/{rdbms,websocket,quota,secrets}</code>, <code>services/rdbms/*</code></td></tr>
+    </tbody>
+  </table></div>
+  <p>Section 8 explains how a call through any of these becomes an oplog record and how it is answered on replay.</p>
+  </div>
+</details>
+
+<h3>How an invocation travels</h3>
+<ol class="steps">
+  <li>A client calls the worker service (HTTP or gRPC). The worker service resolves the agent's shard and forwards to the owning executor over gRPC (<code>src/grpc/mod.rs</code>: <code>invoke_and_await_worker</code> and friends).</li>
+  <li>The executor's shard service confirms it owns the shard (<code>check_worker</code>); otherwise the request is rejected and the worker service retries with fresh assignment.</li>
+  <li>The executor finds or creates the resident <code>Worker</code>. Creating one means loading the component, folding the agent's status from its oplog, and deciding which history the new instance must replay (snapshot baselines, pending updates).</li>
+  <li>The invocation is deduplicated by idempotency key, appended as <code>PendingAgentInvocation</code> and <em>committed</em> before the caller is told "accepted".</li>
+  <li>The invocation loop pops it, appends <code>AgentInvocationStarted</code>, runs the guest export in a Wasmtime Store, and every host call the guest makes is recorded through the durable host context.</li>
+  <li><code>AgentInvocationFinished</code> is appended and committed with <code>CommitLevel::Always</code>; only then are waiters notified and the result returned.</li>
+</ol>
+
+<!-- ===================== 3. ACTORS ===================== -->
+<h2 id="s-actors"><span class="num">3</span>Who is who: agents, entities, streams, peers</h2>
+<p>Most confusion about guarantees comes from mixing up five different kinds of participant. They get different guarantees because they have different amounts of durable state.</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Participant</th><th scope="col">Has its own oplog?</th><th scope="col">Reconstructed after loss?</th><th scope="col">Guarantee when called</th><th scope="col">Where defined</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Durable agent</strong> <span class="pill ok">the default</span></td><td>Yes, in primary storage with archive layers</td><td>Yes — replayed from the oplog, from a snapshot baseline if one exists</td><td>Exactly-once logical invocation per idempotency key; state and pending work survive any crash</td><td><code>AgentMode::Durable</code>; <code>PrimaryOplog</code></td></tr>
+    <tr><td><strong>Ephemeral agent</strong></td><td>Yes — buffered in memory and written straight to archive layers (<code>EphemeralOplog</code>). It is kept after the instance ends so status and results can still be observed, but it is never used to resume</td><td><strong>No.</strong> <code>reconstructed_ephemeral</code> rebuilds it only to observe status and look up results; "an ephemeral agent cannot accept another invocation or be resumed"</td><td>At-most-once: accepted work is never re-executed on a same-key retry, but completion is not guaranteed if the target is lost</td><td><code>AgentMode::Ephemeral</code>; <code>INACTIVE_EPHEMERAL_AGENT_ERROR</code></td></tr>
+    <tr><td><strong>Entity body</strong> (tool sidecar, tool middleware)</td><td><strong>No.</strong> Records into the <em>owner</em> agent's oplog under <code>parent_start_index</code> and shares the owner's replay cursor</td><td>Its Store is recreated per invocation; a completed body is <em>re-executed</em> on replay with its host calls replayed</td><td>Its external effects made through durable host calls happen once; its guest export may run more than once</td><td><code>AgentEntity::{Tool, ToolMiddleware}</code>; <code>durable_host/entity.rs</code></td></tr>
+    <tr><td><strong>Streaming session</strong></td><td>Two journals: the producer's oplog (<code>Stream*</code> hints) and the consumer's <code>StreamSession</code> hints</td><td>Buses, readers and sockets are recreated; delivery resumes by offset</td><td>Each item consumed exactly once per consumer session; exactly one terminal per stream</td><td><code>durable_stream.rs</code>, <code>durable_session.rs</code></td></tr>
+    <tr><td><strong>Arbitrary external service</strong> (HTTP API, database, TCP peer)</td><td>None that Golem controls</td><td>Sockets are recreated; the recorded response is replayed to the guest</td><td>Exactly-once only if the peer deduplicates on the idempotency key Golem sends; otherwise at-least-once in the crash window between the effect and its <code>End</code></td><td><code>durable_host/http/policy.rs</code>, <code>golem:api/host.generate-idempotency-key</code></td></tr>
+  </tbody>
+</table>
+</div>
+
+<h3>Durability guard and durable call sessions: two layers, not two alternatives</h3>
+<p>The two boxes on the second row of the map are easy to confuse because both are about "one durable host call". They are layered. The <strong>durability guard</strong> (<code>DurabilityHost::begin_durable_function</code> / <code>end_durable_function</code> in <code>durability.rs</code>) is the <em>scope</em> layer: it checks that a read-only invocation is not about to perform a write, tracks atomic regions, decides whether a failure may be retried inside the function, and, for non-idempotent writes, records the scope-level <code>Start</code>/<code>End</code> that says "an external effect may have begun here". A <strong><code>DurableCallSession</code></strong> (<code>concurrent/call.rs</code>) is the <em>per-call</em> state machine built on top of it: its <code>start</code> calls <code>begin_durable_function</code>, then it either runs the effect live and appends the terminal entry, or claims the recorded <code>Start</code> and answers from the recorded <code>End</code>, and finally delivers the completion to the guest with a <code>CompletionDelivered</code> marker. Reusing the guard inside the session is what keeps scope semantics identical for every host function, whatever style of host API it implements.</p>
+<p>Almost every host function (random, clocks, key-value, blob store, RPC, tools, …) goes through a <code>DurableCallSession</code>. The guard is called directly only where a single external effect spans several host calls and therefore cannot fit into one session: the HTTP client (<code>outgoing_handler::handle</code>, whose response body arrives through later stream reads) and RDBMS query streams. <a href="#s-hostcalls">§8</a> follows one call through both layers; custom durable invocations written by application code use their own <code>Start</code>/<code>End</code> pair through <code>begin_custom_durable_invocation</code> rather than a session.</p>
+
+<p>"Exactly-once" is also not one promise. RPC between durable agents, oplog-processor delivery, stream items and stream terminals each have their own exactly-once contract with their own mechanism; <a href="#s-external">§15</a> sets them side by side after each has been introduced.</p>
+
+<!-- ===================== 4. STATE ===================== -->
+<h2 id="s-state"><span class="num">4</span>Durable vs. resident state</h2>
+<p>The single most useful question when reasoning about the executor is: <em>which column does this fact live in?</em> Anything in the right column may be rebuilt from the left column at any time. A design that needs something from the right column to survive a restart is wrong.</p>
+
+<div class="widget">
+  <h4>Try it: lose the process <span class="pill js-only">interactive</span></h4>
+  <p class="js-only">Press the button to simulate the executor dying. Everything resident disappears; everything durable is still there and is enough to rebuild the rest.</p>
+  <div class="controls js-only">
+    <button class="btn primary" id="kill-btn" type="button">✕ Kill the executor process</button>
+    <button class="btn" id="rebuild-btn" type="button" disabled>Rebuild from the oplog</button>
+  </div>
+  <div class="two-col">
+    <div class="state-col" id="durable-col">
+      <h4>Durable (authoritative)</h4>
+      <ul>
+        <li>Oplog entries and their payloads</li>
+        <li><code>PendingAgentInvocation</code> / <code>AgentInvocationStarted</code> / <code>AgentInvocationFinished</code> — the durable queue and results</li>
+        <li>Idempotency keys and recorded invocation results</li>
+        <li>Durable-call <code>Start</code>/<code>End</code>/<code>Cancelled</code> and <code>CompletionDelivered</code>/<code>CompletionDiscarded</code> markers</li>
+        <li><code>PendingUpdate</code>/<code>SuccessfulUpdate</code>/<code>FailedUpdate</code>, <code>Snapshot</code> hints and snapshot blobs</li>
+        <li><code>BeginAtomicRegion</code>/<code>EndAtomicRegion</code>/<code>Jump</code> entries</li>
+        <li>Agent status — <em>folded from the oplog</em> (<code>worker/status.rs</code>)</li>
+        <li>Persisted promises and scheduler actions; the shard-keyed <code>RunningWorkers</code> recovery index</li>
+        <li>Producer stream records and consumer <code>StreamSession</code> journals</li>
+      </ul>
+    </div>
+    <div class="state-col" id="resident-col">
+      <h4>Resident (disposable, derived)</h4>
+      <ul>
+        <li>Wasmtime <code>Store</code>, instance, linear memory</li>
+        <li><code>Worker.queue</code> (<code>VecDeque</code> of queued invocations), event subscriptions</li>
+        <li><code>hydrated_invocation_results</code> cache, read-only cache</li>
+        <li><code>DurableCallSession</code>s, <code>ReplayableOneshot</code>s, spawned store tasks</li>
+        <li>In-flight update decision, loaded snapshot bytes</li>
+        <li>Atomic-region logical idempotency counter (rebuilt during replay)</li>
+        <li>Status cache and checkpoints (baselines only)</li>
+        <li>Tokio timers, in-memory wake channels, stream buses, sockets, attachments</li>
+      </ul>
+    </div>
+  </div>
+  <div class="result js-only" id="state-result" aria-live="polite"><div class="verdict">Both columns are populated: the agent is running.</div></div>
+</div>
+
+<h3>Rebuilding status: a fold over the oplog</h3>
+<p>"Rebuilt from the oplog" is not magic; for the agent's <em>status record</em> it is a plain left fold. <code>calculate_latest_worker_status</code> in <code>worker/status.rs</code> reads the entries in index order and updates one record: the status enum, the queue of pending invocations, the invocation whose result is not yet known, the map from idempotency key to result entry, the component revision, the linear-memory size, the regions to skip on replay and the retry state. Two details matter. First, the fold runs in two passes: it collects <code>Jump</code> and <code>Revert</code> regions before folding status, so entries inside a skipped region do not change the status (they were a failed attempt), while their <code>Error</code> entries still count toward the retry state. Second, the fold is incremental in practice: a cached record plus the entries appended since it was computed gives the same answer as recomputing from <code>Create</code>, which is what makes status cheap to keep current.</p>
+
+<div class="widget" id="fold-widget">
+  <h4>Try it: fold a real-looking oplog <span class="pill js-only">interactive</span></h4>
+  <p>The table is the complete oplog of a small durable agent that handled two invocations, retried a failed HTTP call inside an atomic region, and is now asleep in a third invocation. <span class="js-only">Step through the entries and watch the derived record on the right change; the highlighted row is the entry being folded.</span><span class="no-js-only">The right-hand record shows the result of folding all 22 entries.</span></p>
+  <div class="controls js-only">
+    <button class="btn" id="fold-reset" type="button">Reset</button>
+    <button class="btn primary" id="fold-step" type="button">Fold next entry</button>
+    <button class="btn" id="fold-all" type="button">Fold everything</button>
+    <span class="muted" id="fold-pos" aria-live="polite">Before the first entry</span>
+  </div>
+  <div class="fold-grid">
+    <div class="table-wrap">
+      <table class="fold-tape" id="fold-tape">
+        <thead><tr><th scope="col">#</th><th scope="col">Entry</th><th scope="col">Effect on the record</th></tr></thead>
+        <tbody>
+          <tr data-i="0"><td>1</td><td><code>Create</code> <span class="muted">rev 1, 2 MiB</span></td><td>Status <b>Idle</b>; component revision 1; linear memory 2 MiB.</td></tr>
+          <tr data-i="1"><td>2</td><td><code>PendingAgentInvocation</code> <span class="muted">k1 place-order</span> <span class="pill hint">hint</span></td><td>k1 joins the pending queue. Status unchanged.</td></tr>
+          <tr data-i="2"><td>3</td><td><code>AgentInvocationStarted</code> <span class="muted">k1</span></td><td>Status <b>Running</b>; k1 leaves the queue and becomes the current invocation; retry state cleared.</td></tr>
+          <tr data-i="3"><td>4</td><td><code>GrowMemory</code> <span class="muted">+1 MiB</span></td><td>Linear memory 3 MiB. Status unchanged.</td></tr>
+          <tr data-i="4"><td>5</td><td><code>Start</code> <span class="muted">keyvalue/set, WriteRemote</span></td><td>Status Running (a host call is in flight).</td></tr>
+          <tr data-i="5"><td>6</td><td><code>End</code> <span class="muted">keyvalue/set → ok</span></td><td>Status Running.</td></tr>
+          <tr data-i="6"><td>7</td><td><code>CompletionDelivered</code> <span class="muted">for #5</span></td><td>No effect on the record (it matters to replay, not to status).</td></tr>
+          <tr data-i="7"><td>8</td><td><code>AgentInvocationFinished</code> <span class="muted">k1 → Ok</span></td><td>Status <b>Idle</b>; results[k1] = #8; no current invocation; retry state cleared.</td></tr>
+          <tr data-i="8"><td>9</td><td><code>PendingAgentInvocation</code> <span class="muted">k2 charge</span> <span class="pill hint">hint</span></td><td>k2 joins the queue.</td></tr>
+          <tr data-i="9"><td>10</td><td><code>PendingAgentInvocation</code> <span class="muted">k3 ship</span> <span class="pill hint">hint</span></td><td>k3 joins the queue behind k2.</td></tr>
+          <tr data-i="10"><td>11</td><td><code>AgentInvocationStarted</code> <span class="muted">k2</span></td><td>Status <b>Running</b>; queue = [k3]; current = k2.</td></tr>
+          <tr data-i="11"><td>12</td><td><code>BeginAtomicRegion</code></td><td>Status Running. This entry is kept out of the skipped region so the retry can be grouped under it.</td></tr>
+          <tr data-i="12" class="skip"><td>13</td><td><code>Start</code> <span class="muted">http/handle, WriteRemote</span></td><td><em>Skipped</em>: inside the region #13–#15 registered by the Jump at #15. No effect.</td></tr>
+          <tr data-i="13" class="skip"><td>14</td><td><code>Error</code> <span class="muted">connection reset, retry_from=#12, attempt 1</span></td><td><em>Skipped for status</em>, but the retry state still records one attempt for the region starting at #12, and results[k2] provisionally points at #14.</td></tr>
+          <tr data-i="14" class="skip"><td>15</td><td><code>Jump</code> <span class="muted">region #13–#15</span></td><td>Found in the first pass; it is what marks #13–#15 as skipped. Appended by the retrying instance when replay reached #12 and found no <code>EndAtomicRegion</code>.</td></tr>
+          <tr data-i="15"><td>16</td><td><code>Start</code> <span class="muted">http/handle, WriteRemote (second attempt)</span></td><td>Status Running.</td></tr>
+          <tr data-i="16"><td>17</td><td><code>End</code> <span class="muted">http/handle → 200</span></td><td>Status Running.</td></tr>
+          <tr data-i="17"><td>18</td><td><code>CompletionDelivered</code> <span class="muted">for #16</span></td><td>No effect.</td></tr>
+          <tr data-i="18"><td>19</td><td><code>EndAtomicRegion</code></td><td>Status Running; the atomic region is closed, so a future replay will treat #12–#19 as committed.</td></tr>
+          <tr data-i="19"><td>20</td><td><code>AgentInvocationFinished</code> <span class="muted">k2 → Ok</span></td><td>Status <b>Idle</b>; results[k2] = #20 (replacing #14); current cleared; retry state cleared.</td></tr>
+          <tr data-i="20"><td>21</td><td><code>AgentInvocationStarted</code> <span class="muted">k3</span></td><td>Status <b>Running</b>; queue empty; current = k3.</td></tr>
+          <tr data-i="21"><td>22</td><td><code>Suspend</code> <span class="muted">sleep(1h)</span></td><td>Status <b>Suspended</b>. The scheduler owns the wake-up; k3 is still the current invocation.</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="fold-record" id="fold-record" aria-live="polite">
+      <h4>Derived status record</h4>
+      <dl class="kv">
+        <dt>Status</dt><dd id="fr-status"><span class="pill warn">Suspended</span></dd>
+        <dt>Component revision</dt><dd id="fr-rev">1</dd>
+        <dt>Pending queue</dt><dd id="fr-pending"><span class="muted">empty</span></dd>
+        <dt>Current invocation</dt><dd id="fr-current">k3</dd>
+        <dt>Invocation results</dt><dd id="fr-results">k1 → #8, k2 → #20</dd>
+        <dt>Linear memory</dt><dd id="fr-mem">3 MiB</dd>
+        <dt>Skipped regions</dt><dd id="fr-skipped">#13–#15</dd>
+        <dt>Retry state</dt><dd id="fr-retry"><span class="muted">none</span></dd>
+      </dl>
+      <p class="muted" id="fold-note">A new executor that loads this agent starts from exactly this record: it knows k3 is mid-flight and suspended, that nothing is queued, and which entries replay must skip.</p>
+    </div>
+  </div>
+</div>
+
+<h3>Append versus commit</h3>
+<p>Two persistence steps matter for every crash window. <strong>Append</strong> puts an entry into the oplog's in-memory buffer. <strong>Commit</strong> (<code>commit_oplog_and_update_state(CommitLevel)</code>) writes the buffer to storage and makes the entries recoverable. The buffer exists so that not every append costs a storage round trip; where an entry must be recoverable before the executor proceeds, the code commits explicitly:</p>
+<ul>
+  <li>Accepting remote work: <code>PendingAgentInvocation</code> is committed before the caller learns the invocation was accepted.</li>
+  <li>Finishing an invocation: <code>AgentInvocationFinished</code> is committed with <code>CommitLevel::Always</code> before waiters are notified.</li>
+  <li>Stream records are committed before they are published on the live bus.</li>
+</ul>
+<p><code>CommitLevel::Always</code> waits for durable storage; <code>CommitLevel::DurableOnly</code> only does so for durable agents (the ephemeral oplog honours the level, the primary oplog always flushes). Whenever this document says "accepted only after commit", it means the commit, not the append.</p>
+
+<h3>Rediscovery</h3>
+<p>Durability alone is not liveness: after a crash somebody must <em>notice</em> that an agent has pending work. Two mechanisms provide that. A timed wait (sleep, promise with timeout) first schedules its wake-up as a persisted scheduler action (<code>durable_host/suspendable_wait.rs</code>, <code>WakeupScheduler::sleep_until</code>). And the shard-keyed <code>RunningWorkers</code> index is updated synchronously whenever a worker gains or loses pending work (<code>worker/status_flusher.rs</code>), so an executor that takes over a shard can enumerate the agents it must revive. The status blob cache is only an asynchronously flushed baseline.</p>
+
+<!-- ===================== 5. OPLOG ===================== -->
+<h2 id="s-oplog"><span class="num">5</span>The oplog</h2>
+<p>The oplog is an append-only sequence of typed entries per agent, indexed from <code>OplogIndex::INITIAL</code> (the <code>Create</code> entry). Entries are defined once, by the <code>oplog_entry!</code> macro in <code>golem-common/src/base_model/oplog/mod.rs</code>, which generates both the binary <code>OplogEntry</code> and the user-facing <code>PublicOplogEntry</code>.</p>
+
+<h3>Positional entries versus hints</h3>
+<p>Every entry kind is either <strong>positional</strong> or a <strong>hint</strong> (<code>OplogEntry::is_hint()</code>). Replay consumes positional entries in order: the guest's next host call must match the next positional entry. Hints are skipped by the replay cursor (<code>skip_forward</code> moves past them without advancing <code>last_replayed_non_hint_index</code>), take part in no <code>Start</code>/terminal pairing, and never satisfy a claim. Hints record facts <em>about</em> the execution — status, queueing, delivery boundaries, stream records — without being inputs to the guest.</p>
+
+<div class="widget" id="oplog-explorer">
+  <h4>Oplog entry explorer <span class="pill js-only">interactive</span></h4>
+  <div class="controls js-only">
+    <label>Filter by category
+      <select id="oplog-filter">
+        <option value="all">All entries</option>
+        <option value="call">Durable calls &amp; delivery</option>
+        <option value="invocation">Invocations</option>
+        <option value="lifecycle">Lifecycle &amp; status</option>
+        <option value="region">Atomic regions, jumps, reverts</option>
+        <option value="update">Updates &amp; snapshots</option>
+        <option value="stream">Streams &amp; sessions</option>
+        <option value="tx">Remote transactions</option>
+        <option value="other">Resources, plugins, spans, cards</option>
+      </select>
+    </label>
+    <label class="check"><input type="checkbox" id="oplog-hints-only"> hints only</label>
+    <label class="check"><input type="checkbox" id="oplog-pos-only"> positional only</label>
+    <span class="muted" id="oplog-count" aria-live="polite"></span>
+  </div>
+  <div class="legend"><span class="l-pos">positional — replay must match it</span><span class="l-hint">hint — skipped by replay</span></div>
+  <div class="table-wrap">
+  <table id="oplog-table">
+    <thead><tr><th scope="col">Entry</th><th scope="col">Kind</th><th scope="col">Meaning</th></tr></thead>
+    <tbody>
+      <tr data-cat="lifecycle"><td><code>Create</code></td><td><span class="pill pos">positional</span></td><td>First entry of every oplog: agent id, mode, component revision, env, parent, initial plugins, <code>instance_id</code> (the per-incarnation fingerprint).</td></tr>
+      <tr data-cat="call"><td><code>Start</code></td><td><span class="pill pos">positional</span></td><td>Start of a durable host call or scope. Identified by its own index. Carries <code>function_name</code>, optional <code>request</code> payload, <code>durable_function_type</code>, <code>parent_start_index</code> (enclosing scope) and optional <code>observational_owner</code> (root of a custom durable invocation).</td></tr>
+      <tr data-cat="call"><td><code>End</code></td><td><span class="pill pos">positional</span></td><td>Successful terminal of the call at <code>start_index</code>, with the <code>response</code> payload (<code>None</code> for scopes).</td></tr>
+      <tr data-cat="call"><td><code>Cancelled</code></td><td><span class="pill pos">positional</span></td><td>The call at <code>start_index</code> was dropped by the guest before producing a final response; may carry a <code>partial</code> result.</td></tr>
+      <tr data-cat="call"><td><code>CompletionDelivered</code></td><td><span class="pill hint">hint</span></td><td>The guest observed the completion of the accessor call at <code>start_index</code>. Always after its <code>End</code>. Fixes the guest-observation boundary for replay.</td></tr>
+      <tr data-cat="call"><td><code>CompletionDiscarded</code></td><td><span class="pill hint">hint</span></td><td>The guest dropped the completion future of the call at <code>start_index</code> without reading it.</td></tr>
+      <tr data-cat="call"><td><code>HostStreamFrame</code></td><td><span class="pill hint">hint</span></td><td>A frame of a host-owned stream (for example a p3 HTTP request body), attached to its owning call by <code>parent_start_index</code>. Consumers find frames by scanning; interrupted recordings need no closing entry.</td></tr>
+      <tr data-cat="invocation"><td><code>PendingAgentInvocation</code></td><td><span class="pill hint">hint</span></td><td>The durable queue entry: an accepted invocation with its idempotency key and payload.</td></tr>
+      <tr data-cat="invocation"><td><code>AgentInvocationStarted</code></td><td><span class="pill pos">positional</span></td><td>The invocation loop picked up an invocation: key, payload, trace context.</td></tr>
+      <tr data-cat="invocation"><td><code>AgentInvocationFinished</code></td><td><span class="pill pos">positional</span></td><td>The invocation completed with a result; consumed fuel and component revision are recorded.</td></tr>
+      <tr data-cat="invocation"><td><code>CancelPendingInvocation</code></td><td><span class="pill hint">hint</span></td><td>A pending invocation was cancelled before it started.</td></tr>
+      <tr data-cat="lifecycle"><td><code>Suspend</code></td><td><span class="pill hint">hint</span></td><td>The worker was unloaded because it was idle or waiting.</td></tr>
+      <tr data-cat="lifecycle"><td><code>Interrupted</code></td><td><span class="pill hint">hint</span></td><td>The worker was interrupted via the API and stays interrupted until resumed.</td></tr>
+      <tr data-cat="lifecycle"><td><code>Restart</code></td><td><span class="pill hint">hint</span></td><td>A simulated crash was requested (also appended when an ephemeral agent finishes its initial replay).</td></tr>
+      <tr data-cat="lifecycle"><td><code>Exited</code></td><td><span class="pill hint">hint</span></td><td>The guest exited; the agent can no longer be invoked.</td></tr>
+      <tr data-cat="lifecycle"><td><code>Error</code></td><td><span class="pill hint">hint</span></td><td>A failure with <code>retry_from</code> (where the retry replays to), <code>inside_atomic_region</code> and optional <code>retry_policy_state</code>. Retry budgets are counted by grouping <code>Error</code> entries by <code>retry_from</code>.</td></tr>
+      <tr data-cat="region"><td><code>NoOp</code></td><td><span class="pill pos">positional</span></td><td>Marker appended when the guest calls <code>get-oplog-index</code>, to make jump targets predictable.</td></tr>
+      <tr data-cat="region"><td><code>Jump</code></td><td><span class="pill pos">positional</span></td><td>Marks a region of history as skipped (atomic-region rollback, <code>set-oplog-index</code>). Entries keep their indices; replay skips them.</td></tr>
+      <tr data-cat="region"><td><code>BeginAtomicRegion</code> / <code>EndAtomicRegion</code></td><td><span class="pill pos">positional</span></td><td>Bracket an atomic region (<code>mark-begin-operation</code> / <code>mark-end-operation</code>): a trap inside re-executes the region from its beginning and the region owns a logical idempotency counter.</td></tr>
+      <tr data-cat="region"><td><code>Revert</code></td><td><span class="pill hint">hint</span></td><td>Records that history after a cut point was reverted.</td></tr>
+      <tr data-cat="update"><td><code>PendingUpdate</code></td><td><span class="pill hint">hint</span></td><td>An update to a target revision is pending: <code>Automatic</code> (replay old history on the new code) or <code>SnapshotBased</code> (with the recorded snapshot payload).</td></tr>
+      <tr data-cat="update"><td><code>SuccessfulUpdate</code> / <code>FailedUpdate</code></td><td><span class="pill hint">hint</span></td><td>Outcome of an update; a successful one changes the revision every later reconstruction loads.</td></tr>
+      <tr data-cat="update"><td><code>Snapshot</code></td><td><span class="pill hint">hint</span></td><td>An automatic snapshot of guest state was taken at this index for this component revision; a later reconstruction may start from it.</td></tr>
+      <tr data-cat="stream"><td><code>StreamRegistered</code> / <code>StreamItems</code> / <code>StreamEnd</code> / <code>StreamCancel</code></td><td><span class="pill hint">hint</span></td><td>Producer-side stream journal: registration with the producer's <code>AgentFingerprint</code>, batches of items with <code>first_sequence</code>, and terminals (guest- or protocol-authored).</td></tr>
+      <tr data-cat="stream"><td><code>StreamSession</code></td><td><span class="pill hint">hint</span></td><td>Consumer-side session journal: caller attempts, attach/detach, offset mappings, <code>ConsumerItemValue</code> with <code>source_offset</code> and <code>consumer_read_ordinal</code>, terminals, <code>Finished</code>.</td></tr>
+      <tr data-cat="tx"><td><code>BeginRemoteTransaction</code> / <code>PreCommitRemoteTransaction</code> / <code>PreRollbackRemoteTransaction</code> / <code>CommittedRemoteTransaction</code> / <code>RolledBackRemoteTransaction</code></td><td><span class="pill pos">positional</span></td><td>Phases of a remote transaction (for example an RDBMS transaction) so that recovery can finish or roll back what the crash interrupted.</td></tr>
+      <tr data-cat="other"><td><code>SetRetryPolicy</code> / <code>RemoveRetryPolicy</code></td><td><span class="pill pos">positional</span></td><td>Named retry policies set by the guest; persisted so they survive restart.</td></tr>
+      <tr data-cat="other"><td><code>GrowMemory</code>, <code>CreateResource</code>, <code>DropResource</code>, <code>Log</code></td><td><span class="pill hint">hint</span></td><td>Observability and accounting: linear memory growth, resource lifetimes, log lines.</td></tr>
+      <tr data-cat="other"><td><code>ActivatePlugin</code> / <code>DeactivatePlugin</code></td><td><span class="pill hint">hint</span></td><td>Plugin grants activated or deactivated for this agent.</td></tr>
+      <tr data-cat="other"><td><code>StartSpan</code> / <code>FinishSpan</code> / <code>SetSpanAttribute</code></td><td><span class="pill pos">positional</span></td><td>Invocation-context spans created by the guest; positional so span ids reproduce on replay.</td></tr>
+      <tr data-cat="other"><td><code>OplogProcessorCheckpoint</code></td><td><span class="pill hint">hint</span></td><td>Progress of oplog-processor plugin delivery.</td></tr>
+      <tr data-cat="other"><td><code>Card*</code> (<code>CardInstalled</code>, <code>CardTransferred</code>, …)</td><td><span class="pill hint">hint</span></td><td>Capability-card lifecycle events (install, derive, transfer, revoke, expire).</td></tr>
+    </tbody>
+  </table>
+  </div>
+</div>
+
+<h3>Anatomy of a durable call in the oplog</h3>
+<p>A <em>durable call</em> is a <code>Start</code> plus its <em>terminal</em> (<code>End</code> or <code>Cancelled</code>), both identified by the <code>Start</code> index. A terminal is <em>visible</em> when it lies below the replay target and outside a <code>Jump</code>/<code>Revert</code>-skipped region. Request-less <code>Start</code>/<code>End</code> pairs are <em>scopes</em> (batched writes, transactions), named <code>&lt;scope:batched-write&gt;</code> or, when the caller supplies a discriminator, <code>&lt;scope:batched-write:DISCRIMINATOR&gt;</code>; a discriminated claim matches only its exact name.</p>
+
+<div class="tape" role="group" aria-label="Example oplog fragment for one invocation with one durable host call">
+  <div class="entry hint"><span class="idx">#20</span><span class="kind">PendingAgentInvocation</span><span class="meta">key K (h)</span></div>
+  <div class="entry pos"><span class="idx">#21</span><span class="kind">AgentInvocationStarted</span><span class="meta">key K</span></div>
+  <div class="entry pos"><span class="idx">#22</span><span class="kind">Start</span><span class="meta">keyvalue/get, req k</span></div>
+  <div class="entry pos"><span class="idx">#23</span><span class="kind">End</span><span class="meta">start 22, resp v</span></div>
+  <div class="entry hint"><span class="idx">#24</span><span class="kind">CompletionDelivered</span><span class="meta">start 22 (h)</span></div>
+  <div class="entry pos"><span class="idx">#25</span><span class="kind">AgentInvocationFinished</span><span class="meta">result R</span></div>
+</div>
+<p class="src">Notation used throughout: <code>(h)</code> marks hint entries; indices are illustrative; real entries carry timestamps, payload references and function names.</p>
+
+<h3>Storage layers</h3>
+<p>Logically the oplog is one append-only sequence per agent. Physically it is spread over several storage layers that trade write latency for cost, and the <code>MultiLayerOplogService</code> hides the split: from the replay cursor's point of view there is only <code>read(agent, from_index, count)</code> over one contiguous index space.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 480" role="img" aria-labelledby="fig-layers-title fig-layers-desc">
+  <title id="fig-layers-title">How the oplog storage layers compose</title>
+  <desc id="fig-layers-desc">A durable agent's Worker appends entries into the primary oplog's in-memory buffer; commits write the buffer to indexed storage, with large payloads going to blob storage. When the primary layer holds more than the entry-count limit since the last transfer, or when the archive scheduler fires for an idle agent, the oldest prefix moves down: first to a compressed archive in indexed storage, then to a blob-storage archive. Reads are served from the primary layer first and fall through to lower layers for older index ranges. An ephemeral agent's oplog bypasses the primary layer and writes directly to the first archive layer.</desc>
+  <defs><marker id="arr-l" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+
+  <rect class="box accent" x="20" y="20" width="210" height="60"/>
+  <text x="125" y="45" text-anchor="middle" class="title">Durable agent's Worker</text>
+  <text x="125" y="65" text-anchor="middle" class="lbl">add(entry) · commit(level)</text>
+
+  <rect class="box accent" x="670" y="20" width="210" height="60"/>
+  <text x="775" y="45" text-anchor="middle" class="title">Ephemeral agent's Worker</text>
+  <text x="775" y="65" text-anchor="middle" class="lbl">EphemeralOplog, memory buffer</text>
+
+  <rect class="box" x="20" y="120" width="520" height="90"/>
+  <text x="40" y="145" class="title">Primary layer — PrimaryOplogService</text>
+  <text x="40" y="167" class="lbl">in-memory buffer → commit every 128 appends or on explicit commit</text>
+  <text x="40" y="185" class="lbl">entries in indexed storage (Redis / SQLite) · payloads &gt; 64 KiB in blob storage</text>
+  <text x="40" y="203" class="lbl muted">the newest entries of every durable agent live here</text>
+
+  <rect class="box" x="20" y="270" width="520" height="70"/>
+  <text x="40" y="295" class="title">Archive layer 1 — CompressedOplogArchiveService</text>
+  <text x="40" y="315" class="lbl">older prefixes, compressed in chunks, still in indexed storage</text>
+  <text x="40" y="331" class="lbl muted">ephemeral oplogs are written straight here (only for observation)</text>
+
+  <rect class="box" x="20" y="400" width="520" height="60"/>
+  <text x="40" y="425" class="title">Archive layer 2 — BlobOplogArchiveService</text>
+  <text x="40" y="445" class="lbl">oldest prefixes as objects in blob storage (S3-style / filesystem)</text>
+
+  <path class="arrow strong" style="marker-end:url(#arr-l)" d="M125 80 V118"/>
+  <text x="140" y="104" class="lbl">append, commit</text>
+
+  <path class="arrow" style="marker-end:url(#arr-l)" d="M280 210 V268"/>
+  <text x="295" y="232" class="lbl">move the oldest prefix down when</text>
+  <text x="295" y="248" class="lbl">&gt; 1024 new entries (checked on commit)</text>
+  <text x="295" y="264" class="lbl">or the 24 h ArchiveOplog timer fires</text>
+
+  <path class="arrow" style="marker-end:url(#arr-l)" d="M280 340 V398"/>
+  <text x="295" y="366" class="lbl">same rule, one layer further down</text>
+
+  <path class="arrow strong" style="marker-end:url(#arr-l)" d="M775 80 V300 H545"/>
+  <text x="765" y="150" text-anchor="end" class="lbl">commit every 1024 appends;</text>
+  <text x="765" y="166" text-anchor="end" class="lbl">archived when the instance ends</text>
+
+  <rect class="box sunken" x="600" y="330" width="280" height="130"/>
+  <text x="740" y="355" text-anchor="middle" class="title">Reading (replay, status fold, queries)</text>
+  <text x="615" y="380" class="lbl">read(agent, from, count):</text>
+  <text x="615" y="398" class="lbl">1. ask the primary layer for the range</text>
+  <text x="615" y="416" class="lbl">2. missing older indices → archive layer 1</text>
+  <text x="615" y="434" class="lbl">3. still missing → archive layer 2</text>
+  <text x="615" y="452" class="lbl muted">the caller sees one contiguous sequence</text>
+  <path class="arrow dashed" style="marker-end:url(#arr-l)" d="M598 380 H545 V165"/>
+  <path class="arrow dashed" style="marker-end:url(#arr-l)" d="M598 415 H570 V305 H545"/>
+  <path class="arrow dashed" style="marker-end:url(#arr-l)" d="M598 434 H580 V430 H545"/>
+</svg>
+<figcaption>The oplog storage layers: the primary layer takes every append, older entries move down into cheaper archive layers, and readers see one logical sequence.</figcaption>
+</figure>
+
+<p>The pieces, top to bottom:</p>
+<ul>
+  <li><strong>Primary layer.</strong> <code>PrimaryOplogService</code> keeps an in-memory buffer per open oplog and writes it to indexed storage on commit: implicitly after <code>max_operations_before_commit</code> (128) appends, or explicitly wherever the executor needs the entries to be recoverable <em>now</em> (see <a href="#s-state">append versus commit</a>). Payloads above <code>max_payload_size</code> (64 KiB) are stored in blob storage and referenced from the entry, so a huge invocation argument does not bloat the index.</li>
+  <li><strong>Archive layers.</strong> With the default configuration there are two: one <code>CompressedOplogArchiveService</code> (<code>indexed_storage_layers</code> = 2 means "primary plus one compressed layer" in indexed storage) and one <code>BlobOplogArchiveService</code> (<code>blob_storage_layers</code> = 1). On every commit the multi-layer service checks whether more than <code>entry_count_limit</code> (1024) entries were added since the last transfer; if so it moves the oldest prefix one layer down. Independently, a persisted <code>ScheduledAction::ArchiveOplog</code> fires every <code>archive_interval</code> (24 h) and pushes the prefix of an <em>idle</em> agent's oplog down a layer, provided the oplog has not grown since the action was scheduled. Archiving never changes an index: entry #17 is #17 whichever layer holds it.</li>
+  <li><strong>Reads.</strong> <code>read</code> / <code>read_exact</code> ask the primary layer first and fill the remaining index range from lower layers, so a replay of a very old agent may touch all three layers for its first entries and only the primary for the recent tail.</li>
+  <li><strong>Ephemeral oplogs.</strong> An ephemeral agent's <code>EphemeralOplog</code> buffers in memory, commits every <code>max_operations_before_commit_ephemeral</code> (1024) appends directly into the first archive layer, and is archived when the instance ends. It is never read back to resume the agent (<a href="#s-lifecycle">§6</a>); it exists so that what an ephemeral instance did can be inspected afterwards.</li>
+</ul>
+
+<!-- ===================== 6. LIFECYCLE ===================== -->
+<h2 id="s-lifecycle"><span class="num">6</span>Worker lifecycle</h2>
+<p>A <code>Worker</code> (<code>worker/mod.rs</code>) is the resident object for one agent on one executor. It receives invocations, persists them, and processes them in order through the <strong>invocation loop</strong> (<code>worker/invocation_loop.rs::run</code>). The loop has two levels, and understanding them is most of understanding recovery.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 520" role="img" aria-labelledby="loop-title loop-desc">
+  <title id="loop-title">The two-level invocation loop</title>
+  <desc id="loop-desc">The outer loop runs once per resident instance: check shard ownership, acquire a permit, create a Store and instance, then prepare the instance. For a durable agent preparation handles a pending update, tries a snapshot baseline and resumes replay from the oplog; for an ephemeral agent it replays only the initialising invocation, switches to live and records a Restart hint. The inner loop then pops the durable queue, appends AgentInvocationStarted, runs the guest export, appends AgentInvocationFinished and waits for more work, a wake-up or a command. When the instance ends because it went idle, was interrupted, trapped, suspended or was unloaded, a RetryDecision is made: Immediate, Delayed, ReacquirePermits or TryStop lead back to the top of the outer loop with a fresh Store; None stops the worker.</desc>
+  <defs><marker id="arr-loop" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+
+  <rect class="box sunken" x="15" y="15" width="870" height="490" style="fill:transparent"/>
+  <text x="30" y="40" class="title">Outer loop — one iteration = one resident instance (one Wasmtime Store)</text>
+
+  <rect class="box" x="30" y="60" width="170" height="50"/>
+  <text x="115" y="82" text-anchor="middle" class="title">Check shard ownership</text>
+  <text x="115" y="100" text-anchor="middle" class="lbl">is this agent still ours?</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M200 85 H228"/>
+  <rect class="box" x="230" y="60" width="150" height="50"/>
+  <text x="305" y="82" text-anchor="middle" class="title">Acquire permit</text>
+  <text x="305" y="100" text-anchor="middle" class="lbl">memory / instance budget</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M380 85 H408"/>
+  <rect class="box accent" x="410" y="60" width="190" height="50"/>
+  <text x="505" y="82" text-anchor="middle" class="title">Create Store + instance</text>
+  <text x="505" y="100" text-anchor="middle" class="lbl">fresh linear memory</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M600 85 H628"/>
+
+  <rect class="box" x="630" y="60" width="240" height="120"/>
+  <text x="750" y="82" text-anchor="middle" class="title">prepare_instance</text>
+  <text x="640" y="104" class="lbl">durable agent:</text>
+  <text x="652" y="120" class="lbl">handle PendingUpdate → try snapshot</text>
+  <text x="652" y="136" class="lbl">→ resume_replay from the oplog</text>
+  <text x="640" y="156" class="lbl">ephemeral agent:</text>
+  <text x="652" y="172" class="lbl">replay initialise only → live, Restart (h)</text>
+
+  <path class="arrow strong" style="marker-end:url(#arr-loop)" d="M750 180 V218"/>
+
+  <rect class="box ok" x="60" y="220" width="780" height="130"/>
+  <text x="80" y="245" class="title">Inner loop — one iteration = one invocation on this instance</text>
+  <rect class="box" x="80" y="262" width="150" height="46"/>
+  <text x="155" y="282" text-anchor="middle" class="lbl">pop the durable queue</text>
+  <text x="155" y="298" text-anchor="middle" class="lbl">(or wait for work)</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M230 285 H258"/>
+  <rect class="box" x="260" y="262" width="170" height="46"/>
+  <text x="345" y="282" text-anchor="middle" class="lbl">AgentInvocationStarted</text>
+  <text x="345" y="298" text-anchor="middle" class="lbl">append</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M430 285 H458"/>
+  <rect class="box accent" x="460" y="262" width="150" height="46"/>
+  <text x="535" y="282" text-anchor="middle" class="lbl">run the guest export</text>
+  <text x="535" y="298" text-anchor="middle" class="lbl">durable host calls inside</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M610 285 H638"/>
+  <rect class="box" x="640" y="262" width="180" height="46"/>
+  <text x="730" y="282" text-anchor="middle" class="lbl">AgentInvocationFinished</text>
+  <text x="730" y="298" text-anchor="middle" class="lbl">commit, notify waiters</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M730 308 V330 H155 V310"/>
+  <text x="450" y="342" text-anchor="middle" class="lbl">next queued invocation, wake-up or command</text>
+
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M450 350 V388"/>
+  <rect class="box warn" x="200" y="390" width="500" height="44"/>
+  <text x="450" y="409" text-anchor="middle" class="title">Instance ends</text>
+  <text x="450" y="426" text-anchor="middle" class="lbl">idle timeout · interrupt · trap / error · suspend · unload / evict · resharding</text>
+
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M450 434 V458"/>
+  <rect class="box" x="30" y="460" width="620" height="36"/>
+  <text x="340" y="483" text-anchor="middle" class="lbl">RetryDecision:  Immediate  ·  Delayed(d)  ·  ReacquirePermits  ·  TryStop(t)   →  back to the top with a fresh Store</text>
+  <path class="arrow strong" style="marker-end:url(#arr-loop)" d="M30 478 H22 V85 H28"/>
+  <rect class="box bad" x="670" y="460" width="200" height="36"/>
+  <text x="770" y="483" text-anchor="middle" class="lbl">None → stop; Worker is dropped</text>
+  <path class="arrow" style="marker-end:url(#arr-loop)" d="M650 478 H668"/>
+</svg>
+<figcaption>The invocation loop. Every path back to the top creates a fresh Store and replays; there is no path that reuses a damaged instance.</figcaption>
+</figure>
+
+<h3>Agent status</h3>
+<p>The status you see in the API (<code>AgentStatus</code>) is <em>folded from the oplog</em> (<code>worker/status.rs</code>): given the entries, the status is a pure function. Caches and checkpoints only speed up the fold.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 300" role="img" aria-labelledby="status-title status-desc">
+  <title id="status-title">Agent status transitions</title>
+  <desc id="status-desc">Idle becomes Running when an invocation starts. Running returns to Idle on AgentInvocationFinished, becomes Suspended while waiting (sleep, promise), Interrupted on an Interrupted entry, Retrying on an Error entry with a retry scheduled, Failed when retries are exhausted, or Exited when the guest exits. Suspended, Interrupted and Retrying return to Running when the worker is resumed or the retry fires. Failed and Exited are terminal.</desc>
+  <defs><marker id="arr3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <g><rect class="box ok" x="40" y="120" width="130" height="50"/><text x="105" y="150" text-anchor="middle" class="title">Idle</text></g>
+  <g><rect class="box accent" x="300" y="120" width="140" height="50"/><text x="370" y="150" text-anchor="middle" class="title">Running</text></g>
+  <g><rect class="box" x="580" y="30" width="140" height="46"/><text x="650" y="58" text-anchor="middle" class="title">Suspended</text></g>
+  <g><rect class="box warn" x="580" y="95" width="140" height="46"/><text x="650" y="123" text-anchor="middle" class="title">Interrupted</text></g>
+  <g><rect class="box warn" x="580" y="160" width="140" height="46"/><text x="650" y="188" text-anchor="middle" class="title">Retrying</text></g>
+  <g><rect class="box bad" x="580" y="235" width="140" height="46"/><text x="650" y="263" text-anchor="middle" class="title">Failed</text></g>
+  <g><rect class="box sunken" x="760" y="235" width="120" height="46"/><text x="820" y="263" text-anchor="middle" class="title">Exited</text></g>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M170 135 H298"/><text x="234" y="128" text-anchor="middle" class="lbl">AgentInvocationStarted</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M300 158 H172"/><text x="236" y="176" text-anchor="middle" class="lbl">AgentInvocationFinished</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M440 130 C 500 60, 540 53, 578 53"/><text x="500" y="48" text-anchor="middle" class="lbl">waiting: sleep / promise</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M440 140 C 500 118, 540 118, 578 118"/><text x="510" y="108" text-anchor="middle" class="lbl">Interrupted (h)</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M440 150 C 500 183, 540 183, 578 183"/><text x="510" y="200" text-anchor="middle" class="lbl">Error (h), retry scheduled</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M440 160 C 500 258, 540 258, 578 258"/><text x="500" y="248" text-anchor="middle" class="lbl">Error (h), retries exhausted</text>
+  <path class="arrow dashed" style="marker-end:url(#arr3)" d="M650 76 V93"/>
+  <path class="arrow dashed" style="marker-end:url(#arr3)" d="M720 118 C 800 118, 800 180, 720 183"/><text x="805" y="150" text-anchor="middle" class="lbl">resume / wake-up</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M580 183 C 520 230, 470 210, 442 168"/><text x="505" y="232" text-anchor="middle" class="lbl">retry fires → Running (replay first)</text>
+  <path class="arrow" style="marker-end:url(#arr3)" d="M370 170 C 370 290, 700 290, 758 265"/><text x="470" y="292" text-anchor="middle" class="lbl">Exited (h)</text>
+</svg>
+<figcaption>Status values and the oplog entries that move between them. <code>Suspended</code>, <code>Interrupted</code> and <code>Retrying</code> all return to <code>Running</code> through the same reconstruction path.</figcaption>
+</figure>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Status</th><th scope="col">Meaning (from <code>AgentStatus</code> docs)</th></tr></thead>
+  <tbody>
+    <tr><td><code>Running</code></td><td>The worker is running an invoked function.</td></tr>
+    <tr><td><code>Idle</code></td><td>The worker is ready to run an invoked function.</td></tr>
+    <tr><td><code>Suspended</code></td><td>An invocation is active but waiting for something (sleeping, waiting for a promise).</td></tr>
+    <tr><td><code>Interrupted</code></td><td>The last invocation was interrupted but will be resumed.</td></tr>
+    <tr><td><code>Retrying</code></td><td>The last invocation failed and a retry was scheduled.</td></tr>
+    <tr><td><code>Failed</code></td><td>The last invocation failed and the worker can no longer be used.</td></tr>
+    <tr><td><code>Exited</code></td><td>The worker exited after a successful invocation and can no longer be invoked.</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h3>Ephemeral agents in the loop</h3>
+<p>An ephemeral agent goes through the same loop with two differences, and they are easy to conflate.</p>
+<p><strong>Within one life of the Worker, the loop still retries.</strong> An ephemeral <code>Worker</code> accepts exactly one method invocation in its life (its <code>EphemeralInvocationState</code> moves from <code>Available</code> to <code>Accepted(key)</code>; a second key is rejected, the same key is accepted again). The constructor (<code>AgentInitialization</code>) runs first and is recorded in the ephemeral oplog like any other invocation. If the method then fails with a <em>retriable</em> error, the outer loop does what it always does: it drops the instance and creates a fresh Store. <code>prepare_instance</code> now needs the agent object to exist again before the method can be re-run, so it replays <em>only</em> the constructor from the oplog (<code>resume_replay</code> stops after the first <code>AgentInvocationStarted</code> for an ephemeral agent), switches to live, appends a <code>Restart</code> hint and runs the method again, live. That is the purpose of replaying the initialisation: it rebuilds the constructor's state for a retry of the <em>same</em> accepted invocation, not for accepting a new one. When the method finishes, successfully or with a terminal failure, the outcome is <code>BreakInnerLoopAndArchiveEphemeralOplog</code>: the Worker leaves the active set and its oplog is archived for observation.</p>
+<p><strong>Across lives there is no recovery.</strong> If the executor loses the Worker itself (crash, eviction, resharding) and a later request finds the agent's metadata already present, <code>get_or_create</code> builds a <em>reconstructed</em> ephemeral Worker: it can answer status queries and idempotency-key lookups from the archived oplog, but it starts in <code>Accepted(None)</code> and its instance "must never be started again". The invocation that was in flight is lost and the caller sees an error. This is what makes RPC to an ephemeral target at-most-once (<a href="#s-rpc">§12</a>).</p>
+
+<!-- ===================== 7. INVOCATIONS ===================== -->
+<h2 id="s-invocations"><span class="num">7</span>Invocation queue &amp; results</h2>
+<p>The queue of pending invocations is durable: it <em>is</em> the set of <code>PendingAgentInvocation</code> hints not yet matched by an <code>AgentInvocationStarted</code>. The in-memory <code>VecDeque</code> is a cache of that.</p>
+
+<h3>Acceptance</h3>
+<p><code>enqueue_worker_invocation_with_effect</code> (<code>worker/mod.rs</code>) first looks the idempotency key up (<code>lookup_invocation_result</code>). Anything other than <code>LookupResult::New</code> — <code>Pending</code>, <code>Interrupted</code>, or <code>Complete(result)</code> — returns the existing invocation without appending anything. Only for a new key does it append <code>PendingAgentInvocation</code> and <em>commit</em>; the caller learns "accepted" only after that commit. This ordering is what lets a caller that never heard back simply retry with the same key.</p>
+
+<h3>Execution and completion</h3>
+<p>The invocation loop appends <code>AgentInvocationStarted</code>, runs the guest export in <code>InvocationMode::Live</code>, and on success <code>on_agent_invocation_success</code> (<code>durable_host/mod.rs</code>) appends <code>AgentInvocationFinished</code> with the result and commits with <code>CommitLevel::Always</code> <em>before</em> waiters are notified. Failures go through <code>on_invocation_failure</code>, which decides a <code>RetryDecision</code>; whether a failed invocation gets a terminal entry depends on that decision, so never model a trap as "<code>AgentInvocationFinished { Err }</code>".</p>
+<p>During replay the invocation runs in <code>InvocationMode::Replay</code> and the recomputed result is compared with the recorded one (<code>replay_equivalent</code>); a mismatch is an <code>unexpected_oplog_entry</code> determinism error, not something to paper over.</p>
+<p><strong>Tail work</strong> (<code>durable_host/tail_work.rs</code>) keeps the Store's event loop running until no spawned task is still <em>active</em>, so a task's positional <code>Start</code>/<code>End</code> can never land after <code>AgentInvocationFinished</code>. Tasks parked at guest-driven safe park points may span invocations. Hints <em>may</em> follow <code>Finished</code>: the streaming-session completion (protocol terminals, <code>StreamSession { Finished }</code>) is appended by <code>invocation_loop.rs::agent_invocation_finished</code> after the success hook.</p>
+
+<h3>Read-only methods</h3>
+<p>An agent method can be declared <em>read-only</em> in its agent-type metadata (<code>AgentMethodSchema::read_only</code>, with a cache policy and a flag saying whether the result depends on the calling principal). The executor treats such a method as a promise it enforces, and as an opportunity to cache:</p>
+<ul>
+  <li><strong>Same worker, same queue.</strong> A read-only invocation is not forked onto a copy of the agent. It is a normal queued invocation on the same <code>Worker</code>, serialized with the mutating ones, and it appends the usual <code>AgentInvocationStarted</code>/<code>Finished</code> pair so that its result is recorded and deduplicated by idempotency key like any other.</li>
+  <li><strong>Writes trap.</strong> For the duration of the call the host is in read-only strictness (<code>enter_read_only_mode</code>). Every durable function that is a write-type side effect (<code>WriteLocal</code>/<code>WriteRemote</code>/…: outgoing HTTP, RPC, key-value writes, custom durable invocations declared as writes) runs <code>check_read_only_allows</code> first and fails with <code>AgentError::ReadOnlyViolation</code> <em>before</em> anything is appended to the oplog. The violation is not retriable; the invocation fails and the agent stays consistent because the write never began.</li>
+  <li><strong>Per-worker result cache.</strong> <code>worker/read_only_cache.rs</code> keeps results keyed by method, arguments, component revision, an <em>epoch</em>, and (if <code>uses_principal</code>) the caller. The epoch is bumped only when a <em>mutating</em> invocation completes successfully, so a cached value keeps serving while a mutation is merely queued, and is invalidated lazily on the first lookup after the mutation lands. On the awaiting path concurrent misses for the same key coalesce into one execution; on the fire-and-forget path each miss runs and an observer fills the cache on completion, rechecking the epoch so a populate raced by a mutation is dropped.</li>
+</ul>
+<p>Because the cache is resident state (right column of <a href="#s-state">§4</a>) it disappears with the Worker and is simply rebuilt by the next calls; correctness never depends on it.</p>
+
+<div class="widget" id="tl-invocation">
+  <h4>Crash-window walkthrough: one invocation <span class="pill js-only">interactive</span></h4>
+  <p>Drag the slider (or use the arrow keys) to choose where the executor dies. Faded entries were never written; the panel says what the next incarnation does.</p>
+  <div class="controls js-only">
+    <label class="grow">Crash point <input type="range" min="0" max="5" value="0" step="1" data-tl-slider="invocation" aria-valuetext="no crash"></label>
+    <button class="btn small" type="button" data-tl-reset="invocation">Reset</button>
+  </div>
+  <div class="legend"><span class="l-pos">positional</span><span class="l-hint">hint</span><span class="l-lost">not written (lost in crash)</span></div>
+  <div data-tl-tape="invocation"></div>
+  <div class="result" data-tl-result="invocation" aria-live="polite"></div>
+  <details class="disclosure no-js-only" open><summary>All crash windows (static)</summary><div class="body" data-tl-static="invocation">
+<ol class="crash-list"><li><span class="t">No crash.</span> The invocation is accepted (#41 committed), executed (#42–#44) and finished (#45, committed with <code>CommitLevel::Always</code>). Only after that commit does the caller receive the result.</li><li><span class="t">Crash after #41 (accepted, never started).</span> The caller already heard “accepted” because the commit of <code>PendingAgentInvocation</code> happened first. On reconstruction the status fold finds a pending invocation without <code>Finished</code>, so it lands in the new <code>Worker.queue</code> and runs. A caller that retries with key <code>k1</code> gets <code>LookupResult::Pending</code> and attaches to the same invocation; nothing is duplicated. Had the crash happened <em>before</em> #41 was committed, the caller would have received an error instead of “accepted” and would retry with the same key, which then creates the invocation once.</li><li><span class="t">Crash after #42 (started, no host call yet).</span> Replay re-runs the guest export for <code>k1</code> in <code>InvocationMode::Replay</code>. The first host call finds no recorded <code>Start</code>: the cursor is exhausted, the Store switches to live and the call executes for real. From the outside this is indistinguishable from an invocation that simply took longer.</li><li><span class="t">Crash after #43 (Start committed, End missing).</span> Replay claims <code>Start</code> #43 and finds no terminal: an <em>incomplete</em> call. <code>keyvalue/get</code> is <code>ReadRemote</code>, so it may be re-executed; the Store goes live, the read runs again and appends the missing <code>End</code>. For a non-idempotent write this window is the dangerous one — see the host-call walkthrough.</li><li><span class="t">Crash after #44 (host call done, invocation not finished).</span> Replay returns the recorded value 7 to the guest without touching the key-value store. The guest continues from where it was; the invocation finishes live and appends #45. The external effect happened exactly once.</li><li><span class="t">Crash after #45 (finished).</span> Nothing to redo. The result is in the oplog; a caller that never heard back retries with <code>k1</code>, gets <code>LookupResult::Complete(result)</code> and receives the recorded result. Waiters that were connected to the dead process lose their connection but not the result.</li></ol>
+</div></details>
+</div>
+
+<div class="callout">
+  <span class="label">A concrete picture</span>
+  A counter agent receives 32 <code>increment</code> calls with keys k1…k32, the executor is dropped and restarted, and a caller re-sends k1. It receives <code>1</code>, the recorded result, not 33: the result comes straight from the <code>AgentInvocationFinished</code> entry that k1 maps to in the folded record, without re-running anything. The next <em>fresh</em> key returns <code>33</code>, which is the proof that the repeated key did not increment.
+</div>
+
+<!-- ===================== 8. HOST CALLS ===================== -->
+<h2 id="s-hostcalls"><span class="num">8</span>Durable host calls &amp; deterministic replay</h2>
+<p>Every nondeterministic host function — HTTP, key-value, blob store, RDBMS, sockets, clocks, random, RPC, promises, tools — goes through <code>begin_durable_function</code> / <code>end_durable_function</code> (<code>durable_host/durability.rs</code>) and, for the concurrent WASI p3 "accessor" path, a <code>DurableCallSession</code> (<code>durable_host/concurrent/call.rs</code>). The serialized p2 path (<code>&amp;mut self</code> host calls) uses <code>persist_durable_function_invocation</code> / <code>read_persisted_durable_function_invocation</code> with the same <code>Start</code>/<code>End</code> shape but no delivery markers.</p>
+
+<h3>Four steps, four different facts</h3>
+<div class="grid2">
+  <div class="card"><h4>Execute</h4><p>Perform the live effect. Allowed only when the durable context reports live (<code>store_is_live</code> / <code>is_live()</code>) — <em>never</em> because the cursor happens to be at the end of history.</p></div>
+  <div class="card"><h4>Append</h4><p><code>Start</code> is appended eagerly when the call begins; <code>End</code> or <code>Cancelled</code> when it terminates. A trap leaves <code>Start</code> incomplete (<code>abandon_for_trap</code>); a trap never writes <code>Cancelled</code>.</p></div>
+  <div class="card"><h4>Claim</h4><p>On replay, match the host call the guest is making now against a recorded <code>Start</code> by identity (<code>StartClaim</code>: function name, owner, optional request payload). A <code>Start</code> that does not exist in history is a divergence error.</p></div>
+  <div class="card"><h4>Observe</h4><p>The guest reads the result. For accessor calls this is recorded by <code>CompletionDelivered</code> / <code>CompletionDiscarded</code> as the <em>tail</em> operation of the host function. Host completion time and guest observation time are different facts; only the second is a guest input.</p></div>
+</div>
+
+<h3>Live path (accessor)</h3>
+<ol class="steps">
+  <li>Append <code>Start { function_name, request, durable_function_type, parent_start_index }</code>.</li>
+  <li>Run the live action (the HTTP request, the KV read, the RPC dispatch…).</li>
+  <li>Append <code>End { start_index, response }</code> — or <code>Cancelled { start_index, partial }</code> if the guest dropped the future first.</li>
+  <li>Hand the result to the guest.</li>
+  <li>Append <code>CompletionDelivered { start_index }</code> — or <code>CompletionDiscarded</code> if the guest dropped the completion unread.</li>
+</ol>
+
+<h3>Replay path: classification is total</h3>
+<p>Replay claims the matching <code>Start</code>, resolves its terminal through <code>ConcurrentReplayResolver</code>, and classifies the resolution with <code>classify_replay_resolution</code> (<code>concurrent/call.rs</code>). The function is total — every recorded shape has exactly one meaning — and shared by every path.</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Recorded shape</th><th scope="col"><code>ReplayedResolution</code></th><th scope="col">Guest handoff</th></tr></thead>
+  <tbody>
+    <tr><td><code>End</code> + <code>CompletionDelivered</code></td><td><code>Delivered</code>, <code>AtMarker</code></td><td>Released exactly at the recorded marker boundary; <code>ReplayDeliveryBarrier</code> holds the cursor gate until then.</td></tr>
+    <tr><td><code>End</code>, no marker (accessor)</td><td><code>Delivered</code>, <code>AtReplayTail</code></td><td>A crash happened after host completion but before observation. The result is <em>withheld</em> until the cursor drains (<code>await_natural_tail_end</code>), then delivered live-armed as the guest's first post-replay observation. The effect is <strong>not</strong> re-run.</td></tr>
+    <tr><td><code>Cancelled { partial: Some }</code></td><td><code>Delivered</code>, <code>Immediate</code></td><td>Guest-initiated, deterministic drop point; the partial value is delivered with no gating.</td></tr>
+    <tr><td><code>Cancelled { partial: None }</code> or <code>End</code> + <code>CompletionDiscarded</code></td><td><code>Undelivered</code></td><td>The guest never saw a value; the future is parked for the guest's own deterministic drop.</td></tr>
+    <tr><td><code>Start</code> without terminal</td><td><code>Incomplete</code></td><td>See below: re-execute under the <em>same</em> <code>Start</code> if the function type allows, otherwise hard-error into scope recovery.</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h3>Incomplete calls and the re-execution predicate</h3>
+<p>When replay finds a <code>Start</code> without a terminal, <code>prepare_incomplete_live_repair</code> switches the handle to <em>live completion of the existing <code>Start</code></em> — no second <code>Start</code> is appended — provided <code>can_reexecute_on_incomplete_replay</code> says so. That predicate is the <code>DurableFunctionType</code> of the call:</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col"><code>DurableFunctionType</code></th><th scope="col">Examples</th><th scope="col">Re-execute when incomplete? (also: in-function retry eligible?)</th></tr></thead>
+  <tbody>
+    <tr><td><code>ReadLocal</code></td><td>local filesystem read, random, clock</td><td><span class="pill ok">always</span></td></tr>
+    <tr><td><code>WriteLocal</code></td><td>local filesystem write</td><td><span class="pill ok">always</span></td></tr>
+    <tr><td><code>ReadRemote</code></td><td>KV get, HTTP GET, blob read</td><td><span class="pill ok">always</span></td></tr>
+    <tr><td><code>WriteRemote</code></td><td>RPC, KV set, HTTP POST</td><td><span class="pill warn">only while idempotence mode is on</span> (<code>assume_idempotence</code>, default <code>true</code>; <code>golem:api/host.set-idempotence-mode(false)</code> turns it off)</td></tr>
+    <tr><td><code>WriteRemoteBatched(scope)</code></td><td>a multi-call remote write (e.g. streaming an HTTP body)</td><td><span class="pill bad">never</span> — the enclosing scope owns recovery</td></tr>
+    <tr><td><code>WriteRemoteTransaction(scope)</code></td><td>remote transaction phases</td><td><span class="pill bad">never</span></td></tr>
+  </tbody>
+</table>
+</div>
+<p>When re-execution is not allowed, the session hard-errors and the enclosing durable scope's <code>ScopeReplayRecovery</code> decides whether recovery is possible; a hard error by itself is not a recovery. The same predicate governs in-function retries (<a href="#s-retries">§11</a>): a call that may be re-run when its <code>End</code> is missing after a crash may also be re-run inline after a failure.</p>
+
+<div class="widget" id="tl-hostcall">
+  <h4>Crash-window walkthrough: one durable host call <span class="pill js-only">interactive</span></h4>
+  <div class="controls js-only">
+    <label>Function type
+      <select data-tl-variant="hostcall">
+        <option value="read">ReadRemote (e.g. keyvalue/get)</option>
+        <option value="writeidem">WriteRemote, idempotence mode on (default)</option>
+        <option value="writenon">WriteRemote, idempotence mode off</option>
+        <option value="batched">WriteRemoteBatched</option>
+      </select>
+    </label>
+    <label class="grow">Crash point <input type="range" min="0" max="5" value="0" step="1" data-tl-slider="hostcall" aria-valuetext="no crash"></label>
+    <button class="btn small" type="button" data-tl-reset="hostcall">Reset</button>
+  </div>
+  <div class="legend"><span class="l-pos">positional</span><span class="l-hint">hint</span><span class="l-live">external effect (leaves no entry)</span><span class="l-lost">not written</span></div>
+  <div data-tl-tape="hostcall"></div>
+  <div class="result" data-tl-result="hostcall" aria-live="polite"></div>
+  <details class="disclosure no-js-only" open><summary>All crash windows (static)</summary><div class="body" data-tl-static="hostcall">
+<h5>ReadRemote (e.g. keyvalue/get)</h5><ol class="crash-list"><li><span class="t">No crash.</span> Four steps: <code>Start</code> is appended, the effect runs, <code>End</code> records the response, and the guest’s observation is fixed by <code>CompletionDelivered</code>.</li><li><span class="t">Crash after Start, before the effect.</span> Incomplete <code>Start</code>. Reads are always safe to re-execute: the Store switches to live, the read runs again and completes the existing <code>Start</code> by appending <code>End</code>. The executor cannot know whether the effect happened — that is the whole point of the window — so the rule depends only on the function type.</li><li><span class="t">Crash after the effect, before End.</span> Same oplog as the previous window (the effect leaves no entry), so replay behaves identically: incomplete <code>Start</code>. Reads are always safe to re-execute: the Store switches to live, the read runs again and completes the existing <code>Start</code> by appending <code>End</code>.</li><li><span class="t">Crash after End, before delivery.</span> Replay finds <code>End</code> #51 with no marker after it: resolution <code>Delivered/AtReplayTail</code>. The effect is <em>not</em> re-run. The recorded response is withheld until the cursor drains (<code>await_natural_tail_end</code>) and then handed to the guest as its first live observation, which appends the missing marker.</li><li><span class="t">Crash after CompletionDelivered.</span> Replay returns the recorded response and releases it to the guest exactly at marker #52 (<code>ReplayDeliveryBarrier</code>). The guest sees the same value at the same point in its own execution.</li><li><span class="t">Crash after AgentInvocationFinished.</span> Everything is recorded. Reconstruction replays the whole invocation without any external interaction.</li></ol><h5>WriteRemote, idempotence mode on (default)</h5><ol class="crash-list"><li><span class="t">No crash.</span> Four steps: <code>Start</code> is appended, the effect runs, <code>End</code> records the response, and the guest’s observation is fixed by <code>CompletionDelivered</code>.</li><li><span class="t">Crash after Start, before the effect.</span> Incomplete <code>Start</code>. <code>WriteRemote</code> with <code>assume_idempotence = true</code> (the default) is re-executable: the request is sent again with the <em>same</em> idempotency key derived from <code>Start</code> #50, so a receiver that honours the key applies it once. The executor cannot know whether the effect happened — that is the whole point of the window — so the rule depends only on the function type.</li><li><span class="t">Crash after the effect, before End.</span> Same oplog as the previous window (the effect leaves no entry), so replay behaves identically: incomplete <code>Start</code>. <code>WriteRemote</code> with <code>assume_idempotence = true</code> (the default) is re-executable: the request is sent again with the <em>same</em> idempotency key derived from <code>Start</code> #50, so a receiver that honours the key applies it once.</li><li><span class="t">Crash after End, before delivery.</span> Replay finds <code>End</code> #51 with no marker after it: resolution <code>Delivered/AtReplayTail</code>. The effect is <em>not</em> re-run. The recorded response is withheld until the cursor drains (<code>await_natural_tail_end</code>) and then handed to the guest as its first live observation, which appends the missing marker.</li><li><span class="t">Crash after CompletionDelivered.</span> Replay returns the recorded response and releases it to the guest exactly at marker #52 (<code>ReplayDeliveryBarrier</code>). The guest sees the same value at the same point in its own execution.</li><li><span class="t">Crash after AgentInvocationFinished.</span> Everything is recorded. Reconstruction replays the whole invocation without any external interaction.</li></ol><h5>WriteRemote, idempotence mode off</h5><ol class="crash-list"><li><span class="t">No crash.</span> Four steps: <code>Start</code> is appended, the effect runs, <code>End</code> records the response, and the guest’s observation is fixed by <code>CompletionDelivered</code>.</li><li><span class="t">Crash after Start, before the effect.</span> Incomplete <code>Start</code> and <code>can_reexecute_on_incomplete_replay()</code> is false. The executor refuses to re-run the call: unless an enclosing durable scope resolves it, the replay fails with <code>unexpected_oplog_entry("End or Cancelled")</code> and the invocation goes to the failure/retry path. The effect may or may not have happened; the executor will not guess. The executor cannot know whether the effect happened — that is the whole point of the window — so the rule depends only on the function type.</li><li><span class="t">Crash after the effect, before End.</span> Same oplog as the previous window (the effect leaves no entry), so replay behaves identically: incomplete <code>Start</code> and <code>can_reexecute_on_incomplete_replay()</code> is false. The executor refuses to re-run the call: unless an enclosing durable scope resolves it, the replay fails with <code>unexpected_oplog_entry("End or Cancelled")</code> and the invocation goes to the failure/retry path. The effect may or may not have happened; the executor will not guess.</li><li><span class="t">Crash after End, before delivery.</span> Replay finds <code>End</code> #51 with no marker after it: resolution <code>Delivered/AtReplayTail</code>. The effect is <em>not</em> re-run. The recorded response is withheld until the cursor drains (<code>await_natural_tail_end</code>) and then handed to the guest as its first live observation, which appends the missing marker.</li><li><span class="t">Crash after CompletionDelivered.</span> Replay returns the recorded response and releases it to the guest exactly at marker #52 (<code>ReplayDeliveryBarrier</code>). The guest sees the same value at the same point in its own execution.</li><li><span class="t">Crash after AgentInvocationFinished.</span> Everything is recorded. Reconstruction replays the whole invocation without any external interaction.</li></ol><h5>WriteRemoteBatched</h5><ol class="crash-list"><li><span class="t">No crash.</span> Four steps: <code>Start</code> is appended, the effect runs, <code>End</code> records the response, and the guest’s observation is fixed by <code>CompletionDelivered</code>.</li><li><span class="t">Crash after Start, before the effect.</span> Incomplete <code>Start</code>. Batched and transactional writes are never re-executed by the call itself; recovery belongs to the surrounding remote-transaction entries (<code>BeginRemoteTransaction</code> … <code>Committed</code>/<code>RolledBack</code>), which decide whether to finish or roll back the transaction. The executor cannot know whether the effect happened — that is the whole point of the window — so the rule depends only on the function type.</li><li><span class="t">Crash after the effect, before End.</span> Same oplog as the previous window (the effect leaves no entry), so replay behaves identically: incomplete <code>Start</code>. Batched and transactional writes are never re-executed by the call itself; recovery belongs to the surrounding remote-transaction entries (<code>BeginRemoteTransaction</code> … <code>Committed</code>/<code>RolledBack</code>), which decide whether to finish or roll back the transaction.</li><li><span class="t">Crash after End, before delivery.</span> Replay finds <code>End</code> #51 with no marker after it: resolution <code>Delivered/AtReplayTail</code>. The effect is <em>not</em> re-run. The recorded response is withheld until the cursor drains (<code>await_natural_tail_end</code>) and then handed to the guest as its first live observation, which appends the missing marker.</li><li><span class="t">Crash after CompletionDelivered.</span> Replay returns the recorded response and releases it to the guest exactly at marker #52 (<code>ReplayDeliveryBarrier</code>). The guest sees the same value at the same point in its own execution.</li><li><span class="t">Crash after AgentInvocationFinished.</span> Everything is recorded. Reconstruction replays the whole invocation without any external interaction.</li></ol>
+</div></details>
+</div>
+
+<h3>Custom durable invocations</h3>
+<p>Application code can wrap a whole block of guest code as <em>one</em> logical durable operation with <code>golem:durability/durability.begin-custom-durable-invocation</code> (<code>durability.rs::begin_custom_durable_invocation</code>). The Rust SDK exposes it as <code>Durability</code>:</p>
+<pre class="code"><code>use golem_rust::durability::{Durability, DurableFunctionType};
+
+fn charge_card(order: &amp;Order) -&gt; Result&lt;Receipt, PaymentError&gt; {
+    // Names identify the operation in the oplog; the type says how it may
+    // be retried (WriteRemote: a non-idempotent effect on the outside world).
+    Durability::&lt;Receipt, PaymentError&gt;::new(
+        "shop",                      // interface
+        "charge-card",               // function
+        DurableFunctionType::WriteRemote,
+        &amp;order.id,                   // recorded as the request
+    )
+    .run(|| {
+        // Live: this body runs once and its Result is recorded in the End entry.
+        // Replay: the body is skipped and the recorded Result is returned.
+        let token = fetch_token()?;             // nested host calls are fine
+        payment_gateway::charge(token, order)   // ... as are plain computations
+    })
+}</code></pre>
+<p>The wrapper appends a root <code>Start</code> when <code>new</code> is called; <code>run</code> executes the body in live mode and appends the root <code>End</code> with the serialized result (there are <code>run_infallible</code> and <code>run_async</code> variants). Nested host calls inside the body point at the root through <code>observational_owner</code>. On replay, if the root has an <code>End</code>, the recorded result is returned and the body does <strong>not</strong> run; nested entries are consumed as a replay-inert subtree. If the root is incomplete (the process died inside the body), the block goes live under its original root <code>Start</code> and the <strong>whole body re-runs</strong>, re-recording nested calls as new physical <code>Start</code>s. This is the one ordinary durable path where a completed nested effect legitimately repeats, which is why the block author owns idempotency: the body should be written so that running it twice is acceptable, or the function type should be one the executor refuses to re-execute.</p>
+
+<!-- ===================== 9. CURSOR ===================== -->
+<h2 id="s-cursor"><span class="num">9</span>Replay cursor, claims &amp; replay-to-live</h2>
+<p><code>ReplayCursor</code> (<code>durable_host/replay_state/cursor.rs</code>) is the single chokepoint over recorded history: <code>try_get_oplog_entry</code> reads speculatively, <code>commit_consumed_entry</code> commits, <code>move_replay_idx</code> advances and emits <code>ReplayFinished</code> exactly once.</p>
+
+<h3>Claims: matching a live host call to its recorded Start</h3>
+<p>When a replaying guest makes a host call, the executor has to find <em>which</em> recorded <code>Start</code> entry belongs to it. The simplest rule, "the next positional entry", is correct only when the guest makes one host call at a time. Golem guests can have several host calls in flight at once (async tasks, concurrent futures, tool bodies running on the same oplog), and although the <em>guest's</em> behaviour is deterministic, the <em>host's</em> is not: two calls issued concurrently may have had their <code>Start</code> entries appended in either order during the live run, and the replaying host will not necessarily reach them in the same order. So the cursor uses <strong>claims</strong> (<code>replay_state/claims.rs</code>).</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 470" role="img" aria-labelledby="claims-title claims-desc">
+  <title id="claims-title">How a replaying host call claims its recorded Start</title>
+  <desc id="claims-desc">The recorded oplog contains, in order, Start A, Start B, End B, End A and two CompletionDelivered markers. The replay cursor stands before Start A and the replay target is after the last entry. Two concurrent replaying calls arrive. Call B arrives first; it scans forward from the cursor over unclaimed Start entries, skips Start A because its identity does not match, and claims Start B. Call A then arrives and claims Start A, the first unclaimed Start that matches it. Each call resolves its terminal from its claimed Start. The scan never passes a CompletionDelivered marker. A call whose identity matches no unclaimed Start between the cursor and the target is a divergence and replay fails. The cursor itself only advances over entries that are claimed and consumed, never past an unclaimed one.</desc>
+  <defs><marker id="arr-cl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+
+  <text x="40" y="24" class="title">Recorded oplog (appended by the live run)</text>
+  <rect class="box" x="40" y="40" width="125" height="56"/><text x="102" y="62" text-anchor="middle" class="lbl mono">#50</text><text x="102" y="82" text-anchor="middle" class="title" style="font-size:12px">Start A</text>
+  <rect class="box" x="180" y="40" width="125" height="56"/><text x="242" y="62" text-anchor="middle" class="lbl mono">#51</text><text x="242" y="82" text-anchor="middle" class="title" style="font-size:12px">Start B</text>
+  <rect class="box ok" x="320" y="40" width="125" height="56"/><text x="382" y="62" text-anchor="middle" class="lbl mono">#52</text><text x="382" y="82" text-anchor="middle" class="title" style="font-size:12px">End B</text>
+  <rect class="box ok" x="460" y="40" width="125" height="56"/><text x="522" y="62" text-anchor="middle" class="lbl mono">#53</text><text x="522" y="82" text-anchor="middle" class="title" style="font-size:12px">End A</text>
+  <rect class="box hint" x="600" y="40" width="125" height="56"/><text x="662" y="62" text-anchor="middle" class="lbl mono">#54</text><text x="662" y="82" text-anchor="middle" class="lbl">Delivered (B)</text>
+  <rect class="box hint" x="740" y="40" width="125" height="56"/><text x="802" y="62" text-anchor="middle" class="lbl mono">#55</text><text x="802" y="82" text-anchor="middle" class="lbl">Delivered (A)</text>
+
+  <line x1="30" y1="34" x2="30" y2="104" stroke="var(--accent)" stroke-width="2.5"/>
+  <text x="40" y="120" class="lbl" style="fill:var(--accent)">▲ replay cursor: before #50</text>
+  <line x1="875" y1="34" x2="875" y2="104" stroke="var(--fg-muted)" stroke-width="2" stroke-dasharray="4 3"/>
+  <text x="865" y="120" text-anchor="end" class="lbl">replay target: after #55 ▲</text>
+
+  <text x="330" y="170" class="title">Replaying guest issues the same two calls — B reaches the host first</text>
+
+  <rect class="box accent" x="40" y="190" width="210" height="60"/>
+  <text x="145" y="213" text-anchor="middle" class="title" style="font-size:12px">1. call B arrives</text>
+  <text x="145" y="232" text-anchor="middle" class="lbl">identity: B's name, type, scope</text>
+  <path class="arrow dashed" style="marker-end:url(#arr-cl)" d="M102 190 V98"/>
+  <text x="110" y="150" class="lbl" style="fill:var(--warn)">#50? identity differs → skip</text>
+  <path class="arrow strong" style="marker-end:url(#arr-cl)" d="M250 220 H272 V98"/>
+  <text x="280" y="212" class="lbl" style="fill:var(--accent)">#51 matches → claim it</text>
+
+  <rect class="box accent" x="40" y="270" width="210" height="60"/>
+  <text x="145" y="293" text-anchor="middle" class="title" style="font-size:12px">2. call A arrives</text>
+  <text x="145" y="312" text-anchor="middle" class="lbl">identity: A's name, type, scope</text>
+  <path class="arrow strong" style="marker-end:url(#arr-cl)" d="M40 300 H20 V70 H38"/>
+  <text x="40" y="352" class="lbl" style="fill:var(--accent)">#50 is the first unclaimed match → claim it</text>
+
+  <rect class="box sunken" x="330" y="240" width="545" height="150"/>
+  <text x="345" y="263" class="title" style="font-size:12px">What a claim gives the call</text>
+  <text x="345" y="286" class="lbl">• its own Start index, from which the matching End / Cancelled is resolved</text>
+  <text x="345" y="304" class="lbl">  (#52 for B, #53 for A)</text>
+  <text x="345" y="324" class="lbl">• its recorded result, released at its CompletionDelivered marker in recorded order</text>
+  <text x="345" y="344" class="lbl">• the scan stops at the next CompletionDelivered marker, so nothing recorded</text>
+  <text x="345" y="362" class="lbl">  after a guest handoff can be claimed early</text>
+  <text x="345" y="382" class="lbl">• no unclaimed match between cursor and target → divergence error, replay fails</text>
+
+  <text x="40" y="420" class="lbl">The cursor advances only over claimed-and-consumed entries; it never steps past an unclaimed Start.</text>
+  <text x="40" y="440" class="lbl muted">Identity = host function name, durable function type and owning scope; RPC, tool and entity calls also match the recorded request.</text>
+  <text x="40" y="456" class="lbl muted">Entries inside a Jump-deleted region are never candidates.</text>
+</svg>
+<figcaption>Claiming: a replaying call finds the first unclaimed Start between the cursor and the replay target whose identity matches, and takes its recorded result.</figcaption>
+</figure>
+
+<p>The rule is therefore: <code>claim_start_matching</code> claims the <em>first unclaimed matching</em> <code>Start</code> between the cursor and the replay target. Scanning ahead exists only to route concurrent completions to the right awaiter; it does not let the guest make <em>different</em> calls. The scan is also bounded by the next <code>CompletionDelivered</code> marker, so a call can never claim a <code>Start</code> that was recorded after a result the guest has not yet observed in this replay; guest-visible order is preserved exactly. When no matching <code>Start</code> exists in that window, replay stops with a divergence error, which is how nondeterminism in guest code or a host-function bug surfaces instead of being silently absorbed. The one exception is entries inside a region deleted by a <code>Jump</code>, which are never candidates.</p>
+
+<h3>Three facts that are not the same</h3>
+<ol>
+  <li><strong>Cursor exhaustion</strong> — the recorded history has been consumed. An observation only.</li>
+  <li><strong>Shared primary publication</strong> — <code>transition_phase</code> moves <code>Replaying → Settling → Live</code>. <code>ReplayState::switch_to_live</code> with <code>ReplayToLiveRole::PrimaryAgent</code> runs <code>begin_primary_settling</code>, then <code>finish_settling_to_live</code> loops until every <code>HistoricalReconstruction</code> fence (a tool body still validating its recorded terminal) has validated, and <code>CursorTx::finish_primary_settling</code> publishes Live — or reports <code>ReplayResumed</code> when new history appeared meanwhile.</li>
+  <li><strong>Entity-local liveness</strong> — <code>store_is_live(mode, local_live_tail, shared_live_published)</code>: the primary Store is live iff (2) has published; a <code>ReplayingCompleted</code> entity Store is <em>never</em> live; a <code>ReplayingIncomplete</code> or <code>Live</code> entity Store is live iff its own <code>local_live_tail</code> was set by <code>PendingReplayToLive::finish</code>. For <code>ReplayToLiveRole::NonPrimary</code>, <code>switch_to_live</code> skips (2): the entity Store goes live for its own invocation scope without waiting for the primary.</li>
+</ol>
+
+<div class="phase-track" role="group" aria-label="Replay transition phases">
+  <div class="phase on">Replaying<small>consuming recorded entries; live effects refused</small></div>
+  <div class="phase">Settling<small>cursor exhausted; waiting for reconstruction fences</small></div>
+  <div class="phase">Live<small>published; new work appends</small></div>
+</div>
+
+<div class="widget" id="liveness-widget">
+  <h4>Is this Store live? <span class="pill js-only">interactive</span></h4>
+  <p>The answer comes from <code>store_is_live</code> in <code>durable_host/mod.rs</code> — try to predict it before you look.</p>
+  <div class="controls js-only">
+    <label>Store kind
+      <select id="lv-kind">
+        <option value="primary">Primary agent Store</option>
+        <option value="completed">Entity Store, ReplayingCompleted</option>
+        <option value="incomplete">Entity Store, ReplayingIncomplete</option>
+        <option value="live">Entity Store, Live</option>
+      </select>
+    </label>
+    <label class="check"><input type="checkbox" id="lv-exhausted"> cursor exhausted</label>
+    <label class="check"><input type="checkbox" id="lv-published"> primary published Live</label>
+    <label class="check"><input type="checkbox" id="lv-tail"> entity <code>local_live_tail</code> set</label>
+  </div>
+  <div class="result js-only" id="lv-result" aria-live="polite"></div>
+  <div class="no-js-only">
+    <pre><code>fn store_is_live(mode, local_live_tail, shared_live_published) -> bool {
+    match mode {
+        Some(ReplayingCompleted)            => false,
+        Some(ReplayingIncomplete | Live)    => local_live_tail,
+        None /* primary */                  => shared_live_published,
+    }
+}</code></pre>
+  </div>
+</div>
+
+<p><strong>Consequences.</strong> A host function must not perform a live effect because "the cursor is at the end"; it must observe <code>is_live</code> from the durable context. A markerless <code>End</code> is delivered once the cursor drains (<code>await_natural_tail_end</code>) with a live-armed delivery token (<code>CompletionDelivery::prepare_delivery</code>), which makes "crash after <code>End</code>, before delivery" safe without re-executing.</p>
+
+<p><strong>Resetting a cursor is not recreating an instance.</strong> Component metadata, revision and plugin context come from instance creation in the outer loop. When history or provenance changes, go through the outer loop.</p>
+
+<!-- ===================== 10. CONCURRENCY ===================== -->
+<h2 id="s-concurrency"><span class="num">10</span>Concurrency &amp; guest completion delivery</h2>
+<p>WASI p3 <code>Accessor</code> host calls run concurrently inside one Store; p2 <code>&amp;mut self</code> calls are serialized (<code>concurrent/mod.rs</code>). Concurrent completions may finish in any host order, but the guest observes them in exactly one order per run, and <em>that</em> order is recorded by the <code>CompletionDelivered</code> markers. On replay, <code>ReplayDeliveryBarrier</code> transfers the cursor gate so each completion is released at its recorded boundary. <code>supersede_prior_completion_delivery</code> hard-errors if an observer is still armed: delivery must be the tail operation of a host function.</p>
+
+<div class="widget" id="conc-widget">
+  <h4>Host order vs. guest order <span class="pill js-only">interactive</span></h4>
+  <p>Two accessor calls A and B run concurrently. In the original run the guest happened to observe A first. Change how the host finishes them in the <em>replaying</em> run and watch what the guest sees.</p>
+  <div class="controls js-only">
+    <span class="muted">Host completion order on replay:</span>
+    <button class="btn" type="button" data-conc="ab" aria-pressed="true">A then B</button>
+    <button class="btn" type="button" data-conc="ba" aria-pressed="false">B then A</button>
+  </div>
+  <div class="lane"><div class="lane-title">Recorded oplog</div>
+    <div class="tape">
+      <div class="entry pos"><span class="idx">#60</span><span class="kind">Start A</span></div>
+      <div class="entry pos"><span class="idx">#61</span><span class="kind">Start B</span></div>
+      <div class="entry pos"><span class="idx">#62</span><span class="kind">End B</span></div>
+      <div class="entry pos"><span class="idx">#63</span><span class="kind">End A</span></div>
+      <div class="entry hint"><span class="idx">#64</span><span class="kind">CompletionDelivered A</span><span class="meta">(h)</span></div>
+      <div class="entry hint"><span class="idx">#65</span><span class="kind">CompletionDelivered B</span><span class="meta">(h)</span></div>
+    </div>
+  </div>
+  <div class="result js-only" id="conc-result" aria-live="polite"></div>
+  <p class="no-js-only">Whatever order the host resolves <code>End A</code> and <code>End B</code> during replay, the guest receives A first and B second because markers #64 and #65 say so. Host completion order (#62 before #63) is not a guest input; delivery order (#64 before #65) is.</p>
+</div>
+
+<p>The runtime property this relies on holds even with bare Wasmtime and no oplog: the order in which a guest <em>initiates</em> concurrent host calls is stable across re-executions, while the order in which the host <em>completes</em> them is not, and the guest observes exactly the completion order. Recording the completion order as <code>CompletionDelivered</code> markers is what turns the second, nondeterministic order into a replayable one.</p>
+<p>Spawned store tasks that outlive an invocation are safe only while parked at a guest-driven wait (<code>tail_work.rs</code> "safe park points"); pending durable work must finish before <code>AgentInvocationFinished</code>.</p>
+
+<!-- ===================== 11. RETRIES ===================== -->
+<h2 id="s-retries"><span class="num">11</span>Retries: in-function versus trap-based</h2>
+<p>A durable host call that fails with a retryable error has two recovery paths, sharing one budget (<code>durable_host/durability.rs</code>).</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col"></th><th scope="col">In-function (inline) retry</th><th scope="col">Trap-based retry</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">Where</th><td>Inside the same host function, under the <strong>same</strong> <code>Start</code></td><td>The invocation traps; the worker is torn down and reconstructed</td></tr>
+    <tr><th scope="row">Oplog</th><td>One <code>Error { retry_from, … }</code> hint appended and committed per attempt</td><td><code>Error</code> appended in <code>on_invocation_failure</code>, then the outer loop replays to <code>retry_from</code></td></tr>
+    <tr><th scope="row">Cost</th><td>A sleep and a second live action</td><td>Full Store teardown, instance creation, replay of all history since the last baseline</td></tr>
+    <tr><th scope="row">Decided by</th><td><code>InFunctionRetryState::decide_retry_with_properties</code> → <code>AsyncRetryDecision::{Retry, FallBackToTrap, Exhausted}</code></td><td><code>try_trigger_host_trap_retry</code> → <code>on_invocation_failure</code> → <code>RetryDecision</code></td></tr>
+  </tbody>
+</table>
+</div>
+
+<p><strong>One budget.</strong> The attempt count is the in-memory <code>retry_count</code> of this host call <em>plus</em> the number of recorded <code>Error</code> entries with the same <code>retry_from</code> (<code>count_oplog_errors_for</code>, <code>current_retry_state_for</code>). After a trap and replay the in-memory count resets but the oplog count does not, so a policy exhausted inline stays exhausted.</p>
+
+<div class="widget" id="retry-widget">
+  <h4>Retry decision tool <span class="pill js-only">interactive</span></h4>
+  <p>Mirrors the conditions of <code>decide_retry_with_properties</code>. Change the inputs and see which path the failed call takes.</p>
+  <div class="controls js-only">
+    <label>Function type
+      <select id="rt-type">
+        <option value="ReadLocal">ReadLocal</option><option value="ReadRemote" selected>ReadRemote</option><option value="WriteLocal">WriteLocal</option><option value="WriteRemote">WriteRemote</option><option value="WriteRemoteBatched">WriteRemoteBatched</option><option value="WriteRemoteTransaction">WriteRemoteTransaction</option>
+      </select></label>
+    <label class="check"><input type="checkbox" id="rt-permanent"> error classified permanent</label>
+    <label class="check"><input type="checkbox" id="rt-idem" checked> idempotence mode on</label>
+    <label class="check"><input type="checkbox" id="rt-atomic"> inside an atomic region</label>
+    <label>Retry policy verdict
+      <select id="rt-policy"><option value="retry">Retry(delay)</option><option value="giveup">GiveUp (budget exhausted)</option><option value="none">no applicable policy</option></select></label>
+    <label>Delay vs. <code>max_in_function_retry_delay</code>
+      <select id="rt-delay"><option value="short">delay ≤ max</option><option value="long">delay &gt; max</option></select></label>
+  </div>
+  <div class="result js-only" id="rt-result" aria-live="polite"></div>
+  <div class="no-js-only">
+    <p>Inline retry is chosen only when <em>all</em> hold: the type is eligible (<code>ReadLocal</code>/<code>ReadRemote</code>/<code>WriteLocal</code> always; <code>WriteRemote</code> only with idempotence on; batched/transaction never); the call is not inside an atomic region; a named policy returns <code>Retry(delay)</code>; and <code>delay ≤ max_in_function_retry_delay</code>. Otherwise <code>FallBackToTrap</code> (or <code>Exhausted</code>) hands the failure to the trap path; if no policy applies there either, the failure is persisted as the call's result.</p>
+  </div>
+</div>
+
+<h3>What this means for a new durable function</h3>
+<ul>
+  <li>Pick the <code>DurableFunctionType</code> for <strong>re-execution safety</strong>, not for what the peer is. A non-idempotent remote write must be <code>WriteRemote</code> with idempotence off, or batched/transactional, so it is neither retried inline nor re-executed on incomplete replay.</li>
+  <li>If the function has a natural idempotency handle (HTTP <code>idempotency-key</code>, keyed writes), make it <code>WriteRemote</code> so the cheap inline path applies while <code>assume_idempotence</code> is on.</li>
+  <li>Attach <code>RetryProperties</code> so named policies can distinguish, for example, HTTP status classes.</li>
+  <li>Expect both shapes in the oplog: an inline retry that succeeds leaves <code>Error</code> hints under the same <code>retry_from</code> and a single <code>Start</code>/<code>End</code>; a fallback to trap leaves no extra inline hints, and the worker is reconstructed.</li>
+</ul>
+
+<!-- ===================== 12. RPC ===================== -->
+<h2 id="s-rpc"><span class="num">12</span>Exactly-once RPC &amp; atomic regions</h2>
+<p>Agent-to-agent RPC (<code>durable_host/wasm_rpc/mod.rs</code>) is a <code>WriteRemote</code> durable call on the caller whose result is a durable invocation on the target. Exactly-once is a property of the <em>target's logical invocation</em>, not of caller attempts, packets, or replay spans.</p>
+
+<h3>The key is the identity</h3>
+<ol class="steps">
+  <li>The caller appends <code>Start { rpc/invoke-and-await, request }</code>; its index <code>begin_index</code> is the call identity.</li>
+  <li><code>derive_idempotency_key(begin_index)</code> yields <code>IdempotencyKey::derived(current_key, current_idempotency_key_oplog_index(begin_index))</code>. Inside an atomic region the index is the outermost region's <em>logical</em> counter, not the physical index (see below).</li>
+  <li>Caller state the target may depend on is committed before the first dispatch.</li>
+  <li>The target persists <code>PendingAgentInvocation { key }</code> — durable acceptance — then eventually <code>AgentInvocationFinished</code>. Any same-key arrival attaches to that one invocation.</li>
+  <li>Caller replay of a completed call returns the recorded <code>End</code>. Replay of an incomplete call re-dispatches with the <strong>same</strong> key (<code>InvocationFreshnessDisposition::MayExist</code>, the default) — allowed because RPC is <code>WriteRemote</code> and <code>assume_idempotence</code> defaults to <code>true</code>. With <code>set-idempotence-mode(false)</code> the incomplete remote write fails instead.</li>
+</ol>
+
+<div class="widget" id="tl-rpc">
+  <h4>Crash-window walkthrough: caller C invokes target T's <code>increment</code> <span class="pill js-only">interactive</span></h4>
+  <p>Two oplogs, two lanes. Choose where the <em>caller's</em> executor dies. Count T's mutations, not C's attempts.</p>
+  <div class="controls js-only">
+    <label class="grow">Crash point <input type="range" min="0" max="6" value="0" step="1" data-tl-slider="rpc" aria-valuetext="no crash"></label>
+    <button class="btn small" type="button" data-tl-reset="rpc">Reset</button>
+  </div>
+  <div class="legend"><span class="l-pos">positional</span><span class="l-hint">hint</span><span class="l-lost">not written</span></div>
+  <div data-tl-tape="rpc"></div>
+  <div class="result" data-tl-result="rpc" aria-live="polite"></div>
+  <details class="disclosure no-js-only" open><summary>All crash windows (static)</summary><div class="body" data-tl-static="rpc">
+<ol class="crash-list"><li><span class="t">No crash.</span> C derives the idempotency key from its own <code>Start</code> index, T accepts the invocation under that key, runs <code>increment</code> once and records the result; C records <code>End</code> and delivers it.</li><li><span class="t">C dies after C#10, before T accepted.</span> C replays, finds the incomplete <code>Start</code>, derives the <em>same</em> key and re-dispatches (<code>InvocationFreshnessDisposition::MayExist</code>). T has never seen the key, so it creates the invocation now. T’s counter ends at 1.</li><li><span class="t">C dies after T accepted (T#20).</span> T keeps running the invocation regardless of C. C re-dispatches with the same key; T’s <code>lookup_invocation_result</code> returns <code>Pending</code>, so the second arrival attaches to the existing invocation. One execution, counter = 1.</li><li><span class="t">C dies while T is executing (T#21).</span> Identical to the previous window from C’s point of view. T finishes on its own; C’s re-dispatch attaches and waits for the recorded result.</li><li><span class="t">C dies after T finished (T#22), before C#11.</span> C re-dispatches with the same key; T answers from its oplog (<code>LookupResult::Complete</code>) without running <code>increment</code> again. C appends <code>End</code> with the recorded result. Counter = 1.</li><li><span class="t">C dies after C#11, before delivery.</span> C replays <code>End</code> as <code>Delivered/AtReplayTail</code> and hands the value to the guest when the cursor drains. T is never contacted.</li><li><span class="t">C dies after CompletionDelivered.</span> Pure replay on C; nothing crosses the network.</li></ol>
+</div></details>
+</div>
+
+<div class="callout">
+  <span class="label">How to tell exactly-once from "it returned a value"</span>
+  Look at the target, not the caller. T's counter (a provider-side effect) equals 1; the key T observed is identical across both attempts; C's oplog shows one <code>Start</code> with one <code>End</code>. That C received <code>1</code> proves nothing on its own: a duplicated increment also returns a value. In a lost-response scenario where a proxy between C and T drops T's reply and both sides restart, the proxy sees <em>two</em> identical attempts on the wire while T's oplog holds exactly one execution.
+</div>
+
+<h3>Atomic regions keep the key across rollback</h3>
+<p><code>golem:api/host.mark-begin-operation</code> / <code>mark-end-operation</code> open and close an atomic region (<code>BeginAtomicRegion</code>/<code>EndAtomicRegion</code>). If the guest traps inside the region, the retry appends a <code>Jump</code> covering the region's entries so replay skips them and re-executes the region live. The region's outermost <em>logical counter</em>, rebuilt from the region's entries during replay, is what <code>current_idempotency_key_oplog_index</code> feeds into the key, so the re-executed RPC carries the same key and the target deduplicates.</p>
+<figure>
+<svg class="dg" viewBox="0 0 940 305" role="img" aria-labelledby="atomic-title atomic-desc">
+  <title id="atomic-title">Atomic region retry: same idempotency key at a new oplog position</title>
+  <desc id="atomic-desc">Entries 50 to 53: BeginAtomicRegion, Start rpc/invoke with key derived from logical counter n, End, and a Start keyvalue/set at which the guest traps. The retry appends entry 54, a Jump covering 51 to 54, so those entries stay in the oplog but are skipped on replay, while BeginAtomicRegion at 50 is kept. Entry 55 is a new Start rpc/invoke with the identical key derived from the same logical counter n.</desc>
+  <defs><marker id="arr-at" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <rect class="box ok" x="20" y="40" width="150" height="70" rx="6"/>
+  <text x="95" y="60" text-anchor="middle" class="lbl mono">#50</text>
+  <text x="95" y="78" text-anchor="middle" class="title" style="font-size:11.5px">BeginAtomicRegion</text>
+  <text x="95" y="98" text-anchor="middle" class="lbl">region opens</text>
+  <rect class="box sunken" x="185" y="40" width="145" height="70" rx="6"/>
+  <text x="257.5" y="60" text-anchor="middle" class="lbl mono">#51</text>
+  <text x="257.5" y="78" text-anchor="middle" class="title" style="font-size:12px">Start rpc/invoke</text>
+  <text x="257.5" y="98" text-anchor="middle" class="lbl">key = derive(n)</text>
+  <rect class="box sunken" x="345" y="40" width="120" height="70" rx="6"/>
+  <text x="405" y="60" text-anchor="middle" class="lbl mono">#52</text>
+  <text x="405" y="78" text-anchor="middle" class="title" style="font-size:12px">End rpc/invoke</text>
+  <text x="405" y="98" text-anchor="middle" class="lbl">start_index 51</text>
+  <rect class="box bad" x="480" y="40" width="150" height="70" rx="6"/>
+  <text x="555" y="60" text-anchor="middle" class="lbl mono">#53</text>
+  <text x="555" y="78" text-anchor="middle" class="title" style="font-size:12px">Start keyvalue/set</text>
+  <text x="555" y="98" text-anchor="middle" class="lbl">✕ guest traps here</text>
+  <rect class="box warn" x="645" y="40" width="110" height="70" rx="6"/>
+  <text x="700" y="60" text-anchor="middle" class="lbl mono">#54</text>
+  <text x="700" y="78" text-anchor="middle" class="title" style="font-size:12px">Jump</text>
+  <text x="700" y="98" text-anchor="middle" class="lbl">region 51..=54</text>
+  <rect class="box accent" x="770" y="40" width="150" height="70" rx="6"/>
+  <text x="845" y="60" text-anchor="middle" class="lbl mono">#55</text>
+  <text x="845" y="78" text-anchor="middle" class="title" style="font-size:12px">Start rpc/invoke</text>
+  <text x="845" y="98" text-anchor="middle" class="lbl">key = derive(n)</text>
+
+  <path class="arrow dashed" d="M185 130 H755" style="marker-start:url(#arr-at);marker-end:url(#arr-at)"/>
+  <text x="500" y="152" text-anchor="middle" class="lbl">skipped on replay: the Jump's region covers #51..#54, including the Jump itself</text>
+
+  <path class="arrow" d="M95 110 V190" style="marker-end:url(#arr-at)"/>
+  <text x="95" y="210" text-anchor="middle" class="lbl">kept: the region</text>
+  <text x="95" y="226" text-anchor="middle" class="lbl">re-opens from #50</text>
+
+  <path class="arrow strong" d="M257 112 C257 265, 845 265, 845 114" style="marker-end:url(#arr-at)"/>
+  <text x="550" y="278" text-anchor="middle" class="title" style="font-size:12px">same logical counter n ⇒ same idempotency key at the new position</text>
+  <text x="550" y="296" text-anchor="middle" class="lbl">physical position changed (#51 → #55); identity did not</text>
+</svg>
+<figcaption>Retrying an atomic region: the failed attempt stays in the oplog behind a <code>Jump</code>; the retried RPC reuses the key, so the target sees one logical invocation.</figcaption>
+</figure>
+
+<h3>Ephemeral targets, self-calls, owner calls</h3>
+<ul>
+  <li><strong>Ephemeral target.</strong> <code>KnownFresh</code> is allowed only when <code>is_live &amp;&amp; is_ephemeral &amp;&amp; !assume_idempotence</code> and forces a <code>DurableOnly</code> commit before dispatch. The ephemeral phantom identity is <code>ephemeral_invocation_phantom_id</code> = UUIDv5 of the idempotency key — deterministic, never random. Ephemeral targets are deliberately <em>fail-stop</em>: a same-key retry never re-executes accepted incomplete work, but completion is not guaranteed because there is no durability to resume from; a retry that finds the target gone gets <code>INACTIVE_EPHEMERAL_AGENT_ERROR</code>. Distinct calls get distinct final identities.</li>
+  <li><strong>Self-call.</strong> An agent calling itself is rejected: "RPC calls to the same agent are not supported".</li>
+  <li><strong>Body → owner.</strong> A synchronous call from an entity body back into its blocked owner must pass <code>OwnerLane::ensure_synchronous_owner_call</code>; otherwise it is rejected with <code>WouldDeadlock</code> instead of hanging. Asynchronous owner calls are allowed.</li>
+</ul>
+
+<!-- ===================== 13. STREAMS ===================== -->
+<h2 id="s-streams"><span class="num">13</span>Streaming invocations</h2>
+<p>A streaming RPC is an ordinary durable RPC whose method signature carries input or output streams (<code>remote_method_uses_streams</code>). Live streams require invoke-and-await; a fire-and-forget streaming call is rejected with <code>RpcError::ProtocolError</code>. The target is pinned by <code>streaming_target_fingerprint</code>: <code>AgentFingerprint</code> is minted once at agent creation and stable across restarts, so a deleted-and-recreated agent with the same <code>AgentId</code> is a <em>different producer</em>.</p>
+
+<h3>Two durable journals, one optimisation</h3>
+<figure>
+<svg class="dg" viewBox="0 0 900 300" role="img" aria-labelledby="str-title str-desc">
+  <title id="str-title">Streaming data path</title>
+  <desc id="str-desc">The producer's oplog holds StreamRegistered, StreamItems, StreamEnd and StreamCancel records. Records are committed first, then published to the DurableLiveStreamBus, a live-tail optimisation. The consumer's oplog holds a StreamSession journal with attempts, attachment, consumed item offsets and terminals. A restarted consumer replays its own journal, then reads producer oplog segments after its last offset.</desc>
+  <defs><marker id="arr4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <rect class="box accent" x="30" y="40" width="270" height="150"/>
+  <text x="165" y="66" text-anchor="middle" class="title">Producer P oplog (authoritative)</text>
+  <text x="45" y="92" class="lbl">StreamRegistered { stream, fingerprint(P) }</text>
+  <text x="45" y="114" class="lbl">StreamItems { first_sequence, items[ offset ] }</text>
+  <text x="45" y="136" class="lbl">StreamItems { … }</text>
+  <text x="45" y="158" class="lbl">StreamEnd | StreamCancel</text>
+  <text x="45" y="180" class="lbl muted">(all hints; committed before publish)</text>
+  <rect class="box sunken" x="360" y="80" width="180" height="70" rx="12"/>
+  <text x="450" y="108" text-anchor="middle" class="title">DurableLiveStreamBus</text>
+  <text x="450" y="130" text-anchor="middle" class="lbl">bounded live-tail cache</text>
+  <rect class="box ok" x="600" y="40" width="270" height="150"/>
+  <text x="735" y="66" text-anchor="middle" class="title">Consumer C oplog (authoritative)</text>
+  <text x="615" y="92" class="lbl">StreamSession { CallerAttempt id }</text>
+  <text x="615" y="114" class="lbl">StreamSession { Attached, mapping }</text>
+  <text x="615" y="136" class="lbl">StreamSession { ConsumerItemValue</text>
+  <text x="630" y="156" class="lbl">  source_offset, read_ordinal }</text>
+  <text x="615" y="178" class="lbl">StreamSession { terminal, Finished }</text>
+  <path class="arrow" style="marker-end:url(#arr4)" d="M300 115 H358"/><text x="329" y="105" text-anchor="middle" class="lbl">publish_committed</text>
+  <path class="arrow" style="marker-end:url(#arr4)" d="M540 115 H598"/><text x="569" y="105" text-anchor="middle" class="lbl">subscribe</text>
+  <path class="arrow dashed" style="marker-end:url(#arr4)" d="M600 220 C 500 260, 250 260, 165 192"/>
+  <text x="390" y="270" text-anchor="middle" class="lbl">on restart: read_segment after last source_offset (bypasses the bus)</text>
+</svg>
+<figcaption>Only the two oplogs are authoritative. The bus is documented as "a bounded live-tail optimization for events that have already committed to the producer oplog" — losing the bus, a reader or a socket loses nothing.</figcaption>
+</figure>
+
+<ul>
+  <li><strong>Producer journal</strong> (<code>DurableStreamProducer::{register, write_items, end, cancel_open}</code>, <code>durable_host/durable_stream.rs</code>). Each <code>StreamItemsRecordV1</code> carries <code>first_sequence</code>, per-item <code>StreamOffsetV1 { oplog index, sub_index }</code> and <code>producer_fingerprint</code>.</li>
+  <li><strong>Consumer <code>StreamSession</code> journal</strong> (<code>StreamSessionRecordV1</code>): caller attempts, attach/detach, mappings, topology, <code>ConsumerItemValue { source_offset, consumer_read_ordinal }</code>, cancel intent, terminals, the invocation result, and <code>Finished</code>.</li>
+  <li>All stream entries are <strong>hints</strong> in the oplog-entry sense: they take part in no <code>Start</code>/terminal pairing and never satisfy a claim. "Hint" does <em>not</em> mean "not replayed" — see below.</li>
+</ul>
+
+<h3>Why item order is still deterministic on replay</h3>
+<p>If stream records are hints, what guarantees that a consumer that performs a side effect per received item performs them in the same order on replay? Two things, working together.</p>
+<ol>
+  <li><strong>The consumer journals every item before the guest sees it.</strong> When a live consumer pulls the next item, the session appends a <code>ConsumerItemValue { source_offset, consumer_read_ordinal, value }</code> record to <em>its own</em> oplog and commits it <em>before</em> handing the value to the guest. On replay the session does not touch the producer or the bus for those items: it reads its own <code>ConsumerItemValue</code> records back in <code>consumer_read_ordinal</code> order and hands them to the guest one by one. So the replaying guest receives the same values in the same order, with the same batch boundaries. Only items beyond the journal, the ones the guest never saw, are fetched from the producer after the Store goes live.</li>
+  <li><strong>The side effects are ordinary durable calls.</strong> Whatever the guest does with an item, such as an RPC, a key-value write or an HTTP request, is a positional durable call with its own <code>Start</code>/<code>End</code> and, if concurrent, its own <code>CompletionDelivered</code> marker. Because the guest is deterministic (<a href="#s-overview">§1</a>) and receives identical inputs in identical order, it issues those calls in the same order, and the cursor and claims of <a href="#s-cursor">§9</a> pair each one with its recorded entry.</li>
+</ol>
+<p>In other words, the item stream is treated like any other recorded <em>input</em> to the guest, journaled on the consumer side, while the guest's <em>outputs</em> keep the positional machinery. The two do not need to be woven into one <code>Start</code>/<code>End</code> sequence for the interleaving to be reproduced, which is why a change to the stream protocol cannot desynchronise <code>Start</code>/<code>End</code> pairing. Byte streams (HTTP response bodies, TCP sockets) take the other route: <code>DurableDemandStream</code> records a batched parent and one durable child <code>Start</code>/<code>End</code> per demanded chunk, so there the items <em>are</em> positional entries.</p>
+
+<h3>Exactly-once item delivery is by offset, not by connection</h3>
+<p>A restarted consumer first replays its own journal in <code>consumer_read_ordinal</code> order, then reads producer oplog segments after the last <code>source_offset</code> (<code>read_segment</code> / <code>RoutedAttachedStreamSegmentSource</code> in <code>durable_session.rs</code>); a live subscription samples the bus high-water under the publication lock and discards overlap by offset. A restarted producer replays its items from its oplog and resumes writing after the last committed sequence. Producer identity is checked at every boundary: <code>validate_forwarded_mapping</code> requires the session key, consumer and producer fingerprint to match, and producer-side record application rejects records naming another producer incarnation as <code>CorruptHistory</code>.</p>
+<p>Randomness is allowed where it is recorded before it is observed: <code>caller_attempt_id</code> calls <code>AttemptId::fresh()</code> only when no <code>CallerAttempt</code> record exists, appends and commits it, and every later run reads the persisted value.</p>
+
+<h3>RPC result versus stream draining</h3>
+<p>On the synchronous streaming path the caller completes the durable call with the result <em>stripped of streams</em> (<code>strip_streams</code>) and only then returns the stream-bearing value to the guest. The caller's RPC <code>End</code> can therefore already be recorded while items are still flowing. Three crash windows follow:</p>
+<ol>
+  <li><strong>Setup done, RPC result not yet recorded</strong> — replay finds an incomplete <code>Start</code> and re-dispatches with the same key; the target attaches to the same invocation.</li>
+  <li><strong>RPC result recorded, streams partially consumed</strong> — replay returns the recorded result; the consumer session resumes by offset.</li>
+  <li><strong>Invocation finished, session cleanup pending</strong> — <code>agent_invocation_finished</code> runs <code>complete_durable_streaming_session</code> after the success hook, appending protocol terminals and <code>StreamSession { Finished }</code> as hints <em>after</em> <code>AgentInvocationFinished</code>.</li>
+</ol>
+
+<div class="widget" id="tl-stream">
+  <h4>Crash-window walkthrough: producer restarts mid-stream <span class="pill js-only">interactive</span></h4>
+  <p>Caller C invokes <code>P.generate()</code>, whose result is an output stream. Choose where P's executor dies.</p>
+  <div class="controls js-only">
+    <label class="grow">Crash point <input type="range" min="0" max="5" value="0" step="1" data-tl-slider="stream" aria-valuetext="no crash"></label>
+    <button class="btn small" type="button" data-tl-reset="stream">Reset</button>
+  </div>
+  <div class="legend"><span class="l-pos">positional</span><span class="l-hint">hint</span><span class="l-lost">not written</span></div>
+  <div data-tl-tape="stream"></div>
+  <div class="result" data-tl-result="stream" aria-live="polite"></div>
+  <details class="disclosure no-js-only" open><summary>All crash windows (static)</summary><div class="body" data-tl-static="stream">
+<ol class="crash-list"><li><span class="t">No crash.</span> P registers the stream under its <code>AgentFingerprint</code>, commits each batch before publishing it on the live bus, and ends the stream; C journals what it read by producer offset.</li><li><span class="t">P dies after registering.</span> P is reconstructed and re-runs <code>generate()</code> in replay. The registration is already recorded; the first item batch the guest produces is appended live. C, attached or not, has read nothing yet.</li><li><span class="t">P dies after committing items 0–2.</span> On replay P’s guest re-produces items 0–2; they match the recorded batch and are not re-published. Production continues from sequence 3. C received 0–2 from the bus (publish happens only after commit) and keeps them.</li><li><span class="t">P dies after C journaled 0–2.</span> Same for P. C, if it also restarts, replays its own session journal in <code>consumer_read_ordinal</code> order and then reads P’s oplog segment after <code>source_offset</code> 2 — no item is lost, none is delivered twice.</li><li><span class="t">P dies after committing items 3–4.</span> Items 3–4 are durable in P’s oplog. C’s live subscription may have missed the publish; when it re-attaches it samples the bus high-water under the publication lock and reads 3–4 from the segment by offset, discarding any overlap.</li><li><span class="t">P dies after StreamEnd.</span> The stream is complete in P’s oplog. Any consumer that resumes reads to the terminal and finishes its session (<code>StreamSession { Finished }</code>).</li></ol>
+</div></details>
+</div>
+
+<h3>Terminals</h3>
+<p>Terminals are guest-authored (<code>StreamEnd</code> with the guest's result, <code>StreamCancel</code> with <code>GuestDrop</code>/<code>Cancelled</code>) or protocol-authored. When the producing invocation completes or fails with streams still open, the protocol cancels open inputs, ends open outputs with an error context, then appends <code>Finished</code>; a protocol terminal <em>fences</em> any later guest terminal so consumers observe exactly one. A stream failing locally does not fail sibling streams or the invocation. Both sides recover independently: a producer that restarts continues its output after the last committed item, and a consumer that restarts resumes draining from its own journal, whether the restart happened before or after the RPC result itself was committed.</p>
+
+<!-- ===================== 14. TOOLS ===================== -->
+<h2 id="s-tools"><span class="num">14</span>Tool invocations &amp; entity bodies</h2>
+<p><code>durable_host/tool/mod.rs</code> implements <code>golem:tool/host@0.1.0</code>. Tool discovery is a durable read of environment state; authorisation is enforced before any backend runs. What makes tools different from every other host call is <em>where the body runs and where it records</em>.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 280" role="img" aria-labelledby="tool-title tool-desc">
+  <title id="tool-title">Owner Store, entity body Store and the shared owner oplog</title>
+  <desc id="tool-desc">The owner agent's primary Store and a transient entity body Store both record into the same owner oplog and share the same replay cursor. The entity body has no oplog of its own. Its Start entry index is the entity invocation id, and host calls made by the body carry parent_start_index pointing at that Start. The body Store also attaches to the owner's filesystem generation.</desc>
+  <defs><marker id="arr5" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+  <rect class="box accent" x="40" y="30" width="250" height="90"/>
+  <text x="165" y="58" text-anchor="middle" class="title">Owner O — primary Store</text>
+  <text x="165" y="80" text-anchor="middle" class="lbl">guest calls call-tool</text>
+  <text x="165" y="100" text-anchor="middle" class="lbl">OwnerLane permit</text>
+  <rect class="box warn" x="40" y="160" width="250" height="90"/>
+  <text x="165" y="188" text-anchor="middle" class="title">Entity body Store (transient)</text>
+  <text x="165" y="210" text-anchor="middle" class="lbl">sidecar / middleware export</text>
+  <text x="165" y="230" text-anchor="middle" class="lbl">destroyed after invoke_scoped</text>
+  <rect class="box" x="420" y="30" width="440" height="220"/>
+  <text x="640" y="58" text-anchor="middle" class="title">Owner O oplog (the only oplog; shared ReplayCursor)</text>
+  <text x="440" y="90" class="lbl">#61 Start { golem-entity-invoke, sidecar }   ← entity invocation id = 61</text>
+  <text x="440" y="116" class="lbl">#62 Start { http/send, parent_start_index: 61 }   ← body's call</text>
+  <text x="440" y="142" class="lbl">#63 End   { start_index: 62 }</text>
+  <text x="440" y="168" class="lbl">#64 CompletionDelivered { 62 } (h)</text>
+  <text x="440" y="194" class="lbl">#65 End   { start_index: 61, tool result }   ← body terminal</text>
+  <text x="440" y="230" class="lbl muted">trap in body → #61 stays incomplete; no invented terminal</text>
+  <path class="arrow" style="marker-end:url(#arr5)" d="M290 75 C 350 75, 350 90, 418 90"/>
+  <path class="arrow" style="marker-end:url(#arr5)" d="M290 205 C 350 205, 350 116, 418 116"/>
+  <path class="arrow dashed" style="marker-end:url(#arr5)" d="M165 120 V158"/><text x="185" y="143" class="lbl">shares AgentFilesystem generation</text>
+</svg>
+<figcaption>An entity body records into the owner's oplog under <code>parent_start_index</code> and shares the owner's cursor (<code>OwnerExecution</code>, <code>worker/instance.rs</code>). It has neither its own oplog nor its own cursor.</figcaption>
+</figure>
+
+<h3>Dispatch and ownership</h3>
+<p><code>dispatch_tool_call</code> claims (replay, <code>EntityInvocationDurability::replay_tool_access</code>) or creates (live) the entity invocation directly — there is no outer <code>Start { call-tool }</code> wrapping it. <code>EntityInvocationDurability</code> (<code>durable_host/entity.rs</code>, "durable owner-oplog boundary for transient entity bodies") wraps a <code>DurableCallSession&lt;GolemEntityInvoke, LeaveIncompleteOnDrop&gt;</code>; its <code>Start</code> index <em>is</em> the entity invocation ID, and its terminal is an ordinary <code>End</code> or <code>Cancelled</code>. A trap leaves the <code>Start</code> incomplete.</p>
+
+<h3>Why a completed body re-executes</h3>
+<p>The entity Store attaches to the <strong>owner's</strong> <code>AgentFilesystem</code> generation (<code>OwnerRuntimeResources::filesystem_generation_handle</code>), so every file the body reads or writes is the agent's own state. Replaying the agent must rebuild those filesystem effects, which only re-running the body can do. So <code>InvocationExecutionMode</code> is chosen from <code>replay.has_visible_terminal(start_index)</code>:</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Mode</th><th scope="col">What happens</th><th scope="col">External effects</th></tr></thead>
+  <tbody>
+    <tr><td><code>ReplayingCompleted</code></td><td><code>invoke_tool_sidecar</code> still calls the sidecar's guest export; the body re-executes from recorded inputs. <code>drive_access</code> releases the recorded terminal only after the reconstruction validates against the claim (<code>StartClaim::owned_tool_invocation</code>). Completed replays reuse historical memory charges and bypass current attachment memory pressure.</td><td><span class="pill ok">not repeated</span> — the body's durable host calls replay from the owner oplog</td></tr>
+    <tr><td><code>ReplayingCompleted</code>, <code>body_execution = Skipped</code></td><td>Admission was rejected before the body ever ran (e.g. an attachment upgrade hit <code>ResourceExhausted</code>). <code>execute_recorded_skipped_tool_call</code> returns the recorded rejection with no guest call at all.</td><td>none</td></tr>
+    <tr><td><code>ReplayingIncomplete</code></td><td>A <code>Start</code> without terminal: the body switches to live and completes under the <em>original</em> index. It must first be admitted by <code>activate_live_attachment_memory_accounting</code> (<code>Admitted</code> or <code>ResourceExhausted</code>, persisted either way); then <code>PendingReplayToLive::finish</code> with <code>ReplayToLiveRole::NonPrimary</code> sets the entity Store's <code>local_live_tail</code>.</td><td>completed nested effects replay; the incomplete remainder runs live</td></tr>
+    <tr><td><code>Live</code></td><td>Ordinary recording.</td><td>performed once</td></tr>
+  </tbody>
+</table>
+</div>
+<div class="callout">
+  <span class="label">What "replayed correctly" means for a tool call</span>
+  The guarantee is "no repeated external effect", <strong>not</strong> "no second guest call". Replaying a completed tool call may well run guest code again inside the owner; what it must never do is re-run the body's recorded host calls against the outside world.
+</div>
+
+<h3>Fences and scheduling</h3>
+<ul>
+  <li><strong>Reconstruction fences.</strong> <code>HistoricalReconstruction</code> / <code>ReconstructionClaimState</code> (<code>concurrent/replay.rs</code>) keep the primary's <code>PendingReplayToLive</code> fail-closed until every active body has validated. <code>enter_incomplete_live_repair_before_body_access</code> avoids deadlocking the primary's own transition.</li>
+  <li><strong>Attachments</strong> (<code>tool/attachment.rs</code>) are in-memory stdin/stdout endpoints and are recreated, never preserved.</li>
+  <li><strong><code>EntitySlot</code></strong> (<code>worker/entity_slot.rs</code>) only registers active invocations and "never grants execution"; <strong><code>OwnerLane</code></strong> (<code>worker/owner_lane.rs</code>) "serializes filesystem-capable guest bodies at causal invocation boundaries", while filesystem-incapable invocations get an immediate off-lane permit.</li>
+  <li><strong>Body traps</strong> fail the owner invocation and drain the owner group without inventing entity terminals; a blocked sibling body is fenced rather than left hanging.</li>
+</ul>
+
+<!-- ===================== 15. EXTERNAL EFFECTS ===================== -->
+<h2 id="s-external"><span class="num">15</span>External-effect guarantees &amp; boundaries</h2>
+<p>Durability stops at the process boundary. What Golem can guarantee depends entirely on <em>who the peer is</em>.</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Peer</th><th scope="col">Guarantee</th><th scope="col">Who enforces it</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Durable Golem agent</strong> (RPC)</td><td><span class="pill ok">exactly-once</span> logical invocation and result</td><td>Target's durable queue (<code>PendingAgentInvocation</code>) + the shared, replay-stable idempotency key</td></tr>
+    <tr><td><strong>Ephemeral Golem agent</strong> (RPC)</td><td><span class="pill warn">at-most-once</span> per accepted invocation; no resumption after target loss</td><td>Fail-stop target; deterministic phantom id (UUIDv5 of the key)</td></tr>
+    <tr><td><strong>Tool / entity body</strong></td><td><span class="pill ok">exactly-once external effects</span>; body code itself may run again</td><td>Owner oplog under <code>parent_start_index</code>; recorded terminal validated on reconstruction</td></tr>
+    <tr><td><strong>Streaming session</strong></td><td><span class="pill ok">exactly-once item delivery</span> and one terminal per stream</td><td>Producer + consumer journals, <code>StreamOffsetV1</code>, fingerprint checks, protocol terminal fencing</td></tr>
+    <tr><td><strong>Oplog-processor plugin</strong></td><td><span class="pill ok">exactly-once</span> delivery of each oplog batch</td><td>Deterministic batch key + per-plugin checkpoints (<a href="#s-processors">§16</a>)</td></tr>
+    <tr><td><strong>Arbitrary external service</strong> (HTTP/TCP/DB/…)</td><td><span class="pill bad">exactly-once only if the peer deduplicates</span>; otherwise a retry in the ambiguous crash window is visible</td><td>Golem attaches an <code>idempotency-key</code> header to outgoing HTTP (<code>http/policy.rs</code>, from <code>derive_idempotency_key(begin_index)</code>, unless the guest set one) and offers <code>golem:api/host.generate-idempotency-key</code>; the peer must honour it; atomic regions group calls</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h3>The ambiguous window, precisely</h3>
+<p>For a <code>WriteRemote</code> call to a non-Golem peer the ambiguous window is <em>after the request left the executor and before <code>End</code> was appended</em>. With idempotence mode on, recovery re-sends under the same <code>Start</code> (same derived key). If the peer ignores the key, it sees two writes. The guest's choices are:</p>
+<ul>
+  <li>Keep idempotence mode on and make the peer honour <code>idempotency-key</code> (or use a naturally idempotent operation such as PUT-by-id).</li>
+  <li>Call <code>set-idempotence-mode(false)</code> around the write: the incomplete call is then <em>not</em> re-executed on recovery; the invocation fails instead, and the guest decides.</li>
+  <li>Wrap a group of writes in an atomic region so a failure re-runs the whole group with stable keys.</li>
+</ul>
+
+<h3>Four exactly-once contracts that must not be conflated</h3>
+<div class="grid2">
+  <div class="card"><h4>1. RPC exactly-once</h4><p>One logical target invocation per key. Owner: caller's <code>Start</code> + target's durable queue.</p></div>
+  <div class="card"><h4>2. Oplog-processor delivery</h4><p>One delivery per batch. Owner: batch key + <code>confirmed_up_to</code>/<code>sending_up_to</code> checkpoints.</p></div>
+  <div class="card"><h4>3. Stream-item exactly-once</h4><p>Each <code>StreamOffsetV1</code> consumed once per consumer session. Owner: <code>durable_stream.rs</code> / <code>durable_session.rs</code>.</p></div>
+  <div class="card"><h4>4. Exactly-once finalisation</h4><p>One terminal per stream; protocol terminals fence guest terminals.</p></div>
+</div>
+<p>A change that satisfies one of these does not imply the others.</p>
+
+<!-- ===================== 16. OPLOG PROCESSOR ===================== -->
+<h2 id="s-processors"><span class="num">16</span>Oplog processor delivery</h2>
+<p>Oplog-processor plugins receive an agent's oplog entries as they are committed. Delivery is exactly-once per batch (<code>services/oplog/plugin.rs</code>), using the same two ingredients as RPC: a deterministic key and a durable checkpoint.</p>
+
+<figure>
+<svg class="dg" viewBox="0 0 960 446" role="img" aria-labelledby="proc-title proc-desc">
+  <title id="proc-title">Exactly-once oplog processor delivery</title>
+  <desc id="proc-desc">Committed entries of the source agent's oplog are picked up by the plugin forwarder, which cuts a batch from first index to last index and derives a deterministic UUIDv5 idempotency key from the source agent, the plugin grant and the two indices. It persists sending_up_to equal to the last index in the agent status record, invokes the processor agent with the key, and on acknowledgement persists confirmed_up_to. A crash between the two checkpoints re-sends the identical range under the identical key, and the processor agent, a durable agent, deduplicates it through its own invocation queue.</desc>
+  <defs><marker id="arr-proc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+
+  <rect class="box ok" x="20" y="30" width="200" height="100"/>
+  <text x="120" y="55" text-anchor="middle" class="title">Source agent oplog</text>
+  <text x="120" y="78" text-anchor="middle" class="lbl">#120 … #131 committed</text>
+  <text x="120" y="98" text-anchor="middle" class="lbl">only committed entries</text>
+  <text x="120" y="114" text-anchor="middle" class="lbl">are ever forwarded</text>
+
+  <path class="arrow strong" style="marker-end:url(#arr-proc)" d="M220 80 H288"/>
+  <text x="254" y="70" text-anchor="middle" class="lbl">commit</text>
+
+  <rect class="box" x="290" y="30" width="360" height="160"/>
+  <text x="470" y="55" text-anchor="middle" class="title">Plugin forwarder (ForwardingOplog)</text>
+  <text x="305" y="82" class="lbl">batch = first_idx ..= last_idx  →  #120 ..= #131</text>
+  <text x="305" y="104" class="lbl">key = oplog_processor_idempotency_key(</text>
+  <text x="325" y="120" class="lbl">source agent, plugin grant, first_idx, last_idx)</text>
+  <text x="305" y="142" class="lbl">UUIDv5: same batch ⇒ same key, on any executor</text>
+  <text x="305" y="172" class="lbl muted">an unconfirmed batch never widens</text>
+
+  <rect class="box accent" x="720" y="30" width="220" height="100"/>
+  <text x="830" y="55" text-anchor="middle" class="title">Processor agent</text>
+  <text x="830" y="78" text-anchor="middle" class="lbl">a durable agent whose</text>
+  <text x="830" y="96" text-anchor="middle" class="lbl">invocation queue deduplicates</text>
+  <text x="830" y="114" text-anchor="middle" class="lbl">by idempotency key</text>
+
+  <path class="arrow strong" style="marker-end:url(#arr-proc)" d="M650 70 H718"/>
+  <text x="684" y="60" text-anchor="middle" class="lbl">2. invoke(key)</text>
+  <path class="arrow dashed" style="marker-end:url(#arr-proc)" d="M718 105 H652"/>
+  <text x="684" y="122" text-anchor="middle" class="lbl">ack</text>
+
+  <rect class="box sunken" x="290" y="260" width="360" height="80"/>
+  <text x="470" y="285" text-anchor="middle" class="title" style="font-size:12px">AgentStatusRecord.oplog_processor_checkpoints</text>
+  <text x="305" y="310" class="lbl">sending_up_to   = #131   persisted before the invoke</text>
+  <text x="305" y="328" class="lbl">confirmed_up_to = #131   persisted after the ack</text>
+  <path class="arrow" style="marker-end:url(#arr-proc)" d="M380 190 V258"/>
+  <text x="372" y="228" text-anchor="end" class="lbl">1. write sending_up_to</text>
+  <path class="arrow" style="marker-end:url(#arr-proc)" d="M560 190 V258"/>
+  <text x="568" y="228" class="lbl">3. write confirmed_up_to</text>
+
+  <rect class="box warn" x="20" y="370" width="920" height="66"/>
+  <text x="35" y="392" class="title" style="font-size:12px">Crash between 1 and 3: sending_up_to = #131 but confirmed_up_to = #119</text>
+  <text x="35" y="410" class="lbl">The reconstructed forwarder re-sends exactly #120 ..= #131 under exactly the same key;</text>
+  <text x="35" y="426" class="lbl">the processor's queue already knows the key and returns the recorded result — nothing runs twice, nothing is skipped.</text>
+</svg>
+<figcaption>Delivery uses the same two ingredients as durable RPC: a key that is a pure function of the batch, and a checkpoint that is persisted before the send and after the acknowledgement.</figcaption>
+</figure>
+<ul>
+  <li><strong>Key.</strong> <code>oplog_processor_idempotency_key</code> hashes source agent, plugin grant id and the batch's first/last index into a UUIDv5. Two forwarders that both see the same batch derive the same key.</li>
+  <li><strong>Checkpoints.</strong> Per plugin, <code>confirmed_up_to</code> and <code>sending_up_to</code> live in <code>AgentStatusRecord.oplog_processor_checkpoints</code>, so a reconstructed forwarder knows exactly which entries still need delivery. The <code>OplogProcessorCheckpoint</code> hint (<code>plugin_grant_id, target_agent_id, confirmed_up_to, sending_up_to, last_batch_start</code>) records checkpoint advances in the source oplog.</li>
+  <li><strong>Retry never widens the batch.</strong> If <code>sending_up_to &gt; confirmed_up_to</code> when the forwarder wakes up, it re-sends exactly <code>confirmed_up_to+1 ..= sending_up_to</code> — the same range, hence the same key. Only when the previous batch is confirmed does a new batch extend to the committed tail. A range consisting only of checkpoint entries is skipped by advancing both cursors.</li>
+  <li><strong>Target.</strong> The processor is itself a durable agent, so the "exactly-once" is ultimately the ordinary RPC contract of <a href="#s-rpc">§12</a> applied to a deterministically keyed batch.</li>
+</ul>
+
+<!-- ===================== 17. SNAPSHOTS & UPDATES ===================== -->
+<h2 id="s-snapshots"><span class="num">17</span>Snapshots &amp; updates</h2>
+<p>Replaying a long oplog from <code>INITIAL</code> every time an agent is reconstructed would be slow, and a component update needs a way to carry state across code that no longer replays identically. Both use <em>snapshots</em>: guest-provided serialisations of the agent's state.</p>
+
+<h3>A third execution mode</h3>
+<p>Snapshot save/load runs guest code in <em>snapshotting mode</em>: it neither appends nor consumes durable-call oplog entries (<code>DurableCallSession</code> created with <code>persisted: false</code>; <code>durability_is_suppressed</code> is exactly <code>snapshotting_mode</code>). A snapshot load is therefore <strong>not</strong> a fast-forwarded replay — the loaded state <em>replaces</em> skipped history from a revision-scoped baseline.</p>
+
+<h3>Which history does the new instance replay?</h3>
+<p>Decided at <code>Worker</code> construction (<code>worker/mod.rs</code>, <code>component_version_for_replay</code>):</p>
+<ol class="steps">
+  <li>The last <em>manual-update</em> snapshot (a <code>SnapshotBased</code> update) is the baseline; if none, <code>OplogIndex::INITIAL</code>.</li>
+  <li>A revision-matching <em>automatic</em> snapshot overrides it and skips <code>INITIAL+1 ..= snapshot_idx</code> — but only while no update is pending and the resident <code>snapshot_recovery_disabled</code> flag is unset.</li>
+  <li>The component revision to instantiate comes from the same decision. A cursor cannot change it; only the outer loop can.</li>
+</ol>
+
+<h3>Two update flavours</h3>
+<div class="grid2">
+  <div class="card">
+    <h4><code>UpdateDescription::Automatic</code></h4>
+    <p><code>PendingUpdate { target revision r2 }</code> (hint) is appended, the worker is unloaded and reconstructed. Because an update is pending, automatic snapshots are ignored; the new instance is created for <code>r2</code>. <code>prepare_instance</code> runs <code>try_load_snapshot</code> on the baseline, then <code>resume_replay</code> replays the remaining <em>old</em> history against the <code>r2</code> component. Success appends <code>SuccessfulUpdate</code> during that replay.</p>
+    <p>If replay fails while the update is pending, <code>on_worker_update_failed</code> appends <code>FailedUpdate</code> and returns <code>RetryDecision::Immediate</code>: the outer loop rebuilds on the old revision, automatic snapshot eligible again.</p>
+  </div>
+  <div class="card">
+    <h4><code>UpdateDescription::SnapshotBased</code></h4>
+    <p>The <em>save</em> hook ran on the old revision and its payload was recorded <em>before</em> unload. <code>prepare_instance</code> requires the store to be live already and <code>finalize_pending_snapshot_update</code> loads the payload into <code>r2</code>. No old history is replayed against the new code.</p>
+    <p>Use this when the new revision cannot replay the old oplog deterministically (changed host-call sequence, changed data model).</p>
+  </div>
+</div>
+
+<figure>
+<svg class="dg" viewBox="0 0 900 384" role="img" aria-labelledby="upd-title upd-desc">
+  <title id="upd-title">Automatic update timeline</title>
+  <desc id="upd-desc">A PendingUpdate hint for target revision r2 is appended at entry 70. The worker is unloaded and the outer loop creates a new Store for r2. prepare_instance first tries to load a snapshot baseline in snapshotting mode, which appends and consumes nothing, then resumes replay of the old history against r2. If replay succeeds, a SuccessfulUpdate hint is appended and later reconstructions load r2. If replay fails, a FailedUpdate hint is appended, the retry decision is immediate, and the worker is rebuilt on r1.</desc>
+  <defs><marker id="arr-up" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="var(--fg-muted)"/></marker></defs>
+
+  <rect class="box hint" x="20" y="30" width="200" height="70" rx="6"/>
+  <text x="120" y="55" text-anchor="middle" class="lbl mono">#70 PendingUpdate (hint)</text>
+  <text x="120" y="78" text-anchor="middle" class="lbl">target revision r2, Automatic</text>
+
+  <path class="arrow strong" d="M220 65 H268" style="marker-end:url(#arr-up)"/>
+
+  <rect class="box sunken" x="270" y="30" width="200" height="70" rx="6"/>
+  <text x="370" y="55" text-anchor="middle" class="title" style="font-size:12px">worker unloaded</text>
+  <text x="370" y="78" text-anchor="middle" class="lbl">outer loop → new Store for r2</text>
+
+  <path class="arrow strong" d="M470 65 H518" style="marker-end:url(#arr-up)"/>
+
+  <rect class="box" x="520" y="30" width="360" height="130" rx="6"/>
+  <text x="700" y="55" text-anchor="middle" class="title" style="font-size:12px">prepare_instance on r2</text>
+  <text x="535" y="82" class="lbl mono">1. try_load_snapshot(baseline)</text>
+  <text x="555" y="100" class="lbl">snapshotting mode: appends and consumes nothing</text>
+  <text x="535" y="126" class="lbl mono">2. resume_replay(old history against r2)</text>
+  <text x="555" y="144" class="lbl">every recorded Start must be claimed by r2's guest</text>
+
+  <path class="arrow" d="M620 160 V228" style="marker-end:url(#arr-up)"/>
+  <text x="612" y="200" text-anchor="end" class="lbl">replay ok</text>
+  <path class="arrow" d="M790 160 V228" style="marker-end:url(#arr-up)"/>
+  <text x="782" y="200" text-anchor="end" class="lbl">divergence / trap</text>
+
+  <rect class="box ok" x="470" y="230" width="220" height="90" rx="6"/>
+  <text x="580" y="255" text-anchor="middle" class="lbl mono">SuccessfulUpdate (hint)</text>
+  <text x="580" y="278" text-anchor="middle" class="lbl">worker goes live on r2;</text>
+  <text x="580" y="296" text-anchor="middle" class="lbl">later reconstructions load r2</text>
+
+  <rect class="box bad" x="700" y="230" width="180" height="90" rx="6"/>
+  <text x="790" y="255" text-anchor="middle" class="lbl mono">FailedUpdate (hint)</text>
+  <text x="790" y="278" text-anchor="middle" class="lbl">RetryDecision::Immediate</text>
+  <text x="790" y="296" text-anchor="middle" class="lbl">rebuild on r1, keep running</text>
+
+  <text x="20" y="350" class="lbl">Automatic snapshots taken under r1 are never used to start r2;</text>
+  <text x="20" y="366" class="lbl">a snapshot taken after the update succeeded is, and it recovers with the updated component.</text>
+</svg>
+<figcaption>Automatic update: the new revision must prove it can replay the old history before it becomes the durable truth for this agent.</figcaption>
+</figure>
+
+<p>With no update pending, <code>prepare_instance</code> calls <code>try_load_snapshot</code>; if the load <em>fails</em>, the resident <code>Worker</code>'s <code>snapshot_recovery_disabled</code> flag is set and the worker retries immediately with a full replay. The old oplog is untouched by snapshotting mode, so this fallback is always available.</p>
+
+<h3>When may a snapshot be taken?</h3>
+<p>Automatic snapshots are taken only at a <em>safe boundary</em>. <code>SnapshotBoundaryConditions::blocker</code> reports the first blocking condition in precedence order; a request at an unsafe boundary is rejected with that reason and never partially taken.</p>
+
+<div class="widget" id="snap-widget">
+  <h4>Snapshot boundary checker <span class="pill js-only">interactive</span></h4>
+  <div class="controls js-only">
+    <label class="check"><input type="checkbox" id="sb-replaying"> replaying</label>
+    <label class="check"><input type="checkbox" id="sb-atomic"> atomic region open</label>
+    <label class="check"><input type="checkbox" id="sb-scope"> durable scope open</label>
+    <label class="check"><input type="checkbox" id="sb-snapshotting"> save/load already in progress</label>
+    <label class="check"><input type="checkbox" id="sb-inflight"> live host call in flight</label>
+  </div>
+  <div class="result js-only" id="sb-result" aria-live="polite"></div>
+  <div class="table-wrap">
+  <table>
+    <thead><tr><th scope="col">Precedence</th><th scope="col">Condition</th><th scope="col">Why it blocks</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td><code>Replaying</code></td><td>Snapshots are only taken in live mode.</td></tr>
+      <tr><td>2</td><td><code>OpenAtomicRegion</code></td><td>A later trap could append a <code>Jump</code> deleting the oplog tip.</td></tr>
+      <tr><td>3</td><td><code>OpenDurableScope</code></td><td>Its <code>Start</code>/<code>End</code> pair would straddle the snapshot cut.</td></tr>
+      <tr><td>4</td><td><code>Snapshotting</code></td><td>A save/load call is already in progress.</td></tr>
+      <tr><td>5</td><td><code>InFlightHostCall</code></td><td>A live call's <code>Start</code> may precede the cut while its terminal lands after it.</td></tr>
+    </tbody>
+  </table>
+  </div>
+</div>
+
+<h3>Revert and fork</h3>
+<p>Two more history operations live in the same family. <code>golem:api/host.revert-agent</code> appends a <code>Revert</code> hint and reconstructs the agent so that replay stops at an earlier point (by oplog index or by number of invocations) — the later entries remain in storage but are excluded from the fold. <code>golem:api/host.fork</code> copies the oplog to a new agent id up to a chosen index; the new agent replays the copied history and then continues independently.</p>
+
+<!-- ===================== 18. RECOVERY ===================== -->
+<h2 id="s-recovery"><span class="num">18</span>Interrupt, suspend, restart, evict, recover</h2>
+<p>Everything in this section is the same operation seen from different angles: <strong>discard the Store, go round the outer loop</strong>. The hints appended beforehand annotate the history for status folding and observers; none of them changes how reconstruction works.</p>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Trigger</th><th scope="col">Mechanism</th><th scope="col">Oplog</th><th scope="col">Comes back when</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Interrupt</strong> (API)</td><td><code>Worker::set_interrupting(InterruptKind::Interrupt(ts))</code>; the running invocation is aborted at the next host-call boundary</td><td><code>Interrupted</code> (h)</td><td>An explicit resume; status stays <code>Interrupted</code> until then</td></tr>
+    <tr><td><strong>Restart</strong> (simulated crash, API)</td><td><code>InterruptKind::Restart</code></td><td><code>Restart</code> (h) — or nothing at all for a real crash</td><td>Immediately: the outer loop reconstructs at once</td></tr>
+    <tr><td><strong>Suspend</strong></td><td><code>InterruptKind::Suspend(ts)</code>, used when the guest sleeps or waits for a promise long enough to unload</td><td><code>Suspend</code> (h)</td><td>On demand: a new invocation, a promise completion, or a <code>ScheduledAction::Resume</code></td></tr>
+    <tr><td><strong>Jump</strong></td><td><code>InterruptKind::Jump</code> ("jumping back in time"): atomic-region rollback or <code>set-oplog-index</code></td><td><code>Jump { region }</code> (positional)</td><td>Immediately, replaying with the region skipped</td></tr>
+    <tr><td><strong>Eviction</strong> (memory / filesystem pressure)</td><td><code>EvictionClass</code> ordering: <code>LoadedIdle</code> first (cheapest), then <code>WarmRunnable</code> (has durable pending invocations). Executing workers and workers with non-durable in-memory work (internal queue, <code>ResumeReplay</code>, interrupt) are <em>never</em> evicted.</td><td>none</td><td>On the next invocation or scheduled action</td></tr>
+    <tr><td><strong>Resharding</strong></td><td><code>on_shard_assignment_changed</code>: workers whose shard moved away are unloaded here and reconstructed by the new owner</td><td>none</td><td>When the new owner is asked for the worker</td></tr>
+    <tr><td><strong>Process death</strong></td><td>—</td><td>whatever was committed</td><td>When any executor is asked for the worker</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h3>After the instance ends: <code>RetryDecision</code></h3>
+<div class="table-wrap">
+<table>
+  <thead><tr><th scope="col">Decision</th><th scope="col">Effect in the outer loop</th></tr></thead>
+  <tbody>
+    <tr><td><code>Immediate</code></td><td>Recreate the instance now, keeping the existing permits (memory, concurrency).</td></tr>
+    <tr><td><code>Delayed(d)</code></td><td>Recreate after <code>d</code> (retry policy backoff), keeping permits. Status folds to <code>Retrying</code>.</td></tr>
+    <tr><td><code>ReacquirePermits</code></td><td>Recreate immediately but drop and re-acquire permits — used when memory needs were mis-estimated. Accepted, queued live invocations survive this.</td></tr>
+    <tr><td><code>TryStop(t)</code></td><td>Stop if no resume request arrives after <code>t</code>, but allow resuming (unlike <code>None</code>). Idle workers end here before eviction.</td></tr>
+    <tr><td><code>None</code></td><td>No retry possible: retries exhausted or the agent exited. Status folds to <code>Failed</code> / <code>Exited</code>.</td></tr>
+  </tbody>
+</table>
+</div>
+
+<div class="callout">
+  <span class="label">One path</span>
+  Restart does not differ from suspend, eviction, or a crash: each discards the Store; the next incarnation runs <code>prepare_instance → resume_replay</code> from the snapshot baseline to the tail and publishes Live. Tests: <code>counter_resource_test_2_with_restart</code>, simulated-crash tests at arbitrary points (<code>simulated_crash</code>, <code>interrupt</code>).
+</div>
+
+<h3>Scheduled actions</h3>
+<p>Time-based wake-ups are durable too. <code>ScheduledAction</code> (<code>services/scheduler.rs</code>) covers <code>CompletePromise</code>, <code>ArchiveOplog</code>, <code>Invoke</code> and <code>Resume</code>; the scheduler stores them in indexed storage keyed by time and the owning executor fires them, so a sleeping agent does not need a resident timer to be woken.</p>
+
+<!-- ===================== 19. GLOSSARY ===================== -->
+<h2 id="s-glossary"><span class="num">19</span>Glossary</h2>
+<dl class="kv">
+  <dt>Agent</dt><dd>One durable (or ephemeral) instance of an agent type, identified by <code>AgentId</code>; has exactly one oplog.</dd>
+  <dt>Atomic region</dt><dd>A span between <code>mark-begin-operation</code> and <code>mark-end-operation</code> that is re-executed as a whole after a failure, with stable idempotency keys.</dd>
+  <dt>Claim</dt><dd>Matching the host call the guest is making during replay to a recorded <code>Start</code> by identity.</dd>
+  <dt>Commit</dt><dd>Making appended oplog entries durable in storage. <code>CommitLevel::Always</code> forces it; <code>DurableOnly</code> commits only for durable agents.</dd>
+  <dt>Cursor</dt><dd><code>ReplayCursor</code>: the single reader over recorded history during replay.</dd>
+  <dt>Durable function type</dt><dd>Classification of a host call by re-execution safety: <code>ReadLocal</code>, <code>WriteLocal</code>, <code>ReadRemote</code>, <code>WriteRemote</code>, <code>WriteRemoteBatched</code>, <code>WriteRemoteTransaction</code>.</dd>
+  <dt>Entity body</dt><dd>Guest code (tool sidecar, middleware) that runs in its own Store but records into the owner agent's oplog.</dd>
+  <dt>Ephemeral agent</dt><dd>An agent whose state is not recovered after instance loss; RPC to it is at-most-once.</dd>
+  <dt>Fingerprint</dt><dd><code>AgentFingerprint</code>: minted once at creation; distinguishes incarnations sharing an <code>AgentId</code>.</dd>
+  <dt>Hint</dt><dd>An oplog entry that annotates history and is skipped by replay's positional matching.</dd>
+  <dt>Idempotency key</dt><dd>The identity of an invocation; derived from the caller's durable position so retries and replays reuse it.</dd>
+  <dt>Live</dt><dd>The mode in which the guest runs new code and its host calls perform real effects and append to the oplog.</dd>
+  <dt>Marker</dt><dd><code>CompletionDelivered</code> / <code>CompletionDiscarded</code>: records when (or whether) the guest observed a completion.</dd>
+  <dt>Oplog</dt><dd>The append-only, indexed journal of an agent's history; the only durable state.</dd>
+  <dt>Positional entry</dt><dd>An oplog entry that replay must match in order.</dd>
+  <dt>Replay</dt><dd>Re-running the guest from a baseline while feeding it recorded host results instead of performing effects.</dd>
+  <dt>Resident state</dt><dd>Anything held in executor memory: Store, instance, caches, queues. Disposable by definition.</dd>
+  <dt>Snapshot</dt><dd>A guest-serialised state used as a replay baseline (automatic) or to carry state across incompatible revisions (snapshot-based update).</dd>
+  <dt>Store</dt><dd>A Wasmtime store holding one instance and its host context; one per resident incarnation of an agent (plus one per active entity body).</dd>
+  <dt>Terminal</dt><dd>The entry that completes a <code>Start</code>: <code>End</code> or <code>Cancelled</code>.</dd>
+  <dt>Worker</dt><dd>The executor's resident object for one agent: queue, status cache, invocation loop.</dd>
+</dl>
+
+<footer class="muted foot">
+  <p>Source of truth: <code>golem-worker-executor/src</code> and <code>golem-worker-executor/tests</code>. This document was written by hand and checked against the code at the time of writing; when they disagree, the code wins.</p>
+  <p><a href="#top">Back to top ↑</a></p>
+</footer>
+
+<a class="back-top btn small" id="back-top" href="#top" aria-label="Back to top">↑ Top</a>
+</main>
+</div>
+<script>
+(function () {
+  'use strict';
+  var d = document;
+  d.documentElement.classList.add('js');
+  function $(sel, root) { return (root || d).querySelector(sel); }
+  function $$(sel, root) { return Array.prototype.slice.call((root || d).querySelectorAll(sel)); }
+  function esc(s) { return String(s).replace(/[&<>"]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]; }); }
+  function setResult(el, cls, verdict, body) {
+    if (!el) return;
+    el.className = 'result ' + (cls || '') + (el.classList.contains('js-only') ? ' js-only' : '');
+    el.innerHTML = '<div class="verdict">' + verdict + '</div>' + (body || '');
+  }
+
+  /* ---------- theme ---------- */
+  var themeBtn = $('#theme-toggle');
+  function applyTheme(t) {
+    if (t) d.documentElement.setAttribute('data-theme', t); else d.documentElement.removeAttribute('data-theme');
+    if (themeBtn) themeBtn.setAttribute('aria-pressed', t === 'dark' ? 'true' : 'false');
+  }
+  try { applyTheme(localStorage.getItem('wx-theme') || ''); } catch (e) { /* storage unavailable */ }
+  if (themeBtn) themeBtn.addEventListener('click', function () {
+    var cur = d.documentElement.getAttribute('data-theme');
+    var dark = cur ? cur === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var next = dark ? 'light' : 'dark';
+    applyTheme(next);
+    try { localStorage.setItem('wx-theme', next); } catch (e) { /* ignore */ }
+  });
+
+  /* ---------- expand all ---------- */
+  var expandBtn = $('#expand-all');
+  if (expandBtn) expandBtn.addEventListener('click', function () {
+    var all = $$('main details');
+    var anyClosed = all.some(function (x) { return !x.open; });
+    all.forEach(function (x) { x.open = anyClosed; });
+    expandBtn.textContent = anyClosed ? 'Collapse all' : 'Expand all';
+  });
+
+  /* ---------- open details containing the hash target ---------- */
+  function revealHash() {
+    if (!location.hash) return;
+    var t = d.getElementById(location.hash.slice(1));
+    if (!t) return;
+    var p = t.parentElement;
+    while (p) { if (p.tagName === 'DETAILS') p.open = true; p = p.parentElement; }
+  }
+  window.addEventListener('hashchange', revealHash); revealHash();
+
+  /* ---------- scrollspy, progress, back to top ---------- */
+  var headings = $$('main h2[id]');
+  var tocLinks = {};
+  $$('#toc a').forEach(function (a) { tocLinks[a.getAttribute('href').slice(1)] = a; });
+  var progress = $('#progress'), backTop = $('#back-top');
+  var ticking = false;
+  function onScroll() {
+    if (ticking) return; ticking = true;
+    requestAnimationFrame(function () {
+      ticking = false;
+      var y = window.scrollY || d.documentElement.scrollTop;
+      var h = d.documentElement.scrollHeight - window.innerHeight;
+      if (progress) progress.style.width = (h > 0 ? Math.min(100, y / h * 100) : 0) + '%';
+      if (backTop) backTop.classList.toggle('show', y > 600);
+      var current = null;
+      for (var i = 0; i < headings.length; i++) {
+        if (headings[i].getBoundingClientRect().top - 90 <= 0) current = headings[i].id; else break;
+      }
+      Object.keys(tocLinks).forEach(function (id) {
+        var on = id === current;
+        tocLinks[id].classList.toggle('active', on);
+        if (on) tocLinks[id].setAttribute('aria-current', 'true'); else tocLinks[id].removeAttribute('aria-current');
+      });
+    });
+  }
+  window.addEventListener('scroll', onScroll, { passive: true }); onScroll();
+  var sidebarDetails = $('.sidebar > details');
+  if (sidebarDetails && window.matchMedia('(max-width: 980px)').matches) sidebarDetails.open = false;
+  $$('#toc a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      if (window.matchMedia('(max-width: 980px)').matches && sidebarDetails) sidebarDetails.open = false;
+    });
+  });
+
+  /* ---------- component map ---------- */
+  var compDetail = $('#compmap-detail');
+  var compRows = {};
+  $$('#compmap-table tr[data-comp]').forEach(function (tr) { compRows[tr.getAttribute('data-comp')] = tr; });
+  function showComp(id) {
+    var tr = compRows[id]; if (!tr || !compDetail) return;
+    var cells = tr.children;
+    compDetail.innerHTML = '<div class="verdict">' + cells[0].innerHTML + '</div><p class="src">' + cells[1].innerHTML + '</p><p>' + cells[2].innerHTML + '</p>';
+    $$('#compmap-widget g.clickable').forEach(function (g) { g.classList.toggle('selected', g.getAttribute('data-comp') === id); });
+  }
+  $$('#compmap-widget g.clickable').forEach(function (g) {
+    g.addEventListener('click', function () { showComp(g.getAttribute('data-comp')); });
+    g.addEventListener('keydown', function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); showComp(g.getAttribute('data-comp')); } });
+  });
+
+  /* ---------- oplog explorer ---------- */
+  var oplogFilter = $('#oplog-filter'), oplogHints = $('#oplog-hints-only'), oplogPos = $('#oplog-pos-only');
+  function filterOplog() {
+    var cat = oplogFilter ? oplogFilter.value : 'all';
+    var hintsOnly = oplogHints && oplogHints.checked, posOnly = oplogPos && oplogPos.checked;
+    var shown = 0;
+    $$('#oplog-table tbody tr').forEach(function (tr) {
+      var ok = cat === 'all' || tr.getAttribute('data-cat') === cat;
+      var isHint = !!tr.querySelector('.pill.hint');
+      if (hintsOnly && !isHint) ok = false;
+      if (posOnly && isHint) ok = false;
+      tr.hidden = !ok; if (ok) shown++;
+    });
+    var cnt = $('#oplog-count'); if (cnt) cnt.textContent = shown + ' entry kinds shown';
+  }
+  [oplogFilter, oplogHints, oplogPos].forEach(function (el) { if (el) el.addEventListener('change', filterOplog); });
+  if (oplogHints && oplogPos) {
+    oplogHints.addEventListener('change', function () { if (oplogHints.checked) { oplogPos.checked = false; filterOplog(); } });
+    oplogPos.addEventListener('change', function () { if (oplogPos.checked) { oplogHints.checked = false; filterOplog(); } });
+  }
+  filterOplog();
+
+  /* ---------- durable vs resident demo ---------- */
+  var killBtn = $('#kill-btn'), rebuildBtn = $('#rebuild-btn'), residentCol = $('#resident-col'), stateResult = $('#state-result');
+  if (killBtn && rebuildBtn) {
+    killBtn.addEventListener('click', function () {
+      residentCol.classList.add('gone');
+      killBtn.disabled = true; rebuildBtn.disabled = false;
+      setResult(stateResult, 'bad', 'Process gone. The right column no longer exists.',
+        '<p>Nothing in the left column was touched: committed oplog entries, the pending invocation, recorded results, snapshot blobs and scheduler actions are all still in storage. Any executor that owns this agent\u2019s shard can now rebuild the right column.</p>');
+      rebuildBtn.focus();
+    });
+    rebuildBtn.addEventListener('click', function () {
+      residentCol.classList.remove('gone');
+      rebuildBtn.disabled = true; killBtn.disabled = false;
+      setResult(stateResult, 'ok', 'Rebuilt from the oplog.',
+        '<ol><li><code>Worker::get_or_create</code> loads the component and folds status from the oplog (<code>worker/status.rs</code>).</li><li>A fresh <code>Store</code> is created; <code>prepare_instance</code> picks a snapshot baseline or replays from <code>Create</code>.</li><li>Replay re-runs the guest; every recorded host call is answered from its <code>End</code>, the cursor drains, the Store goes live.</li><li>The durable queue (<code>PendingAgentInvocation</code> entries without a matching <code>Finished</code>) becomes the new <code>Worker.queue</code>.</li></ol><p>Nothing external was re-done, and no caller had to resubmit anything.</p>');
+      killBtn.focus();
+    });
+  }
+
+  /* ---------- status fold demo ---------- */
+  var foldTape = $('#fold-tape');
+  if (foldTape) {
+    var pillFor = { Idle: 'ok', Running: 'pos', Suspended: 'warn', Retrying: 'warn', Failed: 'bad' };
+    var FOLD = [
+      function (s) { s.status = 'Idle'; s.rev = '1'; s.mem = '2 MiB'; return ['status', 'rev', 'mem']; },
+      function (s) { s.pending.push('k1'); return ['pending']; },
+      function (s) { s.status = 'Running'; s.pending.shift(); s.current = 'k1'; s.retry = null; return ['status', 'pending', 'current', 'retry']; },
+      function (s) { s.mem = '3 MiB'; return ['mem']; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function () { return []; },
+      function (s) { s.status = 'Idle'; s.results.k1 = '#8'; s.current = null; s.retry = null; return ['status', 'results', 'current', 'retry']; },
+      function (s) { s.pending.push('k2'); return ['pending']; },
+      function (s) { s.pending.push('k3'); return ['pending']; },
+      function (s) { s.status = 'Running'; s.pending.shift(); s.current = 'k2'; return ['status', 'pending', 'current']; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function () { return []; },
+      function (s) { s.retry = 'region at #12: 1 attempt'; s.results.k2 = '#14'; return ['retry', 'results']; },
+      function () { return []; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function () { return []; },
+      function (s) { s.status = 'Running'; return ['status']; },
+      function (s) { s.status = 'Idle'; s.results.k2 = '#20'; s.current = null; s.retry = null; return ['status', 'results', 'current', 'retry']; },
+      function (s) { s.status = 'Running'; s.pending.shift(); s.current = 'k3'; s.retry = null; return ['status', 'pending', 'current', 'retry']; },
+      function (s) { s.status = 'Suspended'; return ['status']; }
+    ];
+    var foldRows = $$('tbody tr', foldTape), foldState, foldIdx;
+    var foldStep = $('#fold-step'), foldAll = $('#fold-all'), foldReset = $('#fold-reset'), foldPos = $('#fold-pos'), foldNote = $('#fold-note');
+    function foldRender(changed) {
+      var f = {
+        status: '<span class="pill ' + (pillFor[foldState.status] || '') + '">' + (foldState.status || '—') + '</span>',
+        rev: foldState.rev || '<span class="muted">unknown</span>',
+        pending: foldState.pending.length ? '[' + foldState.pending.join(', ') + ']' : '<span class="muted">empty</span>',
+        current: foldState.current || '<span class="muted">none</span>',
+        results: Object.keys(foldState.results).length ? Object.keys(foldState.results).map(function (k) { return k + ' \u2192 ' + foldState.results[k]; }).join(', ') : '<span class="muted">none</span>',
+        mem: foldState.mem || '<span class="muted">unknown</span>',
+        skipped: '#13\u2013#15 <span class="muted">(known from the first pass)</span>',
+        retry: foldState.retry || '<span class="muted">none</span>'
+      };
+      Object.keys(f).forEach(function (k) {
+        var dd = $('#fr-' + k);
+        if (!dd) return;
+        dd.innerHTML = f[k];
+        dd.classList.remove('changed');
+        if (changed.indexOf(k) >= 0) { void dd.offsetWidth; dd.classList.add('changed'); }
+      });
+      foldRows.forEach(function (r, i) {
+        r.classList.toggle('todo', i >= foldIdx);
+        r.classList.toggle('cur', i === foldIdx - 1);
+      });
+      var done = foldIdx >= FOLD.length;
+      foldStep.disabled = done;
+      foldAll.disabled = done;
+      foldPos.textContent = foldIdx === 0 ? 'Before the first entry' : (done ? 'All 22 entries folded' : 'Folded entries 1\u2013' + foldIdx + ' of 22');
+      foldNote.textContent = foldIdx === 0
+        ? 'Before the fold starts, the first pass has already found the Jump at #15, so the fold knows to skip #13\u2013#15.'
+        : (done
+          ? 'A new executor that loads this agent starts from exactly this record: it knows k3 is mid-flight and suspended, that nothing is queued, and which entries replay must skip.'
+          : (foldRows[foldIdx - 1].cells[2].textContent));
+    }
+    function foldDoReset() {
+      foldState = { status: null, rev: null, pending: [], current: null, results: {}, mem: null, retry: null };
+      foldIdx = 0;
+      foldRender([]);
+    }
+    function foldNext() {
+      if (foldIdx >= FOLD.length) return;
+      var changed = FOLD[foldIdx](foldState);
+      foldIdx++;
+      foldRender(changed);
+    }
+    foldStep.addEventListener('click', function () {
+      foldNext();
+      var cur = foldRows[foldIdx - 1];
+      if (cur && cur.getBoundingClientRect) {
+        var rect = cur.getBoundingClientRect();
+        if (rect.bottom > window.innerHeight - 40 || rect.top < 60) cur.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    });
+    foldAll.addEventListener('click', function () { while (foldIdx < FOLD.length) foldNext(); });
+    foldReset.addEventListener('click', foldDoReset);
+    foldRows.forEach(function (r, i) {
+      r.addEventListener('click', function () {
+        foldDoReset();
+        while (foldIdx <= i) foldNext();
+      });
+    });
+    foldDoReset();
+  }
+
+  /* ---------- timelines ---------- */
+  // Each entry: {lane, idx, kind, cls: 'pos'|'hint'|'event'} ; crash after k entries (1-based) => windows[k]
+  var TL = {};
+  TL.invocation = {
+    lanes: ['Agent A oplog'],
+    entries: [
+      { lane: 0, idx: '#41', kind: 'PendingAgentInvocation', cls: 'hint', meta: 'key=k1' },
+      { lane: 0, idx: '#42', kind: 'AgentInvocationStarted', cls: 'pos', meta: 'key=k1' },
+      { lane: 0, idx: '#43', kind: 'Start keyvalue/get', cls: 'pos' },
+      { lane: 0, idx: '#44', kind: 'End keyvalue/get', cls: 'pos', meta: 'value=7' },
+      { lane: 0, idx: '#45', kind: 'AgentInvocationFinished', cls: 'pos', meta: 'result=Ok' }
+    ],
+    windows: [
+      { t: 'No crash', cls: 'ok', body: 'The invocation is accepted (#41 committed), executed (#42\u2013#44) and finished (#45, committed with <code>CommitLevel::Always</code>). Only after that commit does the caller receive the result.' },
+      { t: 'Crash after #41 (accepted, never started)', cls: 'warn', body: 'The caller already heard \u201caccepted\u201d because the commit of <code>PendingAgentInvocation</code> happened first. On reconstruction the status fold finds a pending invocation without <code>Finished</code>, so it lands in the new <code>Worker.queue</code> and runs. A caller that retries with key <code>k1</code> gets <code>LookupResult::Pending</code> and attaches to the same invocation; nothing is duplicated. Had the crash happened <em>before</em> #41 was committed, the caller would have received an error instead of \u201caccepted\u201d and would retry with the same key, which then creates the invocation once.' },
+      { t: 'Crash after #42 (started, no host call yet)', cls: 'warn', body: 'Replay re-runs the guest export for <code>k1</code> in <code>InvocationMode::Replay</code>. The first host call finds no recorded <code>Start</code>: the cursor is exhausted, the Store switches to live and the call executes for real. From the outside this is indistinguishable from an invocation that simply took longer.' },
+      { t: 'Crash after #43 (Start committed, End missing)', cls: 'warn', body: 'Replay claims <code>Start</code> #43 and finds no terminal: an <em>incomplete</em> call. <code>keyvalue/get</code> is <code>ReadRemote</code>, so it may be re-executed; the Store goes live, the read runs again and appends the missing <code>End</code>. For a non-idempotent write this window is the dangerous one \u2014 see the host-call walkthrough.' },
+      { t: 'Crash after #44 (host call done, invocation not finished)', cls: 'ok', body: 'Replay returns the recorded value 7 to the guest without touching the key-value store. The guest continues from where it was; the invocation finishes live and appends #45. The external effect happened exactly once.' },
+      { t: 'Crash after #45 (finished)', cls: 'ok', body: 'Nothing to redo. The result is in the oplog; a caller that never heard back retries with <code>k1</code>, gets <code>LookupResult::Complete(result)</code> and receives the recorded result. Waiters that were connected to the dead process lose their connection but not the result.' }
+    ]
+  };
+  function hostcallVariant(name, effectNote, w1, w1cls, w3) {
+    return {
+      lanes: ['Agent oplog'],
+      entries: [
+        { lane: 0, idx: '#50', kind: 'Start ' + name, cls: 'pos', meta: 'type=' + effectNote },
+        { lane: 0, idx: '\u2014', kind: '\u26a1 remote effect happens', cls: 'event' },
+        { lane: 0, idx: '#51', kind: 'End ' + name, cls: 'pos' },
+        { lane: 0, idx: '#52', kind: 'CompletionDelivered', cls: 'hint', meta: 'start=#50' },
+        { lane: 0, idx: '#53', kind: 'AgentInvocationFinished', cls: 'pos' }
+      ],
+      windows: [
+        { t: 'No crash', cls: 'ok', body: 'Four steps: <code>Start</code> is appended, the effect runs, <code>End</code> records the response, and the guest\u2019s observation is fixed by <code>CompletionDelivered</code>.' },
+        { t: 'Crash after Start, before the effect', cls: w1cls, body: w1 + ' The executor cannot know whether the effect happened \u2014 that is the whole point of the window \u2014 so the rule depends only on the function type.' },
+        { t: 'Crash after the effect, before End', cls: w1cls, body: 'Same oplog as the previous window (the effect leaves no entry), so replay behaves identically: ' + w1.charAt(0).toLowerCase() + w1.slice(1) },
+        { t: 'Crash after End, before delivery', cls: 'ok', body: w3 },
+        { t: 'Crash after CompletionDelivered', cls: 'ok', body: 'Replay returns the recorded response and releases it to the guest exactly at marker #52 (<code>ReplayDeliveryBarrier</code>). The guest sees the same value at the same point in its own execution.' },
+        { t: 'Crash after AgentInvocationFinished', cls: 'ok', body: 'Everything is recorded. Reconstruction replays the whole invocation without any external interaction.' }
+      ]
+    };
+  }
+  var delivered = 'Replay finds <code>End</code> #51 with no marker after it: resolution <code>Delivered/AtReplayTail</code>. The effect is <em>not</em> re-run. The recorded response is withheld until the cursor drains (<code>await_natural_tail_end</code>) and then handed to the guest as its first live observation, which appends the missing marker.';
+  TL.hostcall = {
+    read: hostcallVariant('keyvalue/get', 'ReadRemote', 'Incomplete <code>Start</code>. Reads are always safe to re-execute: the Store switches to live, the read runs again and completes the existing <code>Start</code> by appending <code>End</code>.', 'warn', delivered),
+    writeidem: hostcallVariant('http/send', 'WriteRemote', 'Incomplete <code>Start</code>. <code>WriteRemote</code> with <code>assume_idempotence = true</code> (the default) is re-executable: the request is sent again with the <em>same</em> idempotency key derived from <code>Start</code> #50, so a receiver that honours the key applies it once.', 'warn', delivered),
+    writenon: hostcallVariant('http/send', 'WriteRemote (idempotence off)', 'Incomplete <code>Start</code> and <code>can_reexecute_on_incomplete_replay()</code> is false. The executor refuses to re-run the call: unless an enclosing durable scope resolves it, the replay fails with <code>unexpected_oplog_entry("End or Cancelled")</code> and the invocation goes to the failure/retry path. The effect may or may not have happened; the executor will not guess.', 'bad', delivered),
+    batched: hostcallVariant('rdbms/execute', 'WriteRemoteBatched', 'Incomplete <code>Start</code>. Batched and transactional writes are never re-executed by the call itself; recovery belongs to the surrounding remote-transaction entries (<code>BeginRemoteTransaction</code> \u2026 <code>Committed</code>/<code>RolledBack</code>), which decide whether to finish or roll back the transaction.', 'bad', delivered)
+  };
+  TL.rpc = {
+    lanes: ['Caller C oplog', 'Target T oplog'],
+    entries: [
+      { lane: 0, idx: 'C#10', kind: 'Start rpc/invoke-and-await', cls: 'pos', meta: 'key=derived(C#10)' },
+      { lane: 1, idx: 'T#20', kind: 'PendingAgentInvocation', cls: 'hint', meta: 'key=derived(C#10)' },
+      { lane: 1, idx: 'T#21', kind: 'AgentInvocationStarted', cls: 'pos' },
+      { lane: 1, idx: 'T#22', kind: 'AgentInvocationFinished', cls: 'pos', meta: 'counter=1' },
+      { lane: 0, idx: 'C#11', kind: 'End rpc/invoke-and-await', cls: 'pos', meta: 'result=1' },
+      { lane: 0, idx: 'C#12', kind: 'CompletionDelivered', cls: 'hint' }
+    ],
+    windows: [
+      { t: 'No crash', cls: 'ok', body: 'C derives the idempotency key from its own <code>Start</code> index, T accepts the invocation under that key, runs <code>increment</code> once and records the result; C records <code>End</code> and delivers it.' },
+      { t: 'C dies after C#10, before T accepted', cls: 'warn', body: 'C replays, finds the incomplete <code>Start</code>, derives the <em>same</em> key and re-dispatches (<code>InvocationFreshnessDisposition::MayExist</code>). T has never seen the key, so it creates the invocation now. T\u2019s counter ends at 1.' },
+      { t: 'C dies after T accepted (T#20)', cls: 'warn', body: 'T keeps running the invocation regardless of C. C re-dispatches with the same key; T\u2019s <code>lookup_invocation_result</code> returns <code>Pending</code>, so the second arrival attaches to the existing invocation. One execution, counter = 1.' },
+      { t: 'C dies while T is executing (T#21)', cls: 'warn', body: 'Identical to the previous window from C\u2019s point of view. T finishes on its own; C\u2019s re-dispatch attaches and waits for the recorded result.' },
+      { t: 'C dies after T finished (T#22), before C#11', cls: 'ok', body: 'C re-dispatches with the same key; T answers from its oplog (<code>LookupResult::Complete</code>) without running <code>increment</code> again. C appends <code>End</code> with the recorded result. Counter = 1.' },
+      { t: 'C dies after C#11, before delivery', cls: 'ok', body: 'C replays <code>End</code> as <code>Delivered/AtReplayTail</code> and hands the value to the guest when the cursor drains. T is never contacted.' },
+      { t: 'C dies after CompletionDelivered', cls: 'ok', body: 'Pure replay on C; nothing crosses the network.' }
+    ]
+  };
+  TL.stream = {
+    lanes: ['Producer P oplog', 'Consumer C session (in C\u2019s oplog)'],
+    entries: [
+      { lane: 0, idx: 'P#30', kind: 'StreamRegistered', cls: 'hint', meta: 'fp=P@inst1' },
+      { lane: 0, idx: 'P#31', kind: 'StreamItems', cls: 'hint', meta: 'seq 0\u20132' },
+      { lane: 1, idx: 'C#70', kind: 'StreamSession items', cls: 'hint', meta: 'source_offset 0\u20132' },
+      { lane: 0, idx: 'P#32', kind: 'StreamItems', cls: 'hint', meta: 'seq 3\u20134' },
+      { lane: 0, idx: 'P#33', kind: 'StreamEnd', cls: 'hint' }
+    ],
+    windows: [
+      { t: 'No crash', cls: 'ok', body: 'P registers the stream under its <code>AgentFingerprint</code>, commits each batch before publishing it on the live bus, and ends the stream; C journals what it read by producer offset.' },
+      { t: 'P dies after registering', cls: 'warn', body: 'P is reconstructed and re-runs <code>generate()</code> in replay. The registration is already recorded; the first item batch the guest produces is appended live. C, attached or not, has read nothing yet.' },
+      { t: 'P dies after committing items 0\u20132', cls: 'warn', body: 'On replay P\u2019s guest re-produces items 0\u20132; they match the recorded batch and are not re-published. Production continues from sequence 3. C received 0\u20132 from the bus (publish happens only after commit) and keeps them.' },
+      { t: 'P dies after C journaled 0\u20132', cls: 'warn', body: 'Same for P. C, if it also restarts, replays its own session journal in <code>consumer_read_ordinal</code> order and then reads P\u2019s oplog segment after <code>source_offset</code> 2 \u2014 no item is lost, none is delivered twice.' },
+      { t: 'P dies after committing items 3\u20134', cls: 'warn', body: 'Items 3\u20134 are durable in P\u2019s oplog. C\u2019s live subscription may have missed the publish; when it re-attaches it samples the bus high-water under the publication lock and reads 3\u20134 from the segment by offset, discarding any overlap.' },
+      { t: 'P dies after StreamEnd', cls: 'ok', body: 'The stream is complete in P\u2019s oplog. Any consumer that resumes reads to the terminal and finishes its session (<code>StreamSession { Finished }</code>).' }
+    ]
+  };
+
+  function renderTape(cfg, crashAt) {
+    var html = '';
+    cfg.lanes.forEach(function (lane, li) {
+      html += '<div class="lane"><div class="lane-title">' + esc(lane) + '</div><div class="tape">';
+      cfg.entries.forEach(function (e, i) {
+        if (e.lane !== li) return;
+        var lost = crashAt > 0 && i >= crashAt;
+        var cls = 'entry ' + (e.cls === 'event' ? 'live' : e.cls) + (lost ? ' lost' : '');
+        html += '<div class="' + cls + '" title="' + (lost ? 'never written' : '') + '"><span class="idx">' + esc(e.idx) + '</span><span class="kind">' + esc(e.kind) + '</span>' + (e.meta ? '<span class="meta">' + esc(e.meta) + '</span>' : '') + '</div>';
+        if (crashAt > 0 && i === crashAt - 1) html += '<div class="entry crash-marker" aria-label="crash here">\u2715 crash</div>';
+      });
+      html += '</div></div>';
+    });
+    return html;
+  }
+  function renderStatic(cfg) {
+    return '<ol class="crash-list">' + cfg.windows.map(function (w) { return '<li><span class="t">' + w.t + '.</span> ' + w.body + '</li>'; }).join('') + '</ol>';
+  }
+  function renderStaticAll() {
+    var c = TL.hostcall, out = '';
+    $$('[data-tl-variant="hostcall"] option').forEach(function (o) { out += '<h5>' + esc(o.textContent) + '</h5>' + renderStatic(c[o.value]); });
+    return out;
+  }
+  function initTimeline(key) {
+    var slider = $('[data-tl-slider="' + key + '"]'), tape = $('[data-tl-tape="' + key + '"]'), result = $('[data-tl-result="' + key + '"]'),
+        reset = $('[data-tl-reset="' + key + '"]'), variantSel = $('[data-tl-variant="' + key + '"]'), stat = $('[data-tl-static="' + key + '"]');
+    if (!tape) return;
+    function cfg() { var c = TL[key]; return variantSel ? c[variantSel.value] : c; }
+    function render() {
+      var c = cfg(), k = slider ? parseInt(slider.value, 10) : 0;
+      if (slider) { slider.max = String(c.windows.length - 1); slider.setAttribute('aria-valuetext', c.windows[k].t); }
+      tape.innerHTML = renderTape(c, k);
+      var w = c.windows[k];
+      setResult(result, w.cls, w.t, '<p>' + w.body + '</p>');
+      if (stat && !stat.innerHTML.trim()) stat.innerHTML = variantSel ? renderStaticAll() : renderStatic(c);
+    }
+    if (slider) slider.addEventListener('input', render);
+    if (variantSel) variantSel.addEventListener('change', function () { if (slider) slider.value = '0'; render(); });
+    if (reset) reset.addEventListener('click', function () { if (slider) slider.value = '0'; render(); });
+    render();
+  }
+  ['invocation', 'hostcall', 'rpc', 'stream'].forEach(initTimeline);
+
+  /* ---------- liveness ---------- */
+  var lvKind = $('#lv-kind'), lvEx = $('#lv-exhausted'), lvPub = $('#lv-published'), lvTail = $('#lv-tail'), lvRes = $('#lv-result');
+  function liveness() {
+    if (!lvKind) return;
+    var kind = lvKind.value, live, why;
+    if (kind === 'primary') { live = lvPub.checked; why = 'A primary Store is live iff the shared flag was <em>published</em> (Replaying \u2192 Settling \u2192 Live). Cursor exhaustion alone changes nothing.'; }
+    else if (kind === 'completed') { live = false; why = 'An entity Store in <code>ReplayingCompleted</code> mode is never live: the whole invocation was recorded, so every durable call inside it must replay. The guest export re-runs only to rebuild filesystem effects.'; }
+    else { live = lvTail.checked; why = 'An entity Store in <code>ReplayingIncomplete</code> or <code>Live</code> mode is live iff its own <code>local_live_tail</code> was set when its share of the owner\u2019s history ran out. The primary\u2019s published flag is not consulted.'; }
+    var note = lvEx.checked && !live ? ' The cursor being exhausted is an observation, not a permission: live effects wait for the publish.' : '';
+    setResult(lvRes, live ? 'ok' : 'hint', 'store_is_live \u2192 ' + (live ? 'true' : 'false'), '<p>' + why + note + '</p>');
+  }
+  [lvKind, lvEx, lvPub, lvTail].forEach(function (el) { if (el) el.addEventListener('change', liveness); });
+  liveness();
+
+  /* ---------- concurrency ---------- */
+  var concRes = $('#conc-result');
+  function conc(order) {
+    $$('button[data-conc]').forEach(function (b) { b.setAttribute('aria-pressed', b.getAttribute('data-conc') === order ? 'true' : 'false'); });
+    var hostOrder = order === 'ab' ? 'End A then End B' : 'End B then End A';
+    setResult(concRes, 'ok', 'Guest observes: A first, then B \u2014 regardless.',
+      '<p>Host order on replay: <strong>' + hostOrder + '</strong>. Both completions are resolved from the recorded <code>End</code> entries, but each is parked behind the <code>ReplayDeliveryBarrier</code> until the cursor reaches its marker. Marker #64 (<code>CompletionDelivered A</code>) comes before #65, so A is released first. Host completion order (#62/#63) is a fact about the host; delivery order (#64/#65) is the guest input, and only guest inputs must be reproduced.</p>');
+  }
+  $$('button[data-conc]').forEach(function (b) { b.addEventListener('click', function () { conc(b.getAttribute('data-conc')); }); });
+  conc('ab');
+
+  /* ---------- retry decision ---------- */
+  var rt = { type: $('#rt-type'), idem: $('#rt-idem'), atomic: $('#rt-atomic'), policy: $('#rt-policy'), delay: $('#rt-delay'), perm: $('#rt-permanent'), res: $('#rt-result') };
+  function retry() {
+    if (!rt.type) return;
+    var t = rt.type.value, steps = [];
+    if (rt.perm && rt.perm.checked) {
+      steps.push('The error is classified <code>Permanent</code>: no retry of any kind. The failure is persisted as the call\u2019s result and returned to the guest.');
+      return setResult(rt.res, 'hint', 'Persist \u2014 permanent failure', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    var eligible = (t === 'ReadLocal' || t === 'ReadRemote' || t === 'WriteLocal') || (t === 'WriteRemote' && rt.idem.checked);
+    if (!eligible) {
+      steps.push('<code>is_eligible_for_internal_retry()</code> is false for <code>' + t + (t === 'WriteRemote' ? '</code> with idempotence off' : '</code>') + '. The failure goes to the trap path (<code>try_trigger_retry</code>): the whole invocation is retried by reconstruction according to the agent-level retry policy, or the failure is persisted.');
+      return setResult(rt.res, 'warn', 'Trap path \u2014 not eligible for inline retry', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    steps.push('Type <code>' + t + '</code> is eligible for inline retry' + (t === 'WriteRemote' ? ' because idempotence mode is on' : '') + '.');
+    if (rt.atomic.checked) {
+      steps.push('The call is inside an atomic region: <code>FallBackToTrap</code>. The trap re-executes the region from <code>BeginAtomicRegion</code> so that every key inside stays stable.');
+      return setResult(rt.res, 'warn', 'FallBackToTrap \u2014 atomic region', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    steps.push('Not inside an atomic region.');
+    if (rt.policy.value === 'none') {
+      steps.push('No named retry policy matches the failure\u2019s properties: <code>Exhausted</code>. The failure is persisted as the call\u2019s result; the guest sees the error.');
+      return setResult(rt.res, 'hint', 'Exhausted \u2014 no applicable policy', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    if (rt.policy.value === 'giveup') {
+      steps.push('The policy\u2019s verdict is <code>GiveUp</code> (budget spent, counted from <code>Error</code> entries grouped by <code>retry_from</code>): <code>Exhausted</code>. The failure is persisted as the call\u2019s result.');
+      return setResult(rt.res, 'hint', 'Exhausted \u2014 budget spent', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    steps.push('The policy says <code>Retry(delay)</code>.');
+    if (rt.delay.value === 'long') {
+      steps.push('<code>delay &gt; max_in_function_retry_delay</code>: too long to hold the Store; <code>FallBackToTrap</code> hands the wait to the outer loop, which reschedules the invocation.');
+      return setResult(rt.res, 'warn', 'FallBackToTrap \u2014 delay too long', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+    }
+    steps.push('An <code>Error</code> hint is appended under this call\u2019s <code>retry_from</code>, the executor sleeps <em>inside</em> the host function (interrupt-aware) and re-runs the effect. The oplog keeps one <code>Start</code>; the eventual <code>End</code> completes it.');
+    setResult(rt.res, 'ok', 'RetryAfterDelay \u2014 inline retry', '<ol><li>' + steps.join('</li><li>') + '</li></ol>');
+  }
+  Object.keys(rt).forEach(function (k) { if (rt[k] && k !== 'res') rt[k].addEventListener('change', retry); });
+  retry();
+
+  /* ---------- snapshot boundary ---------- */
+  var sb = [['#sb-replaying', 'Replaying', 'Snapshots are taken only in live mode.'], ['#sb-atomic', 'OpenAtomicRegion', 'A later trap could append a <code>Jump</code> that deletes the oplog tip the snapshot points at.'], ['#sb-scope', 'OpenDurableScope', 'The scope\u2019s <code>Start</code>/<code>End</code> pair would straddle the cut.'], ['#sb-snapshotting', 'Snapshotting', 'A save/load is already in progress.'], ['#sb-inflight', 'InFlightHostCall', 'A live call\u2019s <code>Start</code> may precede the cut while its terminal lands after it.']];
+  var sbRes = $('#sb-result');
+  function snapshot() {
+    if (!sbRes) return;
+    for (var i = 0; i < sb.length; i++) {
+      var el = $(sb[i][0]);
+      if (el && el.checked) return setResult(sbRes, 'bad', 'Blocked: <code>' + sb[i][1] + '</code>', '<p>' + sb[i][2] + ' Reported as the first blocker in precedence order (' + (i + 1) + ' of 5); the snapshot request is rejected and nothing is written.</p>');
+    }
+    setResult(sbRes, 'ok', 'Safe boundary \u2014 snapshot may be taken', '<p><code>SnapshotBoundaryConditions::blocker</code> returns <code>None</code>. The guest\u2019s <code>save-snapshot</code> export runs, the blob is stored and a <code>Snapshot</code> hint records the index and component revision; later reconstructions may start there.</p>');
+  }
+  sb.forEach(function (x) { var el = $(x[0]); if (el) el.addEventListener('change', snapshot); });
+  snapshot();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds repository-grounded guidance on how the worker executor implements durable execution. Markdown only; no production code changes.

## What is added

**Scoped `AGENTS.md` files** with the mandatory invariants agents must respect when editing the relevant code:
- `golem-worker-executor/AGENTS.md` — the three axioms (deterministic replay, disposable resident runtime, RPC exactly-once), durable vs resident state, external-effect boundaries, oplog-shape change checklist.
- `golem-worker-executor/src/durable_host/AGENTS.md` — execute/append/claim/observe distinctions, `Start`/`End`/delivery markers, identity on the replay path, retry eligibility as part of `DurableFunctionType`, RPC, durable streams, entity bodies, snapshot suppression.
- `golem-worker-executor/src/worker/AGENTS.md` — reconstruction lifecycle, invocation queue/result persistence, snapshots and updates, teardown ordering.
- `golem-worker-executor/tests/AGENTS.md` — deterministic crash gates, provider-side counters, real restart requirements, oplog assertions.

**Reusable skill `understanding-durable-execution`** (`.agents/skills/understanding-durable-execution/`), registered in the root `AGENTS.md` skills table:
- `SKILL.md` — general architecture model: worker lifecycle and reconstruction, oplog model, durable host call lifecycle, replay cursor/claims, replay-to-live, invocation queue and results, durable RPC exactly-once, snapshots/updates, concurrency and completion delivery, streaming invocations, tool invocations and entity bodies, external-effect boundaries, in-function vs trap-based retries, wrong-model → right-model table, review checklist, debugging workflow.
- `reference/timelines.md` — 15 worked oplog timelines.
- `reference/crash-matrix.md` — recovery behaviour per crash window.
- `reference/testing-patterns.md` — tests that fail under a wrong mental model.
- `reference/streams.md`, `reference/tools.md`, `reference/retries.md`.

All claims reference current source and tests in `golem-worker-executor/src/` and `tests/` rather than tickets or incident threads.

## Known open item

The streaming RPC path derives its idempotency key from the physical `Start` index (`handle.start_index()`) while the non-streaming path uses the atomic-region-aware logical counter (`derive_idempotency_key`). The docs describe this current behaviour and flag it as a discrepancy to investigate separately.
