### PR TITLE
Use HTTPS Ubuntu mirrors in managed XFS CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,6 +220,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           LIMA_VERSION: v2.2.0
         run: |
+          sudo sed -i -E 's#http://(([a-z]{2}\.)?archive\.ubuntu\.com|security\.ubuntu\.com)/ubuntu#https://\1/ubuntu#g' \
+            /etc/apt/sources.list.d/ubuntu.sources \
+            /etc/apt/blacksmith-ubuntu-mirrors.txt
           sudo apt-get update -qq
           sudo apt-get install -qqy --no-install-recommends ovmf qemu-system-x86 qemu-utils
           test -c /dev/kvm


### PR DESCRIPTION
## Summary

- rewrite Ubuntu archive URLs to HTTPS before installing Lima's QEMU dependencies
- update both the standard Ubuntu source definition and Blacksmith's mirror list

## Context

The managed XFS job failed before tests started because HTTP requests to Ubuntu archive servers timed out. Updating only `ubuntu.sources` is insufficient on Blacksmith runners because the primary repositories use `/etc/apt/blacksmith-ubuntu-mirrors.txt` through `mirror+file:`.

## Verification

- `git diff --check`
- exercised the sed expression against representative `ubuntu.sources` and Blacksmith mirror-list fixtures; all Ubuntu HTTP URLs were converted to HTTPS